### PR TITLE
Use NSProxy as base class for FBApplicationProcessProxy

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		7101820D211E026B002FD3A8 /* libAccessibility.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7101820C211E026B002FD3A8 /* libAccessibility.tbd */; };
 		7101820E211E1E19002FD3A8 /* CocoaAsyncSocket.framework in Copy frameworks */ = {isa = PBXBuildFile; fileRef = 710181F7211DF584002FD3A8 /* CocoaAsyncSocket.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7101820F211E3EC9002FD3A8 /* CocoaAsyncSocket.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 710181F7211DF584002FD3A8 /* CocoaAsyncSocket.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1FC3B2E32121ECF600B61EE0 /* FBApplicationProcessProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FC3B2E12121EC8C00B61EE0 /* FBApplicationProcessProxyTests.m */; };
 		711084441DA3AA7500F913D6 /* FBXPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 711084421DA3AA7500F913D6 /* FBXPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		711084451DA3AA7500F913D6 /* FBXPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 711084431DA3AA7500F913D6 /* FBXPath.m */; };
 		7119E1EC1E891F8600D0B125 /* FBPickerWheelSelectTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7119E1EB1E891F8600D0B125 /* FBPickerWheelSelectTests.m */; };
@@ -438,6 +439,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1FC3B2E12121EC8C00B61EE0 /* FBApplicationProcessProxyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBApplicationProcessProxyTests.m; sourceTree = "<group>"; };
 		1BA7DD8C206D694B007C7C26 /* XCTElementSetTransformer-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTElementSetTransformer-Protocol.h"; sourceTree = "<group>"; };
 		44757A831D42CE8300ECF35E /* XCUIDeviceRotationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCUIDeviceRotationTests.m; sourceTree = "<group>"; };
 		710181F7211DF584002FD3A8 /* CocoaAsyncSocket.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaAsyncSocket.framework; path = Carthage/Build/iOS/CocoaAsyncSocket.framework; sourceTree = "<group>"; };
@@ -1183,6 +1185,7 @@
 			isa = PBXGroup;
 			children = (
 				ADBC39951D07840300327304 /* Doubles */,
+				1FC3B2E12121EC8C00B61EE0 /* FBApplicationProcessProxyTests.m */,
 				71A7EAFB1E229302001DA4F2 /* FBClassChainTests.m */,
 				EEE16E961D33A25500172525 /* FBConfigurationTests.m */,
 				ADBC39931D0782CD00327304 /* FBElementCacheTests.m */,
@@ -1955,6 +1958,7 @@
 				EE3F8CFE1D08AA17006F02CE /* FBRunLoopSpinnerTests.m in Sources */,
 				714801D11FA9D9FA00DC5997 /* FBSDKVersionTests.m in Sources */,
 				EE3F8D001D08B05F006F02CE /* FBElementTypeTransformerTests.m in Sources */,
+				1FC3B2E32121ECF600B61EE0 /* FBApplicationProcessProxyTests.m in Sources */,
 				EEE16E971D33A25500172525 /* FBConfigurationTests.m in Sources */,
 				ADBC39941D0782CD00327304 /* FBElementCacheTests.m in Sources */,
 				719FF5B91DAD21F5008E0099 /* FBElementUtilitiesTests.m in Sources */,

--- a/WebDriverAgentLib/FBApplication.m
+++ b/WebDriverAgentLib/FBApplication.m
@@ -133,7 +133,7 @@
     return;
   }
   XCUIApplicationProcess *applicationProcess = change[NSKeyValueChangeNewKey];
-  if (!applicationProcess || ![applicationProcess isMemberOfClass:XCUIApplicationProcess.class]) {
+  if (!applicationProcess || [applicationProcess isProxy] || ![applicationProcess isMemberOfClass:XCUIApplicationProcess.class]) {
     return;
   }
   [object setValue:[FBApplicationProcessProxy proxyWithApplicationProcess:applicationProcess] forKey:keyPath];

--- a/WebDriverAgentLib/FBApplicationProcessProxy.h
+++ b/WebDriverAgentLib/FBApplicationProcessProxy.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
  Proxy that would forward all calls to it's applicationProcess.
  However it will block call to waitForQuiescence if shouldWaitForQuiescence is set to NO
  */
-@interface FBApplicationProcessProxy : NSObject
+@interface FBApplicationProcessProxy : NSProxy
 
 /**
  Convenience initializer

--- a/WebDriverAgentLib/FBApplicationProcessProxy.m
+++ b/WebDriverAgentLib/FBApplicationProcessProxy.m
@@ -20,10 +20,17 @@
 + (instancetype)proxyWithApplicationProcess:(XCUIApplicationProcess *)applicationProcess
 {
   NSParameterAssert(applicationProcess);
-  FBApplicationProcessProxy *proxy = [self.class new];
+  NSParameterAssert([[applicationProcess class] isEqual:XCUIApplicationProcess.class]);
+  FBApplicationProcessProxy *proxy = [[self.class alloc] init];
   proxy.applicationProcess = applicationProcess;
   return proxy;
 }
+
+- (instancetype)init {
+  return self;
+}
+
+#pragma mark - Override XCUIApplicationProcess methods
 
 - (void)waitForQuiescence
 {
@@ -45,9 +52,16 @@
   [self.applicationProcess waitForQuiescenceIncludingAnimationsIdle:includeAnimations];
 }
 
-- (id)forwardingTargetForSelector:(SEL)aSelector
+#pragma mark - Forward not implemented methods to applicationProcess
+
+- (void)forwardInvocation:(NSInvocation *)invocation
 {
-  return self.applicationProcess;
+  [invocation invokeWithTarget:self.applicationProcess];
+}
+
+- (nullable NSMethodSignature *)methodSignatureForSelector:(SEL)sel
+{
+  return [self.applicationProcess methodSignatureForSelector:sel];
 }
 
 @end

--- a/WebDriverAgentTests/UnitTests/FBApplicationProcessProxyTests.m
+++ b/WebDriverAgentTests/UnitTests/FBApplicationProcessProxyTests.m
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+#import "FBApplicationProcessProxy.h"
+#import "XCUIApplicationProcess.h"
+
+@interface FBApplicationProcessProxy (NonProxiedMethod)
+- (void)objectsMethod;
+@end
+
+@implementation FBApplicationProcessProxy (NonProxiedMethod)
+
+- (void)objectsMethod
+{
+  // intentionally empty
+}
+
+@end
+
+@interface FBApplicationProcessProxy (ProxiedMethod)
+- (NSInteger)proxiedMethod;
+@end
+
+@interface XCUIApplicationProcess (TestableMethods)
+- (void)objectsMethod;
+- (int)proxiedMethod;
+@end
+
+@implementation XCUIApplicationProcess (TestableMethods)
+
+- (int)proxiedMethod;
+{
+  return 1;
+}
+
+- (void)objectsMethod
+{
+  NSString *errorMessage = [NSString stringWithFormat:@"Method %@ must NOT be proxied", NSStringFromSelector(_cmd)];
+  NSException * exception = [[NSException alloc] initWithName:@"Test failed" reason:errorMessage userInfo:nil];
+  [exception raise];
+}
+
+@end
+
+@interface FBApplicationProcessProxyTest : XCTestCase
+
+@end
+
+@implementation FBApplicationProcessProxyTest
+
+- (void)testMethodCallIsProxied {
+  XCUIApplicationProcess *applicationProcess = [[XCUIApplicationProcess alloc] init];
+  FBApplicationProcessProxy *proxy = [FBApplicationProcessProxy proxyWithApplicationProcess:applicationProcess];
+  XCTAssertEqual([proxy proxiedMethod], 1);
+}
+
+- (void)testMethodCallIsNotProxied {
+  XCUIApplicationProcess *applicationProcess = [[XCUIApplicationProcess alloc] init];
+  FBApplicationProcessProxy *proxy = [FBApplicationProcessProxy proxyWithApplicationProcess:applicationProcess];
+  XCTAssertNoThrow([proxy objectsMethod]);
+}
+
+- (void)testProxyIsProxy {
+  XCUIApplicationProcess *applicationProcess = [[XCUIApplicationProcess alloc] init];
+  FBApplicationProcessProxy *proxy = [FBApplicationProcessProxy proxyWithApplicationProcess:applicationProcess];
+  XCTAssertTrue([proxy isProxy]);
+}
+
+- (void)testAssertProxyObjectParameter {
+  XCUIApplicationProcess *applicationProcess = [[XCUIApplicationProcess alloc] init];
+  id proxy = (id)[FBApplicationProcessProxy proxyWithApplicationProcess:applicationProcess];
+  XCTAssertThrows([FBApplicationProcessProxy proxyWithApplicationProcess:proxy]);
+}
+
+@end


### PR DESCRIPTION
Allows to forward NSKeyValueObserverRegistration methods.

Fixes issue [#975](https://github.com/facebook/WebDriverAgent/issues/975) (Facebook's original fork) — Allows to work with Xcode 10 beta 5 and beta 6.

Tested for Xcode 9.4.1 as well

(this PR is cherry-pick of [PR 979](https://github.com/facebook/WebDriverAgent/pull/979) to Facebook's WebDriverAgent fork