### PR TITLE
Faster invocation forwarding by FBApplicationProcessProxy

### DIFF
--- a/WebDriverAgentLib/FBApplicationProcessProxy.m
+++ b/WebDriverAgentLib/FBApplicationProcessProxy.m
@@ -54,6 +54,11 @@
 
 #pragma mark - Forward not implemented methods to applicationProcess
 
+- (id)forwardingTargetForSelector:(SEL)aSelector
+{
+  return self.applicationProcess;
+}
+
 - (void)forwardInvocation:(NSInvocation *)invocation
 {
   [invocation invokeWithTarget:self.applicationProcess];

--- a/WebDriverAgentLib/FBApplicationProcessProxy.m
+++ b/WebDriverAgentLib/FBApplicationProcessProxy.m
@@ -59,11 +59,6 @@
   return self.applicationProcess;
 }
 
-- (void)forwardInvocation:(NSInvocation *)invocation
-{
-  [invocation invokeWithTarget:self.applicationProcess];
-}
-
 - (nullable NSMethodSignature *)methodSignatureForSelector:(SEL)sel
 {
   return [self.applicationProcess methodSignatureForSelector:sel];


### PR DESCRIPTION
According to [Apple's documentation](https://developer.apple.com/documentation/objectivec/nsobject/1418855-forwardingtargetforselector#discussion), 
forwarding messages via ```- (void)forwardInvocation:(NSInvocation *)invocation```
is slower than ```- (id)forwardingTargetForSelector:(SEL)aSelector```

Here are results of small benchmark

| forwarding method | time for 1 million forward iterations |
| ------------------- | ---------------- |
| ```- (void)forwardInvocation:(NSInvocation *)invocation``` | **2.75** seconds |
| ```- (id)forwardingTargetForSelector:(SEL)aSelector``` | **0.029** seconds |