### PR TITLE
Improve hit test verification and tap in landscape orientation

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -65,24 +65,20 @@
     return [(NSNumber *)[self fb_attributeValue:FB_XCAXAIsVisibleAttribute] boolValue];
   }
 
-  CGRect frameInWindow = frame;
   XCElementSnapshot *parentWindow = [self fb_parentMatchingType:XCUIElementTypeWindow];
-  if (nil != parentWindow) {
-    frameInWindow = [self fb_frameInContainer:parentWindow hierarchyIntersection:nil];
-  }
-  if (CGRectIsEmpty(frameInWindow)) {
+  if (nil != parentWindow &&
+      CGRectIsEmpty([self fb_frameInContainer:parentWindow hierarchyIntersection:nil])) {
     return NO;
   }
   
   CGRect appFrame = [self fb_rootElement].frame;
   
   CGPoint midPoint = [self.suggestedHitpoints.lastObject CGPointValue];
-  if (!CGRectEqualToRect(appFrame, frameInWindow)) {
+  if (!CGRectEqualToRect(appFrame, nil == parentWindow ? frame : parentWindow.frame)) {
     midPoint = FBInvertPointForApplication(midPoint, appFrame.size, FBApplication.fb_activeApplication.interfaceOrientation);
   }
   XCElementSnapshot *hitElement = [self hitTest:midPoint];
-  if (nil != hitElement &&
-      (self == hitElement || [hitElement _isAncestorOfElement:self] || [self._allDescendants.copy containsObject:hitElement])) {
+  if (self == hitElement || [self._allDescendants.copy containsObject:hitElement]) {
     return YES;
   }
   

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
@@ -60,7 +60,7 @@
     XCElementSnapshot *snapshot = element.fb_lastSnapshot;
     CGRect frameInWindow = snapshot.fb_frameInWindow;
     if (CGRectIsEmpty(frameInWindow)) {
-      NSString *description = [NSString stringWithFormat:@"The element '%@' is not visible on the screen", element.debugDescription];
+      NSString *description = [NSString stringWithFormat:@"The element '%@' is not visible on the screen", element.description];
       if (error) {
         *error = [[FBErrorBuilder.builder withDescription:description] build];
       }

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
@@ -47,6 +47,14 @@
   if (nil == element) {
     // Only absolute offset is defined
     hitPoint = [positionOffset CGPointValue];
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
+      /*
+       Since iOS 10.0 XCTest has a bug when it always returns portrait coordinates for UI elements
+       even if the device is not in portait mode. That is why we need to recalculate them manually
+       based on the current orientation value
+       */
+      hitPoint = FBInvertPointForApplication(hitPoint, self.application.frame.size, self.application.interfaceOrientation);
+    }
   } else {
     // The offset relative to the element is defined
     XCElementSnapshot *snapshot = element.fb_lastSnapshot;
@@ -72,14 +80,11 @@
       hitPoint = CGPointMake(hitPoint.x + offsetValue.x, hitPoint.y + offsetValue.y);
       // TODO: Shall we throw an exception if hitPoint is out of the element frame?
     }
-  }
-  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
-    /*
-     Since iOS 10.0 XCTest has a bug when it always returns portrait coordinates for UI elements
-     even if the device is not in portait mode. That is why we need to recalculate them manually
-     based on the current orientation value
-     */
-    hitPoint = FBInvertPointForApplication(hitPoint, self.application.frame.size, self.application.interfaceOrientation);
+    XCElementSnapshot *parentWindow = [snapshot fb_parentMatchingType:XCUIElementTypeWindow];
+    CGRect parentWindowFrame = nil == parentWindow ? snapshot.frame : parentWindow.frame;
+    if (!CGRectEqualToRect(self.application.frame, parentWindowFrame)) {
+      hitPoint = FBInvertPointForApplication(hitPoint, self.application.frame.size, self.application.interfaceOrientation);
+    }
   }
   return [NSValue valueWithCGPoint:hitPoint];
 }

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
@@ -82,7 +82,9 @@
     }
     XCElementSnapshot *parentWindow = [snapshot fb_parentMatchingType:XCUIElementTypeWindow];
     CGRect parentWindowFrame = nil == parentWindow ? snapshot.frame : parentWindow.frame;
-    if (!CGRectEqualToRect(self.application.frame, parentWindowFrame)) {
+    if (!CGRectEqualToRect(self.application.frame, parentWindowFrame) ||
+        self.application.interfaceOrientation == UIInterfaceOrientationPortraitUpsideDown) {
+      // Fix the hitpoint if the element frame is inverted
       hitPoint = FBInvertPointForApplication(hitPoint, self.application.frame.size, self.application.interfaceOrientation);
     }
   }

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -131,7 +131,7 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   CGPoint hitPoint;
   XCElementSnapshot *snapshot = element.fb_lastSnapshot;
   if (CGRectIsEmpty(snapshot.fb_frameInWindow)) {
-    NSString *description = [NSString stringWithFormat:@"The element '%@' is not visible on the screen", element.debugDescription];
+    NSString *description = [NSString stringWithFormat:@"The element '%@' is not visible on the screen", element.description];
     if (error) {
       *error = [[FBErrorBuilder.builder withDescription:description] build];
     }

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -123,40 +123,33 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
 
 - (nullable NSValue *)hitpointWithElement:(nullable XCUIElement *)element positionOffset:(nullable NSValue *)positionOffset error:(NSError **)error
 {
-  CGPoint hitPoint;
   if (nil == element) {
-    // Only absolute offset is defined
-    hitPoint = [positionOffset CGPointValue];
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
-      /*
-       Since iOS 10.0 XCTest has a bug when it always returns portrait coordinates for UI elements
-       even if the device is not in portait mode. That is why we need to recalculate them manually
-       based on the current orientation value
-       */
-      hitPoint = FBInvertPointForApplication(hitPoint, self.application.frame.size, self.application.interfaceOrientation);
+    return [super hitpointWithElement:element positionOffset:positionOffset error:error];
+  }
+
+  // An offset relative to the element is defined
+  CGPoint hitPoint;
+  XCElementSnapshot *snapshot = element.fb_lastSnapshot;
+  if (CGRectIsEmpty(snapshot.fb_frameInWindow)) {
+    NSString *description = [NSString stringWithFormat:@"The element '%@' is not visible on the screen", element.debugDescription];
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:description] build];
     }
-  } else {
-    // An offset relative to the element is defined
-    XCElementSnapshot *snapshot = element.fb_lastSnapshot;
-    if (CGRectIsEmpty(snapshot.fb_frameInWindow)) {
-      NSString *description = [NSString stringWithFormat:@"The element '%@' is not visible on the screen", element.debugDescription];
-      if (error) {
-        *error = [[FBErrorBuilder.builder withDescription:description] build];
-      }
-      return nil;
-    }
-    CGRect frame = snapshot.frame;
-    hitPoint = CGPointMake(frame.origin.x + frame.size.width / 2, frame.origin.y + frame.size.height / 2);
-    if (nil != positionOffset) {
-      CGPoint offsetValue = [positionOffset CGPointValue];
-      hitPoint = CGPointMake(hitPoint.x + offsetValue.x, hitPoint.y + offsetValue.y);
-      // TODO: Shall we throw an exception if hitPoint is out of the element frame?
-    }
-    XCElementSnapshot *parentWindow = [snapshot fb_parentMatchingType:XCUIElementTypeWindow];
-    CGRect parentWindowFrame = nil == parentWindow ? frame : parentWindow.frame;
-    if (!CGRectEqualToRect(self.application.frame, parentWindowFrame)) {
-      hitPoint = FBInvertPointForApplication(hitPoint, self.application.frame.size, self.application.interfaceOrientation);
-    }
+    return nil;
+  }
+  CGRect frame = snapshot.frame;
+  hitPoint = CGPointMake(frame.origin.x + frame.size.width / 2, frame.origin.y + frame.size.height / 2);
+  if (nil != positionOffset) {
+    CGPoint offsetValue = [positionOffset CGPointValue];
+    hitPoint = CGPointMake(hitPoint.x + offsetValue.x, hitPoint.y + offsetValue.y);
+    // TODO: Shall we throw an exception if hitPoint is out of the element frame?
+  }
+  XCElementSnapshot *parentWindow = [snapshot fb_parentMatchingType:XCUIElementTypeWindow];
+  CGRect parentWindowFrame = nil == parentWindow ? frame : parentWindow.frame;
+  if (!CGRectEqualToRect(self.application.frame, parentWindowFrame) ||
+      self.application.interfaceOrientation == UIInterfaceOrientationPortraitUpsideDown) {
+    // Fix the hitpoint if the element frame is inverted
+    hitPoint = FBInvertPointForApplication(hitPoint, self.application.frame.size, self.application.interfaceOrientation);
   }
   return [NSValue valueWithCGPoint:hitPoint];
 }

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -127,6 +127,14 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   if (nil == element) {
     // Only absolute offset is defined
     hitPoint = [positionOffset CGPointValue];
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
+      /*
+       Since iOS 10.0 XCTest has a bug when it always returns portrait coordinates for UI elements
+       even if the device is not in portait mode. That is why we need to recalculate them manually
+       based on the current orientation value
+       */
+      hitPoint = FBInvertPointForApplication(hitPoint, self.application.frame.size, self.application.interfaceOrientation);
+    }
   } else {
     // An offset relative to the element is defined
     XCElementSnapshot *snapshot = element.fb_lastSnapshot;
@@ -144,14 +152,11 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
       hitPoint = CGPointMake(hitPoint.x + offsetValue.x, hitPoint.y + offsetValue.y);
       // TODO: Shall we throw an exception if hitPoint is out of the element frame?
     }
-  }
-  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
-    /*
-     Since iOS 10.0 XCTest has a bug when it always returns portrait coordinates for UI elements
-     even if the device is not in portait mode. That is why we need to recalculate them manually
-     based on the current orientation value
-     */
-    hitPoint = FBInvertPointForApplication(hitPoint, self.application.frame.size, self.application.interfaceOrientation);
+    XCElementSnapshot *parentWindow = [snapshot fb_parentMatchingType:XCUIElementTypeWindow];
+    CGRect parentWindowFrame = nil == parentWindow ? frame : parentWindow.frame;
+    if (!CGRectEqualToRect(self.application.frame, parentWindowFrame)) {
+      hitPoint = FBInvertPointForApplication(hitPoint, self.application.frame.size, self.application.interfaceOrientation);
+    }
   }
   return [NSValue valueWithCGPoint:hitPoint];
 }


### PR DESCRIPTION
It might be that some elements returns correct frames in landscape mode and some others are inverted. This depends on the parent window of the particular element. If parent window frame matches with application frame then the frame is not inverted and vice versa.