### PR TITLE
Remove obsolete method from snapshot helpers

### DIFF
--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.h
@@ -22,17 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<XCElementSnapshot *> *)fb_descendantsMatchingType:(XCUIElementType)type;
 
 /**
- Returns an array of descendants matching given xpath query. This method will always
- throw an exception if there is an error during XPath evaluation, so the returned array
- is never expected to be equal to nil
- 
- @param xpathQuery requested xpath query. Only XPath v1.0 libxml2-based implementation is supported
- @return an array of descendants matching given xpath query. Empty array will be retuned if
- no matches are found (XPath query should be still valid though)
- */
-- (NSArray<XCElementSnapshot *> *)fb_descendantsMatchingXPathQuery:(NSString *)xpathQuery;
-
-/**
  Returns first (going up element tree) parent that matches given type. If non found returns nil.
 
  @param type requested parent type

--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -10,7 +10,6 @@
 #import "XCElementSnapshot+FBHelpers.h"
 
 #import "FBFindElementCommands.h"
-#import "FBXPathCreator.h"
 #import "FBRunLoopSpinner.h"
 #import "FBLogger.h"
 #import "XCAXClient_iOS.h"
@@ -18,7 +17,6 @@
 #import "XCTestPrivateSymbols.h"
 #import "XCUIElement.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
-#import "FBXPath.h"
 
 inline static BOOL valuesAreEqual(id value1, id value2);
 inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, NSArray<NSNumber *> *types);
@@ -27,13 +25,9 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
 
 - (NSArray<XCElementSnapshot *> *)fb_descendantsMatchingType:(XCUIElementType)type
 {
-  NSString *xpathQuery = [FBXPathCreator xpathWithSubelementsOfType:type];
-  return [self fb_descendantsMatchingXPathQuery:xpathQuery];
-}
-
-- (NSArray<XCElementSnapshot *> *)fb_descendantsMatchingXPathQuery:(NSString *)xpathQuery
-{
-  return [FBXPath matchesWithRootElement:self forQuery:xpathQuery];
+  return [self descendantsByFilteringWithBlock:^BOOL(XCElementSnapshot *snapshot) {
+    return snapshot.elementType == type;
+  }];
 }
 
 - (XCElementSnapshot *)fb_parentMatchingType:(XCUIElementType)type

--- a/WebDriverAgentTests/IntegrationTests/XCElementSnapshotHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCElementSnapshotHelperTests.m
@@ -53,14 +53,6 @@
   XCTAssertEqualObjects(types.lastObject, @(XCUIElementTypeButton), @"matchingSnapshots should contain only one type");
 }
 
-- (void)testDescendantsMatchingXPath
-{
-  NSArray<XCElementSnapshot *> *matchingSnapshots = [self.testedView.fb_lastSnapshot fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButton[@label='Alerts']"];
-  XCTAssertEqual(matchingSnapshots.count, 1);
-  XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeButton);
-  XCTAssertEqualObjects(matchingSnapshots.lastObject.label, @"Alerts");
-}
-
 - (void)testParentMatchingType
 {
   XCUIElement *button = self.testedApplication.buttons[@"Alerts"];


### PR DESCRIPTION
This should simplify and speed up subelements filtering in the snapshot. Also, simplifies the code a lot.

Also, should be a useful addition to https://github.com/appium/WebDriverAgent/pull/80