### PR TITLE
Fix RemoteBridgeView detection for xml tree building and visibility detection

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -94,9 +94,15 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
         } else if (CGSizeEqualToSize(parentFrame.size, containerSize) ||
                    // The size might be inverted in landscape
                    CGSizeEqualToSize(parentFrame.size, CGSizeMake(containerSize.height, containerSize.width))) {
-          // Covers ScrollView case
-          currentRectangle.origin.x -= selfFrame.origin.x;
-          currentRectangle.origin.y -= selfFrame.origin.y;
+          if (CGPointEqualToPoint(parentFrame.origin, CGPointZero)) {
+            // Covers ScrollView case
+            currentRectangle.origin.x -= selfFrame.origin.x;
+            currentRectangle.origin.y -= selfFrame.origin.y;
+          } else {
+            // Covers RemoteBridgeView case
+            currentRectangle.origin.x += parentFrame.origin.x;
+            currentRectangle.origin.y += parentFrame.origin.y;
+          }
         }
         intersectionWithParent = CGRectIntersection(currentRectangle, parentFrame);
       }

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -305,13 +305,13 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
       [((XCUIElement *)root).application fb_waitUntilSnapshotIsStable];
     }
     if ([root isKindOfClass:XCUIApplication.class]) {
+      currentSnapshot = ((XCUIApplication *)root).fb_lastSnapshot;
+      NSArray<XCUIElement *> *windows = [((XCUIElement *)root) fb_filterDescendantsWithSnapshots:currentSnapshot.children];
       NSMutableArray<XCElementSnapshot *> *windowsSnapshots = [NSMutableArray array];
-      NSArray<XCUIElement *> *windows = [((XCUIElement *)root) childrenMatchingType:XCUIElementTypeAny].allElementsBoundByIndex;
-      for (XCUIElement *window in windows) {
+      for (XCUIElement* window in windows) {
         [windowsSnapshots addObject:window.fb_lastSnapshot];
       }
       children = windowsSnapshots.copy;
-      currentSnapshot = ((XCUIApplication *)root).fb_lastSnapshot;
     } else {
       currentSnapshot = ((XCUIElement *)root).fb_lastSnapshot;
       children = currentSnapshot.children;


### PR DESCRIPTION
I have no idea why, but it seems like XCTest requires to query each RemoteView container separately