### PR TITLE
use respondsToSelector to check applicationProcessTracker

### DIFF
--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
@@ -74,7 +74,12 @@ static id FBAXClient = nil;
   static BOOL hasTracker;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    hasTracker = [FBAXClient valueForKey:@"applicationProcessTracker"] != nil;
+    @try {
+      hasTracker = [FBAXClient valueForKey:@"applicationProcessTracker"] != nil;
+    } @catch (NSException *error) {
+      [FBLogger logFmt:@"%@ happened in getting applicationProcessTracker: %@", error.name, error.description];
+      hasTracker = false;
+    }
   });
   return hasTracker;
 }

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
@@ -74,12 +74,7 @@ static id FBAXClient = nil;
   static BOOL hasTracker;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    @try {
-      hasTracker = [FBAXClient valueForKey:@"applicationProcessTracker"] != nil;
-    } @catch (NSException *error) {
-      [FBLogger logFmt:@"%@ happened in getting applicationProcessTracker: %@", error.name, error.description];
-      hasTracker = false;
-    }
+    hasTracker = [FBAXClient respondsToSelector:@selector(applicationProcessTracker)];
   });
   return hasTracker;
 }


### PR DESCRIPTION
When I ran with Xcode9, https://github.com/appium/WebDriverAgent/pull/142#issuecomment-469976734 happened.
We can return `false` in this case because we should show no `applicationProcessTracker` here, I think.

It worked without exception with Xcode 10.1 env. (It had no Xcode 10.2-beta env)