### PR TITLE
Make sure the returned screenshot is always in PNG format

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		7140974C1FAE1B51008FB2C5 /* FBW3CActionsSynthesizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7140974A1FAE1B51008FB2C5 /* FBW3CActionsSynthesizer.m */; };
 		7140974E1FAE20EE008FB2C5 /* FBBaseActionsSynthesizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7140974D1FAE20EE008FB2C5 /* FBBaseActionsSynthesizer.m */; };
 		714801D11FA9D9FA00DC5997 /* FBSDKVersionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 714801D01FA9D9FA00DC5997 /* FBSDKVersionTests.m */; };
+		7150348721A6DAD600A0F4BA /* FBImageUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 7150348521A6DAD600A0F4BA /* FBImageUtils.h */; };
+		7150348821A6DAD600A0F4BA /* FBImageUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 7150348621A6DAD600A0F4BA /* FBImageUtils.m */; };
 		7152EB301F41F9960047EEFF /* FBSessionIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7152EB2F1F41F9960047EEFF /* FBSessionIntegrationTests.m */; };
 		715557D3211DBCE700613B26 /* FBTCPSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 715557D1211DBCE700613B26 /* FBTCPSocket.h */; };
 		715557D4211DBCE700613B26 /* FBTCPSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 715557D2211DBCE700613B26 /* FBTCPSocket.m */; };
@@ -480,6 +482,8 @@
 		7140974D1FAE20EE008FB2C5 /* FBBaseActionsSynthesizer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBBaseActionsSynthesizer.m; sourceTree = "<group>"; };
 		714801D01FA9D9FA00DC5997 /* FBSDKVersionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKVersionTests.m; sourceTree = "<group>"; };
 		714CA3C61DC23186000F12C9 /* FBXPathIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPathIntegrationTests.m; sourceTree = "<group>"; };
+		7150348521A6DAD600A0F4BA /* FBImageUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBImageUtils.h; sourceTree = "<group>"; };
+		7150348621A6DAD600A0F4BA /* FBImageUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBImageUtils.m; sourceTree = "<group>"; };
 		7152EB2F1F41F9960047EEFF /* FBSessionIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSessionIntegrationTests.m; sourceTree = "<group>"; };
 		715557D1211DBCE700613B26 /* FBTCPSocket.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBTCPSocket.h; sourceTree = "<group>"; };
 		715557D2211DBCE700613B26 /* FBTCPSocket.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBTCPSocket.m; sourceTree = "<group>"; };
@@ -1120,6 +1124,8 @@
 				EE3A18611CDE618F00DE4205 /* FBErrorBuilder.m */,
 				EE6A89381D0B38640083E92B /* FBFailureProofTestCase.h */,
 				EE6A89391D0B38640083E92B /* FBFailureProofTestCase.m */,
+				7150348521A6DAD600A0F4BA /* FBImageUtils.h */,
+				7150348621A6DAD600A0F4BA /* FBImageUtils.m */,
 				EE9B76A31CF7A43900275851 /* FBLogger.h */,
 				EE9B76A41CF7A43900275851 /* FBLogger.m */,
 				EE9B76A51CF7A43900275851 /* FBMacros.h */,
@@ -1598,6 +1604,7 @@
 				EE35AD2A1E3B77D600A02D78 /* XCDebugLogDelegate-Protocol.h in Headers */,
 				EE35AD1C1E3B77D600A02D78 /* NSString-XCTAdditions.h in Headers */,
 				EE35AD581E3B77D600A02D78 /* XCTestWaiter.h in Headers */,
+				7150348721A6DAD600A0F4BA /* FBImageUtils.h in Headers */,
 				EE35AD1D1E3B77D600A02D78 /* NSValue-XCTestAdditions.h in Headers */,
 				EE35AD141E3B77D600A02D78 /* _XCTWaiterImpl.h in Headers */,
 				EE9B76A81CF7A43900275851 /* FBLogger.h in Headers */,
@@ -1928,6 +1935,7 @@
 				EE6B64FE1D0F86EF00E85F5D /* XCTestPrivateSymbols.m in Sources */,
 				AD76723E1D6B7CC000610457 /* XCUIElement+FBTyping.m in Sources */,
 				EE158AAF1CBD456F00A3E3F0 /* XCUIElement+FBAccessibility.m in Sources */,
+				7150348821A6DAD600A0F4BA /* FBImageUtils.m in Sources */,
 				EE158AE51CBD456F00A3E3F0 /* FBSession.m in Sources */,
 				EE158AC11CBD456F00A3E3F0 /* FBFindElementCommands.m in Sources */,
 				EE7E271D1D06C69F001BEC7B /* FBDebugLogDelegateDecorator.m in Sources */,

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -105,7 +105,12 @@ static bool fb_isLocked;
 
 - (NSData *)fb_screenshotWithError:(NSError*__autoreleasing*)error
 {
-  return [self fb_rawScreenshotWithQuality:FBConfiguration.screenshotQuality rect:CGRectNull error:error];
+  NSData* screenshotData = [self fb_rawScreenshotWithQuality:FBConfiguration.screenshotQuality rect:CGRectNull error:error];
+  if (nil == screenshotData) {
+    return nil;
+  }
+  UIImage *image = [UIImage imageWithData:screenshotData];
+  return (NSData *)UIImagePNGRepresentation(image);
 }
 
 - (NSData *)fb_rawScreenshotWithQuality:(NSUInteger)quality rect:(CGRect)rect error:(NSError*__autoreleasing*)error

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -110,11 +110,7 @@ static bool fb_isLocked;
   if (nil == screenshotData) {
     return nil;
   }
-  if (FBIsPngImage(screenshotData)) {
-    return screenshotData;
-  }
-  UIImage *image = [UIImage imageWithData:screenshotData];
-  return (NSData *)UIImagePNGRepresentation(image);
+  return FBAdjustScreenshotOrientationForApplication(screenshotData, FBApplication.fb_activeApplication.interfaceOrientation);
 }
 
 - (NSData *)fb_rawScreenshotWithQuality:(NSUInteger)quality rect:(CGRect)rect error:(NSError*__autoreleasing*)error

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -16,6 +16,7 @@
 
 #import "FBSpringboardApplication.h"
 #import "FBErrorBuilder.h"
+#import "FBImageUtils.h"
 #import "FBMacros.h"
 #import "FBMathUtils.h"
 #import "FBXCodeCompatibility.h"
@@ -108,6 +109,9 @@ static bool fb_isLocked;
   NSData* screenshotData = [self fb_rawScreenshotWithQuality:FBConfiguration.screenshotQuality rect:CGRectNull error:error];
   if (nil == screenshotData) {
     return nil;
+  }
+  if (FBIsJpegImage(screenshotData)) {
+    return screenshotData;
   }
   UIImage *image = [UIImage imageWithData:screenshotData];
   return (NSData *)UIImagePNGRepresentation(image);

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -110,7 +110,7 @@ static bool fb_isLocked;
   if (nil == screenshotData) {
     return nil;
   }
-  if (FBIsJpegImage(screenshotData)) {
+  if (FBIsPngImage(screenshotData)) {
     return screenshotData;
   }
   UIImage *image = [UIImage imageWithData:screenshotData];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -13,6 +13,7 @@
 
 #import "FBAlert.h"
 #import "FBLogger.h"
+#import "FBImageUtils.h"
 #import "FBMacros.h"
 #import "FBMathUtils.h"
 #import "FBPredicate.h"

--- a/WebDriverAgentLib/Utilities/FBImageUtils.h
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.h
@@ -7,10 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <XCTest/XcTest.h>
+#import <XCTest/XCTest.h>
 
 /*! Returns YES if the data contains a JPEG image */
 BOOL FBIsJpegImage(NSData *imageData);
+
+/*! Returns YES if the data contains a PNG image */
+BOOL FBIsPngImage(NSData *imageData);
 
 /*! Fixes the screenshot orientation if necessary to match current screen orientation */
 NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIInterfaceOrientation orientation);

--- a/WebDriverAgentLib/Utilities/FBImageUtils.h
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.h
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XcTest.h>
+
+/*! Returns YES if the data contains a JPEG image */
+BOOL FBIsJpegImage(NSData *imageData);
+
+/*! Fixes the screenshot orientation if necessary to match current screen orientation */
+NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIInterfaceOrientation orientation);

--- a/WebDriverAgentLib/Utilities/FBImageUtils.m
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.m
@@ -23,8 +23,8 @@ BOOL FBIsJpegImage(NSData *imageData)
   }
 
   static NSData* jpegMagicStartData = nil;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
+  static dispatch_once_t onceJpegToken;
+  dispatch_once(&onceJpegToken, ^{
     jpegMagicStartData = [NSData dataWithBytesNoCopy:(void*)JPEG_MAGIC length:JPEG_MAGIC_LEN freeWhenDone:NO];
   });
 
@@ -42,8 +42,8 @@ BOOL FBIsPngImage(NSData *imageData)
   }
 
   static NSData* pngMagicStartData = nil;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
+  static dispatch_once_t oncePngToken;
+  dispatch_once(&oncePngToken, ^{
     pngMagicStartData = [NSData dataWithBytesNoCopy:(void*)PNG_MAGIC length:PNG_MAGIC_LEN freeWhenDone:NO];
   });
 

--- a/WebDriverAgentLib/Utilities/FBImageUtils.m
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.m
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBImageUtils.h"
+
+#import "FBMacros.h"
+
+BOOL FBIsJpegImage(NSData *imageData)
+{
+  static const NSUInteger magicLen = 2;
+  if (nil == imageData || [imageData length] < magicLen) {
+    return NO;
+  }
+
+  static NSData* magicStartData = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    static uint8_t magic[] = { 0xff, 0xd8 };
+    magicStartData = [NSData dataWithBytesNoCopy:(void*)magic length:magicLen freeWhenDone:NO];
+  });
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wassign-enum"
+  NSRange range = [imageData rangeOfData:magicStartData options:kNilOptions range:NSMakeRange(0, magicLen)];
+#pragma clang diagnostic pop
+  return range.location != NSNotFound;
+}
+
+NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIInterfaceOrientation orientation)
+{
+  UIImage *image = [UIImage imageWithData:screenshotData];
+  UIImageOrientation imageOrientation;
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+    // In iOS < 11.0 screenshots are already adjusted properly
+    imageOrientation = UIImageOrientationUp;
+  } else if (orientation == UIInterfaceOrientationLandscapeRight) {
+    imageOrientation = UIImageOrientationLeft;
+  } else if (orientation == UIInterfaceOrientationLandscapeLeft) {
+    imageOrientation = UIImageOrientationRight;
+  } else if (orientation == UIInterfaceOrientationPortraitUpsideDown) {
+    imageOrientation = UIImageOrientationDown;
+  } else {
+    return (NSData *)UIImagePNGRepresentation(image);
+  }
+
+  UIGraphicsBeginImageContext(CGSizeMake(image.size.width, image.size.height));
+  [[UIImage imageWithCGImage:(CGImageRef)[image CGImage] scale:1.0 orientation:imageOrientation]
+   drawInRect:CGRectMake(0, 0, image.size.width, image.size.height)];
+  UIImage *fixedImage = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+
+  // The resulting data should be a PNG image
+  return (NSData *)UIImagePNGRepresentation(fixedImage);
+}

--- a/WebDriverAgentLib/Utilities/FBImageUtils.m
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.m
@@ -56,7 +56,6 @@ BOOL FBIsPngImage(NSData *imageData)
 
 NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIInterfaceOrientation orientation)
 {
-  UIImage *image = [UIImage imageWithData:screenshotData];
   UIImageOrientation imageOrientation;
   if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
     // In iOS < 11.0 screenshots are already adjusted properly
@@ -68,9 +67,14 @@ NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIIn
   } else if (orientation == UIInterfaceOrientationPortraitUpsideDown) {
     imageOrientation = UIImageOrientationDown;
   } else {
+    if (FBIsPngImage(screenshotData)) {
+      return screenshotData;
+    }
+    UIImage *image = [UIImage imageWithData:screenshotData];
     return (NSData *)UIImagePNGRepresentation(image);
   }
 
+  UIImage *image = [UIImage imageWithData:screenshotData];
   UIGraphicsBeginImageContext(CGSizeMake(image.size.width, image.size.height));
   [[UIImage imageWithCGImage:(CGImageRef)[image CGImage] scale:1.0 orientation:imageOrientation]
    drawInRect:CGRectMake(0, 0, image.size.width, image.size.height)];

--- a/WebDriverAgentLib/Utilities/FBImageUtils.m
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.m
@@ -11,23 +11,45 @@
 
 #import "FBMacros.h"
 
+static uint8_t JPEG_MAGIC[] = { 0xff, 0xd8 };
+static const NSUInteger JPEG_MAGIC_LEN = 2;
+static uint8_t PNG_MAGIC[] = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+static const NSUInteger PNG_MAGIC_LEN = 8;
+
 BOOL FBIsJpegImage(NSData *imageData)
 {
-  static const NSUInteger magicLen = 2;
-  if (nil == imageData || [imageData length] < magicLen) {
+  if (nil == imageData || [imageData length] < JPEG_MAGIC_LEN) {
     return NO;
   }
 
-  static NSData* magicStartData = nil;
+  static NSData* jpegMagicStartData = nil;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    static uint8_t magic[] = { 0xff, 0xd8 };
-    magicStartData = [NSData dataWithBytesNoCopy:(void*)magic length:magicLen freeWhenDone:NO];
+    jpegMagicStartData = [NSData dataWithBytesNoCopy:(void*)JPEG_MAGIC length:JPEG_MAGIC_LEN freeWhenDone:NO];
   });
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wassign-enum"
-  NSRange range = [imageData rangeOfData:magicStartData options:kNilOptions range:NSMakeRange(0, magicLen)];
+  NSRange range = [imageData rangeOfData:jpegMagicStartData options:kNilOptions range:NSMakeRange(0, JPEG_MAGIC_LEN)];
+#pragma clang diagnostic pop
+  return range.location != NSNotFound;
+}
+
+BOOL FBIsPngImage(NSData *imageData)
+{
+  if (nil == imageData || [imageData length] < PNG_MAGIC_LEN) {
+    return NO;
+  }
+
+  static NSData* pngMagicStartData = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    pngMagicStartData = [NSData dataWithBytesNoCopy:(void*)PNG_MAGIC length:PNG_MAGIC_LEN freeWhenDone:NO];
+  });
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wassign-enum"
+  NSRange range = [imageData rangeOfData:pngMagicStartData options:kNilOptions range:NSMakeRange(0, PNG_MAGIC_LEN)];
 #pragma clang diagnostic pop
   return range.location != NSNotFound;
 }

--- a/WebDriverAgentLib/Utilities/FBMathUtils.h
+++ b/WebDriverAgentLib/Utilities/FBMathUtils.h
@@ -37,8 +37,5 @@ CGPoint FBInvertOffsetForOrientation(CGPoint offset, UIInterfaceOrientation orie
 /*! Inverts size if necessary to match current screen orientation */
 CGSize FBAdjustDimensionsForApplication(CGSize actualSize, UIInterfaceOrientation orientation);
 
-/*! Fixes the screenshot orientation if necessary to match current screen orientation */
-NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIInterfaceOrientation orientation);
-
 /*! Replaces the wdRect dictionary passed as the argument with zero-size wdRect if any of its attributes equal to Infinity */
 NSDictionary<NSString *, NSNumber *> *FBwdRectNoInf(NSDictionary<NSString *, NSNumber *> *wdRect);

--- a/WebDriverAgentLib/Utilities/FBMathUtils.m
+++ b/WebDriverAgentLib/Utilities/FBMathUtils.m
@@ -85,33 +85,6 @@ CGSize FBAdjustDimensionsForApplication(CGSize actualSize, UIInterfaceOrientatio
   return actualSize;
 }
 
-NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIInterfaceOrientation orientation)
-{
-  UIImage *image = [UIImage imageWithData:screenshotData];
-  UIImageOrientation imageOrientation;
-  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
-    // In iOS < 11.0 screenshots are already adjusted properly
-    imageOrientation = UIImageOrientationUp;
-  } else if (orientation == UIInterfaceOrientationLandscapeRight) {
-    imageOrientation = UIImageOrientationLeft;
-  } else if (orientation == UIInterfaceOrientationLandscapeLeft) {
-    imageOrientation = UIImageOrientationRight;
-  } else if (orientation == UIInterfaceOrientationPortraitUpsideDown) {
-    imageOrientation = UIImageOrientationDown;
-  } else {
-    return (NSData *)UIImagePNGRepresentation(image);
-  }
-  
-  UIGraphicsBeginImageContext(CGSizeMake(image.size.width, image.size.height));
-  [[UIImage imageWithCGImage:(CGImageRef)[image CGImage] scale:1.0 orientation:imageOrientation]
-   drawInRect:CGRectMake(0, 0, image.size.width, image.size.height)];
-  UIImage *fixedImage = UIGraphicsGetImageFromCurrentImageContext();
-  UIGraphicsEndImageContext();
-  
-  // The resulting data should be a PNG image
-  return (NSData *)UIImagePNGRepresentation(fixedImage);
-}
-
 NSDictionary<NSString *, NSNumber *> *FBwdRectNoInf(NSDictionary<NSString *, NSNumber *> *wdRect)
 {
   NSMutableDictionary<NSString *, NSNumber *> *result = wdRect.mutableCopy;

--- a/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
@@ -11,6 +11,7 @@
 
 #import "FBApplication.h"
 #import "FBIntegrationTestCase.h"
+#import "FBImageUtils.h"
 #import "FBMacros.h"
 #import "FBTestMacros.h"
 #import "XCUIDevice+FBHelpers.h"
@@ -35,6 +36,7 @@
   NSData *screenshotData = [[XCUIDevice sharedDevice] fb_screenshotWithError:&error];
   XCTAssertNotNil([UIImage imageWithData:screenshotData]);
   XCTAssertNil(error);
+  XCTAssertTrue(FBIsPngImage(screenshotData));
 }
 
 - (void)testWifiAddress


### PR DESCRIPTION
the fb_rawScreenshotWithQuality function may return both screenshots in both PNG and JPEG formats depending on the quality settings. This PR ensures the returned value is always in PNG format