### PR TITLE
Allow image scaling on the mjepg stream

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		1FC3B2E32121ECF600B61EE0 /* FBApplicationProcessProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FC3B2E12121EC8C00B61EE0 /* FBApplicationProcessProxyTests.m */; };
+		63CCF91221ECE4C700E94ABD /* FBImageIOScaler.h in Headers */ = {isa = PBXBuildFile; fileRef = 63CCF91021ECE4C700E94ABD /* FBImageIOScaler.h */; };
+		63CCF91321ECE4C700E94ABD /* FBImageIOScaler.m in Sources */ = {isa = PBXBuildFile; fileRef = 63CCF91121ECE4C700E94ABD /* FBImageIOScaler.m */; };
 		710181F8211DF584002FD3A8 /* CocoaAsyncSocket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 710181F7211DF584002FD3A8 /* CocoaAsyncSocket.framework */; };
 		71018201211DF62C002FD3A8 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 71018200211DF62C002FD3A8 /* libxml2.tbd */; };
 		7101820D211E026B002FD3A8 /* libAccessibility.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7101820C211E026B002FD3A8 /* libAccessibility.tbd */; };
@@ -453,6 +455,8 @@
 		1BA7DD8C206D694B007C7C26 /* XCTElementSetTransformer-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTElementSetTransformer-Protocol.h"; sourceTree = "<group>"; };
 		1FC3B2E12121EC8C00B61EE0 /* FBApplicationProcessProxyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBApplicationProcessProxyTests.m; sourceTree = "<group>"; };
 		44757A831D42CE8300ECF35E /* XCUIDeviceRotationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCUIDeviceRotationTests.m; sourceTree = "<group>"; };
+		63CCF91021ECE4C700E94ABD /* FBImageIOScaler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBImageIOScaler.h; sourceTree = "<group>"; };
+		63CCF91121ECE4C700E94ABD /* FBImageIOScaler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBImageIOScaler.m; sourceTree = "<group>"; };
 		710181F7211DF584002FD3A8 /* CocoaAsyncSocket.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaAsyncSocket.framework; path = Carthage/Build/iOS/CocoaAsyncSocket.framework; sourceTree = "<group>"; };
 		71018200211DF62C002FD3A8 /* libxml2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.tbd; path = usr/lib/libxml2.tbd; sourceTree = SDKROOT; };
 		7101820C211E026B002FD3A8 /* libAccessibility.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libAccessibility.tbd; path = usr/lib/libAccessibility.tbd; sourceTree = SDKROOT; };
@@ -1154,6 +1158,8 @@
 				711084431DA3AA7500F913D6 /* FBXPath.m */,
 				EE6B64FB1D0F86EF00E85F5D /* XCTestPrivateSymbols.h */,
 				EE6B64FC1D0F86EF00E85F5D /* XCTestPrivateSymbols.m */,
+				63CCF91021ECE4C700E94ABD /* FBImageIOScaler.h */,
+				63CCF91121ECE4C700E94ABD /* FBImageIOScaler.m */,
 			);
 			name = Utilities;
 			path = WebDriverAgentLib/Utilities;
@@ -1560,6 +1566,7 @@
 				71BD20731F86116100B36EC2 /* XCUIApplication+FBTouchAction.h in Headers */,
 				EE158ACE1CBD456F00A3E3F0 /* FBCommandHandler.h in Headers */,
 				EE158AC81CBD456F00A3E3F0 /* FBSessionCommands.h in Headers */,
+				63CCF91221ECE4C700E94ABD /* FBImageIOScaler.h in Headers */,
 				EE158AE31CBD456F00A3E3F0 /* FBSession-Private.h in Headers */,
 				716E0BCE1E917E810087A825 /* NSString+FBXMLSafeString.h in Headers */,
 				EE158ACF1CBD456F00A3E3F0 /* FBCommandStatus.h in Headers */,
@@ -1921,6 +1928,7 @@
 				EEE3764A1D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.m in Sources */,
 				EE8DDD7E20C5733C004D4925 /* XCUIElement+FBForceTouch.m in Sources */,
 				71241D7C1FAE3D2500B9559F /* FBTouchActionCommands.m in Sources */,
+				63CCF91321ECE4C700E94ABD /* FBImageIOScaler.m in Sources */,
 				EE158ACB1CBD456F00A3E3F0 /* FBTouchIDCommands.m in Sources */,
 				EE158ABD1CBD456F00A3E3F0 /* FBDebugCommands.m in Sources */,
 				716E0BCF1E917E810087A825 /* NSString+FBXMLSafeString.m in Sources */,

--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		1FC3B2E32121ECF600B61EE0 /* FBApplicationProcessProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FC3B2E12121EC8C00B61EE0 /* FBApplicationProcessProxyTests.m */; };
 		63CCF91221ECE4C700E94ABD /* FBImageIOScaler.h in Headers */ = {isa = PBXBuildFile; fileRef = 63CCF91021ECE4C700E94ABD /* FBImageIOScaler.h */; };
 		63CCF91321ECE4C700E94ABD /* FBImageIOScaler.m in Sources */ = {isa = PBXBuildFile; fileRef = 63CCF91121ECE4C700E94ABD /* FBImageIOScaler.m */; };
+		63FD950221F9D06100A3E356 /* FBImageIOScalerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 631B523421F6174300625362 /* FBImageIOScalerTests.m */; };
+		63FD950321F9D06100A3E356 /* FBImageIOScalerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 631B523421F6174300625362 /* FBImageIOScalerTests.m */; };
+		63FD950421F9D06200A3E356 /* FBImageIOScalerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 631B523421F6174300625362 /* FBImageIOScalerTests.m */; };
 		710181F8211DF584002FD3A8 /* CocoaAsyncSocket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 710181F7211DF584002FD3A8 /* CocoaAsyncSocket.framework */; };
 		71018201211DF62C002FD3A8 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 71018200211DF62C002FD3A8 /* libxml2.tbd */; };
 		7101820D211E026B002FD3A8 /* libAccessibility.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7101820C211E026B002FD3A8 /* libAccessibility.tbd */; };
@@ -455,6 +458,7 @@
 		1BA7DD8C206D694B007C7C26 /* XCTElementSetTransformer-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTElementSetTransformer-Protocol.h"; sourceTree = "<group>"; };
 		1FC3B2E12121EC8C00B61EE0 /* FBApplicationProcessProxyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBApplicationProcessProxyTests.m; sourceTree = "<group>"; };
 		44757A831D42CE8300ECF35E /* XCUIDeviceRotationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCUIDeviceRotationTests.m; sourceTree = "<group>"; };
+		631B523421F6174300625362 /* FBImageIOScalerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBImageIOScalerTests.m; sourceTree = "<group>"; };
 		63CCF91021ECE4C700E94ABD /* FBImageIOScaler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBImageIOScaler.h; sourceTree = "<group>"; };
 		63CCF91121ECE4C700E94ABD /* FBImageIOScaler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBImageIOScaler.m; sourceTree = "<group>"; };
 		710181F7211DF584002FD3A8 /* CocoaAsyncSocket.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaAsyncSocket.framework; path = Carthage/Build/iOS/CocoaAsyncSocket.framework; sourceTree = "<group>"; };
@@ -1219,6 +1223,7 @@
 				71E504941DF59BAD0020C32A /* XCUIElementAttributesTests.m */,
 				EEBBD48D1D4785FC00656A81 /* XCUIElementFBFindTests.m */,
 				EE1E06E11D181CC9007CF043 /* XCUIElementHelperIntegrationTests.m */,
+				631B523421F6174300625362 /* FBImageIOScalerTests.m */,
 			);
 			path = IntegrationTests;
 			sourceTree = "<group>";
@@ -1975,6 +1980,7 @@
 			files = (
 				71241D801FAF087500B9559F /* FBW3CMultiTouchActionsIntegrationTests.m in Sources */,
 				71241D7E1FAF084E00B9559F /* FBW3CTouchActionsIntegrationTests.m in Sources */,
+				63FD950221F9D06100A3E356 /* FBImageIOScalerTests.m in Sources */,
 				719CD8FF2126C90200C7D0C2 /* FBAutoAlertsHandlerTests.m in Sources */,
 				EE2202131ECC612200A29571 /* FBIntegrationTestCase.m in Sources */,
 				71BD20781F869E0F00B36EC2 /* FBAppiumTouchActionsIntegrationTests.m in Sources */,
@@ -1991,6 +1997,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EE5095E51EBCC9090028E2FE /* FBTypingTest.m in Sources */,
+				63FD950321F9D06100A3E356 /* FBImageIOScalerTests.m in Sources */,
 				EE5095EB1EBCC9090028E2FE /* XCElementSnapshotHitPointTests.m in Sources */,
 				EE5095EC1EBCC9090028E2FE /* XCUIApplicationHelperTests.m in Sources */,
 				EE5095ED1EBCC9090028E2FE /* XCElementSnapshotHelperTests.m in Sources */,
@@ -2054,6 +2061,7 @@
 				EE26409D1D0EBA25009BE6B0 /* FBElementAttributeTests.m in Sources */,
 				7119E1EC1E891F8600D0B125 /* FBPickerWheelSelectTests.m in Sources */,
 				EE1E06DA1D1808C2007CF043 /* FBIntegrationTestCase.m in Sources */,
+				63FD950421F9D06200A3E356 /* FBImageIOScalerTests.m in Sources */,
 				EE05BAFA1D13003C00A3EB00 /* FBKeyboardTests.m in Sources */,
 				EE55B3271D1D54CF003AAAEC /* FBScrollingTests.m in Sources */,
 				EE6A89371D0B35920083E92B /* FBFailureProofTestCaseTests.m in Sources */,

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -23,6 +23,8 @@ static NSString* const USE_COMPACT_RESPONSES = @"shouldUseCompactResponses";
 static NSString* const ELEMENT_RESPONSE_ATTRIBUTES = @"elementResponseAttributes";
 static NSString* const MJPEG_SERVER_SCREENSHOT_QUALITY = @"mjpegServerScreenshotQuality";
 static NSString* const MJPEG_SERVER_FRAMERATE = @"mjpegServerFramerate";
+static NSString* const MJPEG_SCALING_FACTOR = @"mjpegScalingFactor";
+static NSString* const MJPEG_COMPRESSION_FACTOR = @"mjpegCompressionFactor";
 static NSString* const SCREENSHOT_QUALITY = @"screenshotQuality";
 
 @implementation FBSessionCommands
@@ -204,6 +206,8 @@ static NSString* const SCREENSHOT_QUALITY = @"screenshotQuality";
       ELEMENT_RESPONSE_ATTRIBUTES: [FBConfiguration elementResponseAttributes],
       MJPEG_SERVER_SCREENSHOT_QUALITY: @([FBConfiguration mjpegServerScreenshotQuality]),
       MJPEG_SERVER_FRAMERATE: @([FBConfiguration mjpegServerFramerate]),
+      MJPEG_SCALING_FACTOR: @([FBConfiguration mjpegScalingFactor]),
+      MJPEG_COMPRESSION_FACTOR: @([FBConfiguration mjpegCompressionFactor]),
       SCREENSHOT_QUALITY: @([FBConfiguration screenshotQuality]),
     }
   );
@@ -229,6 +233,12 @@ static NSString* const SCREENSHOT_QUALITY = @"screenshotQuality";
   }
   if ([settings objectForKey:SCREENSHOT_QUALITY]) {
     [FBConfiguration setScreenshotQuality:[[settings objectForKey:SCREENSHOT_QUALITY] unsignedIntegerValue]];
+  }
+  if ([settings objectForKey:MJPEG_SCALING_FACTOR]) {
+    [FBConfiguration setMjpegScalingFactor:[[settings objectForKey:MJPEG_SCALING_FACTOR] unsignedIntegerValue]];
+  }
+  if ([settings objectForKey:MJPEG_COMPRESSION_FACTOR]) {
+    [FBConfiguration setMjpegCompressionFactor:[[settings objectForKey:MJPEG_COMPRESSION_FACTOR] unsignedIntegerValue]];
   }
 
   return [self handleGetSettings:request];

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -207,7 +207,6 @@ static NSString* const SCREENSHOT_QUALITY = @"screenshotQuality";
       MJPEG_SERVER_SCREENSHOT_QUALITY: @([FBConfiguration mjpegServerScreenshotQuality]),
       MJPEG_SERVER_FRAMERATE: @([FBConfiguration mjpegServerFramerate]),
       MJPEG_SCALING_FACTOR: @([FBConfiguration mjpegScalingFactor]),
-      MJPEG_COMPRESSION_FACTOR: @([FBConfiguration mjpegCompressionFactor]),
       SCREENSHOT_QUALITY: @([FBConfiguration screenshotQuality]),
     }
   );
@@ -236,9 +235,6 @@ static NSString* const SCREENSHOT_QUALITY = @"screenshotQuality";
   }
   if ([settings objectForKey:MJPEG_SCALING_FACTOR]) {
     [FBConfiguration setMjpegScalingFactor:[[settings objectForKey:MJPEG_SCALING_FACTOR] unsignedIntegerValue]];
-  }
-  if ([settings objectForKey:MJPEG_COMPRESSION_FACTOR]) {
-    [FBConfiguration setMjpegCompressionFactor:[[settings objectForKey:MJPEG_COMPRESSION_FACTOR] unsignedIntegerValue]];
   }
 
   return [self handleGetSettings:request];

--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -139,11 +139,11 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
 {
   NSDictionary *env = NSProcessInfo.processInfo.environment;
   NSString *scalingFactor = [env objectForKey:@"MJPEG_SCALING_FACTOR"];
-  if (scalingFactor != nil) {
+  if (scalingFactor != nil && [scalingFactor length] > 0) {
     [FBConfiguration setMjpegScalingFactor:[scalingFactor integerValue]];
   }
   NSString *compressionFactor = [env objectForKey:@"MJPEG_COMPRESSION_FACTOR"];
-  if (compressionFactor != nil) {
+  if (compressionFactor != nil && [compressionFactor length] > 0) {
     [FBConfiguration setMjpegCompressionFactor:[compressionFactor integerValue]];
   }
 }

--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -142,9 +142,9 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   if (scalingFactor != nil && [scalingFactor length] > 0) {
     [FBConfiguration setMjpegScalingFactor:[scalingFactor integerValue]];
   }
-  NSString *compressionFactor = [env objectForKey:@"MJPEG_COMPRESSION_FACTOR"];
-  if (compressionFactor != nil && [compressionFactor length] > 0) {
-    [FBConfiguration setMjpegCompressionFactor:[compressionFactor integerValue]];
+  NSString *screenshotQuality = [env objectForKey:@"MJPEG_SERVER_SCREENSHOT_QUALITY"];
+  if (screenshotQuality != nil && [screenshotQuality length] > 0) {
+    [FBConfiguration setMjpegServerScreenshotQuality:[screenshotQuality integerValue]];
   }
 }
 

--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -115,6 +115,7 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
 
 - (void)initScreenshotsBroadcaster
 {
+  [self readEnvironmentSettings];
   self.screenshotsBroadcaster = [[FBTCPSocket alloc]
                                  initWithPort:(uint16_t)FBConfiguration.mjpegServerPort];
   self.screenshotsBroadcaster.delegate = [[FBMjpegServer alloc] init];
@@ -214,6 +215,18 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   }];
 
   [self registerRouteHandlers:@[FBUnknownCommands.class]];
+}
+
+- (void)readEnvironmentSettings {
+  NSDictionary *env = NSProcessInfo.processInfo.environment;
+  NSString *scalingFactor = [env objectForKey:@"MJPEG_SCALING_FACTOR"];
+  if (scalingFactor != nil) {
+    [FBConfiguration setMjpegScalingFactor:[scalingFactor integerValue]];
+  }
+  NSString *compressionFactor = [env objectForKey:@"MJPEG_COMPRESSION_FACTOR"];
+  if (compressionFactor != nil) {
+    [FBConfiguration setMjpegCompressionFactor:[compressionFactor integerValue]];
+  }
 }
 
 @end

--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -115,7 +115,7 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
 
 - (void)initScreenshotsBroadcaster
 {
-  [self readEnvironmentSettings];
+  [self readMjpegSettingsFromEnv];
   self.screenshotsBroadcaster = [[FBTCPSocket alloc]
                                  initWithPort:(uint16_t)FBConfiguration.mjpegServerPort];
   self.screenshotsBroadcaster.delegate = [[FBMjpegServer alloc] init];
@@ -133,6 +133,19 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   }
 
   [self.screenshotsBroadcaster stop];
+}
+
+- (void)readMjpegSettingsFromEnv
+{
+  NSDictionary *env = NSProcessInfo.processInfo.environment;
+  NSString *scalingFactor = [env objectForKey:@"MJPEG_SCALING_FACTOR"];
+  if (scalingFactor != nil) {
+    [FBConfiguration setMjpegScalingFactor:[scalingFactor integerValue]];
+  }
+  NSString *compressionFactor = [env objectForKey:@"MJPEG_COMPRESSION_FACTOR"];
+  if (compressionFactor != nil) {
+    [FBConfiguration setMjpegCompressionFactor:[compressionFactor integerValue]];
+  }
 }
 
 - (void)stopServing
@@ -215,18 +228,6 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   }];
 
   [self registerRouteHandlers:@[FBUnknownCommands.class]];
-}
-
-- (void)readEnvironmentSettings {
-  NSDictionary *env = NSProcessInfo.processInfo.environment;
-  NSString *scalingFactor = [env objectForKey:@"MJPEG_SCALING_FACTOR"];
-  if (scalingFactor != nil) {
-    [FBConfiguration setMjpegScalingFactor:[scalingFactor integerValue]];
-  }
-  NSString *compressionFactor = [env objectForKey:@"MJPEG_COMPRESSION_FACTOR"];
-  if (compressionFactor != nil) {
-    [FBConfiguration setMjpegCompressionFactor:[compressionFactor integerValue]];
-  }
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -93,6 +93,16 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSInteger)mjpegServerPort;
 
 /**
+ The scaling factor for frames of the mjpeg stream (Default values is 100 and does not perform scaling).
+ */
++ (NSInteger)mjpegScalingFactor;
+
+/**
+ JPEG compression rate for mjpeg frames (Default value is 30)
+ */
++ (NSInteger)mjpegCompressionFactor;
+
+/**
  YES if verbose logging is enabled. NO otherwise.
  */
 + (BOOL)verboseLoggingEnabled;

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The scaling factor for frames of the mjpeg stream (Default values is 100 and does not perform scaling).
  */
-+ (NSInteger)mjpegScalingFactor;
++ (NSUInteger)mjpegScalingFactor;
 
 /**
  JPEG compression rate for mjpeg frames (Default value is 30)

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -97,10 +97,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSUInteger)mjpegScalingFactor;
 
++ (void)setMjpegScalingFactor:(NSUInteger)scalingFactor;
+
 /**
  JPEG compression rate for mjpeg frames (Default value is 30)
  */
 + (NSInteger)mjpegCompressionFactor;
+
++ (void)setMjpegCompressionFactor:(NSUInteger)compressionFactor;
 
 /**
  YES if verbose logging is enabled. NO otherwise.

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -99,12 +99,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setMjpegScalingFactor:(NSUInteger)scalingFactor;
 
 /**
- JPEG compression rate for mjpeg frames (Default value is 30)
- */
-+ (NSInteger)mjpegCompressionFactor;
-+ (void)setMjpegCompressionFactor:(NSUInteger)compressionFactor;
-
-/**
  YES if verbose logging is enabled. NO otherwise.
  */
 + (BOOL)verboseLoggingEnabled;

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -96,14 +96,12 @@ NS_ASSUME_NONNULL_BEGIN
  The scaling factor for frames of the mjpeg stream (Default values is 100 and does not perform scaling).
  */
 + (NSUInteger)mjpegScalingFactor;
-
 + (void)setMjpegScalingFactor:(NSUInteger)scalingFactor;
 
 /**
  JPEG compression rate for mjpeg frames (Default value is 30)
  */
 + (NSInteger)mjpegCompressionFactor;
-
 + (void)setMjpegCompressionFactor:(NSUInteger)compressionFactor;
 
 /**

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -29,8 +29,8 @@ static NSUInteger FBMaxTypingFrequency = 60;
 static NSUInteger FBMjpegServerScreenshotQuality = 25;
 static NSUInteger FBMjpegServerFramerate = 10;
 static NSUInteger FBScreenshotQuality = 1;
-static NSUInteger DefaultMjpegScalingFactor = 100;
-static NSUInteger DefaultMjpegCompressionFactor = 30;
+static NSUInteger FBMjpegScalingFactor = 100;
+static NSUInteger FBMjpegCompressionFactor = 30;
 
 @implementation FBConfiguration
 
@@ -78,22 +78,20 @@ static NSUInteger DefaultMjpegCompressionFactor = 30;
 
 + (NSUInteger)mjpegScalingFactor
 {
-  if (NSProcessInfo.processInfo.environment[@"MJPEG_SCALING_FACTOR"] &&
-      [NSProcessInfo.processInfo.environment[@"MJPEG_SCALING_FACTOR"] length] > 0) {
-    return [NSProcessInfo.processInfo.environment[@"MJPEG_SCALING_FACTOR"] integerValue];
-  }
+  return FBMjpegScalingFactor;
+}
 
-  return DefaultMjpegScalingFactor;
++ (void)setMjpegScalingFactor:(NSUInteger)scalingFactor {
+  FBMjpegScalingFactor = scalingFactor;
 }
 
 + (NSInteger)mjpegCompressionFactor
 {
-  if (NSProcessInfo.processInfo.environment[@"MJPEG_COMPRESSION_FACTOR"] &&
-      [NSProcessInfo.processInfo.environment[@"MJPEG_COMPRESSION_FACTOR"] length] > 0) {
-    return [NSProcessInfo.processInfo.environment[@"MJPEG_COMPRESSION_FACTOR"] integerValue];
-  }
+  return FBMjpegCompressionFactor;
+}
 
-  return DefaultMjpegCompressionFactor;
++ (void)setMjpegCompressionFactor:(NSUInteger)compressionFactor {
+  FBMjpegCompressionFactor = compressionFactor;
 }
 
 + (BOOL)verboseLoggingEnabled

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -30,7 +30,6 @@ static NSUInteger FBMjpegServerScreenshotQuality = 25;
 static NSUInteger FBMjpegServerFramerate = 10;
 static NSUInteger FBScreenshotQuality = 1;
 static NSUInteger FBMjpegScalingFactor = 100;
-static NSUInteger FBMjpegCompressionFactor = 30;
 
 @implementation FBConfiguration
 
@@ -83,15 +82,6 @@ static NSUInteger FBMjpegCompressionFactor = 30;
 
 + (void)setMjpegScalingFactor:(NSUInteger)scalingFactor {
   FBMjpegScalingFactor = scalingFactor;
-}
-
-+ (NSInteger)mjpegCompressionFactor
-{
-  return FBMjpegCompressionFactor;
-}
-
-+ (void)setMjpegCompressionFactor:(NSUInteger)compressionFactor {
-  FBMjpegCompressionFactor = compressionFactor;
 }
 
 + (BOOL)verboseLoggingEnabled

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -76,7 +76,7 @@ static NSUInteger DefaultMjpegCompressionFactor = 30;
   return DefaultMjpegServerPort;
 }
 
-+ (NSInteger)mjpegScalingFactor
++ (NSUInteger)mjpegScalingFactor
 {
   if (NSProcessInfo.processInfo.environment[@"MJPEG_SCALING_FACTOR"] &&
       [NSProcessInfo.processInfo.environment[@"MJPEG_SCALING_FACTOR"] length] > 0) {

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -29,6 +29,8 @@ static NSUInteger FBMaxTypingFrequency = 60;
 static NSUInteger FBMjpegServerScreenshotQuality = 25;
 static NSUInteger FBMjpegServerFramerate = 10;
 static NSUInteger FBScreenshotQuality = 1;
+static NSUInteger DefaultMjpegScalingFactor = 100;
+static NSUInteger DefaultMjpegCompressionFactor = 30;
 
 @implementation FBConfiguration
 
@@ -72,6 +74,26 @@ static NSUInteger FBScreenshotQuality = 1;
   }
 
   return DefaultMjpegServerPort;
+}
+
++ (NSInteger)mjpegScalingFactor
+{
+  if (NSProcessInfo.processInfo.environment[@"MJPEG_SCALING_FACTOR"] &&
+      [NSProcessInfo.processInfo.environment[@"MJPEG_SCALING_FACTOR"] length] > 0) {
+    return [NSProcessInfo.processInfo.environment[@"MJPEG_SCALING_FACTOR"] integerValue];
+  }
+
+  return DefaultMjpegScalingFactor;
+}
+
++ (NSInteger)mjpegCompressionFactor
+{
+  if (NSProcessInfo.processInfo.environment[@"MJPEG_COMPRESSION_FACTOR"] &&
+      [NSProcessInfo.processInfo.environment[@"MJPEG_COMPRESSION_FACTOR"] length] > 0) {
+    return [NSProcessInfo.processInfo.environment[@"MJPEG_COMPRESSION_FACTOR"] integerValue];
+  }
+
+  return DefaultMjpegCompressionFactor;
 }
 
 + (BOOL)verboseLoggingEnabled

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.h
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.h
@@ -12,6 +12,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// Those values define the allowed ranges for the scaling factor and compression quality settings
+extern const CGFloat FBMinScalingFactor;
+extern const CGFloat FBMaxScalingFactor;
+extern const CGFloat FBMinCompressionQuality;
+extern const CGFloat FBMaxCompressionQuality;
+
+
 /**
  Scales images and compresses it to JPEG using Image I/O
  It allows to enqueue only a single screenshot. If a new one arrives before the currently queued gets discared

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.h
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.h
@@ -17,7 +17,18 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface FBImageIOScaler : NSObject
 
+/**
+ @param scalingFactor the scaling factor (between 1 and 100) to use. A value of 100 won't perform scaling at all
+ @param compressionQuality the compression quality of the JPEG output image
+ */
 - (id)initWithScalingFactor:(NSUInteger)scalingFactor compressionQuality:(NSUInteger)compressionQuality;
+
+/**
+ Puts the passed image on the queue and dispatches a scaling operation. If there is already a image on the
+ queue it will be replaced with the new one
+ @param image The image to scale down
+ @param completionHandler called after successfully scaling down an image
+ */
 - (void)submitImage:(NSData *)image completionHandler:(void(^)(NSData *scaled))completionHandler;
 
 @end

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.h
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.h
@@ -23,8 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
  queue it will be replaced with the new one
  @param image The image to scale down
  @param completionHandler called after successfully scaling down an image
- @param scalingFactor the scaling factor (between 0.01 and 1.0) to use. A value of 1.0 won't perform scaling at all
- @param compressionQuality the compression quality (between 0.01 and 1.0) of the JPEG output image
+ @param scalingFactor the scaling factor in range 0.01..1.0. A value of 1.0 won't perform scaling at all
+ @param compressionQuality the compression quality in range 0.0..1.0 (0.0 for max. compression and 1.0 for lossless compression)
  */
 - (void)submitImage:(NSData *)image scalingFactor:(CGFloat)scalingFactor compressionQuality:(CGFloat)compressionQuality completionHandler:(void (^)(NSData *))completionHandler;
 

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.h
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.h
@@ -17,6 +17,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface FBImageIOScaler : NSObject
 
+/** Can be checked if a scaling operation will be performed on submitting an image
+  * or if the image will be passed unmodified to the completion handler
+ */
+@property(nonatomic, readonly, getter=isScalingEnabled) BOOL scalingEnabled;
+
 /**
  @param scalingFactor the scaling factor (between 1 and 100) to use. A value of 100 won't perform scaling at all
  @param compressionQuality the compression quality of the JPEG output image

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.h
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.h
@@ -8,6 +8,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,24 +18,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface FBImageIOScaler : NSObject
 
-/** Can be checked if a scaling operation will be performed on submitting an image
-  * or if the image will be passed unmodified to the completion handler
- */
-@property(nonatomic, readonly, getter=isScalingEnabled) BOOL scalingEnabled;
-
-/**
- @param scalingFactor the scaling factor (between 1 and 100) to use. A value of 100 won't perform scaling at all
- @param compressionQuality the compression quality of the JPEG output image
- */
-- (id)initWithScalingFactor:(NSUInteger)scalingFactor compressionQuality:(NSUInteger)compressionQuality;
-
 /**
  Puts the passed image on the queue and dispatches a scaling operation. If there is already a image on the
  queue it will be replaced with the new one
  @param image The image to scale down
  @param completionHandler called after successfully scaling down an image
+ @param scalingFactor the scaling factor (between 0.01 and 1.0) to use. A value of 1.0 won't perform scaling at all
+ @param compressionQuality the compression quality (between 0.01 and 1.0) of the JPEG output image
  */
-- (void)submitImage:(NSData *)image completionHandler:(void(^)(NSData *scaled))completionHandler;
+- (void)submitImage:(NSData *)image scalingFactor:(CGFloat)scalingFactor compressionQuality:(CGFloat)compressionQuality completionHandler:(void (^)(NSData *))completionHandler;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.h
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.h
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Scales images and compresses it to JPEG using Image I/O
+ It allows to enqueue only a single screenshot. If a new one arrives before the currently queued gets discared
+ */
+@interface FBImageIOScaler : NSObject
+
+- (id)initWithScalingFactor:(NSUInteger)scalingFactor compressionQuality:(NSUInteger)compressionQuality;
+- (void)submitImage:(NSData *)image completionHandler:(void(^)(NSData *scaled))completionHandler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBImageIOScaler.h"
+#import <ImageIO/ImageIO.h>
+#import <CoreServices/CoreServices.h>
+#import "FBLogger.h"
+
+@interface FBImageIOScaler ()
+
+@property (nonatomic, readonly) CGFloat scalingFactor;
+
+@property (nonatomic) NSData *nextImage;
+@property (nonatomic, readonly) NSLock *nextImageLock;
+@property (nonatomic, readonly) dispatch_queue_t scalingQueue;
+
+@property (nonatomic, readonly) CFDictionaryRef compressionOptions;
+
+@end
+
+@implementation FBImageIOScaler
+
+- (id)initWithScalingFactor:(NSUInteger)scalingFactor compressionQuality:(NSUInteger)compressionQuality {
+  self = [super init];
+  if (self) {
+    _scalingFactor = scalingFactor / 100.0f;
+
+    _nextImageLock = [[NSLock alloc] init];
+    _scalingQueue = dispatch_queue_create("image.scaling.queue", NULL);
+
+    _compressionOptions = (__bridge CFDictionaryRef)@{
+                                                      (id)kCGImageDestinationLossyCompressionQuality: @(compressionQuality / 100.f)
+                                                      };
+  }
+  return self;
+}
+- (void)submitImage:(NSData *)image completionHandler:(void(^)(NSData *scaled))completionHandler {
+  if (fabs(1.0 - self.scalingFactor) < DBL_EPSILON) {
+    completionHandler(image);
+    return;
+  }
+  [self.nextImageLock lock];
+  if (self.nextImage != nil) {
+    [FBLogger verboseLog:@"Discarding screenshot"];
+  }
+  self.nextImage = image;
+  [self.nextImageLock unlock];
+
+  dispatch_async(self.scalingQueue, ^{
+    [self.nextImageLock lock];
+    NSData *next = self.nextImage;
+    self.nextImage = nil;
+    [self.nextImageLock unlock];
+    if (next == nil) {
+      return;
+    }
+    NSData *scaled = [self scaleImage:next];
+    if (scaled == nil) {
+      [FBLogger log:@"Could not scale down image"];
+      return;
+    }
+    completionHandler(scaled);
+  });
+}
+
+- (NSData *)scaleImage:(NSData *)image {
+  CGImageSourceRef imageData = CGImageSourceCreateWithData((CFDataRef)image, nil);
+
+  CGSize size = [self getImageSize:imageData];
+  CGFloat scaledMaxPixelSize = MAX(size.width, size.height) * self.scalingFactor;
+
+  CFDictionaryRef params = (__bridge CFDictionaryRef)@{
+                                                       (id)kCGImageSourceCreateThumbnailWithTransform: @(YES),
+                                                       (id)kCGImageSourceCreateThumbnailFromImageIfAbsent: @(YES),
+                                                       (id)kCGImageSourceThumbnailMaxPixelSize: @(scaledMaxPixelSize)
+                                                       };
+
+  CGImageRef scaled = CGImageSourceCreateThumbnailAtIndex(imageData, 0, params);
+  if (scaled == nil) {
+    [FBLogger log:@"Failed to scale image"];
+    CFRelease(imageData);
+    return nil;
+  }
+  NSData *jpegData = [self convertToJpeg:scaled];
+  CFRelease(scaled);
+  CFRelease(imageData);
+  return jpegData;
+}
+
+- (NSData *)convertToJpeg:(CGImageRef)imageRef {
+  NSMutableData *newImageData = [NSMutableData data];
+  CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((CFMutableDataRef)newImageData, kUTTypeJPEG, 1, NULL);
+
+  CGImageDestinationAddImage(imageDestination, imageRef, self.compressionOptions);
+  if(!CGImageDestinationFinalize(imageDestination)) {
+    [FBLogger log:@"Failed to write image"];
+    newImageData = nil;
+  }
+  CFRelease(imageDestination);
+  return newImageData;
+}
+
+- (CGSize)getImageSize:(CGImageSourceRef)imageSource {
+  NSDictionary *options = @{
+                            (NSString *)kCGImageSourceShouldCache: @(NO)
+                            };
+  CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, (CFDictionaryRef)options);
+
+  NSNumber *width = [(__bridge NSDictionary *)properties objectForKey:(id)kCGImagePropertyPixelWidth];
+  NSNumber *height = [(__bridge NSDictionary *)properties objectForKey:(id)kCGImagePropertyPixelHeight];
+
+  CGSize size = CGSizeMake([width floatValue], [height floatValue]);
+  CFRelease(properties);
+  return size;
+}
+
+@end

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -26,7 +26,8 @@
 
 @implementation FBImageIOScaler
 
-- (id)initWithScalingFactor:(NSUInteger)scalingFactor compressionQuality:(NSUInteger)compressionQuality {
+- (id)initWithScalingFactor:(NSUInteger)scalingFactor compressionQuality:(NSUInteger)compressionQuality
+{
   self = [super init];
   if (self) {
     _scalingFactor = scalingFactor / 100.0f;
@@ -40,7 +41,8 @@
   }
   return self;
 }
-- (void)submitImage:(NSData *)image completionHandler:(void(^)(NSData *scaled))completionHandler {
+- (void)submitImage:(NSData *)image completionHandler:(void(^)(NSData *scaled))completionHandler
+{
   if (fabs(1.0 - self.scalingFactor) < DBL_EPSILON) {
     completionHandler(image);
     return;
@@ -69,7 +71,8 @@
   });
 }
 
-- (NSData *)scaledImageWithImage:(NSData *)image {
+- (NSData *)scaledImageWithImage:(NSData *)image
+{
   CGImageSourceRef imageData = CGImageSourceCreateWithData((CFDataRef)image, nil);
 
   CGSize size = [FBImageIOScaler imageSizeWithImage:imageData];
@@ -93,7 +96,8 @@
   return jpegData;
 }
 
-- (NSData *)jpegDataWithImage:(CGImageRef)imageRef {
+- (NSData *)jpegDataWithImage:(CGImageRef)imageRef
+{
   NSMutableData *newImageData = [NSMutableData data];
   CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((CFMutableDataRef)newImageData, kUTTypeJPEG, 1, NULL);
 
@@ -106,7 +110,8 @@
   return newImageData;
 }
 
-+ (CGSize)imageSizeWithImage:(CGImageSourceRef)imageSource{
++ (CGSize)imageSizeWithImage:(CGImageSourceRef)imageSource
+{
   NSDictionary *options = @{
                             (NSString *)kCGImageSourceShouldCache: @(NO)
                             };

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -9,7 +9,7 @@
 
 #import "FBImageIOScaler.h"
 #import <ImageIO/ImageIO.h>
-#import <CoreServices/CoreServices.h>
+#import <MobileCoreServices/MobileCoreServices.h>
 #import "FBLogger.h"
 
 static const CGFloat FBMinScalingFactor = 0.01f;
@@ -73,9 +73,9 @@ static const CGFloat FBMaxCompressionQuality = 1.0f;
   CGFloat scaledMaxPixelSize = MAX(size.width, size.height) * scalingFactor;
 
   CFDictionaryRef params = (__bridge CFDictionaryRef)@{
-                                                       (id)kCGImageSourceCreateThumbnailWithTransform: @(YES),
-                                                       (id)kCGImageSourceCreateThumbnailFromImageIfAbsent: @(YES),
-                                                       (id)kCGImageSourceThumbnailMaxPixelSize: @(scaledMaxPixelSize)
+                                                       (const NSString *)kCGImageSourceCreateThumbnailWithTransform: @(YES),
+                                                       (const NSString *)kCGImageSourceCreateThumbnailFromImageIfAbsent: @(YES),
+                                                       (const NSString *)kCGImageSourceThumbnailMaxPixelSize: @(scaledMaxPixelSize)
                                                        };
 
   CGImageRef scaled = CGImageSourceCreateThumbnailAtIndex(imageData, 0, params);
@@ -97,7 +97,7 @@ static const CGFloat FBMaxCompressionQuality = 1.0f;
   CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((CFMutableDataRef)newImageData, kUTTypeJPEG, 1, NULL);
 
   CFDictionaryRef compressionOptions = (__bridge CFDictionaryRef)@{
-                                                    (id)kCGImageDestinationLossyCompressionQuality: @(compressionQuality)
+                                                    (const NSString *)kCGImageDestinationLossyCompressionQuality: @(compressionQuality)
                                                     };
 
   CGImageDestinationAddImage(imageDestination, imageRef, compressionOptions);
@@ -112,12 +112,12 @@ static const CGFloat FBMaxCompressionQuality = 1.0f;
 + (CGSize)imageSizeWithImage:(CGImageSourceRef)imageSource
 {
   NSDictionary *options = @{
-                            (NSString *)kCGImageSourceShouldCache: @(NO)
+                            (const NSString *)kCGImageSourceShouldCache: @(NO)
                             };
   CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, (CFDictionaryRef)options);
 
-  NSNumber *width = [(__bridge NSDictionary *)properties objectForKey:(id)kCGImagePropertyPixelWidth];
-  NSNumber *height = [(__bridge NSDictionary *)properties objectForKey:(id)kCGImagePropertyPixelHeight];
+  NSNumber *width = [(__bridge NSDictionary *)properties objectForKey:(const NSString *)kCGImagePropertyPixelWidth];
+  NSNumber *height = [(__bridge NSDictionary *)properties objectForKey:(const NSString *)kCGImagePropertyPixelHeight];
 
   CGSize size = CGSizeMake([width floatValue], [height floatValue]);
   CFRelease(properties);

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -54,7 +54,7 @@
                                   scalingFactor:scalingFactor
                               compressionQuality:compressionQuality];
     if (scaled == nil) {
-      [FBLogger log:@"Could not scale down image"];
+      [FBLogger log:@"Could not scale down the image"];
       return;
     }
     completionHandler(scaled);

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -72,7 +72,7 @@
 - (NSData *)scaledImageWithImage:(NSData *)image {
   CGImageSourceRef imageData = CGImageSourceCreateWithData((CFDataRef)image, nil);
 
-  CGSize size = [self imageSizeWithImage:imageData];
+  CGSize size = [FBImageIOScaler imageSizeWithImage:imageData];
   CGFloat scaledMaxPixelSize = MAX(size.width, size.height) * self.scalingFactor;
 
   CFDictionaryRef params = (__bridge CFDictionaryRef)@{
@@ -106,7 +106,7 @@
   return newImageData;
 }
 
-- (CGSize)imageSizeWithImage:(CGImageSourceRef)imageSource {
++ (CGSize)imageSizeWithImage:(CGImageSourceRef)imageSource{
   NSDictionary *options = @{
                             (NSString *)kCGImageSourceShouldCache: @(NO)
                             };

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -12,10 +12,10 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 #import "FBLogger.h"
 
-static const CGFloat FBMinScalingFactor = 0.01f;
-static const CGFloat FBMaxScalingFactor = 1.0f;
-static const CGFloat FBMinCompressionQuality = 0.0f;
-static const CGFloat FBMaxCompressionQuality = 1.0f;
+const CGFloat FBMinScalingFactor = 0.01f;
+const CGFloat FBMaxScalingFactor = 1.0f;
+const CGFloat FBMinCompressionQuality = 0.0f;
+const CGFloat FBMaxCompressionQuality = 1.0f;
 
 @interface FBImageIOScaler ()
 

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -66,7 +66,7 @@ static const CGFloat FBMaxCompressionQuality = 1.0f;
   });
 }
 
-- (NSData *)scaledImageWithImage:(NSData *)image scalingFactor:(CGFloat)scalingFactor compressionQuality:(CGFloat)compressionQuality {
+- (nullable NSData *)scaledImageWithImage:(NSData *)image scalingFactor:(CGFloat)scalingFactor compressionQuality:(CGFloat)compressionQuality {
   CGImageSourceRef imageData = CGImageSourceCreateWithData((CFDataRef)image, nil);
 
   CGSize size = [FBImageIOScaler imageSizeWithImage:imageData];
@@ -91,7 +91,7 @@ static const CGFloat FBMaxCompressionQuality = 1.0f;
   return jpegData;
 }
 
-- (NSData *)jpegDataWithImage:(CGImageRef)imageRef compressionQuality:(CGFloat)compressionQuality
+- (nullable NSData *)jpegDataWithImage:(CGImageRef)imageRef compressionQuality:(CGFloat)compressionQuality
 {
   NSMutableData *newImageData = [NSMutableData data];
   CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((CFMutableDataRef)newImageData, kUTTypeJPEG, 1, NULL);

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -86,7 +86,7 @@ static const CGFloat FBMaxCompressionQuality = 1.0f;
   }
   NSData *jpegData = [self jpegDataWithImage:scaled
                            compressionQuality:compressionQuality];
-  CFRelease(scaled);
+  CGImageRelease(scaled);
   CFRelease(imageData);
   return jpegData;
 }

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -32,6 +32,8 @@
   if (self) {
     _scalingFactor = MAX(1, MIN(100, scalingFactor)) / 100.0f;
 
+    _scalingEnabled = fabs(1.0 - self.scalingFactor) > DBL_EPSILON;
+
     _nextImageLock = [[NSLock alloc] init];
     _scalingQueue = dispatch_queue_create("image.scaling.queue", NULL);
 
@@ -43,7 +45,7 @@
 }
 - (void)submitImage:(NSData *)image completionHandler:(void(^)(NSData *scaled))completionHandler
 {
-  if (fabs(1.0 - self.scalingFactor) < DBL_EPSILON) {
+  if (!self.isScalingEnabled) {
     completionHandler(image);
     return;
   }

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -88,7 +88,7 @@
 
   CGImageRef scaled = CGImageSourceCreateThumbnailAtIndex(imageData, 0, params);
   if (scaled == nil) {
-    [FBLogger log:@"Failed to scale image"];
+    [FBLogger log:@"Failed to scale the image"];
     CFRelease(imageData);
     return nil;
   }
@@ -105,7 +105,7 @@
 
   CGImageDestinationAddImage(imageDestination, imageRef, self.compressionOptions);
   if(!CGImageDestinationFinalize(imageDestination)) {
-    [FBLogger log:@"Failed to write image"];
+    [FBLogger log:@"Failed to write the image"];
     newImageData = nil;
   }
   CFRelease(imageDestination);

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -12,6 +12,11 @@
 #import <CoreServices/CoreServices.h>
 #import "FBLogger.h"
 
+static const CGFloat FBMinScalingFactor = 0.01f;
+static const CGFloat FBMaxScalingFactor = 1.0f;
+static const CGFloat FBMinCompressionQuality = 0.0f;
+static const CGFloat FBMaxCompressionQuality = 1.0f;
+
 @interface FBImageIOScaler ()
 
 @property (nonatomic) NSData *nextImage;
@@ -37,8 +42,8 @@
   if (self.nextImage != nil) {
     [FBLogger verboseLog:@"Discarding screenshot"];
   }
-  scalingFactor = MAX(0.01, MIN(1.0, scalingFactor));
-  compressionQuality = MAX(0.01, MIN(1.0, compressionQuality));
+  scalingFactor = MAX(FBMinScalingFactor, MIN(FBMaxScalingFactor, scalingFactor));
+  compressionQuality = MAX(FBMinCompressionQuality, MIN(FBMaxCompressionQuality, compressionQuality));
   self.nextImage = image;
   [self.nextImageLock unlock];
 

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -14,45 +14,31 @@
 
 @interface FBImageIOScaler ()
 
-@property (nonatomic, readonly) CGFloat scalingFactor;
-
 @property (nonatomic) NSData *nextImage;
 @property (nonatomic, readonly) NSLock *nextImageLock;
 @property (nonatomic, readonly) dispatch_queue_t scalingQueue;
-
-@property (nonatomic, readonly) CFDictionaryRef compressionOptions;
 
 @end
 
 @implementation FBImageIOScaler
 
-- (id)initWithScalingFactor:(NSUInteger)scalingFactor compressionQuality:(NSUInteger)compressionQuality
+- (id)init
 {
   self = [super init];
   if (self) {
-    _scalingFactor = MAX(1, MIN(100, scalingFactor)) / 100.0f;
-
-    _scalingEnabled = fabs(1.0 - self.scalingFactor) > DBL_EPSILON;
-
     _nextImageLock = [[NSLock alloc] init];
     _scalingQueue = dispatch_queue_create("image.scaling.queue", NULL);
-
-    _compressionOptions = (__bridge CFDictionaryRef)@{
-                                                      (id)kCGImageDestinationLossyCompressionQuality: @(compressionQuality / 100.f)
-                                                      };
   }
   return self;
 }
-- (void)submitImage:(NSData *)image completionHandler:(void(^)(NSData *scaled))completionHandler
-{
-  if (!self.isScalingEnabled) {
-    completionHandler(image);
-    return;
-  }
+
+- (void)submitImage:(NSData *)image scalingFactor:(CGFloat)scalingFactor compressionQuality:(CGFloat)compressionQuality completionHandler:(void (^)(NSData *))completionHandler {
   [self.nextImageLock lock];
   if (self.nextImage != nil) {
     [FBLogger verboseLog:@"Discarding screenshot"];
   }
+  scalingFactor = MAX(0.01, MIN(1.0, scalingFactor));
+  compressionQuality = MAX(0.01, MIN(1.0, compressionQuality));
   self.nextImage = image;
   [self.nextImageLock unlock];
 
@@ -64,7 +50,9 @@
     if (next == nil) {
       return;
     }
-    NSData *scaled = [self scaledImageWithImage:next];
+    NSData *scaled = [self scaledImageWithImage:next
+                                  scalingFactor:scalingFactor
+                              compressionQuality:compressionQuality];
     if (scaled == nil) {
       [FBLogger log:@"Could not scale down image"];
       return;
@@ -73,12 +61,11 @@
   });
 }
 
-- (NSData *)scaledImageWithImage:(NSData *)image
-{
+- (NSData *)scaledImageWithImage:(NSData *)image scalingFactor:(CGFloat)scalingFactor compressionQuality:(CGFloat)compressionQuality {
   CGImageSourceRef imageData = CGImageSourceCreateWithData((CFDataRef)image, nil);
 
   CGSize size = [FBImageIOScaler imageSizeWithImage:imageData];
-  CGFloat scaledMaxPixelSize = MAX(size.width, size.height) * self.scalingFactor;
+  CGFloat scaledMaxPixelSize = MAX(size.width, size.height) * scalingFactor;
 
   CFDictionaryRef params = (__bridge CFDictionaryRef)@{
                                                        (id)kCGImageSourceCreateThumbnailWithTransform: @(YES),
@@ -92,18 +79,23 @@
     CFRelease(imageData);
     return nil;
   }
-  NSData *jpegData = [self jpegDataWithImage:scaled];
+  NSData *jpegData = [self jpegDataWithImage:scaled
+                           compressionQuality:compressionQuality];
   CFRelease(scaled);
   CFRelease(imageData);
   return jpegData;
 }
 
-- (NSData *)jpegDataWithImage:(CGImageRef)imageRef
+- (NSData *)jpegDataWithImage:(CGImageRef)imageRef compressionQuality:(CGFloat)compressionQuality
 {
   NSMutableData *newImageData = [NSMutableData data];
   CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((CFMutableDataRef)newImageData, kUTTypeJPEG, 1, NULL);
 
-  CGImageDestinationAddImage(imageDestination, imageRef, self.compressionOptions);
+  CFDictionaryRef compressionOptions = (__bridge CFDictionaryRef)@{
+                                                    (id)kCGImageDestinationLossyCompressionQuality: @(compressionQuality)
+                                                    };
+
+  CGImageDestinationAddImage(imageDestination, imageRef, compressionOptions);
   if(!CGImageDestinationFinalize(imageDestination)) {
     [FBLogger log:@"Failed to write the image"];
     newImageData = nil;

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -30,7 +30,7 @@
 {
   self = [super init];
   if (self) {
-    _scalingFactor = scalingFactor / 100.0f;
+    _scalingFactor = MAX(1, MIN(100, scalingFactor)) / 100.0f;
 
     _nextImageLock = [[NSLock alloc] init];
     _scalingQueue = dispatch_queue_create("image.scaling.queue", NULL);

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -60,7 +60,7 @@
     if (next == nil) {
       return;
     }
-    NSData *scaled = [self scaleImage:next];
+    NSData *scaled = [self scaledImageWithImage:next];
     if (scaled == nil) {
       [FBLogger log:@"Could not scale down image"];
       return;
@@ -69,10 +69,10 @@
   });
 }
 
-- (NSData *)scaleImage:(NSData *)image {
+- (NSData *)scaledImageWithImage:(NSData *)image {
   CGImageSourceRef imageData = CGImageSourceCreateWithData((CFDataRef)image, nil);
 
-  CGSize size = [self getImageSize:imageData];
+  CGSize size = [self imageSizeWithImage:imageData];
   CGFloat scaledMaxPixelSize = MAX(size.width, size.height) * self.scalingFactor;
 
   CFDictionaryRef params = (__bridge CFDictionaryRef)@{
@@ -87,13 +87,13 @@
     CFRelease(imageData);
     return nil;
   }
-  NSData *jpegData = [self convertToJpeg:scaled];
+  NSData *jpegData = [self jpegDataWithImage:scaled];
   CFRelease(scaled);
   CFRelease(imageData);
   return jpegData;
 }
 
-- (NSData *)convertToJpeg:(CGImageRef)imageRef {
+- (NSData *)jpegDataWithImage:(CGImageRef)imageRef {
   NSMutableData *newImageData = [NSMutableData data];
   CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((CFMutableDataRef)newImageData, kUTTypeJPEG, 1, NULL);
 
@@ -106,7 +106,7 @@
   return newImageData;
 }
 
-- (CGSize)getImageSize:(CGImageSourceRef)imageSource {
+- (CGSize)imageSizeWithImage:(CGImageSourceRef)imageSource {
   NSDictionary *options = @{
                             (NSString *)kCGImageSourceShouldCache: @(NO)
                             };

--- a/WebDriverAgentLib/Utilities/FBMjpegServer.m
+++ b/WebDriverAgentLib/Utilities/FBMjpegServer.m
@@ -50,8 +50,7 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
     dispatch_async(_backgroundQueue, ^{
       [self streamScreenshot];
     });
-    _imageScaler = [[FBImageIOScaler alloc] initWithScalingFactor:[FBConfiguration mjpegScalingFactor]
-                                               compressionQuality:[FBConfiguration mjpegCompressionFactor]];
+    _imageScaler = [[FBImageIOScaler alloc] init];
   }
   return self;
 }
@@ -109,8 +108,11 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
     [self scheduleNextScreenshotWithInterval:timerInterval timeStarted:timeStarted];
     return;
   }
-  if (self.imageScaler.isScalingEnabled) {
+  CGFloat scalingFactor = [FBConfiguration mjpegScalingFactor]/100.0;
+  if (fabs(1.0 - scalingFactor) > DBL_EPSILON) {
     [self.imageScaler submitImage:screenshotData
+                    scalingFactor:[FBConfiguration mjpegScalingFactor]/100.0
+               compressionQuality:[FBConfiguration mjpegCompressionFactor]/100.0
                 completionHandler:^(NSData * _Nonnull scaled) {
                   [self sendScreenshot:scaled];
                 }];

--- a/WebDriverAgentLib/Utilities/FBMjpegServer.m
+++ b/WebDriverAgentLib/Utilities/FBMjpegServer.m
@@ -108,11 +108,11 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
     [self scheduleNextScreenshotWithInterval:timerInterval timeStarted:timeStarted];
     return;
   }
-  CGFloat scalingFactor = [FBConfiguration mjpegScalingFactor]/100.0;
+  CGFloat scalingFactor = [FBConfiguration mjpegScalingFactor] / 100.0f;
   if (fabs(1.0 - scalingFactor) > DBL_EPSILON) {
     [self.imageScaler submitImage:screenshotData
-                    scalingFactor:[FBConfiguration mjpegScalingFactor]/100.0
-               compressionQuality:[FBConfiguration mjpegCompressionFactor]/100.0
+                    scalingFactor:scalingFactor
+               compressionQuality:[FBConfiguration mjpegCompressionFactor] / 100.0f
                 completionHandler:^(NSData * _Nonnull scaled) {
                   [self sendScreenshot:scaled];
                 }];

--- a/WebDriverAgentLib/Utilities/FBMjpegServer.m
+++ b/WebDriverAgentLib/Utilities/FBMjpegServer.m
@@ -109,10 +109,15 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
     [self scheduleNextScreenshotWithInterval:timerInterval timeStarted:timeStarted];
     return;
   }
-  [self.imageScaler submitImage:screenshotData
-              completionHandler:^(NSData * _Nonnull scaled) {
-                [self sendScreenshot:scaled];
-              }];
+  if (self.imageScaler.isScalingEnabled) {
+    [self.imageScaler submitImage:screenshotData
+                completionHandler:^(NSData * _Nonnull scaled) {
+                  [self sendScreenshot:scaled];
+                }];
+  } else {
+    [self sendScreenshot:screenshotData];
+  }
+
   [self scheduleNextScreenshotWithInterval:timerInterval timeStarted:timeStarted];
 }
 

--- a/WebDriverAgentLib/Utilities/FBMjpegServer.m
+++ b/WebDriverAgentLib/Utilities/FBMjpegServer.m
@@ -91,14 +91,14 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
   __block NSData *screenshotData = nil;
 
   CGFloat scalingFactor = [FBConfiguration mjpegScalingFactor] / 100.0f;
-  BOOL usesScaling = fabs(1.0 - scalingFactor) > DBL_EPSILON;
+  BOOL usesScaling = fabs(FBMaxScalingFactor - scalingFactor) > DBL_EPSILON;
 
   CGFloat compressionQuality = FBConfiguration.mjpegServerScreenshotQuality / 100.0f;
 
   // If scaling is applied we perform another JPEG compression after scaling
   // To get the desired compressionQuality we need to do a lossless compression here
   if (usesScaling) {
-    compressionQuality = 1.0;
+    compressionQuality = FBMaxScalingFactor;
   }
   id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
   dispatch_semaphore_t sem = dispatch_semaphore_create(0);

--- a/WebDriverAgentLib/Utilities/FBMjpegServer.m
+++ b/WebDriverAgentLib/Utilities/FBMjpegServer.m
@@ -112,7 +112,7 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
   if (fabs(1.0 - scalingFactor) > DBL_EPSILON) {
     [self.imageScaler submitImage:screenshotData
                     scalingFactor:scalingFactor
-               compressionQuality:[FBConfiguration mjpegCompressionFactor] / 100.0f
+               compressionQuality:compressionQuality
                 completionHandler:^(NSData * _Nonnull scaled) {
                   [self sendScreenshot:scaled];
                 }];

--- a/WebDriverAgentTests/IntegrationTests/FBImageIOScalerTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBImageIOScalerTests.m
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+#import "FBImageIOScaler.h"
+
+@interface FBImageIOScalerTests : XCTestCase
+
+@property (nonatomic) NSData *originalImage;
+@property (nonatomic) CGSize originalSize;
+
+@end
+
+@implementation FBImageIOScalerTests
+
+- (void)setUp {
+  XCUIApplication *app = [[XCUIApplication alloc] init];
+  [app launch];
+  XCUIScreenshot *screenshot = app.screenshot;
+  self.originalImage = UIImageJPEGRepresentation(screenshot.image, 1.0);
+  self.originalSize = [FBImageIOScalerTests scaledSizeFromImage:screenshot.image];
+}
+
+- (void)testExample {
+  NSUInteger halfScale = 50;
+  CGSize expectedHalfScaleSize = [FBImageIOScalerTests sizeFromSize:self.originalSize withScalingFactor:50];
+  [self scaleImageWithFactor:halfScale
+                expectedSize:expectedHalfScaleSize];
+
+  // 1 is the smalles scaling factor we accept
+  NSUInteger minScale = 0;
+  CGSize expectedMinScaleSize = [FBImageIOScalerTests sizeFromSize:self.originalSize withScalingFactor:1];
+  [self scaleImageWithFactor:minScale
+                expectedSize:expectedMinScaleSize];
+
+  // For scaling factors above 100 we don't perform any scaling and just return the unmodified image
+  NSUInteger unscaled = 200;
+  [self scaleImageWithFactor:unscaled
+                expectedSize:self.originalSize];
+}
+
+- (void)scaleImageWithFactor:(NSUInteger)scalingFactor expectedSize:(CGSize)excpectedSize {
+  FBImageIOScaler *scaler = [[FBImageIOScaler alloc] initWithScalingFactor:scalingFactor
+                                                        compressionQuality:100];
+
+  id expScaled = [self expectationWithDescription:@"Receive scaled image"];
+
+  [scaler submitImage:self.originalImage
+    completionHandler:^(NSData *scaled) {
+      UIImage *scaledImage = [UIImage imageWithData:scaled];
+      CGSize scaledSize = [FBImageIOScalerTests scaledSizeFromImage:scaledImage];
+
+      XCTAssertEqualWithAccuracy(scaledSize.width, excpectedSize.width, DBL_EPSILON);
+      XCTAssertEqualWithAccuracy(scaledSize.height, excpectedSize.height, DBL_EPSILON);
+
+      [expScaled fulfill];
+    }];
+
+  [self waitForExpectations:@[expScaled]
+                    timeout:0.5];
+
+}
+
++ (CGSize)scaledSizeFromImage:(UIImage *)image {
+  return CGSizeMake(image.size.width * image.scale, image.size.height * image.scale);
+}
+
++ (CGSize)sizeFromSize:(CGSize)size withScalingFactor:(NSUInteger)scalingFactor {
+  return CGSizeMake(round(size.width * (scalingFactor / 100.0)), round(size.height * (scalingFactor / 100.0)));
+}
+
+@end
+

--- a/WebDriverAgentTests/IntegrationTests/FBImageIOScalerTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBImageIOScalerTests.m
@@ -28,30 +28,31 @@
 }
 
 - (void)testExample {
-  NSUInteger halfScale = 50;
-  CGSize expectedHalfScaleSize = [FBImageIOScalerTests sizeFromSize:self.originalSize withScalingFactor:50];
+  CGFloat halfScale = 0.5;
+  CGSize expectedHalfScaleSize = [FBImageIOScalerTests sizeFromSize:self.originalSize withScalingFactor:0.5];
   [self scaleImageWithFactor:halfScale
                 expectedSize:expectedHalfScaleSize];
 
   // 1 is the smalles scaling factor we accept
-  NSUInteger minScale = 0;
-  CGSize expectedMinScaleSize = [FBImageIOScalerTests sizeFromSize:self.originalSize withScalingFactor:1];
+  CGFloat minScale = 0.0;
+  CGSize expectedMinScaleSize = [FBImageIOScalerTests sizeFromSize:self.originalSize withScalingFactor:0.01];
   [self scaleImageWithFactor:minScale
                 expectedSize:expectedMinScaleSize];
 
   // For scaling factors above 100 we don't perform any scaling and just return the unmodified image
-  NSUInteger unscaled = 200;
+  CGFloat unscaled = 2.0;
   [self scaleImageWithFactor:unscaled
                 expectedSize:self.originalSize];
 }
 
-- (void)scaleImageWithFactor:(NSUInteger)scalingFactor expectedSize:(CGSize)excpectedSize {
-  FBImageIOScaler *scaler = [[FBImageIOScaler alloc] initWithScalingFactor:scalingFactor
-                                                        compressionQuality:100];
+- (void)scaleImageWithFactor:(CGFloat)scalingFactor expectedSize:(CGSize)excpectedSize {
+  FBImageIOScaler *scaler = [[FBImageIOScaler alloc] init];
 
   id expScaled = [self expectationWithDescription:@"Receive scaled image"];
 
   [scaler submitImage:self.originalImage
+        scalingFactor:scalingFactor
+   compressionQuality:1.0
     completionHandler:^(NSData *scaled) {
       UIImage *scaledImage = [UIImage imageWithData:scaled];
       CGSize scaledSize = [FBImageIOScalerTests scaledSizeFromImage:scaledImage];
@@ -71,8 +72,8 @@
   return CGSizeMake(image.size.width * image.scale, image.size.height * image.scale);
 }
 
-+ (CGSize)sizeFromSize:(CGSize)size withScalingFactor:(NSUInteger)scalingFactor {
-  return CGSizeMake(round(size.width * (scalingFactor / 100.0)), round(size.height * (scalingFactor / 100.0)));
++ (CGSize)sizeFromSize:(CGSize)size withScalingFactor:(CGFloat)scalingFactor {
+  return CGSizeMake(round(size.width * scalingFactor), round(size.height * scalingFactor));
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/FBImageIOScalerTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBImageIOScalerTests.m
@@ -28,7 +28,7 @@
   self.originalSize = [FBImageIOScalerTests scaledSizeFromImage:screenshot.image];
 }
 
-- (void)testExample {
+- (void)testScaling {
   CGFloat halfScale = 0.5;
   CGSize expectedHalfScaleSize = [FBImageIOScalerTests sizeFromSize:self.originalSize withScalingFactor:0.5];
   [self scaleImageWithFactor:halfScale

--- a/WebDriverAgentTests/IntegrationTests/FBImageIOScalerTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBImageIOScalerTests.m
@@ -9,8 +9,9 @@
 
 #import <XCTest/XCTest.h>
 #import "FBImageIOScaler.h"
+#import "FBIntegrationTestCase.h"
 
-@interface FBImageIOScalerTests : XCTestCase
+@interface FBImageIOScalerTests : FBIntegrationTestCase
 
 @property (nonatomic) NSData *originalImage;
 @property (nonatomic) CGSize originalSize;

--- a/WebDriverAgentTests/IntegrationTests/FBImageIOScalerTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBImageIOScalerTests.m
@@ -30,13 +30,13 @@
 
 - (void)testScaling {
   CGFloat halfScale = 0.5;
-  CGSize expectedHalfScaleSize = [FBImageIOScalerTests sizeFromSize:self.originalSize withScalingFactor:0.5];
+  CGSize expectedHalfScaleSize = [FBImageIOScalerTests sizeFromSize:self.originalSize scalingFactor:0.5];
   [self scaleImageWithFactor:halfScale
                 expectedSize:expectedHalfScaleSize];
 
   // 1 is the smalles scaling factor we accept
   CGFloat minScale = 0.0;
-  CGSize expectedMinScaleSize = [FBImageIOScalerTests sizeFromSize:self.originalSize withScalingFactor:0.01];
+  CGSize expectedMinScaleSize = [FBImageIOScalerTests sizeFromSize:self.originalSize scalingFactor:0.01];
   [self scaleImageWithFactor:minScale
                 expectedSize:expectedMinScaleSize];
 
@@ -73,7 +73,7 @@
   return CGSizeMake(image.size.width * image.scale, image.size.height * image.scale);
 }
 
-+ (CGSize)sizeFromSize:(CGSize)size withScalingFactor:(CGFloat)scalingFactor {
++ (CGSize)sizeFromSize:(CGSize)size scalingFactor:(CGFloat)scalingFactor {
   return CGSizeMake(round(size.width * scalingFactor), round(size.height * scalingFactor));
 }
 


### PR DESCRIPTION
Currently we get full scale screenshots on the mjpeg stream. To reduce bandwidth or to make processing the screenshots on the host more efficient we could scale down images already on the device.