### PR TITLE
Implement pasteboard handlers

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -40,6 +40,9 @@
 		716E0BCF1E917E810087A825 /* NSString+FBXMLSafeString.m in Sources */ = {isa = PBXBuildFile; fileRef = 716E0BCD1E917E810087A825 /* NSString+FBXMLSafeString.m */; };
 		716E0BD11E917F260087A825 /* FBXMLSafeStringTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 716E0BD01E917F260087A825 /* FBXMLSafeStringTests.m */; };
 		7174AF041D9D39AF008C8AD5 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7174AF031D9D39AF008C8AD5 /* libxml2.tbd */; };
+		71930C4220662E1F00D3AFEC /* FBPasteboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 71930C4020662E1F00D3AFEC /* FBPasteboard.h */; };
+		71930C4320662E1F00D3AFEC /* FBPasteboard.m in Sources */ = {isa = PBXBuildFile; fileRef = 71930C4120662E1F00D3AFEC /* FBPasteboard.m */; };
+		71930C472066434000D3AFEC /* FBPasteboardTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71930C462066434000D3AFEC /* FBPasteboardTests.m */; };
 		719A97AC1F88E7370063B4BD /* FBAppiumMultiTouchActionsIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 719A97AB1F88E7370063B4BD /* FBAppiumMultiTouchActionsIntegrationTests.m */; };
 		719FF5B91DAD21F5008E0099 /* FBElementUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 719FF5B81DAD21F5008E0099 /* FBElementUtilitiesTests.m */; };
 		71A224E51DE2F56600844D55 /* NSPredicate+FBFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A224E31DE2F56600844D55 /* NSPredicate+FBFormat.h */; };
@@ -450,6 +453,9 @@
 		716E0BCD1E917E810087A825 /* NSString+FBXMLSafeString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+FBXMLSafeString.m"; sourceTree = "<group>"; };
 		716E0BD01E917F260087A825 /* FBXMLSafeStringTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXMLSafeStringTests.m; sourceTree = "<group>"; };
 		7174AF031D9D39AF008C8AD5 /* libxml2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.tbd; path = usr/lib/libxml2.tbd; sourceTree = SDKROOT; };
+		71930C4020662E1F00D3AFEC /* FBPasteboard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBPasteboard.h; sourceTree = "<group>"; };
+		71930C4120662E1F00D3AFEC /* FBPasteboard.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBPasteboard.m; sourceTree = "<group>"; };
+		71930C462066434000D3AFEC /* FBPasteboardTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBPasteboardTests.m; sourceTree = "<group>"; };
 		719A97AB1F88E7370063B4BD /* FBAppiumMultiTouchActionsIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBAppiumMultiTouchActionsIntegrationTests.m; sourceTree = "<group>"; };
 		719FF5B81DAD21F5008E0099 /* FBElementUtilitiesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBElementUtilitiesTests.m; sourceTree = "<group>"; };
 		71A224E31DE2F56600844D55 /* NSPredicate+FBFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSPredicate+FBFormat.h"; path = "../Utilities/NSPredicate+FBFormat.h"; sourceTree = "<group>"; };
@@ -1057,6 +1063,8 @@
 				EE9B76A51CF7A43900275851 /* FBMacros.h */,
 				EE1888381DA661C400307AA8 /* FBMathUtils.h */,
 				EE1888391DA661C400307AA8 /* FBMathUtils.m */,
+				71930C4020662E1F00D3AFEC /* FBPasteboard.h */,
+				71930C4120662E1F00D3AFEC /* FBPasteboard.m */,
 				EEEC7C901F21F27A0053426C /* FBPredicate.h */,
 				EEEC7C911F21F27A0053426C /* FBPredicate.m */,
 				EEE9B4701CD02B88009D2030 /* FBRunLoopSpinner.h */,
@@ -1115,6 +1123,7 @@
 				EE1E06DB1D18090F007CF043 /* FBIntegrationTestCase.h */,
 				EE1E06D91D1808C2007CF043 /* FBIntegrationTestCase.m */,
 				EE05BAF91D13003C00A3EB00 /* FBKeyboardTests.m */,
+				71930C462066434000D3AFEC /* FBPasteboardTests.m */,
 				7119E1EB1E891F8600D0B125 /* FBPickerWheelSelectTests.m */,
 				715AFAC31FFA2AAF0053896D /* FBScreenTests.m */,
 				EE55B3261D1D54CF003AAAEC /* FBScrollingTests.m */,
@@ -1523,6 +1532,7 @@
 				EE35AD6F1E3B77D600A02D78 /* XCUIElement.h in Headers */,
 				EE35AD2F1E3B77D600A02D78 /* XCKeyboardInputSolver.h in Headers */,
 				EE7E271E1D06C69F001BEC7B /* FBXCTestCaseImplementationFailureHoldingProxy.h in Headers */,
+				71930C4220662E1F00D3AFEC /* FBPasteboard.h in Headers */,
 				714097471FAE1B32008FB2C5 /* FBAppiumActionsSynthesizer.h in Headers */,
 				EE7E271C1D06C69F001BEC7B /* FBDebugLogDelegateDecorator.h in Headers */,
 				EEDFE1211D9C06F800E6FFE5 /* XCUIDevice+FBHealthCheck.h in Headers */,
@@ -1848,6 +1858,7 @@
 				EE006EB11EBA1AA9006900A4 /* XCElementSnapshot+FBHitPoint.m in Sources */,
 				EE9B76A71CF7A43900275851 /* FBConfiguration.m in Sources */,
 				EE158AD31CBD456F00A3E3F0 /* FBElementCache.m in Sources */,
+				71930C4320662E1F00D3AFEC /* FBPasteboard.m in Sources */,
 				AD6C26951CF2379700F8B5FF /* FBAlert.m in Sources */,
 				EE158ABF1CBD456F00A3E3F0 /* FBElementCommands.m in Sources */,
 				EE158AD51CBD456F00A3E3F0 /* FBExceptionHandler.m in Sources */,
@@ -1873,6 +1884,7 @@
 				719A97AC1F88E7370063B4BD /* FBAppiumMultiTouchActionsIntegrationTests.m in Sources */,
 				715AFAC41FFA2AAF0053896D /* FBScreenTests.m in Sources */,
 				EE22021E1ECC618900A29571 /* FBTapTest.m in Sources */,
+				71930C472066434000D3AFEC /* FBPasteboardTests.m in Sources */,
 				71AB82B21FDAE8C000D1D7C3 /* FBElementScreenshotTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -157,6 +157,9 @@
   NSString *contentType = request.arguments[@"contentType"] ?: @"plaintext";
   NSData *content = [[NSData alloc] initWithBase64EncodedString:(NSString *)request.arguments[@"content"]
                                                         options:NSDataBase64DecodingIgnoreUnknownCharacters];
+  if (nil == content) {
+    return FBResponseWithStatus(FBCommandStatusInvalidArgument, @"Cannot decode the pasteboard content from base64");
+  }
   NSError *error;
   if (![FBPasteboard setData:content forType:contentType error:&error]) {
     return FBResponseWithError(error);

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -154,9 +154,9 @@
 
 + (id<FBResponsePayload>)handleSetPasteboard:(FBRouteRequest *)request
 {
-  NSString *contentType = request.arguments[@"contentType"];
+  NSString *contentType = request.arguments[@"contentType"] ?: @"plaintext";
   NSData *content = [[NSData alloc] initWithBase64EncodedString:(NSString *)request.arguments[@"content"]
-                                                        options:0];
+                                                        options:NSDataBase64DecodingIgnoreUnknownCharacters];
   NSError *error;
   if (![FBPasteboard setData:content forType:contentType error:&error]) {
     return FBResponseWithError(error);
@@ -166,7 +166,7 @@
 
 + (id<FBResponsePayload>)handleGetPasteboard:(FBRouteRequest *)request
 {
-  NSString *contentType = request.arguments[@"contentType"];
+  NSString *contentType = request.arguments[@"contentType"] ?: @"plaintext";
   NSError *error;
   id result = [FBPasteboard dataForType:contentType error:&error];
   if (nil == result) {

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -175,10 +175,8 @@
   if (nil == result) {
     return FBResponseWithError(error);
   }
-  if ([result isKindOfClass:NSData.class]) {
-    return FBResponseWithStatus(FBCommandStatusNoError, [result base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength]);
-  }
-  return FBResponseWithStatus(FBCommandStatusNoError, result);
+  return FBResponseWithStatus(FBCommandStatusNoError,
+                              [result base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength]);
 }
 
 @end

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -14,6 +14,7 @@
 #import "FBApplication.h"
 #import "FBConfiguration.h"
 #import "FBExceptionHandler.h"
+#import "FBPasteboard.h"
 #import "FBResponsePayload.h"
 #import "FBRoute.h"
 #import "FBRouteRequest.h"
@@ -46,7 +47,9 @@
     [[FBRoute GET:@"/wda/locked"] respondWithTarget:self action:@selector(handleIsLocked:)],
     [[FBRoute GET:@"/wda/screen"] respondWithTarget:self action:@selector(handleGetScreen:)],
     [[FBRoute GET:@"/wda/activeAppInfo"] respondWithTarget:self action:@selector(handleActiveAppInfo:)],
-    [[FBRoute GET:@"/wda/activeAppInfo"].withoutSession respondWithTarget:self action:@selector(handleActiveAppInfo:)]
+    [[FBRoute GET:@"/wda/activeAppInfo"].withoutSession respondWithTarget:self action:@selector(handleActiveAppInfo:)],
+    [[FBRoute POST:@"/wda/setPasteboard"] respondWithTarget:self action:@selector(handleSetPasteboard:)],
+    [[FBRoute POST:@"/wda/getPasteboard"] respondWithTarget:self action:@selector(handleGetPasteboard:)],
   ];
 }
 
@@ -147,6 +150,32 @@
     @"bundleId": app.bundleID,
     @"name": app.identifier
   });
+}
+
++ (id<FBResponsePayload>)handleSetPasteboard:(FBRouteRequest *)request
+{
+  NSString *contentType = request.arguments[@"contentType"];
+  NSData *content = [[NSData alloc] initWithBase64EncodedString:(NSString *)request.arguments[@"content"]
+                                                        options:0];
+  NSError *error;
+  if (![FBPasteboard setData:content forType:contentType error:&error]) {
+    return FBResponseWithError(error);
+  }
+  return FBResponseWithOK();
+}
+
++ (id<FBResponsePayload>)handleGetPasteboard:(FBRouteRequest *)request
+{
+  NSString *contentType = request.arguments[@"contentType"];
+  NSError *error;
+  id result = [FBPasteboard dataForType:contentType error:&error];
+  if (nil == result) {
+    return FBResponseWithError(error);
+  }
+  if ([result isKindOfClass:NSData.class]) {
+    return FBResponseWithStatus(FBCommandStatusNoError, [result base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength]);
+  }
+  return FBResponseWithStatus(FBCommandStatusNoError, result);
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBPasteboard.h
+++ b/WebDriverAgentLib/Utilities/FBPasteboard.h
@@ -28,10 +28,10 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param type one of the possible data types to get: plaintext, url, image
  @param error If there is an error, upon return contains an NSError object that describes the problem
- @return NSData object, containing the pasteboard content or [NSNull null] if the pasteboard is empty.
+ @return NSData object, containing the pasteboard content or an empty string if the pasteboard is empty.
  nil is returned if there was an error while getting the data from the pasteboard
  */
-+ (nullable id)dataForType:(NSString *)type error:(NSError **)error;
++ (nullable NSData *)dataForType:(NSString *)type error:(NSError **)error;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBPasteboard.h
+++ b/WebDriverAgentLib/Utilities/FBPasteboard.h
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FBPasteboard : NSObject
+
+/**
+ Sets data to the general pasteboard
+
+ @param data base64-encoded string containing the data chunk which is going to be written to the pasteboard
+ @param type one of the possible data types to set: plaintext, url, image
+ @param error If there is an error, upon return contains an NSError object that describes the problem
+ @return YES if the operation was successful
+ */
++ (BOOL)setData:(NSData *)data forType:(NSString *)type error:(NSError **)error;
+
+/**
+ Gets the data contained in the general pasteboard
+
+ @param type one of the possible data types to get: plaintext, url, image
+ @param error If there is an error, upon return contains an NSError object that describes the problem
+ @return NSData object, containing the pasteboard content or [NSNull null] if the pasteboard is empty. nil is returned if there was an error while getting the data from the pasteboard
+ */
++ (nullable id)dataForType:(NSString *)type error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/WebDriverAgentLib/Utilities/FBPasteboard.h
+++ b/WebDriverAgentLib/Utilities/FBPasteboard.h
@@ -28,7 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param type one of the possible data types to get: plaintext, url, image
  @param error If there is an error, upon return contains an NSError object that describes the problem
- @return NSData object, containing the pasteboard content or [NSNull null] if the pasteboard is empty. nil is returned if there was an error while getting the data from the pasteboard
+ @return NSData object, containing the pasteboard content or [NSNull null] if the pasteboard is empty.
+ nil is returned if there was an error while getting the data from the pasteboard
  */
 + (nullable id)dataForType:(NSString *)type error:(NSError **)error;
 

--- a/WebDriverAgentLib/Utilities/FBPasteboard.m
+++ b/WebDriverAgentLib/Utilities/FBPasteboard.m
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBPasteboard.h"
+
+#import "FBErrorBuilder.h"
+
+@implementation FBPasteboard
+
++ (BOOL)setData:(NSData *)data forType:(NSString *)type error:(NSError **)error
+{
+  UIPasteboard *pb = UIPasteboard.generalPasteboard;
+  if ([type.lowercaseString isEqualToString:@"plaintext"]) {
+    pb.string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+  } else if ([type.lowercaseString isEqualToString:@"image"]) {
+    pb.image = [UIImage imageWithData:data];
+  } else if ([type.lowercaseString isEqualToString:@"url"]) {
+    NSString *urlString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    pb.URL = [[NSURL alloc] initWithString:urlString];
+  } else {
+    NSString *description = [NSString stringWithFormat:@"Unsupported content type: %@", type];
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:description] build];
+    }
+    return NO;
+  }
+  return YES;
+}
+
++ (id)dataForType:(NSString *)type error:(NSError **)error
+{
+  UIPasteboard *pb = UIPasteboard.generalPasteboard;
+  if ([type.lowercaseString isEqualToString:@"plaintext"]) {
+    if (pb.hasStrings) {
+      return [pb.string dataUsingEncoding:NSUTF8StringEncoding];
+    }
+  } else if ([type.lowercaseString isEqualToString:@"image"]) {
+    if (pb.hasImages) {
+      return UIImagePNGRepresentation((UIImage *)pb.image);
+    }
+  } else if ([type.lowercaseString isEqualToString:@"url"]) {
+    if (pb.hasURLs) {
+      return [NSData dataWithContentsOfURL:(NSURL *)pb.URL];
+    }
+  } else {
+    NSString *description = [NSString stringWithFormat:@"Unsupported content type: %@", type];
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:description] build];
+    }
+    return nil;
+  }
+  return [NSNull null];
+}
+
+@end

--- a/WebDriverAgentLib/Utilities/FBPasteboard.m
+++ b/WebDriverAgentLib/Utilities/FBPasteboard.m
@@ -33,7 +33,7 @@
   return YES;
 }
 
-+ (id)dataForType:(NSString *)type error:(NSError **)error
++ (NSData *)dataForType:(NSString *)type error:(NSError **)error
 {
   UIPasteboard *pb = UIPasteboard.generalPasteboard;
   if ([type.lowercaseString isEqualToString:@"plaintext"]) {
@@ -55,7 +55,7 @@
     }
     return nil;
   }
-  return [NSNull null];
+  return [@"" dataUsingEncoding:NSUTF8StringEncoding];
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/FBPasteboardTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBPasteboardTests.m
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FBIntegrationTestCase.h"
+#import "XCUIElement+FBTyping.h"
+#import "FBPasteboard.h"
+#import "FBTestMacros.h"
+#import "FBXCodeCompatibility.h"
+
+@interface FBPasteboardTests : FBIntegrationTestCase
+@end
+
+@implementation FBPasteboardTests
+
+- (void)setUp
+{
+  [super setUp];
+  [self launchApplication];
+  [self goToAttributesPage];
+}
+
+- (void)testSetPasteboard
+{
+  NSString *text = @"Happy pasting";
+  XCUIElement *textField = self.testedApplication.textFields[@"aIdentifier"];
+  NSError *error;
+  BOOL result = [FBPasteboard setData:(NSData *)[text dataUsingEncoding:NSUTF8StringEncoding]
+                              forType:@"plaintext"
+                                error:&error];
+  XCTAssertTrue(result);
+  XCTAssertNil(error);
+  [textField tap];
+  XCTAssertTrue([textField fb_clearTextWithError:&error]);
+  [textField pressForDuration:2.0];
+  XCUIElement *pasteItem = [[self.testedApplication descendantsMatchingType:XCUIElementTypeAny] matchingIdentifier:@"Paste"].fb_firstMatch;
+  XCTAssertNotNil(pasteItem);
+  [pasteItem tap];
+  FBAssertWaitTillBecomesTrue([textField.value isEqualToString:text]);
+}
+
+- (void)testGetPasteboard
+{
+  NSString *text = @"Happy copying";
+  XCUIElement *textField = self.testedApplication.textFields[@"aIdentifier"];
+  NSError *error;
+  XCTAssertTrue([textField fb_typeText:text error:&error]);
+  [textField pressForDuration:2.0];
+  XCUIElement *selectAllItem = [[self.testedApplication descendantsMatchingType:XCUIElementTypeAny]
+                                matchingIdentifier:@"Select All"].fb_firstMatch;
+  XCTAssertNotNil(selectAllItem);
+  [selectAllItem tap];
+  [textField pressForDuration:2.0];
+  XCUIElement *copyItem = [[self.testedApplication descendantsMatchingType:XCUIElementTypeAny]
+                           matchingIdentifier:@"Copy"].fb_firstMatch;
+  XCTAssertNotNil(copyItem);
+  [copyItem tap];
+  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1]];
+  id result = [FBPasteboard dataForType:@"plaintext" error:&error];
+  XCTAssertTrue([result isKindOfClass:NSData.class]);
+  XCTAssertNil(error);
+  XCTAssertEqualObjects(textField.value, [[NSString alloc] initWithData:result encoding:NSUTF8StringEncoding]);
+}
+
+@end
+
+

--- a/WebDriverAgentTests/IntegrationTests/FBPasteboardTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBPasteboardTests.m
@@ -64,8 +64,7 @@
   XCTAssertNotNil(copyItem);
   [copyItem tap];
   [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1]];
-  id result = [FBPasteboard dataForType:@"plaintext" error:&error];
-  XCTAssertTrue([result isKindOfClass:NSData.class]);
+  NSData *result = [FBPasteboard dataForType:@"plaintext" error:&error];
   XCTAssertNil(error);
   XCTAssertEqualObjects(textField.value, [[NSString alloc] initWithData:result encoding:NSUTF8StringEncoding]);
 }

--- a/WebDriverAgentTests/IntegrationTests/FBPasteboardTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBPasteboardTests.m
@@ -40,7 +40,8 @@
   [textField tap];
   XCTAssertTrue([textField fb_clearTextWithError:&error]);
   [textField pressForDuration:2.0];
-  XCUIElement *pasteItem = [[self.testedApplication descendantsMatchingType:XCUIElementTypeAny] matchingIdentifier:@"Paste"].fb_firstMatch;
+  XCUIElement *pasteItem = [[self.testedApplication descendantsMatchingType:XCUIElementTypeAny]
+                            matchingIdentifier:@"Paste"].fb_firstMatch;
   XCTAssertNotNil(pasteItem);
   [pasteItem tap];
   FBAssertWaitTillBecomesTrue([textField.value isEqualToString:text]);


### PR DESCRIPTION
This adds endpoints, which allow to use iOS pasteboard on both simulator and real devices plus supports different content types, like images, urls and plain text.