### PR TITLE
Add required method implementation NSProxy forwardInvocation

### DIFF
--- a/WebDriverAgentLib/FBApplicationProcessProxy.m
+++ b/WebDriverAgentLib/FBApplicationProcessProxy.m
@@ -64,4 +64,9 @@
   return [self.applicationProcess methodSignatureForSelector:sel];
 }
 
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+  [anInvocation setTarget:self.applicationProcess];
+  [anInvocation invoke];
+}
 @end


### PR DESCRIPTION
Fixes the ```[NSProxy forwardInvocation:] called!``` error when creating a session.

Appium's bug https://github.com/appium/appium/issues/11397