### PR TITLE
Update the caching logic

### DIFF
--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
@@ -71,8 +71,8 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "COMMIT_HASH"
-            value = "$(COMMIT_HASH)"
+            key = "UPGRADE_TIMESTAMP"
+            value = "$(UPGRADE_TIMESTAMP)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -153,9 +153,9 @@
     @"time" : [self.class buildTimestamp],
     @"productBundleIdentifier" : productBundleIdentifier,
   }];
-  NSString *commitHash = NSProcessInfo.processInfo.environment[@"COMMIT_HASH"];
-  if (nil != commitHash && commitHash.length > 0) {
-    [buildInfo setObject:commitHash forKey:@"commitHash"];
+  NSString *upgradeTimestamp = NSProcessInfo.processInfo.environment[@"UPGRADE_TIMESTAMP"];
+  if (nil != upgradeTimestamp && upgradeTimestamp.length > 0) {
+    [buildInfo setObject:upgradeTimestamp forKey:@"upgraded"];
   }
 
   return

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -155,7 +155,7 @@
   }];
   NSString *upgradeTimestamp = NSProcessInfo.processInfo.environment[@"UPGRADE_TIMESTAMP"];
   if (nil != upgradeTimestamp && upgradeTimestamp.length > 0) {
-    [buildInfo setObject:upgradeTimestamp forKey:@"upgraded"];
+    [buildInfo setObject:upgradeTimestamp forKey:@"upgraded_at"];
   }
 
   return


### PR DESCRIPTION
Instead of detecting whether WDA is cached based on commit hash, which is not so easy to retrieve we will be doing that based on carthage resolution timestamp, as we know we only need to refresh these dependencies as soon as a new appium module version is downloaded, so the timestamp for the same module version will always be the same.