### PR TITLE
Fix activate selector detection

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -31,7 +31,7 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
     return NO;
   }
   [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:MAX(duration, FBMinimumAppSwitchWait)]];
-  if (self.class.fb_isActivateSupported) {
+  if (self.fb_isActivateSupported) {
     [self fb_activate];
     return YES;
   }

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
@@ -33,7 +33,7 @@ extern NSString *const FBApplicationMethodNotSupportedException;
 
 /**
  Get the state of the application. This method only returns reliable results on Xcode SDK 9+
-
+ 
  @return State value as enum item. See https://developer.apple.com/documentation/xctest/xcuiapplicationstate?language=objc for more details.
  */
 - (NSUInteger)fb_state;
@@ -42,17 +42,17 @@ extern NSString *const FBApplicationMethodNotSupportedException;
  Activate the application by restoring it from the background.
  Nothing will happen if the application is already in foreground.
  This method is only supported since Xcode9.
-
+ 
  @throws FBApplicationMethodNotSupportedException if the method is called on Xcode SDK older than 9.
  */
 - (void)fb_activate;
 
 /**
  Use this method to check whether application activation is supported by the current iOS SDK.
-
+ 
  @return YES if application activation is supported.
  */
-+ (BOOL)fb_isActivateSupported;
+- (BOOL)fb_isActivateSupported;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -50,7 +50,7 @@ static dispatch_once_t onceActivate;
 
 - (void)fb_activate
 {
-  if (!self.class.fb_isActivateSupported) {
+  if (!self.fb_isActivateSupported) {
     [[NSException exceptionWithName:FBApplicationMethodNotSupportedException reason:@"'activate' method is not supported by the current iOS SDK" userInfo:@{}] raise];
   }
   [self activate];
@@ -61,7 +61,7 @@ static dispatch_once_t onceActivate;
   return [[self valueForKey:@"state"] intValue];
 }
 
-+ (BOOL)fb_isActivateSupported
+- (BOOL)fb_isActivateSupported
 {
   dispatch_once(&onceActivate, ^{
     FBCanUseActivate = [self respondsToSelector:@selector(activate)];
@@ -70,6 +70,7 @@ static dispatch_once_t onceActivate;
 }
 
 @end
+
 
 static BOOL FBShouldUseFirstMatchSelector = NO;
 static dispatch_once_t onceFirstMatchToken;
@@ -91,3 +92,4 @@ static dispatch_once_t onceFirstMatchToken;
 }
 
 @end
+


### PR DESCRIPTION
The current implementation tries to verify method presence for the class rather than to the class instance, which always results in false response.