### PR TITLE
iOS 9.3 crashes when calling `_XCT_setAXTimeout:`

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -147,17 +147,15 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
   __block NSError *innerError = nil;
   id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
   dispatch_semaphore_t sem = dispatch_semaphore_create(0);
-  [proxy _XCT_setAXTimeout:AX_TIMEOUT reply:^(int res) {
-    [proxy _XCT_requestElementAtPoint:point
-                                reply:^(XCAccessibilityElement *element, NSError *error) {
-      if (nil == error) {
-        result = element;
-      } else {
-        innerError = error;
-      }
-      dispatch_semaphore_signal(sem);
-    }];
-  }];
+  [proxy _XCT_requestElementAtPoint:point
+                              reply:^(XCAccessibilityElement *element, NSError *error) {
+                                if (nil == error) {
+                                  result = element;
+                                } else {
+                                  innerError = error;
+                                }
+                                dispatch_semaphore_signal(sem);
+                              }];
   dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(AX_TIMEOUT * NSEC_PER_SEC)));
   if (nil != innerError) {
     [FBLogger logFmt:@"Cannot get the accessibility element for the point where %@ snapshot is located. Original error: '%@'", innerError.description, self.description];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -147,14 +147,18 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber 
   __block NSError *innerError = nil;
   id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
   dispatch_semaphore_t sem = dispatch_semaphore_create(0);
-  [proxy _XCT_requestElementAtPoint:point
-                              reply:^(XCAccessibilityElement *element, NSError *error) {
-                                if (nil == error) {
-                                  result = element;
-                                } else {
-                                  innerError = error;
-                                }
-                                dispatch_semaphore_signal(sem);
+  [FBXCTestDaemonsProxy tryToSetAxTimeout:AX_TIMEOUT
+                                 forProxy:proxy
+                              withHandler:^(int res) {
+                                [proxy _XCT_requestElementAtPoint:point
+                                                            reply:^(XCAccessibilityElement *element, NSError *error) {
+                                                              if (nil == error) {
+                                                                result = element;
+                                                              } else {
+                                                                innerError = error;
+                                                              }
+                                                              dispatch_semaphore_signal(sem);
+                                                            }];
                               }];
   dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(AX_TIMEOUT * NSEC_PER_SEC)));
   if (nil != innerError) {

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -119,17 +119,21 @@ static const NSTimeInterval AX_TIMEOUT = 15.;
   __block NSError *innerError = nil;
   id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
   dispatch_semaphore_t sem = dispatch_semaphore_create(0);
-  [proxy _XCT_snapshotForElement:self.lastSnapshot.accessibilityElement
-                      attributes:axAttributes
-                      parameters:defaultParameters
-                           reply:^(XCElementSnapshot *snapshot, NSError *error) {
-                             if (nil == error) {
-                               snapshotWithAttributes = snapshot;
-                             } else {
-                               innerError = error;
-                             }
-                             dispatch_semaphore_signal(sem);
-                           }];
+  [FBXCTestDaemonsProxy tryToSetAxTimeout:AX_TIMEOUT
+                                 forProxy:proxy
+                              withHandler:^(int res) {
+                                [proxy _XCT_snapshotForElement:self.lastSnapshot.accessibilityElement
+                                                    attributes:axAttributes
+                                                    parameters:defaultParameters
+                                                         reply:^(XCElementSnapshot *snapshot, NSError *error) {
+                                                           if (nil == error) {
+                                                             snapshotWithAttributes = snapshot;
+                                                           } else {
+                                                             innerError = error;
+                                                           }
+                                                           dispatch_semaphore_signal(sem);
+                                                         }];
+                              }];
   dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(AX_TIMEOUT * NSEC_PER_SEC)));
   if (nil == snapshotWithAttributes) {
     [FBLogger logFmt:@"Getting the snapshot timed out after %@ seconds", @(AX_TIMEOUT)];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -119,19 +119,17 @@ static const NSTimeInterval AX_TIMEOUT = 15.;
   __block NSError *innerError = nil;
   id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
   dispatch_semaphore_t sem = dispatch_semaphore_create(0);
-  [proxy _XCT_setAXTimeout:AX_TIMEOUT reply:^(int res) {
-    [proxy _XCT_snapshotForElement:self.lastSnapshot.accessibilityElement
-                        attributes:axAttributes
-                        parameters:defaultParameters
-                             reply:^(XCElementSnapshot *snapshot, NSError *error) {
-                               if (nil == error) {
-                                 snapshotWithAttributes = snapshot;
-                               } else {
-                                 innerError = error;
-                               }
-                               dispatch_semaphore_signal(sem);
-                             }];
-  }];
+  [proxy _XCT_snapshotForElement:self.lastSnapshot.accessibilityElement
+                      attributes:axAttributes
+                      parameters:defaultParameters
+                           reply:^(XCElementSnapshot *snapshot, NSError *error) {
+                             if (nil == error) {
+                               snapshotWithAttributes = snapshot;
+                             } else {
+                               innerError = error;
+                             }
+                             dispatch_semaphore_signal(sem);
+                           }];
   dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(AX_TIMEOUT * NSEC_PER_SEC)));
   if (nil == snapshotWithAttributes) {
     [FBLogger logFmt:@"Getting the snapshot timed out after %@ seconds", @(AX_TIMEOUT)];

--- a/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.h
+++ b/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.h
@@ -26,6 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)synthesizeEventWithRecord:(XCSynthesizedEventRecord *)record error:(NSError *__autoreleasing*)error;
 
++ (void)tryToSetAxTimeout:(double)timeout forProxy:(id<XCTestManager_ManagerInterface>)proxy withHandler:(void (^)(int res))handler;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.m
@@ -103,10 +103,7 @@ static dispatch_once_t onceTestRunnerDaemonClass;
     return NO;
   }
   id<NSObject> obj = (id<NSObject>)proxy;
-  if (![obj respondsToSelector:@selector(_XCT_setAXTimeout:reply:)]) {
-    return NO;
-  }
-  return YES;
+  return [obj respondsToSelector:@selector(_XCT_setAXTimeout:reply:)];
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.m
@@ -89,4 +89,24 @@ static dispatch_once_t onceTestRunnerDaemonClass;
   return didSucceed;
 }
 
++ (void)tryToSetAxTimeout:(double)timeout forProxy:(id<XCTestManager_ManagerInterface>)proxy withHandler:(void (^)(int res))handler {
+  if ([self canSetAXTimeout:proxy]) {
+    [proxy _XCT_setAXTimeout:timeout
+                       reply:handler];
+    return;
+  }
+  handler(0);
+}
+
++ (BOOL)canSetAXTimeout:(id<XCTestManager_ManagerInterface>)proxy {
+  if (![object_getClass(proxy) conformsToProtocol:@protocol(NSObject)]) {
+    return NO;
+  }
+  id<NSObject> obj = (id<NSObject>)proxy;
+  if (![obj respondsToSelector:@selector(_XCT_setAXTimeout:reply:)]) {
+    return NO;
+  }
+  return YES;
+}
+
 @end


### PR DESCRIPTION
### Problem
Sessions on iOS 9.3 devices could not be started anymore. Appium returns a `Appium did not get any response from 'getScreenInfo' command` error.
It seems like this also happens on simulators and it's caused by the call to `_XCT_setAXTimeout:`. Since there's also the semaphore that times out it looks like the AX timeout isn't strictly necessary.

### Steps to reproduce
1. Start a new session on an iOS 9.3 simulator
2. Call `GET /wda/screen` on that session

