### PR TITLE
Add bundle identifier in environment argument

### DIFF
--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       systemAttachmentLifetime = "keepNever"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
@@ -48,7 +47,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -68,6 +66,11 @@
          <EnvironmentVariable
             key = "USE_PORT"
             value = "$(USE_PORT)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "WDA_PRODUCT_BUNDLE_IDENTIFIER"
+            value = "$(WDA_PRODUCT_BUNDLE_IDENTIFIER)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       systemAttachmentLifetime = "keepNever"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
@@ -47,6 +48,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -139,7 +139,8 @@
 {
   // For updatedWDABundleId capability by Appium
   NSString *productBundleIdentifier = @"com.facebook.WebDriverAgentRunner";
-  if (NSProcessInfo.processInfo.environment[@"WDA_PRODUCT_BUNDLE_IDENTIFIER"]) {
+  NSString *envproductBundleIdentifier = NSProcessInfo.processInfo.environment[@"WDA_PRODUCT_BUNDLE_IDENTIFIER"];
+  if (envproductBundleIdentifier && ([envproductBundleIdentifier length] != 0)) {
     productBundleIdentifier = NSProcessInfo.processInfo.environment[@"WDA_PRODUCT_BUNDLE_IDENTIFIER"];
   }
 

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -39,7 +39,7 @@
 
     // Health check might modify simulator state so it should only be called in-between testing sessions
     [[FBRoute GET:@"/wda/healthcheck"].withoutSession respondWithTarget:self action:@selector(handleGetHealthCheck:)],
-    
+
     // Settings endpoints
     [[FBRoute GET:@"/appium/settings"] respondWithTarget:self action:@selector(handleGetSettings:)],
     [[FBRoute POST:@"/appium/settings"] respondWithTarget:self action:@selector(handleSetSettings:)],
@@ -137,6 +137,12 @@
 
 + (id<FBResponsePayload>)handleGetStatus:(FBRouteRequest *)request
 {
+  // For updatedWDABundleId capability by Appium
+  NSString *productBundleIdentifier = @"com.facebook.WebDriverAgentRunner";
+  if (NSProcessInfo.processInfo.environment[@"WDA_PRODUCT_BUNDLE_IDENTIFIER"]) {
+    productBundleIdentifier = NSProcessInfo.processInfo.environment[@"WDA_PRODUCT_BUNDLE_IDENTIFIER"];
+  }
+
   return
   FBResponseWithStatus(
     FBCommandStatusNoError,
@@ -156,6 +162,7 @@
       @"build" :
         @{
           @"time" : [self.class buildTimestamp],
+          @"productBundleIdentifier" : productBundleIdentifier,
         },
     }
   );
@@ -184,17 +191,17 @@
 + (id<FBResponsePayload>)handleSetSettings:(FBRouteRequest *)request
 {
   NSDictionary* settings = request.arguments[@"settings"];
-  
+
   if ([settings objectForKey:@"shouldUseCompactResponses"]) {
     BOOL shouldUseCompactResponses = [[settings objectForKey:@"shouldUseCompactResponses"] boolValue];
     [FBConfiguration setShouldUseCompactResponses:shouldUseCompactResponses];
   }
-  
+
   if ([settings objectForKey:@"elementResponseAttributes"]) {
     NSString* elementResponseAttribute = [settings objectForKey:@"elementResponseAttributes"];
     [FBConfiguration setElementResponseAttributes:elementResponseAttribute];
   }
-  
+
   return [self handleGetSettings:request];
 }
 

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -140,7 +140,7 @@
   // For updatedWDABundleId capability by Appium
   NSString *productBundleIdentifier = @"com.facebook.WebDriverAgentRunner";
   NSString *envproductBundleIdentifier = NSProcessInfo.processInfo.environment[@"WDA_PRODUCT_BUNDLE_IDENTIFIER"];
-  if (envproductBundleIdentifier && ([envproductBundleIdentifier length] != 0)) {
+  if (envproductBundleIdentifier && [envproductBundleIdentifier length] != 0) {
     productBundleIdentifier = NSProcessInfo.processInfo.environment[@"WDA_PRODUCT_BUNDLE_IDENTIFIER"];
   }
 


### PR DESCRIPTION
Depends on https://github.com/appium/appium-xcuitest-driver/pull/712#issuecomment-401088068

If WDA gets `WDA_PRODUCT_BUNDLE_IDENTIFIER`  as a process argument, WDA returns it as a parameter of `productBundleIdentifier`.
The status needs for `updatedWDABundleId` capability.