### PR TITLE
Use self.fb_lastSnapshot every time in fb_tree to get JSON resource

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -43,9 +43,7 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
 - (NSDictionary *)fb_tree
 {
   [self fb_waitUntilSnapshotIsStable];
-  // If getting the snapshot with attributes fails we use the snapshot with lazily initialized attributes
-  XCElementSnapshot *snapshot = self.fb_snapshotWithAttributes ?: self.fb_lastSnapshot;
-  return [self.class dictionaryForElement:snapshot];
+  return [self.class dictionaryForElement:self.fb_lastSnapshot];
 }
 
 - (NSDictionary *)fb_accessibilityTree

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -43,7 +43,25 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
 - (NSDictionary *)fb_tree
 {
   [self fb_waitUntilSnapshotIsStable];
-  return [self.class dictionaryForElement:self.fb_lastSnapshot];
+  XCElementSnapshot *snapshot = self.fb_snapshotWithAttributes;
+
+  if (snapshot) {
+    NSArray<XCElementSnapshot *> *children;
+
+    NSArray<XCUIElement *> *windows = [((XCUIElement *)self) fb_filterDescendantsWithSnapshots:snapshot.children];
+    NSMutableArray<XCElementSnapshot *> *windowsSnapshots = [NSMutableArray array];
+
+    for (XCUIElement* window in windows) {
+      [windowsSnapshots addObject:window.fb_snapshotWithAttributes ?: window.fb_lastSnapshot];
+    }
+
+    children = windowsSnapshots.copy;
+    snapshot.children = children;
+  } else {
+    snapshot = self.fb_lastSnapshot;
+  }
+
+  return [self.class dictionaryForElement:snapshot];
 }
 
 - (NSDictionary *)fb_accessibilityTree


### PR DESCRIPTION
JSON formatted page source returns some wrong attributes like `label` in 1.8.1 and later. It happened frequently in nested elements in my and [some friends'](https://github.com/Magic-Pod/AppiumRegressionCheck/issues/18) case. The _wrong_ means some elements have another element's `label`, `name` and `rect` for example.

After getting rid of `fb_snapshotWithAttributes`, it worked correctly again. (Because calling  `self.fb_lastSnapshot` is the same behaviour in Appium 1.8.0. )
https://gist.github.com/KazuCocoa/019fd52553de320eaba5c3e474db0154 is an example. Each JSON is long though...

The change was introduced to improve the performance. https://github.com/appium/WebDriverAgent/pull/80
I found a comment _fb_tree is only used to get the json source, but the xml one is handled in other place_ in https://github.com/appium/WebDriverAgent/pull/80/files#diff-84f041418d527761840437ef72e34211R47 . And we haven't get any issues about wrong elements or something probably related with https://github.com/appium/WebDriverAgent/pull/80 .

Thus, I think this kind of issue happens only get source x JSON format.

---

Xcode 9.4 and iOS 11

---
[update]

With https://github.com/appium/WebDriverAgent/pull/91/commits/29be5cca906b5bcebcce4a61e12f7ae6f9ba92e2 and https://github.com/appium/WebDriverAgent/pull/91/commits/087adbf4e6be5958bc9fb5c5894960a881bdbde9, I could get the almost same hierarchy. **Almost** means some redundant attributes disappear. It's a good improvement. 👍 
https://gist.github.com/KazuCocoa/019fd52553de320eaba5c3e474db0154#gistcomment-2628446
