### PR TITLE
Return empty string instead of null from handleGetText

### DIFF
--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -112,7 +112,7 @@
   FBElementCache *elementCache = request.session.elementCache;
   XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]];
   id text = FBFirstNonEmptyValue(element.wdValue, element.wdLabel);
-  text = text ?: [NSNull null];
+  text = text ?: @"";
   return FBResponseWithStatus(FBCommandStatusNoError, text);
 }
 


### PR DESCRIPTION
If nothing is retrieved, return an empty string rather than null. Right now, for iOS 10 the value returned for an empty text field is already an empty string, while on iOS 11 it is null.

While it is hard to tell what is right from the spec, the Selenium clients point toward an empty string (for instance, the Java client's [ExpectedConditions .textToBePresentInElement](https://github.com/SeleniumHQ/selenium/blob/selenium-3.5.3/java/client/src/org/openqa/selenium/support/ui/ExpectedConditions.java#L334-L353) function will not work if null is returned).

Cc: @abdullahawara