### PR TITLE
Skip source dumping for elements which cannot be resolved

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -56,6 +56,9 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
 
   for (XCUIElement* child in children) {
     XCElementSnapshot *childSnapshot = child.fb_snapshotWithAttributes ?: child.fb_lastSnapshot;
+    if (nil == childSnapshot) {
+      continue;
+    }
     [childrenTree addObject:[self.class dictionaryForElement:childSnapshot recursive:YES]];
   }
 

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -310,7 +310,12 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
       NSArray<XCUIElement *> *windows = [((XCUIElement *)root) fb_filterDescendantsWithSnapshots:currentSnapshot.children];
       NSMutableArray<XCElementSnapshot *> *windowsSnapshots = [NSMutableArray array];
       for (XCUIElement* window in windows) {
-        [windowsSnapshots addObject:window.fb_snapshotWithAttributes ?: window.fb_lastSnapshot];
+        XCElementSnapshot *windowSnapshot = window.fb_snapshotWithAttributes ?: window.fb_lastSnapshot;
+        if (nil == windowSnapshot) {
+          [FBLogger logFmt:@"Skipping source dumping for %@ because its snapshot cannot be resolved", window.description];
+          continue;
+        }
+        [windowsSnapshots addObject:windowSnapshot];
       }
       children = windowsSnapshots.copy;
     } else {


### PR DESCRIPTION
I saw some exceptions when the returned snapshot was turned to nil. Lets only dump what we can and log an error instead of throwing an exception