### PR TITLE
Return the element, which holds the keyboard input, as the active one

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
@@ -44,6 +44,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSString *)fb_descriptionRepresentation;
 
+/**
+ Returns the element, which currently holds the keyboard input focus or nil if there are no such elements.
+ */
+- (nullable XCUIElement *)fb_activeElement;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -128,11 +128,9 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
 
 - (XCUIElement *)fb_activeElement
 {
-  NSPredicate *predicate = [NSPredicate predicateWithFormat:@"hasKeyboardFocus == YES"];
-  return [[[[self descendantsMatchingType:XCUIElementTypeAny]
-            matchingPredicate:predicate]
-           allElementsBoundByIndex]
-          firstObject];
+  return [[[self descendantsMatchingType:XCUIElementTypeAny]
+           matchingPredicate:[NSPredicate predicateWithFormat:@"hasKeyboardFocus == YES"]]
+          fb_firstMatch];
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -126,4 +126,13 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
   return (0 == childrenDescriptions.count) ? self.debugDescription : [childrenDescriptions componentsJoinedByString:@"\n\n"];
 }
 
+- (XCUIElement *)fb_activeElement
+{
+  NSPredicate *predicate = [NSPredicate predicateWithFormat:@"hasKeyboardFocus == YES"];
+  return [[[[self descendantsMatchingType:XCUIElementTypeAny]
+            matchingPredicate:predicate]
+           allElementsBoundByIndex]
+          firstObject];
+}
+
 @end

--- a/WebDriverAgentLib/Commands/FBFindElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBFindElementCommands.m
@@ -10,18 +10,18 @@
 #import "FBFindElementCommands.h"
 
 #import "FBAlert.h"
+#import "FBApplication.h"
 #import "FBConfiguration.h"
 #import "FBElementCache.h"
 #import "FBExceptionHandler.h"
-#import "FBRouteRequest.h"
 #import "FBMacros.h"
-#import "FBElementCache.h"
 #import "FBPredicate.h"
+#import "FBRouteRequest.h"
 #import "FBSession.h"
-#import "FBApplication.h"
+#import "XCUIApplication+FBHelpers.h"
+#import "XCUIElement+FBClassChain.h"
 #import "XCUIElement+FBFind.h"
 #import "XCUIElement+FBIsVisible.h"
-#import "XCUIElement+FBClassChain.h"
 
 static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteRequest *request)
 {
@@ -42,6 +42,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
   return
   @[
     [[FBRoute POST:@"/element"] respondWithTarget:self action:@selector(handleFindElement:)],
+    [[FBRoute GET:@"/element/active"] respondWithTarget:self action:@selector(handleGetActiveElement:)],
     [[FBRoute POST:@"/elements"] respondWithTarget:self action:@selector(handleFindElements:)],
     [[FBRoute POST:@"/element/:uuid/element"] respondWithTarget:self action:@selector(handleFindSubElement:)],
     [[FBRoute POST:@"/element/:uuid/elements"] respondWithTarget:self action:@selector(handleFindSubElements:)],
@@ -98,6 +99,15 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
                          shouldReturnAfterFirstMatch:NO];
 
   return FBResponseWithCachedElements(foundElements, request.session.elementCache, FBConfiguration.shouldUseCompactResponses);
+}
+
++ (id<FBResponsePayload>)handleGetActiveElement:(FBRouteRequest *)request
+{
+  XCUIElement *element = request.session.activeApplication.fb_activeElement;
+  if (nil == element) {
+    return FBNoSuchElementErrorResponseForRequest(request);
+  }
+  return FBResponseWithCachedElement(element, request.session.elementCache, FBConfiguration.shouldUseCompactResponses);
 }
 
 

--- a/WebDriverAgentTests/IntegrationTests/XCUIApplicationHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIApplicationHelperTests.m
@@ -11,6 +11,7 @@
 
 #import "FBApplication.h"
 #import "FBIntegrationTestCase.h"
+#import "FBElement.h"
 #import "FBTestMacros.h"
 #import "FBSpringboardApplication.h"
 #import "XCUIApplication+FBHelpers.h"
@@ -80,6 +81,17 @@
   XCTAssertTrue([FBApplication fb_activeApplication].buttons[@"Alerts"].fb_isVisible);
   [self goToSpringBoardFirstPage];
   XCTAssertTrue([FBApplication fb_activeApplication].icons[@"Safari"].fb_isVisible);
+}
+
+- (void)testActiveElement
+{
+  [self goToAttributesPage];
+  XCTAssertNil(self.testedApplication.fb_activeElement);
+  XCUIElement *textField = self.testedApplication.textFields[@"aIdentifier"];
+  [textField tap];
+  FBAssertWaitTillBecomesTrue(nil != self.testedApplication.fb_activeElement);
+  XCTAssertEqual(((id<FBElement>)self.testedApplication.fb_activeElement).wdUID,
+                 ((id<FBElement>)textField).wdUID);
 }
 
 @end


### PR DESCRIPTION
Currently we just throw an exception in response to `/element/active` request, but instead we could return the instance of an element, which currently holds the input focus.