### PR TITLE
Include parent window and application to ancestors list

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -173,9 +173,22 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
     midPoint = FBInvertPointForApplication(midPoint, appFrame.size, FBApplication.fb_activeApplication.interfaceOrientation);
   }
   XCElementSnapshot *hitElement = [self hitTest:midPoint];
-  if (nil == hitElement || self == hitElement || [ancestors containsObject:hitElement] ||
-      (hasChilren && [self._allDescendants containsObject:hitElement])) {
+  if (nil == hitElement || self == hitElement || [ancestors containsObject:hitElement]) {
     return [self fb_cacheVisibilityWithValue:YES forAncestors:ancestors.copy];
+  }
+  if (self.children.count > 0) {
+    if (nil != hitElement && [hitElement _isDescendantOfElement:self]) {
+      NSMutableArray<XCElementSnapshot *> *hitElementAncestors = [NSMutableArray array];
+      XCElementSnapshot *hitElementParent = hitElement.parent;
+      while (hitElementParent) {
+        [hitElementAncestors addObject:hitElementParent];
+        hitElementParent = hitElementParent.parent;
+      }
+      return [hitElement fb_cacheVisibilityWithValue:YES forAncestors:hitElementAncestors.copy];
+    }
+    if (self.fb_hasAnyVisibleLeafs) {
+      return [self fb_cacheVisibilityWithValue:YES forAncestors:ancestors.copy];
+    }
   }
   return [self fb_cacheVisibilityWithValue:NO forAncestors:ancestors.copy];
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -75,7 +75,7 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
   CGRect currentRectangle = nil == intersectionRectange ? self.frame : [intersectionRectange CGRectValue];
   XCElementSnapshot *parent = self.parent;
   CGRect parentFrame = parent.frame;
-  CGRect intersectionWithParent = CGRectIntersection(currentRectangle, parent.frame);
+  CGRect intersectionWithParent = CGRectIntersection(currentRectangle, parentFrame);
   if (CGRectIsEmpty(intersectionWithParent) && parent != container) {
     CGSize containerSize = container.frame.size;
     if ((CGSizeEqualToSize(parentFrame.size, containerSize) ||

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -158,15 +158,11 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
   if (CGRectIsEmpty(rectInContainer)) {
     return [self fb_cacheVisibilityWithValue:NO forAncestors:ancestors.copy];
   }
-  BOOL hasChilren = self.children.count > 0;
-  if (hasChilren && self.fb_hasAnyVisibleLeafs) {
-    return [self fb_cacheVisibilityWithValue:YES forAncestors:ancestors.copy];
-  }
   CGPoint midPoint = CGPointMake(rectInContainer.origin.x + rectInContainer.size.width / 2,
                                  rectInContainer.origin.y + rectInContainer.size.height / 2);
-  CGRect parentWindowFrame = parentWindow.frame;
-  if ((appFrame.size.height > appFrame.size.width && parentWindowFrame.size.height < parentWindowFrame.size.width) ||
-      (appFrame.size.height < appFrame.size.width && parentWindowFrame.size.height > parentWindowFrame.size.width)) {
+  CGRect windowFrame = nil == parentWindow ? selfFrame : parentWindow.frame;
+  if ((appFrame.size.height > appFrame.size.width && windowFrame.size.height < windowFrame.size.width) ||
+      (appFrame.size.height < appFrame.size.width && windowFrame.size.height > windowFrame.size.width)) {
     // This is the indication of the fact that transformation is broken and coordinates should be
     // recalculated manually.
     // However, upside-down case cannot be covered this way, which is not important for Appium

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -175,10 +175,10 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
   if (self.children.count > 0) {
     if (nil != hitElement && [hitElement _isDescendantOfElement:self]) {
       NSMutableArray<XCElementSnapshot *> *hitElementAncestors = [NSMutableArray array];
-      XCElementSnapshot *hitElementParent = hitElement.parent;
-      while (hitElementParent) {
-        [hitElementAncestors addObject:hitElementParent];
-        hitElementParent = hitElementParent.parent;
+      XCElementSnapshot *hitElementAncestor = hitElement.parent;
+      while (hitElementAncestor) {
+        [hitElementAncestors addObject:hitElementAncestor];
+        hitElementAncestor = hitElementAncestor.parent;
       }
       return [hitElement fb_cacheVisibilityWithValue:YES forAncestors:hitElementAncestors.copy];
     }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -169,7 +169,7 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
     midPoint = FBInvertPointForApplication(midPoint, appFrame.size, FBApplication.fb_activeApplication.interfaceOrientation);
   }
   XCElementSnapshot *hitElement = [self hitTest:midPoint];
-  if (nil == hitElement || self == hitElement || [ancestors containsObject:hitElement]) {
+  if (nil != hitElement && (self == hitElement || [ancestors containsObject:hitElement])) {
     return [self fb_cacheVisibilityWithValue:YES forAncestors:ancestors.copy];
   }
   if (self.children.count > 0) {

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -132,8 +132,8 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
     return [cachedValue boolValue];
   }
   
-  CGRect frame = self.frame;
-  if (CGRectIsEmpty(frame)) {
+  CGRect selfFrame = self.frame;
+  if (CGRectIsEmpty(selfFrame)) {
     return [self fb_cacheVisibilityWithValue:NO forAncestors:nil];
   }
   
@@ -154,7 +154,7 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
   }
   
   CGRect appFrame = [self fb_rootElement].frame;
-  CGRect rectInContainer = nil == parentWindow ? self.frame : [self fb_frameInContainer:parentWindow hierarchyIntersection:nil];
+  CGRect rectInContainer = nil == parentWindow ? selfFrame : [self fb_frameInContainer:parentWindow hierarchyIntersection:nil];
   if (CGRectIsEmpty(rectInContainer)) {
     return [self fb_cacheVisibilityWithValue:NO forAncestors:ancestors.copy];
   }


### PR DESCRIPTION
The more descendant elements there are the longer time it requires to detect whether an element is visible. Marking all parent elements as visible if any child is visible is OK to make `/source` endpoint work even faster.