### PR TITLE
Apply custom helper for true visibility detection

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -139,6 +139,8 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
 {
   if ([FBConfiguration shouldLoadSnapshotWithAttributes]) {
     NSNumber *isVisible = self.additionalAttributes[FB_XCAXAIsVisibleAttribute];
+    // We can only rely on the system attribute if it is true
+    // Unfortunately, XCTest often sets this attribute to false for elements that are actually visible in the UI
     if (nil != isVisible && isVisible.boolValue) {
       return isVisible.boolValue;
     }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -139,7 +139,7 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
 {
   if ([FBConfiguration shouldLoadSnapshotWithAttributes]) {
     NSNumber *isVisible = self.additionalAttributes[FB_XCAXAIsVisibleAttribute];
-    if (isVisible != nil) {
+    if (nil != isVisible && isVisible.boolValue) {
       return isVisible.boolValue;
     }
   }


### PR DESCRIPTION
It looks like the built-in visibility properly does not always properly returns visibility for elements, which are actually visible in the UI. That is why we also try to apply our pretty custom visibility detection algorithm if "native" visibility of a particular element is falsy.