### PR TITLE
Changed fb_framelessFuzzyMatchesElement implementation to non payload…

### DIFF
--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -57,9 +57,16 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
   return (id __nonnull)attributesResult[attribute];
 }
 
+inline static BOOL valuesAreEqual(id value1, id value2);
+
 - (BOOL)fb_framelessFuzzyMatchesElement:(XCElementSnapshot *)snapshot
 {
-  return [self.wdUID isEqualToString:snapshot.wdUID];
+  return self.elementType == snapshot.elementType &&
+  valuesAreEqual(self.identifier, snapshot.identifier) &&
+  valuesAreEqual(self.title, snapshot.title) &&
+  valuesAreEqual(self.label, snapshot.label) &&
+  valuesAreEqual(self.value, snapshot.value) &&
+  valuesAreEqual(self.placeholderValue, snapshot.placeholderValue);
 }
 
 - (NSArray<XCElementSnapshot *> *)fb_descendantsCellSnapshots
@@ -113,4 +120,9 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
    }
   }
   return NO;
+}
+
+inline static BOOL valuesAreEqual(id value1, id value2)
+{
+  return value1 == value2 || [value1 isEqual:value2];
 }

--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -63,15 +63,18 @@ inline static BOOL isNilOrEmpty(id value);
 
 - (BOOL)fb_framelessFuzzyMatchesElement:(XCElementSnapshot *)snapshot
 {
+    // Pure payload-based comparison sometimes yield false negatives, therefore relying on it only if all of the identifying properties are blank
   if (isNilOrEmpty(self.identifier) && isNilOrEmpty(self.title) && isNilOrEmpty(self.label) &&
-      isNilOrEmpty(self.value) && isNilOrEmpty(self.placeholderValue))
+      isNilOrEmpty(self.value) && isNilOrEmpty(self.placeholderValue)) {
     return [self.wdUID isEqualToString:snapshot.wdUID];
+  }
+  
   return self.elementType == snapshot.elementType &&
-  valuesAreEqual(self.identifier, snapshot.identifier) &&
-  valuesAreEqual(self.title, snapshot.title) &&
-  valuesAreEqual(self.label, snapshot.label) &&
-  valuesAreEqual(self.value, snapshot.value) &&
-  valuesAreEqual(self.placeholderValue, snapshot.placeholderValue);
+    valuesAreEqual(self.identifier, snapshot.identifier) &&
+    valuesAreEqual(self.title, snapshot.title) &&
+    valuesAreEqual(self.label, snapshot.label) &&
+    valuesAreEqual(self.value, snapshot.value) &&
+    valuesAreEqual(self.placeholderValue, snapshot.placeholderValue);
 }
 
 - (NSArray<XCElementSnapshot *> *)fb_descendantsCellSnapshots
@@ -134,7 +137,8 @@ inline static BOOL valuesAreEqual(id value1, id value2)
 
 inline static BOOL isNilOrEmpty(id value)
 {
-  if ([value respondsToSelector:@selector(length)])
-    return [(NSData*)value length] == 0;
+  if ([value isKindOfClass:NSClassFromString(@"NSString")]) {
+    return [(NSString*)value length] == 0;
+  }
   return value == nil;
 }

--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -59,8 +59,13 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
 
 inline static BOOL valuesAreEqual(id value1, id value2);
 
+inline static BOOL isNilOrEmpty(id value);
+
 - (BOOL)fb_framelessFuzzyMatchesElement:(XCElementSnapshot *)snapshot
 {
+  if (isNilOrEmpty(self.identifier) && isNilOrEmpty(self.title) && isNilOrEmpty(self.label) &&
+      isNilOrEmpty(self.value) && isNilOrEmpty(self.placeholderValue))
+    return [self.wdUID isEqualToString:snapshot.wdUID];
   return self.elementType == snapshot.elementType &&
   valuesAreEqual(self.identifier, snapshot.identifier) &&
   valuesAreEqual(self.title, snapshot.title) &&
@@ -125,4 +130,11 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
 inline static BOOL valuesAreEqual(id value1, id value2)
 {
   return value1 == value2 || [value1 isEqual:value2];
+}
+
+inline static BOOL isNilOrEmpty(id value)
+{
+  if ([value respondsToSelector:@selector(length)])
+    return [(NSData*)value length] == 0;
+  return value == nil;
 }

--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -137,7 +137,7 @@ inline static BOOL valuesAreEqual(id value1, id value2)
 
 inline static BOOL isNilOrEmpty(id value)
 {
-  if ([value isKindOfClass:NSClassFromString(@"NSString")]) {
+  if ([value isKindOfClass:NSString.class]) {
     return [(NSString*)value length] == 0;
   }
   return value == nil;

--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -63,17 +63,15 @@ inline static BOOL isNilOrEmpty(id value);
 
 - (BOOL)fb_framelessFuzzyMatchesElement:(XCElementSnapshot *)snapshot
 {
-  // Pure payload-based comparison sometimes yield false negatives, therefore relying on it only if all of the identifying properties are blank
   if (isNilOrEmpty(self.identifier) && isNilOrEmpty(self.title) && isNilOrEmpty(self.label) &&
-      isNilOrEmpty(self.value) && isNilOrEmpty(self.placeholderValue)) {
+      isNilOrEmpty(self.value) && isNilOrEmpty(self.placeholderValue))
     return [self.wdUID isEqualToString:snapshot.wdUID];
-  }
   return self.elementType == snapshot.elementType &&
-    valuesAreEqual(self.identifier, snapshot.identifier) &&
-    valuesAreEqual(self.title, snapshot.title) &&
-    valuesAreEqual(self.label, snapshot.label) &&
-    valuesAreEqual(self.value, snapshot.value) &&
-    valuesAreEqual(self.placeholderValue, snapshot.placeholderValue);
+  valuesAreEqual(self.identifier, snapshot.identifier) &&
+  valuesAreEqual(self.title, snapshot.title) &&
+  valuesAreEqual(self.label, snapshot.label) &&
+  valuesAreEqual(self.value, snapshot.value) &&
+  valuesAreEqual(self.placeholderValue, snapshot.placeholderValue);
 }
 
 - (NSArray<XCElementSnapshot *> *)fb_descendantsCellSnapshots
@@ -137,6 +135,6 @@ inline static BOOL valuesAreEqual(id value1, id value2)
 inline static BOOL isNilOrEmpty(id value)
 {
   if ([value respondsToSelector:@selector(length)])
-    return [value performSelector:@selector(length)] == 0;
+    return [(NSData*)value length] == 0;
   return value == nil;
 }

--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -63,15 +63,17 @@ inline static BOOL isNilOrEmpty(id value);
 
 - (BOOL)fb_framelessFuzzyMatchesElement:(XCElementSnapshot *)snapshot
 {
+  // Pure payload-based comparison sometimes yield false negatives, therefore relying on it only if all of the identifying properties are blank
   if (isNilOrEmpty(self.identifier) && isNilOrEmpty(self.title) && isNilOrEmpty(self.label) &&
-      isNilOrEmpty(self.value) && isNilOrEmpty(self.placeholderValue))
+      isNilOrEmpty(self.value) && isNilOrEmpty(self.placeholderValue)) {
     return [self.wdUID isEqualToString:snapshot.wdUID];
+  }
   return self.elementType == snapshot.elementType &&
-  valuesAreEqual(self.identifier, snapshot.identifier) &&
-  valuesAreEqual(self.title, snapshot.title) &&
-  valuesAreEqual(self.label, snapshot.label) &&
-  valuesAreEqual(self.value, snapshot.value) &&
-  valuesAreEqual(self.placeholderValue, snapshot.placeholderValue);
+    valuesAreEqual(self.identifier, snapshot.identifier) &&
+    valuesAreEqual(self.title, snapshot.title) &&
+    valuesAreEqual(self.label, snapshot.label) &&
+    valuesAreEqual(self.value, snapshot.value) &&
+    valuesAreEqual(self.placeholderValue, snapshot.placeholderValue);
 }
 
 - (NSArray<XCElementSnapshot *> *)fb_descendantsCellSnapshots
@@ -135,6 +137,6 @@ inline static BOOL valuesAreEqual(id value1, id value2)
 inline static BOOL isNilOrEmpty(id value)
 {
   if ([value respondsToSelector:@selector(length)])
-    return [(NSData*)value length] == 0;
+    return [value performSelector:@selector(length)] == 0;
   return value == nil;
 }


### PR DESCRIPTION
… based due to scrolling regression

It appears as if in some instances the recently merged payload-based snapshot comparison method does not return the correct results required for scrolling in TableViews (https://github.com/facebook/WebDriverAgent/pull/879).

From what I saw, sometimes the extracted payload values of the matching snapshot does not match the one of the original XCUIElement, and thus the calculated UID does not match and the scrolling does not stop at the required location.

This PR reverts the fb_framelessFuzzyMatchesElement method to the previous property-based comparison implementation.