### PR TITLE
Actions generation

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBTouchAction.h
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBTouchAction.h
@@ -42,7 +42,6 @@ NS_ASSUME_NONNULL_BEGIN
  - 'tap': 'count' (defines count of taps to be performed in a row; 1 by default)
  - 'longPress': 'duration' (number of milliseconds to hold/move the virtual finger; 500.0 ms by default)
  - 'wait': 'ms' (number of milliseconds to wait for the preceeding action; 0.0 ms by default)
- - 'press', 'longPress': 'pressure' (float number, which defines pressure value; 0.0 by default)
  
  List of lists can be passed there is order to perform multi-finger touch action. Each single actions chain is going to be executed by a separate virtual finger in such case.
  

--- a/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
@@ -299,14 +299,6 @@ const CGFloat FBMinimumTouchEventDelay = 0.1f;
       },
     @{
       @"action": @"release"
-      },
-    // Tapping cells immediately after scrolling may fail due to way UIKit is handling touches.
-    // We should wait till scroll view cools off, before continuing
-    @{
-      @"action": @"wait",
-      @"options": @{
-          @"ms": @(FBScrollCoolOffTime * 1000),
-          }
       }
     ];
   return [application fb_performAppiumTouchActions:gesture elementCache:nil error:error];

--- a/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
@@ -260,7 +260,9 @@ static NSString *const FB_ELEMENT_KEY = @"element";
       return @[eventPath];
     }
   }
-  return @[[[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:FBMillisToSeconds(self.offset + self.duration)]];
+  XCPointerEventPath *result = [[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:FBMillisToSeconds(self.offset + self.duration)];
+  [result liftUpAtOffset:FBMillisToSeconds(self.offset + self.duration)];
+  return @[result];
 }
 
 - (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options

--- a/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
@@ -30,7 +30,6 @@ static NSString *const FB_ACTION_CANCEL = @"cancel";
 static NSString *const FB_ACTION_WAIT = @"wait";
 
 static NSString *const FB_OPTION_DURATION = @"duration";
-static NSString *const FB_OPTION_PRESSURE = @"pressure";
 static NSString *const FB_OPTION_COUNT = @"count";
 static NSString *const FB_OPTION_MS = @"ms";
 
@@ -154,27 +153,27 @@ static NSString *const FB_ELEMENT_KEY = @"element";
   return YES;
 }
 
-- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index count:(NSUInteger)count error:(NSError **)error
+- (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error
 {
   NSTimeInterval currentOffset = FBMillisToSeconds(self.offset);
-  if (index > 0) {
-    [eventPath moveToPoint:self.atPosition atOffset:currentOffset];
-    [eventPath pressDownAtOffset:currentOffset];
-  }
+  NSMutableArray<XCPointerEventPath *> *result = [NSMutableArray array];
+  XCPointerEventPath *currentPath = [[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:currentOffset];
+  [result addObject:currentPath];
   currentOffset += FBMillisToSeconds(FB_TAP_DURATION_MS);
-  [eventPath liftUpAtOffset:currentOffset];
+  [currentPath liftUpAtOffset:currentOffset];
   
   id options = [self.actionItem objectForKey:FB_OPTIONS_KEY];
   if ([options isKindOfClass:NSDictionary.class]) {
     NSNumber *tapCount = [options objectForKey:FB_OPTION_COUNT] ?: @1;
     for (NSInteger times = 1; times < tapCount.integerValue; ++times) {
       currentOffset += FBMillisToSeconds(FB_INTERTAP_MIN_DURATION_MS);
-      [eventPath pressDownAtOffset:currentOffset];
+      XCPointerEventPath *nextPath = [[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:currentOffset];
+      [result addObject:nextPath];
       currentOffset += FBMillisToSeconds(FB_TAP_DURATION_MS);
-      [eventPath liftUpAtOffset:currentOffset];
+      [nextPath liftUpAtOffset:currentOffset];
     }
   }
-  return YES;
+  return result.copy;
 }
 
 - (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options
@@ -200,20 +199,9 @@ static NSString *const FB_ELEMENT_KEY = @"element";
   return YES;
 }
 
-- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index count:(NSUInteger)count error:(NSError **)error
+- (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error
 {
-  if (index > 0) {
-    [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
-  }
-  
-  id options = [self.actionItem objectForKey:FB_OPTIONS_KEY];
-  NSNumber *pressure = [options isKindOfClass:NSDictionary.class] ? [options objectForKey:FB_OPTION_PRESSURE] : nil;
-  if (nil == pressure) {
-    [eventPath pressDownAtOffset:FBMillisToSeconds(self.offset)];
-  } else {
-    [eventPath pressDownWithPressure:pressure.doubleValue atOffset:FBMillisToSeconds(self.offset)];
-  }
-  return YES;
+  return @[[[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:FBMillisToSeconds(self.offset)]];
 }
 
 - (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options
@@ -235,20 +223,9 @@ static NSString *const FB_ELEMENT_KEY = @"element";
   return YES;
 }
 
-- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index count:(NSUInteger)count error:(NSError **)error
+- (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error
 {
-  if (index > 0) {
-    [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
-  }
-  
-  id options = [self.actionItem objectForKey:FB_OPTIONS_KEY];
-  NSNumber *pressure = [options isKindOfClass:NSDictionary.class] ? [options objectForKey:FB_OPTION_PRESSURE] : nil;
-  if (nil == pressure) {
-    [eventPath pressDownAtOffset:FBMillisToSeconds(self.offset)];
-  } else {
-    [eventPath pressDownWithPressure:pressure.doubleValue atOffset:FBMillisToSeconds(self.offset)];
-  }
-  return YES;
+  return @[[[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:FBMillisToSeconds(self.offset)]];
 }
 
 - (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options
@@ -272,12 +249,25 @@ static NSString *const FB_ELEMENT_KEY = @"element";
   return NO;
 }
 
-- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index count:(NSUInteger)count error:(NSError **)error
+- (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error
 {
-  if (index == count - 1) {
-    [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
+  NSTimeInterval currentOffset = FBMillisToSeconds(self.offset + self.duration);
+  if (nil != eventPath && currentItemIndex < allItems.count) {
+    if (0 == currentItemIndex) {
+      return @[eventPath];
+    }
+    FBBaseGestureItem *preceedingItem = [allItems objectAtIndex:currentItemIndex - 1];
+    if (![preceedingItem isKindOfClass:FBReleaseItem.class]){
+      if (currentItemIndex == allItems.count - 1) {
+        [eventPath moveToPoint:self.atPosition atOffset:currentOffset];
+      }
+      return @[eventPath];
+    }
   }
-  return YES;
+  // Emulate pause by tapping non-existing coordinates
+  XCPointerEventPath *result = [[XCPointerEventPath alloc] initForTouchAtPoint:CGPointMake(CGFLOAT_MIN, CGFLOAT_MIN) offset:FBMillisToSeconds(self.offset)];
+  [result liftUpAtOffset:currentOffset];
+  return @[result];
 }
 
 - (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options
@@ -301,10 +291,10 @@ static NSString *const FB_ELEMENT_KEY = @"element";
   return YES;
 }
 
-- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index count:(NSUInteger)count error:(NSError **)error
+- (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error
 {
   [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
-  return YES;
+  return @[eventPath];
 }
 
 @end
@@ -321,10 +311,10 @@ static NSString *const FB_ELEMENT_KEY = @"element";
   return NO;
 }
 
-- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index count:(NSUInteger)count error:(NSError **)error
+- (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error
 {
   [eventPath liftUpAtOffset:FBMillisToSeconds(self.offset)];
-  return YES;
+  return @[eventPath];
 }
 
 - (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options
@@ -396,7 +386,7 @@ static NSString *const FB_ELEMENT_KEY = @"element";
   return [[result reverseObjectEnumerator] allObjects];
 }
 
-- (nullable XCPointerEventPath *)eventPathWithAction:(NSArray<NSDictionary<NSString *, id> *> *)action error:(NSError **)error
+- (nullable NSArray<XCPointerEventPath *> *)eventPathsWithAction:(NSArray<NSDictionary<NSString *, id> *> *)action error:(NSError **)error
 {
   static NSDictionary<NSString *, Class> *gestureItemsMapping;
   static dispatch_once_t onceToken;
@@ -456,7 +446,7 @@ static NSString *const FB_ELEMENT_KEY = @"element";
     [chain addItem:gestureItem];
   }
   
-  return [chain asEventPathWithError:error];
+  return [chain asEventPathsWithError:error];
 }
 
 - (nullable XCSynthesizedEventRecord *)synthesizeWithError:(NSError **)error
@@ -468,11 +458,13 @@ static NSString *const FB_ELEMENT_KEY = @"element";
                  interfaceOrientation:[FBXCTestDaemonsProxy orientationWithApplication:self.application]];
   for (NSArray<NSDictionary<NSString *, id> *> *action in (isMultiTouch ? self.actions : @[self.actions])) {
     NSArray<NSDictionary<NSString *, id> *> *preprocessedAction = [self preprocessAction:action];
-    XCPointerEventPath *eventPath = [self eventPathWithAction:preprocessedAction error:error];
-    if (nil == eventPath) {
+    NSArray<XCPointerEventPath *> *eventPaths = [self eventPathsWithAction:preprocessedAction error:error];
+    if (nil == eventPaths) {
       return nil;
     }
-    [eventRecord addPointerEventPath:eventPath];
+    for (XCPointerEventPath *eventPath in eventPaths) {
+      [eventRecord addPointerEventPath:eventPath];
+    }
   }
   return eventRecord;
 }

--- a/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
@@ -251,23 +251,16 @@ static NSString *const FB_ELEMENT_KEY = @"element";
 
 - (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error
 {
-  NSTimeInterval currentOffset = FBMillisToSeconds(self.offset + self.duration);
-  if (nil != eventPath && currentItemIndex < allItems.count) {
+  if (nil != eventPath) {
     if (0 == currentItemIndex) {
       return @[eventPath];
     }
     FBBaseGestureItem *preceedingItem = [allItems objectAtIndex:currentItemIndex - 1];
-    if (![preceedingItem isKindOfClass:FBReleaseItem.class]){
-      if (currentItemIndex == allItems.count - 1) {
-        [eventPath moveToPoint:self.atPosition atOffset:currentOffset];
-      }
+    if (![preceedingItem isKindOfClass:FBReleaseItem.class] && currentItemIndex < allItems.count - 1) {
       return @[eventPath];
     }
   }
-  // Emulate pause by tapping non-existing coordinates
-  XCPointerEventPath *result = [[XCPointerEventPath alloc] initForTouchAtPoint:CGPointMake(CGFLOAT_MIN, CGFLOAT_MIN) offset:FBMillisToSeconds(self.offset)];
-  [result liftUpAtOffset:currentOffset];
-  return @[result];
+  return @[[[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:FBMillisToSeconds(self.offset + self.duration)]];
 }
 
 - (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options

--- a/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
@@ -260,8 +260,11 @@ static NSString *const FB_ELEMENT_KEY = @"element";
       return @[eventPath];
     }
   }
-  XCPointerEventPath *result = [[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:FBMillisToSeconds(self.offset + self.duration)];
-  [result liftUpAtOffset:FBMillisToSeconds(self.offset + self.duration)];
+  NSTimeInterval currentOffset = FBMillisToSeconds(self.offset + self.duration);
+  XCPointerEventPath *result = [[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:currentOffset];
+  if (currentItemIndex == allItems.count - 1) {
+    [result liftUpAtOffset:currentOffset];
+  }
   return @[result];
 }
 

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.h
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.h
@@ -37,13 +37,13 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Add the current gesture to XCPointerEventPath instance. This method is expected to be overriden in subclasses.
  
- @param eventPath The destination XCPointerEventPath instance
- @param index The index of the current gesture in the chain. Starts from zero
- @param count The count of all gestures in the chain
+ @param eventPath The destination XCPointerEventPath instance. If nil value is passed then a new XCPointerEventPath instance is going to be created
+ @param allItems The existing actions chain to be transformed into event path
+ @param currentItemIndex The index of the current item in allItems array
  @param error If there is an error, upon return contains an NSError object that describes the problem
- @return YES if the gesture has been successully added to the XCPointerEventPath instance
+ @return the constructed XCPointerEventPath instance or nil in case of failure
  */
-- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index count:(NSUInteger)count error:(NSError **)error;
+- (nullable NSArray<XCPointerEventPath *> *)addToEventPath:(nullable XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error;
 
 /**
  Returns fixed hit point coordinates for the case when XCTest fails to transform element snaapshot properly on screen rotation.
@@ -85,9 +85,9 @@ NS_ASSUME_NONNULL_BEGIN
  Represents the chain as XCPointerEventPath instance.
  
  @param error If there is an error, upon return contains an NSError object that describes the problem
- @return The constructed XCPointerEventPath instance or nil if there was a failure
+ @return The constructed array of XCPointerEventPath instances or nil if there was a failure
  */
-- (nullable XCPointerEventPath *)asEventPathWithError:(NSError **)error;
+- (nullable NSArray<XCPointerEventPath *> *)asEventPathsWithError:(NSError **)error;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
@@ -32,7 +32,7 @@
 - (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error
 {
   @throw [[FBErrorBuilder.builder withDescription:@"Override this method in subclasses"] build];
-  return NO;
+  return nil;
 }
 
 - (CGPoint)fixedHitPointWith:(CGPoint)hitPoint forSnapshot:(XCElementSnapshot *)snapshot

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -166,6 +166,12 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
 
 - (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error
 {
+  if (nil != eventPath && currentItemIndex == 1) {
+    FBBaseGestureItem *preceedingItem = [allItems objectAtIndex:currentItemIndex - 1];
+    if ([preceedingItem isKindOfClass:FBPointerMoveItem.class]) {
+      return @[eventPath];
+    }
+  }
   return @[[[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:FBMillisToSeconds(self.offset)]];
 }
 

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -49,7 +49,6 @@ static NSString *const FB_ACTION_ITEM_KEY_DURATION = @"duration";
 static NSString *const FB_ACTION_ITEM_KEY_X = @"x";
 static NSString *const FB_ACTION_ITEM_KEY_Y = @"y";
 static NSString *const FB_ACTION_ITEM_KEY_BUTTON = @"button";
-static NSString *const FB_ACTION_ITEM_KEY_PRESSURE = @"pressure";
 
 static NSString *const FB_KEY_ID = @"id";
 static NSString *const FB_KEY_PARAMETERS = @"parameters";
@@ -63,8 +62,6 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
 @end
 
 @interface FBPointerDownItem : FBW3CGestureItem
-
-@property (readonly, nonatomic) double pressure;
 
 @end
 
@@ -162,35 +159,14 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
 
 @implementation FBPointerDownItem
 
-- (nullable instancetype)initWithActionItem:(NSDictionary<NSString *, id> *)actionItem application:(XCUIApplication *)application previousItem:(nullable FBBaseGestureItem *)previousItem offset:(double)offset error:(NSError **)error
-{
-  self = [super initWithActionItem:actionItem application:application previousItem:previousItem offset:offset error:error];
-  if (self) {
-    _pressure = 0.0;
-    NSNumber *pressureObj = [actionItem objectForKey:FB_ACTION_ITEM_KEY_PRESSURE];
-    if (nil != pressureObj) {
-      _pressure = [pressureObj doubleValue];
-    }
-  }
-  return self;
-}
-
 + (NSString *)actionName
 {
   return FB_ACTION_ITEM_TYPE_POINTER_DOWN;
 }
 
-- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index count:(NSUInteger)count error:(NSError **)error
+- (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error
 {
-  if (index > 0) {
-    [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
-  }
-  if (self.pressure > 0.0) {
-    [eventPath pressDownWithPressure:self.pressure atOffset:FBMillisToSeconds(self.offset)];
-  } else {
-    [eventPath pressDownAtOffset:FBMillisToSeconds(self.offset)];
-  }
-  return YES;
+  return @[[[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:FBMillisToSeconds(self.offset)]];
 }
 
 @end
@@ -258,10 +234,13 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   return FB_ACTION_ITEM_TYPE_POINTER_MOVE;
 }
 
-- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index count:(NSUInteger)count error:(NSError **)error
+- (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error
 {
+  if (nil == eventPath) {
+    return @[[[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:FBMillisToSeconds(self.offset)]];
+  }
   [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
-  return YES;
+  return @[eventPath];
 }
 
 @end
@@ -273,12 +252,25 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   return FB_ACTION_ITEM_TYPE_PAUSE;
 }
 
-- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index count:(NSUInteger)count error:(NSError **)error
+- (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error
 {
-  if (index == count - 1) {
-    [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
+  NSTimeInterval currentOffset = FBMillisToSeconds(self.offset + self.duration);
+  if (nil != eventPath && currentItemIndex < allItems.count) {
+    if (0 == currentItemIndex) {
+      return @[eventPath];
+    }
+    FBBaseGestureItem *preceedingItem = [allItems objectAtIndex:currentItemIndex - 1];
+    if (![preceedingItem isKindOfClass:FBPointerUpItem.class]){
+      if (currentItemIndex == allItems.count - 1) {
+        [eventPath moveToPoint:self.atPosition atOffset:currentOffset];
+      }
+      return @[eventPath];
+    }
   }
-  return YES;
+  // Emulate pause by tapping non-existing coordinates
+  XCPointerEventPath *result = [[XCPointerEventPath alloc] initForTouchAtPoint:CGPointMake(CGFLOAT_MIN, CGFLOAT_MIN) offset:FBMillisToSeconds(self.offset)];
+  [result liftUpAtOffset:currentOffset];
+  return @[result];
 }
 
 @end
@@ -290,10 +282,10 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   return FB_ACTION_ITEM_TYPE_POINTER_UP;
 }
 
-- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index count:(NSUInteger)count error:(NSError **)error
+- (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error
 {
   [eventPath liftUpAtOffset:FBMillisToSeconds(self.offset)];
-  return YES;
+  return @[eventPath];
 }
 
 @end
@@ -363,7 +355,7 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   return [[result reverseObjectEnumerator] allObjects];
 }
 
-- (nullable XCPointerEventPath *)eventPathWithActionDescription:(NSDictionary<NSString *, id> *)actionDescription forActionId:(NSString *)actionId error:(NSError **)error
+- (nullable NSArray<XCPointerEventPath *> *)eventPathsWithActionDescription:(NSDictionary<NSString *, id> *)actionDescription forActionId:(NSString *)actionId error:(NSError **)error
 {
   static NSDictionary<NSString *, Class> *gestureItemsMapping;
   static NSArray<NSString *> *supportedActionItemTypes;
@@ -443,7 +435,7 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
     [chain addItem:gestureItem];
   }
   
-  return [chain asEventPathWithError:error];
+  return [chain asEventPathsWithError:error];
 }
 
 - (nullable XCSynthesizedEventRecord *)synthesizeWithError:(NSError **)error
@@ -474,11 +466,13 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   }
   for (NSString *actionId in actionIds.copy) {
     NSDictionary<NSString *, id> *actionDescription = [actionsMapping objectForKey:actionId];
-    XCPointerEventPath *eventPath = [self eventPathWithActionDescription:actionDescription forActionId:actionId error:error];
-    if (nil == eventPath) {
+    NSArray<XCPointerEventPath *> *eventPaths = [self eventPathsWithActionDescription:actionDescription forActionId:actionId error:error];
+    if (nil == eventPaths) {
       return nil;
     }
-    [eventRecord addPointerEventPath:eventPath];
+    for (XCPointerEventPath *eventPath in eventPaths) {
+      [eventRecord addPointerEventPath:eventPath];
+    }
   }
   return eventRecord;
 }

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -254,23 +254,16 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
 
 - (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error
 {
-  NSTimeInterval currentOffset = FBMillisToSeconds(self.offset + self.duration);
-  if (nil != eventPath && currentItemIndex < allItems.count) {
+  if (nil != eventPath) {
     if (0 == currentItemIndex) {
       return @[eventPath];
     }
     FBBaseGestureItem *preceedingItem = [allItems objectAtIndex:currentItemIndex - 1];
-    if (![preceedingItem isKindOfClass:FBPointerUpItem.class]){
-      if (currentItemIndex == allItems.count - 1) {
-        [eventPath moveToPoint:self.atPosition atOffset:currentOffset];
-      }
+    if (![preceedingItem isKindOfClass:FBPointerUpItem.class] && currentItemIndex < allItems.count - 1) {
       return @[eventPath];
     }
   }
-  // Emulate pause by tapping non-existing coordinates
-  XCPointerEventPath *result = [[XCPointerEventPath alloc] initForTouchAtPoint:CGPointMake(CGFLOAT_MIN, CGFLOAT_MIN) offset:FBMillisToSeconds(self.offset)];
-  [result liftUpAtOffset:currentOffset];
-  return @[result];
+  return @[[[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:FBMillisToSeconds(self.offset + self.duration)]];
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -263,8 +263,11 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
       return @[eventPath];
     }
   }
-  XCPointerEventPath *result = [[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:FBMillisToSeconds(self.offset + self.duration)];
-  [result liftUpAtOffset:FBMillisToSeconds(self.offset + self.duration)];
+  NSTimeInterval currentOffset = FBMillisToSeconds(self.offset + self.duration);
+  XCPointerEventPath *result = [[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:currentOffset];
+  if (currentItemIndex == allItems.count - 1) {
+    [result liftUpAtOffset:currentOffset];
+  }
   return @[result];
 }
 

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -263,7 +263,9 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
       return @[eventPath];
     }
   }
-  return @[[[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:FBMillisToSeconds(self.offset + self.duration)]];
+  XCPointerEventPath *result = [[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:FBMillisToSeconds(self.offset + self.duration)];
+  [result liftUpAtOffset:FBMillisToSeconds(self.offset + self.duration)];
+  return @[result];
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -243,7 +243,7 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
 - (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath allItems:(NSArray<FBBaseGestureItem *> *)allItems currentItemIndex:(NSUInteger)currentItemIndex error:(NSError **)error
 {
   if (nil == eventPath) {
-    return @[[[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:FBMillisToSeconds(self.offset)]];
+    return @[[[XCPointerEventPath alloc] initForTouchAtPoint:self.atPosition offset:FBMillisToSeconds(self.offset + self.duration)]];
   }
   [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
   return @[eventPath];

--- a/WebDriverAgentTests/IntegrationTests/FBAppiumTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBAppiumTouchActionsIntegrationTests.m
@@ -235,8 +235,7 @@
       @"options": @{
           @"x": @(elementFrame.origin.x + 1),
           @"y": @(elementFrame.origin.y + 1),
-          @"duration": @5,
-          @"pressure": @0.1
+          @"duration": @5
           }
       },
     @{

--- a/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
@@ -411,7 +411,7 @@
       @"id": @"finger1",
       @"parameters": @{@"pointerType": @"touch"},
       @"actions": @[
-          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.pickerWheel, @"x": @0, @"y": @0},
+          @{@"type": @"pointerMove", @"duration": @250, @"origin": self.pickerWheel, @"x": @0, @"y": @0},
           @{@"type": @"pointerDown"},
           @{@"type": @"pause", @"duration": @500},
           @{@"type": @"pointerMove", @"duration": @0, @"origin": @"pointer", @"x": @0, @"y": @(-pickerFrame.size.height / 2)},

--- a/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
@@ -323,7 +323,7 @@
   [self verifyGesture:gesture orientation:UIDeviceOrientationLandscapeRight];
 }
 
-- (void)testLongPressWithPressure
+- (void)testLongPress
 {
   UIDeviceOrientation orientation = UIDeviceOrientationLandscapeLeft;
   [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:orientation];
@@ -335,7 +335,7 @@
       @"parameters": @{@"pointerType": @"touch"},
       @"actions": @[
           @{@"type": @"pointerMove", @"duration": @0, @"x": @(elementFrame.origin.x + 1), @"y": @(elementFrame.origin.y + 1)},
-          @{@"type": @"pointerDown", @"pressure": @0.1},
+          @{@"type": @"pointerDown"},
           @{@"type": @"pause", @"duration": @500},
           @{@"type": @"pointerUp"},
           ],


### PR DESCRIPTION
It turns out, that XCTest is unable to properly generate multiple press/lift up events in scope of a single XCPointerEventPath instance and it is necessary to add multiple instances of XCPointerEventPath for each gesture, that starts  with press.