### PR TITLE
Use fb_screenPoint instead of screenPoint for scrolling

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
@@ -280,8 +280,8 @@ const CGFloat FBMinimumTouchEventDelay = 0.1f;
   @[@{
       @"action": @"longPress",
       @"options": @{
-          @"x": @(startCoordinate.screenPoint.x),
-          @"y": @(startCoordinate.screenPoint.y),
+          @"x": @(startCoordinate.fb_screenPoint.x),
+          @"y": @(startCoordinate.fb_screenPoint.y),
           }
       },
     @{
@@ -293,8 +293,8 @@ const CGFloat FBMinimumTouchEventDelay = 0.1f;
     @{
       @"action": @"moveTo",
       @"options": @{
-          @"x": @(endCoordinate.screenPoint.x),
-          @"y": @(endCoordinate.screenPoint.y),
+          @"x": @(endCoordinate.fb_screenPoint.x),
+          @"y": @(endCoordinate.fb_screenPoint.y),
           }
       },
     @{


### PR DESCRIPTION
iOS 11.2 and below on Xcode 9.3 crash when getting `screenPoint` while scrolling. This fixes that, while still working with iOS 11.3.