### PR TITLE
Revert "Apply custom helper for true visibility detection"

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -139,9 +139,7 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
 {
   if ([FBConfiguration shouldLoadSnapshotWithAttributes]) {
     NSNumber *isVisible = self.additionalAttributes[FB_XCAXAIsVisibleAttribute];
-    // We can only rely on the system attribute if it is true
-    // Unfortunately, XCTest often sets this attribute to false for elements that are actually visible in the UI
-    if (nil != isVisible && isVisible.boolValue) {
+    if (isVisible != nil) {
       return isVisible.boolValue;
     }
   }


### PR DESCRIPTION
Reverts appium/WebDriverAgent#93

As https://github.com/appium/appium-xcuitest-driver/pull/716#issuecomment-402185201 , this PR will fix the regression.
@imurchie 

But as @mykola-mokhnach said, 

> there are other cases in my application under test where elements, that are actually visible, are detected as invisible.

will happen again... Visibility..

---

📝 
https://github.com/facebook/WebDriverAgent/blob/master/WebDriverAgentLib/Utilities/XCTestPrivateSymbols.m#L24 is the visibility attribute by WDA.
