### PR TITLE
Make screenshots for MJPEG stream in the background thread

### DIFF
--- a/WebDriverAgentLib/Utilities/FBMjpegServer.m
+++ b/WebDriverAgentLib/Utilities/FBMjpegServer.m
@@ -28,10 +28,8 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
 
 @interface FBMjpegServer()
 
-@property (nonatomic) NSTimer *mainTimer;
 @property (nonatomic) dispatch_queue_t backgroundQueue;
 @property (nonatomic) NSMutableArray<GCDAsyncSocket *> *activeClients;
-@property (nonatomic) NSUInteger currentFramerate;
 
 @end
 
@@ -43,37 +41,28 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
   if ((self = [super init])) {
     _activeClients = [NSMutableArray array];
     _backgroundQueue = dispatch_queue_create(QUEUE_NAME, DISPATCH_QUEUE_SERIAL);
-    if (![self.class canStreamScreenshots]) {
-      [FBLogger log:@"MJPEG server cannot start because the current iOS version is not supported"];
-      return self;
-    }
-    [self resetTimer:FBConfiguration.mjpegServerFramerate];
+    dispatch_async(_backgroundQueue, ^{
+      [self streamScreenshot];
+    });
   }
   return self;
 }
 
-- (void)resetTimer:(NSUInteger)framerate
-{
-  if (self.mainTimer && self.mainTimer.valid) {
-    [self.mainTimer invalidate];
-  }
-  self.currentFramerate = framerate;
-  NSTimeInterval timerInterval = 1.0 / ((0 == framerate || framerate > MAX_FPS) ? MAX_FPS : framerate);
-  self.mainTimer = [NSTimer scheduledTimerWithTimeInterval:timerInterval
-                                                   repeats:YES
-                                                     block:^(NSTimer * _Nonnull timer) {
-                                                       if (self.currentFramerate == FBConfiguration.mjpegServerFramerate) {
-                                                         [self streamScreenshot];
-                                                       } else {
-                                                         [self resetTimer:FBConfiguration.mjpegServerFramerate];
-                                                       }
-                                                     }];
-}
-
 - (void)streamScreenshot
 {
+  if (![self.class canStreamScreenshots]) {
+    [FBLogger log:@"MJPEG server cannot start because the current iOS version is not supported"];
+    return;
+  }
+
+  NSUInteger framerate = FBConfiguration.mjpegServerFramerate;
+  NSTimeInterval timerInterval = 1.0 / ((0 == framerate || framerate > MAX_FPS) ? MAX_FPS : framerate);
+  int64_t delta = (int64_t)(timerInterval * NSEC_PER_SEC);
   @synchronized (self.activeClients) {
     if (0 == self.activeClients.count) {
+      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delta), self.backgroundQueue, ^{
+        [self streamScreenshot];
+      });
       return;
     }
   }
@@ -87,24 +76,28 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
                                             uti:(__bridge id)kUTTypeJPEG
                              compressionQuality:compressionQuality
                                       withReply:^(NSData *data, NSError *error) {
-      screenshotData = data;
-      dispatch_semaphore_signal(sem);
-                                      }];
+    screenshotData = data;
+    dispatch_semaphore_signal(sem);
+  }];
   dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(SCREENSHOT_TIMEOUT * NSEC_PER_SEC)));
   if (nil == screenshotData) {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delta), self.backgroundQueue, ^{
+      [self streamScreenshot];
+    });
     return;
   }
 
-  dispatch_async(self.backgroundQueue, ^{
-    NSString *chunkHeader = [NSString stringWithFormat:@"--BoundaryString\r\nContent-type: image/jpg\r\nContent-Length: %@\r\n\r\n", @(screenshotData.length)];
-    NSMutableData *chunk = [[chunkHeader dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
-    [chunk appendData:screenshotData];
-    [chunk appendData:(id)[@"\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
-    @synchronized (self.activeClients) {
-      for (GCDAsyncSocket *client in self.activeClients) {
-        [client writeData:chunk withTimeout:-1 tag:0];
-      }
+  NSString *chunkHeader = [NSString stringWithFormat:@"--BoundaryString\r\nContent-type: image/jpg\r\nContent-Length: %@\r\n\r\n", @(screenshotData.length)];
+  NSMutableData *chunk = [[chunkHeader dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
+  [chunk appendData:screenshotData];
+  [chunk appendData:(id)[@"\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
+  @synchronized (self.activeClients) {
+    for (GCDAsyncSocket *client in self.activeClients) {
+      [client writeData:chunk withTimeout:-1 tag:0];
     }
+  }
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delta), self.backgroundQueue, ^{
+    [self streamScreenshot];
   });
 }
 
@@ -120,15 +113,8 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
 
 - (void)didClientConnect:(GCDAsyncSocket *)newClient activeClients:(NSArray<GCDAsyncSocket *> *)activeClients
 {
-  if (![self.class canStreamScreenshots]) {
-    return;
-  }
-
-  dispatch_async(self.backgroundQueue, ^{
-    NSString *streamHeader = [NSString stringWithFormat:@"HTTP/1.0 200 OK\r\nServer: %@\r\nConnection: close\r\nMax-Age: 0\r\nExpires: 0\r\nCache-Control: no-cache, private\r\nPragma: no-cache\r\nContent-Type: multipart/x-mixed-replace; boundary=--BoundaryString\r\n\r\n", SERVER_NAME];
-    [newClient writeData:(id)[streamHeader dataUsingEncoding:NSUTF8StringEncoding] withTimeout:-1 tag:0];
-  });
-
+  NSString *streamHeader = [NSString stringWithFormat:@"HTTP/1.0 200 OK\r\nServer: %@\r\nConnection: close\r\nMax-Age: 0\r\nExpires: 0\r\nCache-Control: no-cache, private\r\nPragma: no-cache\r\nContent-Type: multipart/x-mixed-replace; boundary=--BoundaryString\r\n\r\n", SERVER_NAME];
+  [newClient writeData:(id)[streamHeader dataUsingEncoding:NSUTF8StringEncoding] withTimeout:-1 tag:0];
   @synchronized (self.activeClients) {
     [self.activeClients removeAllObjects];
     [self.activeClients addObjectsFromArray:activeClients];
@@ -137,10 +123,6 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
 
 - (void)didClientDisconnect:(NSArray<GCDAsyncSocket *> *)activeClients
 {
-  if (![self.class canStreamScreenshots]) {
-    return;
-  }
-
   @synchronized (self.activeClients) {
     [self.activeClients removeAllObjects];
     [self.activeClients addObjectsFromArray:activeClients];


### PR DESCRIPTION
XCTest does not mind if we call framebuffer snapshot getter primitive not in the main queue. Lets use it to improve the server performance and simplify the code.