### PR TITLE
Fix low-level synchronization for the background screenshoting streamer

### DIFF
--- a/PrivateHeaders/XCTest/XCTestManager_ManagerInterface-Protocol.h
+++ b/PrivateHeaders/XCTest/XCTestManager_ManagerInterface-Protocol.h
@@ -6,7 +6,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class NSArray, NSDictionary, NSNumber, NSString, NSUUID, XCAccessibilityElement, XCDeviceEvent, XCSynthesizedEventRecord, XCTouchGesture, NSXPCListenerEndpoint;
+@class NSArray, NSDictionary, NSNumber, NSString, NSUUID, XCAccessibilityElement, XCDeviceEvent, XCSynthesizedEventRecord, XCTouchGesture, NSXPCListenerEndpoint, XCElementSnapshot;
 
 @protocol XCTestManager_ManagerInterface
 - (void)_XCT_loadAccessibilityWithTimeout:(double)arg1 reply:(void (^)(BOOL, NSError *))arg2;
@@ -39,4 +39,8 @@
 - (void)_XCT_requestEndpointForTestTargetWithPID:(int)arg1 preferredBackendPath:(NSString *)arg2 reply:(void (^)(NSXPCListenerEndpoint *, NSError *))arg3;
 - (void)_XCT_requestSocketForSessionIdentifier:(NSUUID *)arg1 reply:(void (^)(NSFileHandle *))arg2;
 - (void)_XCT_exchangeProtocolVersion:(unsigned long long)arg1 reply:(void (^)(unsigned long long))arg2;
+
+// Available since Xcode9
+- (void)_XCT_requestScreenshotOfScreenWithID:(unsigned int)arg1 withRect:(struct CGRect)arg2 uti:(NSString *)arg3 compressionQuality:(double)arg4 withReply:(void (^)(NSData *, NSError *))arg5;
+- (void)_XCT_requestScreenshotOfScreenWithID:(unsigned int)arg1 withRect:(struct CGRect)arg2 withReply:(void (^)(NSData *, NSError *))arg3;
 @end

--- a/WebDriverAgentLib/Utilities/FBMjpegServer.m
+++ b/WebDriverAgentLib/Utilities/FBMjpegServer.m
@@ -17,12 +17,13 @@
 #import "XCTestManager_ManagerInterface-Protocol.h"
 #import "FBXCTestDaemonsProxy.h"
 
-static const NSTimeInterval FPS = 10;
+static const NSUInteger FPS = 10;
 static const NSTimeInterval SCREENSHOT_TIMEOUT = 0.5;
 static const double SCREENSHOT_QUALITY = 0.25;
 
 static NSString *const SERVER_NAME = @"WDA MJPEG Server";
 static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
+
 
 @interface FBMjpegServer()
 
@@ -33,8 +34,8 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
 
 @end
 
-@implementation FBMjpegServer
 
+@implementation FBMjpegServer
 
 - (instancetype)init
 {

--- a/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.m
@@ -32,9 +32,9 @@ static dispatch_once_t onceTestRunnerDaemonClass;
 {
   static id<XCTestManager_ManagerInterface> proxy = nil;
   if ([FBConfiguration shouldUseSingletonTestManager]) {
-    [FBLogger logFmt:@"Using singleton test manager"];
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+      [FBLogger logFmt:@"Using singleton test manager"];
       proxy = [self.class retrieveTestRunnerProxy];
     });
   } else {


### PR DESCRIPTION
The previous implementation was causing unexpected race condition issues when screenshoting stream was running is parallel with tests. Now this should be addressed