### PR TITLE
Implement caching for custom snapshot attributes 

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -287,7 +287,7 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSMutable
     };
   };
   
-  return [self fb_cacheValue:rectGetter() forAttributeName:attributeNament ];
+  return [self fb_cacheValue:rectGetter() forAttributeName:attributeName];
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -127,8 +127,11 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSMutable
   
   id (^nameGetter)(void) = ^id(void) {
     NSString *identifier = self.identifier;
+    if (nil != identifier && identifier.length != 0) {
+      return identifier;
+    }
     NSString *label = self.label;
-    return FBTransferEmptyStringToNil(FBFirstNonEmptyValue(identifier, label));
+    return FBTransferEmptyStringToNil(label);
   };
   
   return [self fb_cacheValue:nameGetter() forAttributeName:attributeName];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -143,10 +143,11 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSMutable
   }
 
   id (^labelGetter)(void) = ^id(void) {
+    NSString *label = self.label;
     if (self.elementType == XCUIElementTypeTextField) {
-      return self.label;
+      return label;
     }
-    return FBTransferEmptyStringToNil(self.label);
+    return FBTransferEmptyStringToNil(label);
   };
   
   return [self fb_cacheValue:labelGetter() forAttributeName:attributeName];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -43,6 +43,40 @@
 
 @implementation XCElementSnapshot (WebDriverAttributes)
 
+static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSMutableDictionary<NSString*, id> *> *> *fb_wdAttributesCache;
+
++ (void)load
+{
+  fb_wdAttributesCache = [NSMutableDictionary dictionary];
+}
+
+- (nullable id)fb_cachedValueWithAttributeName:(NSString *)name
+{
+  NSNumber *generation = [NSNumber numberWithUnsignedLongLong:self.generation];
+  NSMutableDictionary<NSString *, NSMutableDictionary<NSString*, id> *> *cachedSnapshotsForGeneration = [fb_wdAttributesCache objectForKey:generation];
+  if (nil == cachedSnapshotsForGeneration) {
+    [fb_wdAttributesCache removeAllObjects];
+    [fb_wdAttributesCache setObject:[NSMutableDictionary dictionary] forKey:generation];
+  }
+  NSString *selfId = [NSString stringWithFormat:@"%p", (void *)self];
+  NSMutableDictionary<NSString*, id> *snapshotAttributes = [cachedSnapshotsForGeneration objectForKey:selfId];
+  if (nil == snapshotAttributes) {
+    [cachedSnapshotsForGeneration setObject:[NSMutableDictionary dictionary] forKey:selfId];
+    return nil;
+  }
+  return [snapshotAttributes objectForKey:name];
+}
+
+- (id)fb_cacheValue:(nullable id)value forAttributeName:(NSString *)name
+{
+  NSNumber *generation = [NSNumber numberWithUnsignedLongLong:self.generation];
+  NSMutableDictionary<NSString *, NSMutableDictionary<NSString*, id> *> *cachedSnapshotsForGeneration = [fb_wdAttributesCache objectForKey:generation];
+  NSString *selfId = [NSString stringWithFormat:@"%p", (void *)self];
+  NSMutableDictionary<NSString*, id> *snapshotAttributes = [cachedSnapshotsForGeneration objectForKey:selfId];
+  [snapshotAttributes setObject:(nil == value ? [NSNull null] : (id)value) forKey:name];
+  return value;
+}
+
 - (id)fb_valueForWDAttributeName:(NSString *)name
 {
   return [self valueForKey:[FBElementUtils wdAttributeNameForAttributeName:name]];
@@ -50,115 +84,210 @@
 
 - (NSString *)wdValue
 {
-  id value = self.value;
-  if (self.elementType == XCUIElementTypeStaticText) {
-    value = FBFirstNonEmptyValue(self.value, self.label);
+  NSString *attributeName = NSStringFromSelector(_cmd);
+  id cachedValue = [self fb_cachedValueWithAttributeName:attributeName];
+  if (nil != cachedValue) {
+    return cachedValue == [NSNull null] ? nil : cachedValue;
   }
-  if (self.elementType == XCUIElementTypeButton) {
-    value = FBFirstNonEmptyValue(self.value, (self.isSelected ? @YES : nil));
-  }
-  if (self.elementType == XCUIElementTypeSwitch) {
-    value = @([self.value boolValue]);
-  }
-  if (self.elementType == XCUIElementTypeTextView ||
-      self.elementType == XCUIElementTypeTextField ||
-      self.elementType == XCUIElementTypeSecureTextField) {
-    value = FBFirstNonEmptyValue(self.value, self.placeholderValue);
-  }
-  value = FBTransferEmptyStringToNil(value);
-  if (value) {
-    value = [NSString stringWithFormat:@"%@", value];
-  }
-  return value;
+  
+  id (^valueGetter)(void) = ^id(void) {
+    id value = self.value;
+    XCUIElementType elementType = self.elementType;
+    if (elementType == XCUIElementTypeStaticText) {
+      NSString *label = self.label;
+      value = FBFirstNonEmptyValue(value, label);
+    } else if (elementType == XCUIElementTypeButton) {
+      NSNumber *isSelected = self.isSelected ? @YES : nil;
+      value = FBFirstNonEmptyValue(value, isSelected);
+    } else if (elementType == XCUIElementTypeSwitch) {
+      value = @([value boolValue]);
+    } else if (elementType == XCUIElementTypeTextView ||
+               elementType == XCUIElementTypeTextField ||
+               elementType == XCUIElementTypeSecureTextField) {
+      NSString *placeholderValue = self.placeholderValue;
+      value = FBFirstNonEmptyValue(value, placeholderValue);
+    }
+    value = FBTransferEmptyStringToNil(value);
+    if (value) {
+      value = [NSString stringWithFormat:@"%@", value];
+    }
+    return value;
+  };
+  
+  return [self fb_cacheValue:valueGetter() forAttributeName:attributeName];
 }
 
 - (NSString *)wdName
 {
-  return FBTransferEmptyStringToNil(FBFirstNonEmptyValue(self.identifier, self.label));
+  NSString *attributeName = NSStringFromSelector(_cmd);
+  id cachedValue = [self fb_cachedValueWithAttributeName:attributeName];
+  if (nil != cachedValue) {
+    return cachedValue == [NSNull null] ? nil : cachedValue;
+  }
+  
+  id (^nameGetter)(void) = ^id(void) {
+    NSString *identifier = self.identifier;
+    NSString *label = self.label;
+    return FBTransferEmptyStringToNil(FBFirstNonEmptyValue(identifier, label));
+  };
+  
+  return [self fb_cacheValue:nameGetter() forAttributeName:attributeName];
 }
 
 - (NSString *)wdLabel
 {
-  if (self.elementType == XCUIElementTypeTextField) {
-    return self.label;
+  NSString *attributeName = NSStringFromSelector(_cmd);
+  id cachedValue = [self fb_cachedValueWithAttributeName:attributeName];
+  if (nil != cachedValue) {
+    return cachedValue == [NSNull null] ? nil : cachedValue;
   }
-  return FBTransferEmptyStringToNil(self.label);
+
+  id (^labelGetter)(void) = ^id(void) {
+    if (self.elementType == XCUIElementTypeTextField) {
+      return self.label;
+    }
+    return FBTransferEmptyStringToNil(self.label);
+  };
+  
+  return [self fb_cacheValue:labelGetter() forAttributeName:attributeName];
 }
 
 - (NSString *)wdType
 {
-  return [FBElementTypeTransformer stringWithElementType:self.elementType];
+  NSString *attributeName = NSStringFromSelector(_cmd);
+  id cachedValue = [self fb_cachedValueWithAttributeName:attributeName];
+  if (nil != cachedValue) {
+    return cachedValue == [NSNull null] ? nil : cachedValue;
+  }
+  
+  return [self fb_cacheValue:[FBElementTypeTransformer stringWithElementType:self.elementType] forAttributeName:attributeName];
 }
 
 - (NSUInteger)wdUID
 {
-  return self.fb_uid;
+  NSString *attributeName = NSStringFromSelector(_cmd);
+  id cachedValue = [self fb_cachedValueWithAttributeName:attributeName];
+  if (nil != cachedValue) {
+    return [cachedValue integerValue];
+  }
+  
+  return [[self fb_cacheValue:@(self.fb_uid) forAttributeName:attributeName] integerValue];
 }
 
 - (CGRect)wdFrame
 {
-  return CGRectIntegral(self.frame);
+  NSString *attributeName = NSStringFromSelector(_cmd);
+  id cachedValue = [self fb_cachedValueWithAttributeName:attributeName];
+  if (nil != cachedValue) {
+    return [cachedValue CGRectValue];
+  }
+  
+  return [[self fb_cacheValue:@(CGRectIntegral(self.frame)) forAttributeName:attributeName] CGRectValue];
 }
 
 - (BOOL)isWDVisible
 {
-  return self.fb_isVisible;
+  NSString *attributeName = NSStringFromSelector(_cmd);
+  id cachedValue = [self fb_cachedValueWithAttributeName:attributeName];
+  if (nil != cachedValue) {
+    return [cachedValue boolValue];
+  }
+  
+  return [[self fb_cacheValue:@(self.fb_isVisible) forAttributeName:attributeName] boolValue];
 }
 
 - (BOOL)isWDAccessible
 {
-  // Special cases:
-  // Table view cell: we consider it accessible if it's container is accessible
-  // Text fields: actual accessible element isn't text field itself, but nested element
-  if (self.elementType == XCUIElementTypeCell) {
-    if (!self.fb_isAccessibilityElement) {
-      XCElementSnapshot *containerView = [[self children] firstObject];
-      if (!containerView.fb_isAccessibilityElement) {
-        return NO;
+  NSString *attributeName = NSStringFromSelector(_cmd);
+  id cachedValue = [self fb_cachedValueWithAttributeName:attributeName];
+  if (nil != cachedValue) {
+    return [cachedValue boolValue];
+  }
+  
+  id (^isAccessibleGetter)(void) = ^id(void) {
+    XCUIElementType elementType = self.elementType;
+    // Special cases:
+    // Table view cell: we consider it accessible if it's container is accessible
+    // Text fields: actual accessible element isn't text field itself, but nested element
+    if (elementType == XCUIElementTypeCell) {
+      if (!self.fb_isAccessibilityElement) {
+        XCElementSnapshot *containerView = [[self children] firstObject];
+        if (!containerView.fb_isAccessibilityElement) {
+          return @NO;
+        }
+      }
+    } else if (elementType != XCUIElementTypeTextField && elementType != XCUIElementTypeSecureTextField) {
+      if (!self.fb_isAccessibilityElement) {
+        return @NO;
       }
     }
-  } else if (self.elementType != XCUIElementTypeTextField && self.elementType != XCUIElementTypeSecureTextField) {
-    if (!self.fb_isAccessibilityElement) {
-      return NO;
+    XCElementSnapshot *parentSnapshot = self.parent;
+    while (parentSnapshot) {
+      // In the scenario when table provides Search results controller, table could be marked as accessible element, even though it isn't
+      // As it is highly unlikely that table view should ever be an accessibility element itself,
+      // for now we work around that by skipping Table View in container checks
+      if (parentSnapshot.fb_isAccessibilityElement && parentSnapshot.elementType != XCUIElementTypeTable) {
+        return @NO;
+      }
+      parentSnapshot = parentSnapshot.parent;
     }
-  }
-  XCElementSnapshot *parentSnapshot = self.parent;
-  while (parentSnapshot) {
-    // In the scenario when table provides Search results controller, table could be marked as accessible element, even though it isn't
-    // As it is highly unlikely that table view should ever be an accessibility element itself,
-    // for now we work around that by skipping Table View in container checks
-    if (parentSnapshot.fb_isAccessibilityElement && parentSnapshot.elementType != XCUIElementTypeTable) {
-      return NO;
-    }
-    parentSnapshot = parentSnapshot.parent;
-  }
-  return YES;
+    return @YES;
+  };
+  
+  return [[self fb_cacheValue:isAccessibleGetter() forAttributeName:attributeName] boolValue];
 }
 
 - (BOOL)isWDAccessibilityContainer
 {
-  for (XCElementSnapshot *child in self.children) {
-    if (child.isWDAccessibilityContainer || child.fb_isAccessibilityElement) {
-      return YES;
-    }
+  NSString *attributeName = NSStringFromSelector(_cmd);
+  id cachedValue = [self fb_cachedValueWithAttributeName:attributeName];
+  if (nil != cachedValue) {
+    return [cachedValue boolValue];
   }
-  return NO;
+  
+  id (^isAccessibilityContainerGetter)(void) = ^id(void) {
+    NSArray<XCElementSnapshot *> *children = self.children;
+    for (XCElementSnapshot *child in children) {
+      if (child.isWDAccessibilityContainer || child.fb_isAccessibilityElement) {
+        return @YES;
+      }
+    }
+    return @NO;
+  };
+  
+  return [[self fb_cacheValue:isAccessibilityContainerGetter() forAttributeName:attributeName] boolValue];
 }
 
 - (BOOL)isWDEnabled
 {
-  return self.isEnabled;
+  NSString *attributeName = NSStringFromSelector(_cmd);
+  id cachedValue = [self fb_cachedValueWithAttributeName:attributeName];
+  if (nil != cachedValue) {
+    return [cachedValue boolValue];
+  }
+  
+  return [[self fb_cacheValue:@(self.isEnabled) forAttributeName:attributeName] boolValue];
 }
 
 - (NSDictionary *)wdRect
 {
-  CGRect frame = self.wdFrame;
-  return @{
-    @"x": @(CGRectGetMinX(frame)),
-    @"y": @(CGRectGetMinY(frame)),
-    @"width": @(CGRectGetWidth(frame)),
-    @"height": @(CGRectGetHeight(frame)),
+  NSString *attributeName = NSStringFromSelector(_cmd);
+  id cachedValue = [self fb_cachedValueWithAttributeName:attributeName];
+  if (nil != cachedValue) {
+    return cachedValue == [NSNull null] ? nil : cachedValue;
+  }
+  
+  id (^rectGetter)(void) = ^id(void) {
+    CGRect frame = self.wdFrame;
+    return @{
+      @"x": @(CGRectGetMinX(frame)),
+      @"y": @(CGRectGetMinY(frame)),
+      @"width": @(CGRectGetWidth(frame)),
+      @"height": @(CGRectGetHeight(frame)),
+    };
   };
+  
+  return [self fb_cacheValue:rectGetter() forAttributeName:attributeNament ];
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -157,7 +157,7 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSMutable
 - (CGRect)wdFrame
 {
   id (^getter)(void) = ^id(void) {
-    return @(CGRectIntegral(self.frame));
+    return [NSValue valueWithCGRect:CGRectIntegral(self.frame)];
   };
   
   return [[self fb_cachedValueWithAttributeName:@"wdFrame" valueGetter:getter] CGRectValue];


### PR DESCRIPTION
The PR adds caching to custom attribute values based on the current snapshot's `generation`. I've also minimized the count of XCTest attributes invocations count, since each invocation slows down the flow.