### PR TITLE
Tune visibility detection for scroll views

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -99,19 +99,19 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
   CGRect intersectionWithParent = CGRectIntersectsRect(parentFrame, containerFrame)
     ? CGRectIntersection(currentRectangle, parentFrame)
     : currentRectangle;
-  if (CGRectIsEmpty(intersectionWithParent) && parent != container) {
-    if (self.elementType == XCUIElementTypeOther) {
-      // Special case (or XCTest bug). Shift the origin and continue
-      if (CGSizeEqualToSize(parentFrame.size, containerFrame.size) ||
-          // The size might be inverted in landscape
-          CGSizeEqualToSize(parentFrame.size, CGSizeMake(containerFrame.size.height, containerFrame.size.width)) ||
-          CGSizeEqualToSize(self.frame.size, CGSizeZero)) {
-        // Covers ActivityListView and RemoteBridgeView cases
-        currentRectangle.origin.x += parentFrame.origin.x;
-        currentRectangle.origin.y += parentFrame.origin.y;
-      }
-      intersectionWithParent = CGRectIntersection(currentRectangle, parentFrame);
+  if (CGRectIsEmpty(intersectionWithParent) &&
+      parent != container &&
+      self.elementType == XCUIElementTypeOther) {
+    // Special case (or XCTest bug). Shift the origin and continue
+    if (CGSizeEqualToSize(parentFrame.size, containerFrame.size) ||
+        // The size might be inverted in landscape
+        CGSizeEqualToSize(parentFrame.size, CGSizeMake(containerFrame.size.height, containerFrame.size.width)) ||
+        CGSizeEqualToSize(self.frame.size, CGSizeZero)) {
+      // Covers ActivityListView and RemoteBridgeView cases
+      currentRectangle.origin.x += parentFrame.origin.x;
+      currentRectangle.origin.y += parentFrame.origin.y;
     }
+    intersectionWithParent = CGRectIntersection(currentRectangle, parentFrame);
   }
   if (CGRectIsEmpty(intersectionWithParent) || parent == container) {
     return intersectionWithParent;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -75,8 +75,16 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
       CGPointEqualToPoint(parentFrame.origin, CGPointZero)) {
     // Special case (or XCTest bug). Shift the origin and return immediately
     XCElementSnapshot *nextParent = parent.parent;
+    BOOL isGrandparent = YES;
     while (nextParent && nextParent != container) {
       CGRect nextParentFrame = nextParent.frame;
+      if (isGrandparent &&
+          CGSizeEqualToSize(nextParentFrame.size, CGSizeZero) &&
+          CGPointEqualToPoint(nextParentFrame.origin, CGPointZero)) {
+        // Double zero-size inclusion means that element coordinates are absolute
+        return CGRectIntersection(currentRectangle, container.frame);
+      }
+      isGrandparent = NO;
       if (!CGPointEqualToPoint(nextParentFrame.origin, CGPointZero)) {
         currentRectangle.origin.x += nextParentFrame.origin.x;
         currentRectangle.origin.y += nextParentFrame.origin.y;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -152,7 +152,8 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
     calculatedRect = [self fb_frameInContainer:parentWindow hierarchyIntersection:nil];
   }
   CGRect visibleRect = nil == calculatedRect ? selfFrame : calculatedRect.CGRectValue;
-  if (CGRectIsEmpty(visibleRect)) {
+  if (CGRectIsEmpty(visibleRect) ||
+      (nil == calculatedRect && nil != parentWindow && !CGRectIntersectsRect(visibleRect, parentWindow.frame))) {
     return [self fb_cacheVisibilityWithValue:NO forAncestors:ancestors];
   }
   CGPoint midPoint = CGPointMake(visibleRect.origin.x + visibleRect.size.width / 2,

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -151,9 +151,15 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
   if (nil != parentWindow) {
     calculatedRect = [self fb_frameInContainer:parentWindow hierarchyIntersection:nil];
   }
-  CGRect visibleRect = nil == calculatedRect ? selfFrame : calculatedRect.CGRectValue;
-  if (CGRectIsEmpty(visibleRect) ||
-      (nil == calculatedRect && nil != parentWindow && !CGRectIntersectsRect(visibleRect, parentWindow.frame))) {
+  CGRect visibleRect = selfFrame;
+  if (nil == calculatedRect) {
+    if (nil != parentWindow) {
+      visibleRect = CGRectIntersection(visibleRect, parentWindow.frame);
+    }
+  } else {
+    visibleRect = calculatedRect.CGRectValue;
+  }
+  if (CGRectIsEmpty(visibleRect)) {
     return [self fb_cacheVisibilityWithValue:NO forAncestors:ancestors];
   }
   CGPoint midPoint = CGPointMake(visibleRect.origin.x + visibleRect.size.width / 2,

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -90,6 +90,7 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
         currentRectangle.origin.y += nextParentFrame.origin.y;
         return CGRectIntersection(currentRectangle, container.frame);
       }
+      nextParent = nextParent.parent;
     }
     return CGRectIntersection(currentRectangle, container.frame);
   }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -102,16 +102,16 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
   if (CGRectIsEmpty(intersectionWithParent) &&
       parent != container &&
       self.elementType == XCUIElementTypeOther) {
-    // Special case (or XCTest bug). Shift the origin and continue
-    if (CGSizeEqualToSize(parentFrame.size, containerFrame.size) ||
+    // Special case (or XCTest bug). Shift the origin
+    if (CGSizeEqualToSize(self.frame.size, CGSizeZero) ||
+        CGSizeEqualToSize(parentFrame.size, containerFrame.size) ||
         // The size might be inverted in landscape
-        CGSizeEqualToSize(parentFrame.size, CGSizeMake(containerFrame.size.height, containerFrame.size.width)) ||
-        CGSizeEqualToSize(self.frame.size, CGSizeZero)) {
+        CGSizeEqualToSize(parentFrame.size, CGSizeMake(containerFrame.size.height, containerFrame.size.width))) {
       // Covers ActivityListView and RemoteBridgeView cases
       currentRectangle.origin.x += parentFrame.origin.x;
       currentRectangle.origin.y += parentFrame.origin.y;
+      return CGRectIntersection(currentRectangle, containerFrame);
     }
-    intersectionWithParent = CGRectIntersection(currentRectangle, parentFrame);
   }
   if (CGRectIsEmpty(intersectionWithParent) || parent == container) {
     return intersectionWithParent;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -103,10 +103,10 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
       parent != container &&
       self.elementType == XCUIElementTypeOther) {
     // Special case (or XCTest bug). Shift the origin
-    if (CGSizeEqualToSize(self.frame.size, CGSizeZero) ||
-        CGSizeEqualToSize(parentFrame.size, containerFrame.size) ||
+    if (CGSizeEqualToSize(parentFrame.size, containerFrame.size) ||
         // The size might be inverted in landscape
-        CGSizeEqualToSize(parentFrame.size, CGSizeMake(containerFrame.size.height, containerFrame.size.width))) {
+        CGSizeEqualToSize(parentFrame.size, CGSizeMake(containerFrame.size.height, containerFrame.size.width)) ||
+        CGSizeEqualToSize(self.frame.size, CGSizeZero)) {
       // Covers ActivityListView and RemoteBridgeView cases
       currentRectangle.origin.x += parentFrame.origin.x;
       currentRectangle.origin.y += parentFrame.origin.y;


### PR DESCRIPTION
Make sure the element frame is always a part of its container if visible frame cannot be calculated properly