### PR TITLE
Return an empty text instead of null if an alert contains to text

### DIFF
--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -107,8 +107,8 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
   if (resultText.count) {
     return [resultText componentsJoinedByString:@"\n"];
   }
-  // return null to reflect the fact there is an alert, but it does not contain any text
-  return (id)[NSNull null];
+  // return an empty string to reflect the fact there is an alert, but it does not contain any text
+  return @"";
 }
 
 - (BOOL)typeText:(NSString *)text error:(NSError **)error


### PR DESCRIPTION
Selenium clients don't expect the returned value there to ever be equal to null, so it would be safer to return an empty string instead.