### PR TITLE
Make sure we are broadcasting screenshots in JPEG format

### DIFF
--- a/WebDriverAgentLib/Utilities/FBMjpegServer.m
+++ b/WebDriverAgentLib/Utilities/FBMjpegServer.m
@@ -68,7 +68,7 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
     magicStartData = [NSData dataWithBytesNoCopy:(void*)magic length:magicLen freeWhenDone:NO];
   });
 
-  NSRange range = [data rangeOfData:magicStartData options:0 range:NSMakeRange(0, magicLen)];
+  NSRange range = [data rangeOfData:magicStartData options:kNilOptions range:NSMakeRange(0, magicLen)];
   return range.location != NSNotFound;
 }
 

--- a/WebDriverAgentLib/Utilities/FBMjpegServer.m
+++ b/WebDriverAgentLib/Utilities/FBMjpegServer.m
@@ -68,7 +68,10 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
     magicStartData = [NSData dataWithBytesNoCopy:(void*)magic length:magicLen freeWhenDone:NO];
   });
 
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wassign-enum"
   NSRange range = [data rangeOfData:magicStartData options:kNilOptions range:NSMakeRange(0, magicLen)];
+  #pragma clang diagnostic pop
   return range.location != NSNotFound;
 }
 


### PR DESCRIPTION
This resolves as issue when it was not possible to record video on some real devices because XCTest was providing PNG screenshots instead of JPEG