### PR TITLE
Implement automatic alerts handling

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -84,6 +84,9 @@
   if (requirements[@"shouldUseSingletonTestManager"]) {
     [FBConfiguration setShouldUseSingletonTestManager:[requirements[@"shouldUseSingletonTestManager"] boolValue]];
   }
+  if (requirements[@"autoAlertAction"]) {
+    [FBConfiguration setAutoAlertAction:[((id) requirements[@"autoAlertAction"]) stringValue]];
+  }
 
   FBApplication *app = [[FBApplication alloc] initPrivateWithPath:appPath bundleID:bundleID];
   app.fb_shouldWaitForQuiescence = [requirements[@"shouldWaitForQuiescence"] boolValue];
@@ -174,7 +177,8 @@
   return FBResponseWithObject(
     @{
       @"shouldUseCompactResponses": @([FBConfiguration shouldUseCompactResponses]),
-      @"elementResponseAttributes": [FBConfiguration elementResponseAttributes]
+      @"elementResponseAttributes": [FBConfiguration elementResponseAttributes],
+      @"autoAlertAction": [FBConfiguration autoAlertAction]
     }
   );
 }
@@ -193,6 +197,10 @@
   if ([settings objectForKey:@"elementResponseAttributes"]) {
     NSString* elementResponseAttribute = [settings objectForKey:@"elementResponseAttributes"];
     [FBConfiguration setElementResponseAttributes:elementResponseAttribute];
+  }
+
+  if ([settings objectForKey:@"autoAlertAction"]) {
+    [FBConfiguration setAutoAlertAction:[(id)[settings objectForKey:@"autoAlertAction"] stringValue]];
   }
   
   return [self handleGetSettings:request];

--- a/WebDriverAgentLib/FBAlert.h
+++ b/WebDriverAgentLib/FBAlert.h
@@ -33,6 +33,11 @@ extern NSString *const FBAlertObstructingElementException;
 + (instancetype)alertWithApplication:(XCUIApplication *)application;
 
 /**
+ Creates alert helper for the given element
+ */
++ (instancetype)alertWithElement:(XCUIElement *)element;
+
+/**
  Determines whether alert is present
  */
 - (BOOL)isPresent;

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -65,7 +65,8 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
 @end
 
 @interface FBAlert ()
-@property (nonatomic, strong) XCUIApplication *application;
+@property (nonatomic, strong, nullable) XCUIApplication *application;
+@property (nonatomic, strong, nullable) XCUIElement *element;
 @end
 
 @implementation FBAlert
@@ -79,6 +80,15 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
 {
   FBAlert *alert = [FBAlert new];
   alert.application = application;
+  alert.element = nil;
+  return alert;
+}
+
++ (instancetype)alertWithElement:(XCUIElement *)element
+{
+  FBAlert *alert = [FBAlert new];
+  alert.application = nil;
+  alert.element = element;
   return alert;
 }
 
@@ -248,8 +258,14 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
 
 - (XCUIElement *)alertElement
 {
-  XCUIElement *alert = self.application.fb_alertElement ?: [FBSpringboardApplication fb_springboard].fb_alertElement;
-  if (!alert.exists) {
+  XCUIElement *alert = nil;
+  if (nil != self.element) {
+    alert = self.element;
+  }
+  if (nil != self.application) {
+    alert = self.application.fb_alertElement ?: [FBSpringboardApplication fb_springboard].fb_alertElement;
+  }
+  if (nil == alert || !alert.exists) {
     return nil;
   }
   [alert resolve];

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -12,6 +12,13 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
+ The set of available actions for automated alerts handling
+ */
+extern NSString *const FB_ALERT_ACCEPT_ACTION;
+extern NSString *const FB_ALERT_DISMISS_ACTION;
+extern NSString *const FB_ALERT_NONE_ACTION;
+
+/**
  Accessors for Global Constants.
  */
 @interface FBConfiguration : NSObject
@@ -41,6 +48,10 @@ NS_ASSUME_NONNULL_BEGIN
 /* Use singleton test manager proxy */
 + (void)setShouldUseSingletonTestManager:(BOOL)value;
 + (BOOL)shouldUseSingletonTestManager;
+
+/* Control automatic resposne on UI interruption events */
++ (void)setAutoAlertAction:(NSString *)value;
++ (NSString *)autoAlertAction;
 
 /**
  The range of ports that the HTTP Server should attempt to bind on launch

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -15,12 +15,17 @@
 #import "XCTestPrivateSymbols.h"
 #import "XCElementSnapshot.h"
 
+NSString *const FB_ALERT_ACCEPT_ACTION = @"accept";
+NSString *const FB_ALERT_DISMISS_ACTION = @"dismiss";
+NSString *const FB_ALERT_NONE_ACTION = @"none";
+
 static NSUInteger const DefaultStartingPort = 8100;
 static NSUInteger const DefaultPortRange = 100;
 
 static BOOL FBShouldUseTestManagerForVisibilityDetection = NO;
 static BOOL FBShouldUseSingletonTestManager = YES;
 static BOOL FBShouldUseCompactResponses = YES;
+static NSString *FBAutoAlertAction = FB_ALERT_NONE_ACTION;
 static NSString *FBElementResponseAttributes = @"type,label";
 static NSUInteger FBMaxTypingFrequency = 60;
 
@@ -134,6 +139,16 @@ static NSUInteger FBMaxTypingFrequency = 60;
     return NSMakeRange(NSNotFound, 0);
   }
   return NSMakeRange(port, 1);
+}
+
++ (void)setAutoAlertAction:(NSString *)value
+{
+  FBAutoAlertAction = [value lowercaseString];
+}
+
++ (NSString *)autoAlertAction
+{
+  return FBAutoAlertAction;
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -25,7 +25,7 @@ static NSUInteger const DefaultPortRange = 100;
 static BOOL FBShouldUseTestManagerForVisibilityDetection = NO;
 static BOOL FBShouldUseSingletonTestManager = YES;
 static BOOL FBShouldUseCompactResponses = YES;
-static NSString *FBAutoAlertAction = FB_ALERT_NONE_ACTION;
+static NSString *FBAutoAlertAction = nil;
 static NSString *FBElementResponseAttributes = @"type,label";
 static NSUInteger FBMaxTypingFrequency = 60;
 
@@ -148,7 +148,7 @@ static NSUInteger FBMaxTypingFrequency = 60;
 
 + (NSString *)autoAlertAction
 {
-  return FBAutoAlertAction;
+  return FBAutoAlertAction ?: FB_ALERT_NONE_ACTION;
 }
 
 @end


### PR DESCRIPTION
Automatic alerts handling with XCTest does not work very well, since it is requires to interact with the app in order for the framework to call the UI interruption handler. This should not be a problem for swiping/clicking. Although, an alert is still not going to be handled if we, for example, need to check element presence. 
Anyway I think this is better than nothing.

Some topics on this, which might be interesting:
https://developer.apple.com/documentation/xctest/xctestcase/1496273-adduiinterruptionmonitorwithdesc
https://forums.developer.apple.com/thread/86989
https://stackoverflow.com/questions/32148965/xcode-7-ui-testing-how-to-dismiss-a-series-of-system-alerts-in-code