### PR TITLE
Delay -[XCUIApplicationProcess setEventLoopHasIdled:] to quiescence apps

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1FC3B2E32121ECF600B61EE0 /* FBApplicationProcessProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FC3B2E12121EC8C00B61EE0 /* FBApplicationProcessProxyTests.m */; };
+		6385F4A7220A40760095BBDB /* XCUIApplicationProcessDelay.m in Sources */ = {isa = PBXBuildFile; fileRef = 6385F4A5220A40760095BBDB /* XCUIApplicationProcessDelay.m */; };
 		63CCF91221ECE4C700E94ABD /* FBImageIOScaler.h in Headers */ = {isa = PBXBuildFile; fileRef = 63CCF91021ECE4C700E94ABD /* FBImageIOScaler.h */; };
 		63CCF91321ECE4C700E94ABD /* FBImageIOScaler.m in Sources */ = {isa = PBXBuildFile; fileRef = 63CCF91121ECE4C700E94ABD /* FBImageIOScaler.m */; };
 		63FD950221F9D06100A3E356 /* FBImageIOScalerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 631B523421F6174300625362 /* FBImageIOScalerTests.m */; };
@@ -459,6 +460,7 @@
 		1FC3B2E12121EC8C00B61EE0 /* FBApplicationProcessProxyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBApplicationProcessProxyTests.m; sourceTree = "<group>"; };
 		44757A831D42CE8300ECF35E /* XCUIDeviceRotationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCUIDeviceRotationTests.m; sourceTree = "<group>"; };
 		631B523421F6174300625362 /* FBImageIOScalerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBImageIOScalerTests.m; sourceTree = "<group>"; };
+		6385F4A5220A40760095BBDB /* XCUIApplicationProcessDelay.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XCUIApplicationProcessDelay.m; sourceTree = "<group>"; };
 		63CCF91021ECE4C700E94ABD /* FBImageIOScaler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBImageIOScaler.h; sourceTree = "<group>"; };
 		63CCF91121ECE4C700E94ABD /* FBImageIOScaler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBImageIOScaler.m; sourceTree = "<group>"; };
 		710181F7211DF584002FD3A8 /* CocoaAsyncSocket.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaAsyncSocket.framework; path = Carthage/Build/iOS/CocoaAsyncSocket.framework; sourceTree = "<group>"; };
@@ -1164,6 +1166,7 @@
 				EE6B64FC1D0F86EF00E85F5D /* XCTestPrivateSymbols.m */,
 				63CCF91021ECE4C700E94ABD /* FBImageIOScaler.h */,
 				63CCF91121ECE4C700E94ABD /* FBImageIOScaler.m */,
+				6385F4A5220A40760095BBDB /* XCUIApplicationProcessDelay.m */,
 			);
 			name = Utilities;
 			path = WebDriverAgentLib/Utilities;
@@ -1895,6 +1898,7 @@
 				EE158AC71CBD456F00A3E3F0 /* FBScreenshotCommands.m in Sources */,
 				EEEC7C931F21F27A0053426C /* FBPredicate.m in Sources */,
 				7136A47A1E8918E60024FC3D /* XCUIElement+FBPickerWheel.m in Sources */,
+				6385F4A7220A40760095BBDB /* XCUIApplicationProcessDelay.m in Sources */,
 				711084451DA3AA7500F913D6 /* FBXPath.m in Sources */,
 				719CD8FD2126C88B00C7D0C2 /* XCUIApplication+FBAlert.m in Sources */,
 				71241D781FAE31F100B9559F /* FBAppiumActionsSynthesizer.m in Sources */,

--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
@@ -85,6 +85,11 @@
             value = "$(WDA_PRODUCT_BUNDLE_IDENTIFIER)"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "EVENTLOOP_IDLE_DELAY_SEC"
+            value = "5"
+            isEnabled = "NO">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>

--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
@@ -87,8 +87,8 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "EVENTLOOP_IDLE_DELAY_SEC"
-            value = "5"
-            isEnabled = "NO">
+            value = "0"
+            isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>

--- a/WebDriverAgentLib/Utilities/XCUIApplicationProcessDelay.m
+++ b/WebDriverAgentLib/Utilities/XCUIApplicationProcessDelay.m
@@ -12,7 +12,7 @@
 #import "FBLogger.h"
 
 static void (*orig_set_event_loop_has_idled)(id, SEL, BOOL);
-static unsigned int delay = 0;
+static NSUInteger delay = 0;
 
 @interface XCUIApplicationProcessDelay : NSObject
 
@@ -27,20 +27,20 @@ static unsigned int delay = 0;
     [FBLogger verboseLog:@"don't delay -[XCUIApplicationProcess setEventLoopHasIdled:]"];
     return;
   }
-  delay = [setEventLoopIdleDelay intValue];
+  delay = [setEventLoopIdleDelay integerValue];
   Method original = class_getInstanceMethod([XCUIApplicationProcess class], @selector(setEventLoopHasIdled:));
   if (original == nil) {
     [FBLogger log:@"Could not find method -[XCUIApplicationProcess setEventLoopHasIdled:]"];
     return;
   }
-  [FBLogger verboseLog:[NSString stringWithFormat:@"Delay -[XCUIApplicationProcess setEventLoopHasIdled:] by %u seconds", delay]];
+  [FBLogger verboseLog:[NSString stringWithFormat:@"Delay -[XCUIApplicationProcess setEventLoopHasIdled:] by %lu seconds", (unsigned long)delay]];
   orig_set_event_loop_has_idled = (void(*)(id, SEL, BOOL)) method_getImplementation(original);
   Method replace = class_getClassMethod([XCUIApplicationProcessDelay class], @selector(setEventLoopHasIdled:));
   method_setImplementation(original, method_getImplementation(replace));
 }
 
 + (void)setEventLoopHasIdled:(BOOL)idled {
-  sleep(delay);
+  [NSThread sleepForTimeInterval:delay];
   orig_set_event_loop_has_idled(self, _cmd, idled);
 }
 

--- a/WebDriverAgentLib/Utilities/XCUIApplicationProcessDelay.m
+++ b/WebDriverAgentLib/Utilities/XCUIApplicationProcessDelay.m
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <objc/runtime.h>
+#import "XCUIApplicationProcess.h"
+#import "FBLogger.h"
+
+static void (*orig_set_event_loop_has_idled)(id, SEL, BOOL);
+static unsigned int delay = 0;
+
+@interface XCUIApplicationProcessDelay : NSObject
+
+@end
+
+@implementation XCUIApplicationProcessDelay
+
++ (void)load {
+  NSDictionary *env = [[NSProcessInfo processInfo] environment];
+  NSString *setEventLoopIdleDelay = [env objectForKey:@"DELAY_SET_EVENTLOOP_IDLE"];
+  if (!setEventLoopIdleDelay || [setEventLoopIdleDelay length] == 0) {
+    [FBLogger verboseLog:@"don't delay -[XCUIApplicationProcess setEventLoopHasIdled:]"];
+    return;
+  }
+  delay = [setEventLoopIdleDelay intValue];
+  Method original = class_getInstanceMethod([XCUIApplicationProcess class], @selector(setEventLoopHasIdled:));
+  if (original == nil) {
+    [FBLogger log:@"Could not find method -[XCUIApplicationProcess setEventLoopHasIdled:]"];
+    return;
+  }
+  [FBLogger verboseLog:[NSString stringWithFormat:@"Delay -[XCUIApplicationProcess setEventLoopHasIdled:] by %u seconds", delay]];
+  orig_set_event_loop_has_idled = (void(*)(id, SEL, BOOL)) method_getImplementation(original);
+  Method replace = class_getClassMethod([XCUIApplicationProcessDelay class], @selector(setEventLoopHasIdled:));
+  method_setImplementation(original, method_getImplementation(replace));
+}
+
++ (void)setEventLoopHasIdled:(BOOL)idled {
+  sleep(delay);
+  orig_set_event_loop_has_idled(self, _cmd, idled);
+}
+
+@end

--- a/WebDriverAgentLib/Utilities/XCUIApplicationProcessDelay.m
+++ b/WebDriverAgentLib/Utilities/XCUIApplicationProcessDelay.m
@@ -44,13 +44,13 @@ static NSUInteger delay = 0;
     [FBLogger log:@"Could not find method -[XCUIApplicationProcess setEventLoopHasIdled:]"];
     return;
   }
-  [FBLogger verboseLog:[NSString stringWithFormat:@"Delay -[XCUIApplicationProcess setEventLoopHasIdled:] by %lu seconds", (unsigned long)delay]];
   orig_set_event_loop_has_idled = (void(*)(id, SEL, BOOL)) method_getImplementation(original);
   Method replace = class_getClassMethod([XCUIApplicationProcessDelay class], @selector(setEventLoopHasIdled:));
   method_setImplementation(original, method_getImplementation(replace));
 }
 
 + (void)setEventLoopHasIdled:(BOOL)idled {
+  [FBLogger verboseLog:[NSString stringWithFormat:@"Delay -[XCUIApplicationProcess setEventLoopHasIdled:] by %lu seconds", (unsigned long)delay]];
   [NSThread sleepForTimeInterval:delay];
   orig_set_event_loop_has_idled(self, _cmd, idled);
 }

--- a/WebDriverAgentLib/Utilities/XCUIApplicationProcessDelay.m
+++ b/WebDriverAgentLib/Utilities/XCUIApplicationProcessDelay.m
@@ -19,13 +19,14 @@
  '-[XCUIApplicationProcess setAnimationsHaveFinished:]', which are the properties that are checked to
  determine whether an app has quiescenced or not.
  Delaying the call to on of the setters can fix this issue. Setting the environment variable
- 'DELAY_SET_EVENTLOOP_IDLE' will swizzle the method '-[XCUIApplicationProcess setEventLoopHasIdled:]'
+ 'DELAY_SET_EVENTLOOP_IDLE_S' will swizzle the method '-[XCUIApplicationProcess setEventLoopHasIdled:]'
  and add a thread sleep of the value specified in the environment variable in seconds.
  */
 @interface XCUIApplicationProcessDelay : NSObject
 
 @end
 
+static NSString *const DELAY_SET_EVENTLOOP_IDLE_S = @"DELAY_SET_EVENTLOOP_IDLE_S";
 static void (*orig_set_event_loop_has_idled)(id, SEL, BOOL);
 static NSUInteger delay = 0;
 
@@ -33,7 +34,7 @@ static NSUInteger delay = 0;
 
 + (void)load {
   NSDictionary *env = [[NSProcessInfo processInfo] environment];
-  NSString *setEventLoopIdleDelay = [env objectForKey:@"DELAY_SET_EVENTLOOP_IDLE"];
+  NSString *setEventLoopIdleDelay = [env objectForKey:DELAY_SET_EVENTLOOP_IDLE_S];
   if (!setEventLoopIdleDelay || [setEventLoopIdleDelay length] == 0) {
     [FBLogger verboseLog:@"don't delay -[XCUIApplicationProcess setEventLoopHasIdled:]"];
     return;

--- a/WebDriverAgentLib/Utilities/XCUIApplicationProcessDelay.m
+++ b/WebDriverAgentLib/Utilities/XCUIApplicationProcessDelay.m
@@ -40,7 +40,7 @@ static NSTimeInterval delay = 0;
     return;
   }
   delay = [setEventLoopIdleDelay doubleValue];
-  if (fabs(delay) < DBL_EPSILON) {
+  if (delay < DBL_EPSILON) {
     [FBLogger log:[NSString stringWithFormat:@"Value of '%@' has to be greater than zero to delay -[XCUIApplicationProcess setEventLoopHasIdled:]",
                    EVENTLOOP_IDLE_DELAY_SEC]];
     return;


### PR DESCRIPTION
In certain cases a `POST /session` request won't return because WebDriverAgent waits for the app under test to quiescence.

testmanagerd should send a notification `AnimationsNonActive` at some point when the app is launched. The notification is handled by `-[XCAXClient_iOS handleUserTestingNotification:]` and this client changes the values for `eventLoopHasIdled` and `animationsHaveFinished` in `XCUIApplicationProcess`, but in the app and devices I was testing with, this notification never arrived.
By adding breakpoints the app quiescenced eventually and by adding a sleep of at least 2 seconds (this may be device specific, but on a SE device 1s was to little) to one of the setters `-[XCUIApplicationProcess setAnimationsHaveFinished:]` or `-[XCUIApplicationProcess setEventLoopHasIdled:]` (doesn't matter which one) I saw the same behaviour.

Since this will increase session creation time in most cases where it's working fine anyways this should be only enabled when needed by setting `DELAY_SET_EVENTLOOP_IDLE_S`.