### PR TITLE
Make sure the returned visibility value is in sync with page source

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -22,7 +22,7 @@
 
 - (BOOL)fb_isVisible
 {
-  return self.fb_lastSnapshot.fb_isVisible;
+  return (self.fb_snapshotWithAttributes ?: self.fb_lastSnapshot).fb_isVisible;
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -26,13 +26,16 @@
 {
   struct objc_method_description descr = protocol_getMethodDescription(@protocol(FBElement), aSelector, YES, YES);
   BOOL isWebDriverAttributesSelector = descr.name != nil;
-  if(!isWebDriverAttributesSelector) {
+  if (!isWebDriverAttributesSelector) {
     return nil;
   }
   if (!self.exists) {
     return [XCElementSnapshot new];
   }
 
+  if (descr.name == @selector(isWDVisible)) {
+    return (self.fb_snapshotWithAttributes ?: self.fb_lastSnapshot) ?: [XCElementSnapshot new];
+  }
   // If lastSnapshot is still missing aplication is probably not active. Returning empty element instead of crashing.
   // This will work well, if element search is requested (will not match anything) and reqesting properties values (will return nils).
   return self.fb_lastSnapshot ?: [XCElementSnapshot new];


### PR DESCRIPTION
We could get a situation when visibility value returned by page source is different from the visibility value returned in response to `displayed` query. This PR fixes that problem.