### PR TITLE
Use visibleRect for coordinates calculation if possible

### DIFF
--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -138,6 +138,8 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
     }
     return nil;
   }
+  CGRect visibleFrame = snapshot.visibleFrame;
+  frame = CGRectIsEmpty(visibleFrame) ? frame : visibleFrame;
   // W3C standard requires that relative element coordinates start at the center of the element's rectangle
   CGPoint hitPoint = CGPointMake(frame.origin.x + frame.size.width / 2, frame.origin.y + frame.size.height / 2);
   CGPoint offsetValue = [positionOffset CGPointValue];

--- a/WebDriverAgentTests/IntegrationTests/FBAppiumTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBAppiumTouchActionsIntegrationTests.m
@@ -174,6 +174,23 @@
   [self verifyGesture:gesture orientation:UIDeviceOrientationPortrait];
 }
 
+- (void)testTapByCoordinates
+{
+  CGRect elementRect = self.testedApplication.buttons[FBShowAlertButtonName].frame;
+  CGFloat x = elementRect.origin.x + elementRect.size.width / 2;
+  CGFloat y = elementRect.origin.y + elementRect.size.height / 2;
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"action": @"tap",
+      @"options": @{
+          @"x": @(x),
+          @"y": @(y)
+          }
+      }
+    ];
+  [self verifyGesture:gesture orientation:UIDeviceOrientationPortrait];
+}
+
 - (void)testDoubleTap
 {
   NSArray<NSDictionary<NSString *, id> *> *gesture =


### PR DESCRIPTION
This optimises some calculations need in order to perform touch actions and switches the algorithm to use visibleFrame property instead of frame, which might be more precise for some element types.