### PR TITLE
Comment out firstMatch usage completely, since there is no simple way to detect the root element

### DIFF
--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -79,12 +79,13 @@ static dispatch_once_t onceFirstMatchToken;
 - (XCUIElement *)fb_firstMatch
 {
   dispatch_once(&onceFirstMatchToken, ^{
-    FBShouldUseFirstMatchSelector = [self respondsToSelector:@selector(firstMatch)];
-  });
-  if (FBShouldUseFirstMatchSelector && [self isKindOfClass:XCUIApplication.class]) {
     // Unfortunately, firstMatch property does not work properly if
     // the lookup is not executed in application context:
     // https://github.com/appium/appium/issues/10101
+    //    FBShouldUseFirstMatchSelector = [self respondsToSelector:@selector(firstMatch)];
+    FBShouldUseFirstMatchSelector = NO;
+  });
+  if (FBShouldUseFirstMatchSelector) {
     XCUIElement* result = self.firstMatch;
     return result.exists ? result : nil;
   }


### PR DESCRIPTION
`[self isKindOfClass:XCUIApplication.class]` is never going to be true for XCUIElementQuery instances, so it will just be simpler to disable firstMatch usage completely for now.