### PR TITLE
Fix xpath lookup and visibility detection for elements, which don't have parent XCUIElementTypeWindow

### DIFF
--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.h
@@ -58,6 +58,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable XCElementSnapshot *)fb_parentMatchingOneOfTypes:(NSArray<NSNumber *> *)types filter:(BOOL(^)(XCElementSnapshot *snapshot))filter;
 
 /**
+ Retrieves the list of all element ancestors in the snapshot hierarchy.
+ 
+ @return the list of element ancestors or an empty list if the snapshot has no parent.
+ */
+- (NSArray<XCElementSnapshot *> *)fb_ancestors;
+
+/**
  Returns value for given accessibility property identifier.
 
  @param attribute attribute's accessibility identifier

--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -91,6 +91,17 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
     return cellSnapshots;
 }
 
+- (NSArray<XCElementSnapshot *> *)fb_ancestors
+{
+  NSMutableArray<XCElementSnapshot *> *ancestors = [NSMutableArray array];
+  XCElementSnapshot *parent = self.parent;
+  while (parent) {
+    [ancestors addObject:parent];
+    parent = parent.parent;
+  }
+  return ancestors.copy;
+}
+
 - (XCElementSnapshot *)fb_parentCellSnapshot
 {
     XCElementSnapshot *targetCellSnapshot = self;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -169,11 +169,11 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
     midPoint = FBInvertPointForApplication(midPoint, appFrame.size, FBApplication.fb_activeApplication.interfaceOrientation);
   }
   XCElementSnapshot *hitElement = [self hitTest:midPoint];
-  if (nil != hitElement && (self == hitElement || [ancestors containsObject:hitElement])) {
+  if (nil == hitElement || self == hitElement || [ancestors containsObject:hitElement]) {
     return [self fb_cacheVisibilityWithValue:YES forAncestors:ancestors];
   }
   if (self.children.count > 0) {
-    if (nil != hitElement && [self._allDescendants containsObject:hitElement]) {
+    if ([self._allDescendants containsObject:hitElement]) {
       return [hitElement fb_cacheVisibilityWithValue:YES forAncestors:hitElement.fb_ancestors];
     }
     if (self.fb_hasAnyVisibleLeafs) {

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -108,11 +108,12 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
 
 - (CGRect)fb_frameInWindow
 {
-  XCElementSnapshot *parentWindow = [self fb_parentMatchingType:XCUIElementTypeWindow];
-  if (nil != parentWindow) {
-    return [self fb_frameInContainer:parentWindow hierarchyIntersection:nil];
+  NSArray<XCElementSnapshot *> *ancestors = self.fb_ancestors;
+  XCElementSnapshot *parentWindow = ancestors.count > 1 ? [ancestors objectAtIndex:ancestors.count - 2] : nil;
+  if (nil == parentWindow) {
+    return self.frame;
   }
-  return self.frame;
+  return [self fb_frameInContainer:parentWindow hierarchyIntersection:nil];
 }
 
 - (BOOL)fb_hasAnyVisibleLeafs
@@ -148,21 +149,14 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
     return [self fb_cacheVisibilityWithValue:isVisible forAncestors:nil];
   }
   
-  XCElementSnapshot *parentWindow = nil;
-  NSMutableArray<XCElementSnapshot *> *ancestors = [NSMutableArray array];
-  XCElementSnapshot *parent = self.parent;
-  while (parent) {
-    if (parent.elementType == XCUIElementTypeWindow) {
-      parentWindow = parent;
-    }
-    [ancestors addObject:parent];
-    parent = parent.parent;
-  }
+  NSArray<XCElementSnapshot *> *ancestors = self.fb_ancestors;
+  XCElementSnapshot *parentWindow = ancestors.count > 1 ? [ancestors objectAtIndex:ancestors.count - 2] : nil;
+  XCElementSnapshot *appElement = ancestors.count > 0 ? [ancestors lastObject] : self;
   
-  CGRect appFrame = [self fb_rootElement].frame;
+  CGRect appFrame = appElement.frame;
   CGRect rectInContainer = nil == parentWindow ? selfFrame : [self fb_frameInContainer:parentWindow hierarchyIntersection:nil];
   if (CGRectIsEmpty(rectInContainer)) {
-    return [self fb_cacheVisibilityWithValue:NO forAncestors:ancestors.copy];
+    return [self fb_cacheVisibilityWithValue:NO forAncestors:ancestors];
   }
   CGPoint midPoint = CGPointMake(rectInContainer.origin.x + rectInContainer.size.width / 2,
                                  rectInContainer.origin.y + rectInContainer.size.height / 2);
@@ -176,23 +170,17 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
   }
   XCElementSnapshot *hitElement = [self hitTest:midPoint];
   if (nil != hitElement && (self == hitElement || [ancestors containsObject:hitElement])) {
-    return [self fb_cacheVisibilityWithValue:YES forAncestors:ancestors.copy];
+    return [self fb_cacheVisibilityWithValue:YES forAncestors:ancestors];
   }
   if (self.children.count > 0) {
-    if (nil != hitElement && [hitElement _isDescendantOfElement:self]) {
-      NSMutableArray<XCElementSnapshot *> *hitElementAncestors = [NSMutableArray array];
-      XCElementSnapshot *hitElementAncestor = hitElement.parent;
-      while (hitElementAncestor) {
-        [hitElementAncestors addObject:hitElementAncestor];
-        hitElementAncestor = hitElementAncestor.parent;
-      }
-      return [hitElement fb_cacheVisibilityWithValue:YES forAncestors:hitElementAncestors.copy];
+    if (nil != hitElement && [self._allDescendants containsObject:hitElement]) {
+      return [hitElement fb_cacheVisibilityWithValue:YES forAncestors:hitElement.fb_ancestors];
     }
     if (self.fb_hasAnyVisibleLeafs) {
-      return [self fb_cacheVisibilityWithValue:YES forAncestors:ancestors.copy];
+      return [self fb_cacheVisibilityWithValue:YES forAncestors:ancestors];
     }
   }
-  return [self fb_cacheVisibilityWithValue:NO forAncestors:ancestors.copy];
+  return [self fb_cacheVisibilityWithValue:NO forAncestors:ancestors];
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -169,16 +169,20 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
     midPoint = FBInvertPointForApplication(midPoint, appFrame.size, FBApplication.fb_activeApplication.interfaceOrientation);
   }
   XCElementSnapshot *hitElement = [self hitTest:midPoint];
-  if (nil == hitElement || self == hitElement || [ancestors containsObject:hitElement]) {
+  if (nil != hitElement && (self == hitElement || [ancestors containsObject:hitElement])) {
     return [self fb_cacheVisibilityWithValue:YES forAncestors:ancestors];
   }
   if (self.children.count > 0) {
-    if ([self._allDescendants containsObject:hitElement]) {
+    if (nil != hitElement && [self._allDescendants containsObject:hitElement]) {
       return [hitElement fb_cacheVisibilityWithValue:YES forAncestors:hitElement.fb_ancestors];
     }
     if (self.fb_hasAnyVisibleLeafs) {
       return [self fb_cacheVisibilityWithValue:YES forAncestors:ancestors];
     }
+  } else if (nil == hitElement) {
+    // Sometimes XCTest returns nil for leaf elements hit test even if such elements are hittable
+    // Assume such elements are visible if their rectInContainer is visible
+    return [self fb_cacheVisibilityWithValue:YES forAncestors:ancestors];
   }
   return [self fb_cacheVisibilityWithValue:NO forAncestors:ancestors];
 }

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
@@ -13,6 +13,7 @@
 #import "FBLogger.h"
 #import "FBMacros.h"
 #import "FBMathUtils.h"
+#import "XCUIApplication+FBHelpers.h"
 #import "XCUIElement+FBIsVisible.h"
 #import "XCElementSnapshot.h"
 #import "XCElementSnapshot+FBHelpers.h"
@@ -73,8 +74,7 @@
     XCElementSnapshot *snapshot = element.fb_lastSnapshot;
     CGRect frameInWindow = snapshot.fb_frameInWindow;
     if (CGRectIsEmpty(frameInWindow)) {
-      XCElementSnapshot *root = [snapshot fb_parentMatchingType:XCUIElementTypeWindow];
-      [FBLogger log:(nil == root ? snapshot : root).debugDescription];
+      [FBLogger log:self.application.fb_descriptionRepresentation];
       NSString *description = [NSString stringWithFormat:@"The element '%@' is not visible on the screen and thus is not interactable", element.description];
       if (error) {
         *error = [[FBErrorBuilder.builder withDescription:description] build];

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -306,7 +306,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
     }
     if ([root isKindOfClass:XCUIApplication.class]) {
       NSMutableArray<XCElementSnapshot *> *windowsSnapshots = [NSMutableArray array];
-      NSArray<XCUIElement *> *windows = [((XCUIElement *)root) childrenMatchingType:XCUIElementTypeWindow].allElementsBoundByIndex;
+      NSArray<XCUIElement *> *windows = [((XCUIElement *)root) childrenMatchingType:XCUIElementTypeAny].allElementsBoundByIndex;
       for (XCUIElement *window in windows) {
         [windowsSnapshots addObject:window.fb_lastSnapshot];
       }


### PR DESCRIPTION
It looks like XCTest does not always put  XCUIElementTypeWindow on top of local hierarchy and the following source is possible:

```
Attributes: Other, 0x600000193b40, {{0.0, 0.0}, {375.0, 667.0}}
Element subtree:
 →Other, 0x600000193b40, {{0.0, 0.0}, {375.0, 667.0}}
Path to element:
 →Application, 0x60000018cf30, pid: 51436, {{0.0, 0.0}, {375.0, 667.0}}, label: 'UICatalog'
  ↳Other, 0x600000193b40, {{0.0, 0.0}, {375.0, 667.0}}
Query chain:
 →Find: Application "com.example.apple-samplecode.UICatalog" 0x6040002ab7c0
  Output: {
    Application, 0x60000018cf30, pid: 51436, {{0.0, 0.0}, {375.0, 667.0}}, label: 'UICatalog'
  }
  ↪︎Find: Children matching type Any
    Output: {
      Other, 0x600000193b40, {{0.0, 0.0}, {375.0, 667.0}}
      Window, 0x6000003805b0, {{0.0, 52.2}, {375.0, 562.5}}
      Window, 0x60000019eb90, {{0.0, 52.2}, {375.0, 562.5}}
      Window, 0x60000019f960, {{0.0, 52.2}, {375.0, 562.5}}
      Other, 0x60000019fa30, Main Window, {{0.0, 52.2}, {375.0, 562.5}}
    }
    ↪︎Find: Element at index 0
      Output: {
        Other, 0x600000193b40, {{0.0, 0.0}, {375.0, 667.0}}
      }


Attributes: Window, 0x6000003805b0, {{0.0, 52.2}, {375.0, 562.5}}
Element subtree:
 →Window, 0x6000003805b0, {{0.0, 52.2}, {375.0, 562.5}}
    Other, 0x600000380270, traits: 8589934592, {{0.0, 52.2}, {375.0, 562.5}}
      NavigationBar, 0x60000019fe40, traits: 35192962023424, {{0.0, 75.7}, {375.0, 51.6}}, identifier: 'Action Sheets'
        Button, 0x60000019ff10, traits: 8724152321, {{9.4, 82.7}, {111.3, 35.2}}, label: 'UICatalog'
        StaticText, 0x60000019e5e0, traits: 8590000192, {{127.7, 85.1}, {131.2, 31.6}}, label: 'Action Sheets'
      Other, 0x60000019f210, traits: 8589934592, {{0.0, 52.2}, {375.0, 562.5}}
        Other, 0x60000019f140, traits: 8589934592, {{0.0, 52.2}, {375.0, 562.5}}
          Table, 0x60000019f070, traits: 35192962023424, {{0.0, 52.2}, {375.0, 562.5}}
            Cell, 0x60000019ec60, traits: 8589934592, {{0.0, 127.2}, {375.0, 51.6}}
              StaticText, 0x60000019eed0, traits: 8589934656, {{18.8, 127.2}, {338.7, 51.0}}, label: 'Okay / Cancel'
              Other, 0x60000019e6b0, traits: 8589934592, {{17.6, 177.6}, {357.4, 1.2}}
              Other, 0x60000019ee00, traits: 8589934592, {{18.8, 178.2}, {356.2, 0.6}}
            Cell, 0x60000019ed30, traits: 8589934592, {{0.0, 178.8}, {375.0, 51.6}}
              StaticText, 0x60000019e780, traits: 8589934656, {{18.8, 178.8}, {338.7, 51.0}}, label: 'Other'
              Other, 0x60000019eac0, traits: 8589934592, {{17.6, 229.2}, {357.4, 1.2}}
              Other, 0x60000019efa0, traits: 8589934592, {{18.8, 229.8}, {356.2, 0.6}}
Path to element:
 →Application, 0x60000018cf30, pid: 51436, {{0.0, 0.0}, {375.0, 667.0}}, label: 'UICatalog'
  ↳Window, 0x6000003805b0, {{0.0, 52.2}, {375.0, 562.5}}
Query chain:
 →Find: Application "com.example.apple-samplecode.UICatalog" 0x6040002ab7c0
  Output: {
    Application, 0x60000018cf30, pid: 51436, {{0.0, 0.0}, {375.0, 667.0}}, label: 'UICatalog'
  }
  ↪︎Find: Children matching type Any
    Output: {
      Other, 0x600000193b40, {{0.0, 0.0}, {375.0, 667.0}}
      Window, 0x6000003805b0, {{0.0, 52.2}, {375.0, 562.5}}
      Window, 0x60000019eb90, {{0.0, 52.2}, {375.0, 562.5}}
      Window, 0x60000019f960, {{0.0, 52.2}, {375.0, 562.5}}
      Other, 0x60000019fa30, Main Window, {{0.0, 52.2}, {375.0, 562.5}}
    }
    ↪︎Find: Element at index 1
      Output: {
        Window, 0x6000003805b0, {{0.0, 52.2}, {375.0, 562.5}}
      }


Attributes: Window, 0x60000019eb90, {{0.0, 52.2}, {375.0, 562.5}}
Element subtree:
 →Window, 0x60000019eb90, {{0.0, 52.2}, {375.0, 562.5}}
    Other, 0x60000019e9f0, traits: 8589934592, {{0.0, 52.2}, {375.0, 562.5}}
      Other, 0x60000019fca0, traits: 8589934592, {{0.0, 614.8}, {375.0, 253.1}}
Path to element:
 →Application, 0x60000018cf30, pid: 51436, {{0.0, 0.0}, {375.0, 667.0}}, label: 'UICatalog'
  ↳Window, 0x60000019eb90, {{0.0, 52.2}, {375.0, 562.5}}
Query chain:
 →Find: Application "com.example.apple-samplecode.UICatalog" 0x6040002ab7c0
  Output: {
    Application, 0x60000018cf30, pid: 51436, {{0.0, 0.0}, {375.0, 667.0}}, label: 'UICatalog'
  }
  ↪︎Find: Children matching type Any
    Output: {
      Other, 0x600000193b40, {{0.0, 0.0}, {375.0, 667.0}}
      Window, 0x6000003805b0, {{0.0, 52.2}, {375.0, 562.5}}
      Window, 0x60000019eb90, {{0.0, 52.2}, {375.0, 562.5}}
      Window, 0x60000019f960, {{0.0, 52.2}, {375.0, 562.5}}
      Other, 0x60000019fa30, Main Window, {{0.0, 52.2}, {375.0, 562.5}}
    }
    ↪︎Find: Element at index 2
      Output: {
        Window, 0x60000019eb90, {{0.0, 52.2}, {375.0, 562.5}}
      }


Attributes: Window, 0x60000019f960, {{0.0, 52.2}, {375.0, 562.5}}
Element subtree:
 →Window, 0x60000019f960, {{0.0, 52.2}, {375.0, 562.5}}
    StatusBar, 0x60000019f890, {{0.0, 52.2}, {375.0, 23.4}}
      Other, 0x60000019f6f0, {{0.0, 52.2}, {375.0, 23.4}}
      Other, 0x60000019f2e0, {{0.0, 52.2}, {375.0, 23.4}}
        Other, 0x60000019f3b0, traits: 8388608, {{7.0, 52.2}, {45.7, 23.4}}
        Other, 0x60000019f480, traits: 8388608, {{58.6, 52.2}, {17.6, 23.4}}, label: '3 of 3 Wi-Fi bars', value: SSID
        Other, 0x60000019f550, traits: 8389120, {{160.5, 52.2}, {59.8, 23.4}}, label: '9:53 AM'
        Other, 0x60000019f7c0, traits: 8388608, {{328.1, 52.2}, {41.0, 23.4}}, label: '-100% battery power'
Path to element:
 →Application, 0x60000018cf30, pid: 51436, {{0.0, 0.0}, {375.0, 667.0}}, label: 'UICatalog'
  ↳Window, 0x60000019f960, {{0.0, 52.2}, {375.0, 562.5}}
Query chain:
 →Find: Application "com.example.apple-samplecode.UICatalog" 0x6040002ab7c0
  Output: {
    Application, 0x60000018cf30, pid: 51436, {{0.0, 0.0}, {375.0, 667.0}}, label: 'UICatalog'
  }
  ↪︎Find: Children matching type Any
    Output: {
      Other, 0x600000193b40, {{0.0, 0.0}, {375.0, 667.0}}
      Window, 0x6000003805b0, {{0.0, 52.2}, {375.0, 562.5}}
      Window, 0x60000019eb90, {{0.0, 52.2}, {375.0, 562.5}}
      Window, 0x60000019f960, {{0.0, 52.2}, {375.0, 562.5}}
      Other, 0x60000019fa30, Main Window, {{0.0, 52.2}, {375.0, 562.5}}
    }
    ↪︎Find: Element at index 3
      Output: {
        Window, 0x60000019f960, {{0.0, 52.2}, {375.0, 562.5}}
      }


Attributes: Other, 0x60000019fa30, Main Window, {{0.0, 52.2}, {375.0, 562.5}}
Element subtree:
 →Other, 0x60000019fa30, Main Window, {{0.0, 52.2}, {375.0, 562.5}}
    Other, 0x60000019fb00, traits: 8589934592, {{0.0, 52.2}, {375.0, 562.5}}
    Other, 0x60000019f620, {{0.0, 52.2}, {375.0, 562.5}}
      Other, 0x600000380340, {{0.0, 52.2}, {375.0, 562.5}}
      Other, 0x6000003804e0, {{0.0, 52.2}, {375.0, 562.5}}
      Sheet, 0x600000380410, traits: 8589934592, {{11.7, 460.1}, {351.6, 143.0}}
        Other, 0x600000380d00, traits: 8589934592, {{11.7, 460.1}, {351.6, 143.0}}
          Other, 0x6000003801a0, traits: 8589934592, {{11.7, 460.1}, {351.6, 66.8}}
            Other, 0x600000380750, traits: 8589934592, {{11.7, 460.1}, {351.6, 66.8}}
              Other, 0x600000380a90, traits: 8589934592, {{11.7, 460.1}, {351.6, 66.8}}
              Other, 0x6000003809c0, traits: 8589934592, {{11.7, 460.1}, {351.6, 66.8}}
                Other, 0x6000003808f0, traits: 8589934592, {{11.7, 460.1}, {351.6, 66.8}}
                Other, 0x600000380820, traits: 8589934592, {{11.7, 460.1}, {351.6, 66.8}}
            Other, 0x600000380680, traits: 8589934592, {{11.7, 460.1}, {351.6, 66.8}}
              Other, 0x600000380dd0, traits: 8589934592, {{11.7, 460.1}, {351.6, 66.8}}
                Other, 0x600000380f70, traits: 8589934592, {{11.7, 460.1}, {351.6, 66.8}}
                  Other, 0x600000380ea0, traits: 8589934592, {{11.7, 460.1}, {351.6, 66.8}}
                    Other, 0x60000018c570, traits: 8589934592, {{11.7, 460.1}, {351.6, 66.8}}
                      Button, 0x60000019e440, traits: 8589934593, {{11.7, 460.1}, {351.6, 66.8}}, label: 'OK'
          Other, 0x6000003800d0, traits: 8589934592, {{11.7, 536.2}, {351.6, 66.8}}
            Other, 0x600000380b60, traits: 8589934592, {{11.7, 536.2}, {351.6, 66.8}}
              Other, 0x600000381040, traits: 8589934592, {{11.7, 536.2}, {351.6, 66.8}}
              Other, 0x6000003815f0, traits: 8589934592, {{11.7, 536.2}, {351.6, 66.8}}
                Other, 0x600000380c30, traits: 8589934592, {{11.7, 536.2}, {351.6, 66.8}}
                Other, 0x600000381520, traits: 8589934592, {{11.7, 536.2}, {351.6, 66.8}}
            Other, 0x600000381450, traits: 8589934592, {{11.7, 536.2}, {351.6, 66.8}}
              Other, 0x600000381110, traits: 8589934592, {{11.7, 536.2}, {351.6, 66.8}}
                Other, 0x600000381380, traits: 8589934592, {{11.7, 536.2}, {351.6, 66.8}}
                  Other, 0x6000003812b0, traits: 8589934592, {{11.7, 536.2}, {351.6, 66.8}}
                    Other, 0x6000003811e0, traits: 8589934592, {{11.7, 536.2}, {351.6, 66.8}}
                      Other, 0x60000019fbd0, traits: 8589934592, {{11.7, 536.2}, {351.6, 66.8}}
                        Other, 0x600000380000, traits: 8589934592, {{11.7, 536.2}, {351.6, 66.8}}
                      Button, 0x60000019fd70, traits: 8589934593, {{11.7, 536.2}, {351.6, 66.8}}, label: 'Cancel'
Path to element:
 →Application, 0x60000018cf30, pid: 51436, {{0.0, 0.0}, {375.0, 667.0}}, label: 'UICatalog'
  ↳Other, 0x60000019fa30, Main Window, {{0.0, 52.2}, {375.0, 562.5}}
Query chain:
 →Find: Application "com.example.apple-samplecode.UICatalog" 0x6040002ab7c0
  Output: {
    Application, 0x60000018cf30, pid: 51436, {{0.0, 0.0}, {375.0, 667.0}}, label: 'UICatalog'
  }
  ↪︎Find: Children matching type Any
    Output: {
      Other, 0x600000193b40, {{0.0, 0.0}, {375.0, 667.0}}
      Window, 0x6000003805b0, {{0.0, 52.2}, {375.0, 562.5}}
      Window, 0x60000019eb90, {{0.0, 52.2}, {375.0, 562.5}}
      Window, 0x60000019f960, {{0.0, 52.2}, {375.0, 562.5}}
      Other, 0x60000019fa30, Main Window, {{0.0, 52.2}, {375.0, 562.5}}
    }
    ↪︎Find: Element at index 4
      Output: {
        Other, 0x60000019fa30, Main Window, {{0.0, 52.2}, {375.0, 562.5}}
      }

```

This PR adresses such cases and also simplifies some other stuff related to this topic.