### PR TITLE
Detect gesture recogniser of the parent cell if present

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -66,9 +66,14 @@
   }
 
   XCElementSnapshot *parentWindow = [self fb_parentMatchingType:XCUIElementTypeWindow];
-  if (nil != parentWindow &&
-      CGRectIsEmpty([self fb_frameInContainer:parentWindow hierarchyIntersection:nil])) {
-    return NO;
+  if (nil != parentWindow) {
+    if (CGRectIsEmpty([self fb_frameInContainer:parentWindow hierarchyIntersection:nil])) {
+      return NO;
+    }
+    XCElementSnapshot *parentCell = [self fb_parentMatchingType:XCUIElementTypeCell];
+    if (nil != parentCell) {
+      return parentCell.fb_isVisible;
+    }
   }
   
   CGRect appFrame = [self fb_rootElement].frame;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -70,9 +70,11 @@
     if (CGRectIsEmpty([self fb_frameInContainer:parentWindow hierarchyIntersection:nil])) {
       return NO;
     }
-    XCElementSnapshot *parentCell = [self fb_parentMatchingType:XCUIElementTypeCell];
-    if (nil != parentCell) {
-      return parentCell.fb_isVisible;
+    if (self.elementType != XCUIElementTypeCell) {
+      XCElementSnapshot *parentCell = [self fb_parentMatchingType:XCUIElementTypeCell];
+      if (nil != parentCell) {
+        return parentCell.fb_isVisible;
+      }
     }
   }
   


### PR DESCRIPTION
All collections views might have gesture recognisers and a situation is possible when the stuff inside cell is detected as invisible because it is not hittable, but at the same time all hits are properly handled by the parent cell. This PR verifies whether an element is visible by checking the hittability of its parent cell (if the element is inside the cell).