### PR TITLE
Handle the case for ActivityListView elements visibility

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -64,7 +64,17 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
 {
   CGRect currentRectangle = nil == intersectionRectange ? self.frame : [intersectionRectange CGRectValue];
   XCElementSnapshot *parent = self.parent;
-  CGRect intersectionWithParent = CGRectIntersection(currentRectangle, parent.frame);
+  CGRect parentFrame = parent.frame;
+  CGRect intersectionWithParent = CGRectIntersection(currentRectangle, parentFrame);
+  if (CGRectIsEmpty(intersectionWithParent)
+      && parent != container
+      && CGSizeEqualToSize(parentFrame.size, container.frame.size)
+      && parent.elementType == XCUIElementTypeOther) {
+    // Special case (or a XCTest bug). We need to shift the origin
+    currentRectangle.origin.x += parentFrame.origin.x;
+    currentRectangle.origin.y += parentFrame.origin.y;
+    intersectionWithParent = CGRectIntersection(currentRectangle, parentFrame);
+  }
   if (CGRectIsEmpty(intersectionWithParent) || parent == container) {
     return intersectionWithParent;
   }

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
@@ -79,6 +79,11 @@
     XCElementSnapshot *snapshot = element.fb_lastSnapshot;
     CGRect frameInWindow = snapshot.fb_frameInWindow;
     if (CGRectIsEmpty(frameInWindow)) {
+      XCElementSnapshot *root = [snapshot fb_parentMatchingType:XCUIElementTypeWindow];
+      if (nil == root) {
+        root = snapshot;
+      }
+      [FBLogger logFmt:@"Window source: %@", root.debugDescription];
       NSString *description = [NSString stringWithFormat:@"The element '%@' is not visible on the screen and thus is not interactable", element.description];
       if (error) {
         *error = [[FBErrorBuilder.builder withDescription:description] build];

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -131,6 +131,11 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   XCElementSnapshot *snapshot = element.fb_lastSnapshot;
   CGRect frameInWindow = snapshot.fb_frameInWindow;
   if (CGRectIsEmpty(frameInWindow)) {
+    XCElementSnapshot *root = [snapshot fb_parentMatchingType:XCUIElementTypeWindow];
+    if (nil == root) {
+      root = snapshot;
+    }
+    [FBLogger logFmt:@"Window source: %@", root.debugDescription];
     NSString *description = [NSString stringWithFormat:@"The element '%@' is not visible on the screen and thus is not interactable", element.description];
     if (error) {
       *error = [[FBErrorBuilder.builder withDescription:description] build];


### PR DESCRIPTION
for some elements, for example action sheets descendants XCTest may return the following output:

```
    Other, 0x6000003804e0, {{0.0, 0.0}, {375.0, 667.0}}
      Other, 0x600000380820, {{0.0, 0.0}, {375.0, 667.0}}
      Other, 0x60000019a9c0, {{8.0, 360.0}, {359.0, 234.0}}
        Other, 0x60000058d750, {{8.0, 360.0}, {359.0, 234.0}}
        Other, 0x60000058f700, {{8.0, 360.0}, {359.0, 234.0}}
          Other, 0x60000058fb10, {{8.0, 360.0}, {359.0, 234.0}}
          Other, 0x60000058a5c0, {{8.0, 360.0}, {359.0, 234.0}}
      Other, 0x60000058da90, traits: 8589934592, {{8.0, 360.0}, {359.0, 234.0}}, identifier: 'ActivityListView'
        Other, 0x600000396580, traits: 8589934592, {{8.0, 360.0}, {359.0, 234.0}}
          Other, 0x60000058ab70, {{0.0, 0.0}, {0.0, 0.0}}
            Other, 0x60000019a8f0, traits: 8589934592, {{0.0, 0.0}, {359.0, 234.0}}
              Other, 0x60000058cd90, traits: 8589934592, {{0.0, 0.0}, {359.0, 234.0}}
                Other, 0x60000058dd00, traits: 8589934592, {{0.0, 0.0}, {359.0, 234.0}}
                  CollectionView, 0x60000019f890, traits: 35192962023424, {{0.0, 0.0}, {359.0, 234.0}}
                    Cell, 0x6000005997e0, traits: 8589934592, {{0.0, 0.0}, {359.0, 116.5}}
                      Other, 0x60000058ed40, traits: 8589934592, {{0.0, 0.0}, {359.0, 116.5}}
                        Other, 0x60000039e030, traits: 8589934592, {{0.0, 0.0}, {359.0, 116.5}}
                          CollectionView, 0x60000058f3c0, traits: 35192962023424, {{0.0, 0.0}, {359.0, 116.5}}
                            Button, 0x60000058e110, traits: 8589934593, {{9.0, 19.0}, {72.0, 78.5}}, label: 'More'
                    Cell, 0x600000396240, traits: 8589934592, {{0.0, 116.5}, {359.0, 1.0}}
                      Other, 0x60000058f7d0, traits: 8589934592, {{0.0, 116.5}, {359.0, 1.0}}
                        Other, 0x60000038fa40, traits: 8589934592, {{0.0, 116.5}, {359.0, 1.0}}
                        Other, 0x60000058f8a0, traits: 8589934592, {{0.0, 116.5}, {359.0, 1.0}}
                      Other, 0x60000058ac40, traits: 8589934592, {{0.0, 116.5}, {359.0, 1.0}}
                    Cell, 0x60000039eac0, traits: 8589934592, {{0.0, 117.5}, {359.0, 116.5}}
                      Other, 0x600000390190, traits: 8589934592, {{0.0, 117.5}, {359.0, 116.5}}
                        Other, 0x60000019e370, traits: 8589934592, {{0.0, 117.5}, {359.0, 116.5}}
                          CollectionView, 0x60000039cbe0, traits: 35192962023424, {{0.0, 117.5}, {359.0, 116.5}}
                            Button, 0x60000038e790, traits: 283467841537, {{9.0, 136.5}, {72.0, 78.5}}, label: 'Copy'
                            Button, 0x60000058a830, traits: 283467841537, {{93.0, 136.5}, {72.0, 78.5}}, label: 'Save to Files'
                            Button, 0x60000058f560, traits: 8589934593, {{177.0, 136.5}, {72.0, 78.5}}, label: 'More'
      Other, 0x600000397900, {{8.0, 602.0}, {359.0, 57.0}}
```

this makes all descendant elements unclickable by default since they all are located in a parent container with zero size. The PR workarounds the issue by adding some additional checks to the visible rectangle calculation algorithm.