### PR TITLE
Using swizzle to handle quiescence validation usage

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		1FC3B2E32121ECF600B61EE0 /* FBApplicationProcessProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FC3B2E12121EC8C00B61EE0 /* FBApplicationProcessProxyTests.m */; };
+		31EC77FC224F7D0600380FCD /* XCUIApplicationProcessQuiescence.h in Headers */ = {isa = PBXBuildFile; fileRef = 31EC77FA224F7D0600380FCD /* XCUIApplicationProcessQuiescence.h */; };
+		31EC77FD224F7D0600380FCD /* XCUIApplicationProcessQuiescence.h in Headers */ = {isa = PBXBuildFile; fileRef = 31EC77FA224F7D0600380FCD /* XCUIApplicationProcessQuiescence.h */; };
+		31EC77FE224F7D0600380FCD /* XCUIApplicationProcessQuiescence.m in Sources */ = {isa = PBXBuildFile; fileRef = 31EC77FB224F7D0600380FCD /* XCUIApplicationProcessQuiescence.m */; };
+		31EC77FF224F7D0600380FCD /* XCUIApplicationProcessQuiescence.m in Sources */ = {isa = PBXBuildFile; fileRef = 31EC77FB224F7D0600380FCD /* XCUIApplicationProcessQuiescence.m */; };
 		6385F4A7220A40760095BBDB /* XCUIApplicationProcessDelay.m in Sources */ = {isa = PBXBuildFile; fileRef = 6385F4A5220A40760095BBDB /* XCUIApplicationProcessDelay.m */; };
 		63CCF91221ECE4C700E94ABD /* FBImageIOScaler.h in Headers */ = {isa = PBXBuildFile; fileRef = 63CCF91021ECE4C700E94ABD /* FBImageIOScaler.h */; };
 		63CCF91321ECE4C700E94ABD /* FBImageIOScaler.m in Sources */ = {isa = PBXBuildFile; fileRef = 63CCF91121ECE4C700E94ABD /* FBImageIOScaler.m */; };
@@ -793,6 +797,8 @@
 /* Begin PBXFileReference section */
 		1BA7DD8C206D694B007C7C26 /* XCTElementSetTransformer-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTElementSetTransformer-Protocol.h"; sourceTree = "<group>"; };
 		1FC3B2E12121EC8C00B61EE0 /* FBApplicationProcessProxyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBApplicationProcessProxyTests.m; sourceTree = "<group>"; };
+		31EC77FA224F7D0600380FCD /* XCUIApplicationProcessQuiescence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCUIApplicationProcessQuiescence.h; sourceTree = "<group>"; };
+		31EC77FB224F7D0600380FCD /* XCUIApplicationProcessQuiescence.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XCUIApplicationProcessQuiescence.m; sourceTree = "<group>"; };
 		44757A831D42CE8300ECF35E /* XCUIDeviceRotationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCUIDeviceRotationTests.m; sourceTree = "<group>"; };
 		631B523421F6174300625362 /* FBImageIOScalerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBImageIOScalerTests.m; sourceTree = "<group>"; };
 		633E904A220DEE7F007CADF9 /* XCUIApplicationProcessDelay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCUIApplicationProcessDelay.h; sourceTree = "<group>"; };
@@ -1574,6 +1580,8 @@
 				63CCF91121ECE4C700E94ABD /* FBImageIOScaler.m */,
 				633E904A220DEE7F007CADF9 /* XCUIApplicationProcessDelay.h */,
 				6385F4A5220A40760095BBDB /* XCUIApplicationProcessDelay.m */,
+				31EC77FA224F7D0600380FCD /* XCUIApplicationProcessQuiescence.h */,
+				31EC77FB224F7D0600380FCD /* XCUIApplicationProcessQuiescence.m */,
 			);
 			name = Utilities;
 			path = WebDriverAgentLib/Utilities;
@@ -1914,6 +1922,7 @@
 				641EE65E2240C5CA00173FCB /* XCUICoordinate+FBFix.h in Headers */,
 				641EE65F2240C5CA00173FCB /* XCSourceCodeTreeNodeEnumerator.h in Headers */,
 				641EE6602240C5CA00173FCB /* XCUIElement+FBIsVisible.h in Headers */,
+				31EC77FD224F7D0600380FCD /* XCUIApplicationProcessQuiescence.h in Headers */,
 				641EE6612240C5CA00173FCB /* XCUIElement+FBTap.h in Headers */,
 				641EE6622240C5CA00173FCB /* FBResponsePayload.h in Headers */,
 				641EE6632240C5CA00173FCB /* FBUnknownCommands.h in Headers */,
@@ -2113,6 +2122,7 @@
 				EEC9EED620064FAA00BC0D5B /* XCUICoordinate+FBFix.h in Headers */,
 				EE35AD371E3B77D600A02D78 /* XCSourceCodeTreeNodeEnumerator.h in Headers */,
 				EE158AB01CBD456F00A3E3F0 /* XCUIElement+FBIsVisible.h in Headers */,
+				31EC77FC224F7D0600380FCD /* XCUIApplicationProcessQuiescence.h in Headers */,
 				EE158AB41CBD456F00A3E3F0 /* XCUIElement+FBTap.h in Headers */,
 				EE158ADC1CBD456F00A3E3F0 /* FBResponsePayload.h in Headers */,
 				EE158ACC1CBD456F00A3E3F0 /* FBUnknownCommands.h in Headers */,
@@ -2581,6 +2591,7 @@
 				641EE70F2240CE4800173FCB /* FBTVNavigationTracker.m in Sources */,
 				641EE5DE2240C5CA00173FCB /* XCUIApplication+FBTouchAction.m in Sources */,
 				641EE5DF2240C5CA00173FCB /* FBWebServer.m in Sources */,
+				31EC77FF224F7D0600380FCD /* XCUIApplicationProcessQuiescence.m in Sources */,
 				641EE5E02240C5CA00173FCB /* FBTCPSocket.m in Sources */,
 				641EE5E12240C5CA00173FCB /* FBErrorBuilder.m in Sources */,
 				641EE5E22240C5CA00173FCB /* XCUIElement+FBClassChain.m in Sources */,
@@ -2671,6 +2682,7 @@
 				641EE70E2240CE4800173FCB /* FBTVNavigationTracker.m in Sources */,
 				71BD20741F86116100B36EC2 /* XCUIApplication+FBTouchAction.m in Sources */,
 				EE158AE71CBD456F00A3E3F0 /* FBWebServer.m in Sources */,
+				31EC77FE224F7D0600380FCD /* XCUIApplicationProcessQuiescence.m in Sources */,
 				715557D4211DBCE700613B26 /* FBTCPSocket.m in Sources */,
 				EE3A18631CDE618F00DE4205 /* FBErrorBuilder.m in Sources */,
 				71A7EAF61E20516B001DA4F2 /* XCUIElement+FBClassChain.m in Sources */,

--- a/WebDriverAgentLib/FBApplication.m
+++ b/WebDriverAgentLib/FBApplication.m
@@ -20,6 +20,7 @@
 #import "XCUIElement.h"
 #import "XCUIElementQuery.h"
 #import "FBXCAXClientProxy.h"
+#import "XCUIApplicationProcessQuiescence.h"
 
 @interface FBApplication ()
 @property (nonatomic, assign) BOOL fb_isObservingAppImplCurrentProcess;
@@ -89,10 +90,7 @@
 
 - (void)launch
 {
-  if (!self.fb_shouldWaitForQuiescence && ![FBXCAXClientProxy.sharedClient hasProcessTracker]) {
-    [self.fb_appImpl addObserver:self forKeyPath:FBStringify(XCUIApplicationImpl, currentProcess) options:(NSKeyValueObservingOptions)(NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew) context:nil];
-    self.fb_isObservingAppImplCurrentProcess = YES;
-  }
+  [XCUIApplicationProcessQuiescence setQuiescenceCheck:self.fb_shouldWaitForQuiescence];
   [super launch];
   [FBApplication fb_registerApplication:self withProcessID:self.processID];
 }

--- a/WebDriverAgentLib/Utilities/XCUIApplicationProcessQuiescence.h
+++ b/WebDriverAgentLib/Utilities/XCUIApplicationProcessQuiescence.h
@@ -11,9 +11,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ This class allows disabling/enabling the usage of application launch quiescence validation.
+ */
 @interface XCUIApplicationProcessQuiescence : NSObject
 
-+ (void) setQuiescenceCheck:(BOOL)value;
+/**
+ Set the usage of application quiescence validation (defaults to NO).
+ */
++ (void)setQuiescenceCheck:(BOOL)value;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/XCUIApplicationProcessQuiescence.h
+++ b/WebDriverAgentLib/Utilities/XCUIApplicationProcessQuiescence.h
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface XCUIApplicationProcessQuiescence : NSObject
+
++ (void) setQuiescenceCheck:(BOOL)value;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/XCUIApplicationProcessQuiescence.m
+++ b/WebDriverAgentLib/Utilities/XCUIApplicationProcessQuiescence.m
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "XCUIApplicationProcessQuiescence.h"
+#import "XCUIApplicationProcess.h"
+#import <objc/runtime.h>
+#import "FBLogger.h"
+
+static void (*original_waitForQuiescenceIncludingAnimationsIdle)(id, SEL, BOOL);
+static BOOL isWaitForQuiescence = NO;
+
+@implementation XCUIApplicationProcessQuiescence
+
++ (void)load
+{
+  Method waitForQuiescenceMethod = class_getInstanceMethod([XCUIApplicationProcess class], @selector(waitForQuiescenceIncludingAnimationsIdle:));
+  if (waitForQuiescenceMethod != nil) {
+    original_waitForQuiescenceIncludingAnimationsIdle = (void(*)(id, SEL, BOOL)) method_getImplementation(waitForQuiescenceMethod);
+    Method newMethod = class_getClassMethod([XCUIApplicationProcessQuiescence class], @selector(swizzledWaitForQuiescenceIncludingAnimationsIdle:));
+    method_setImplementation(waitForQuiescenceMethod, method_getImplementation(newMethod));
+  } else {
+    [FBLogger log:@"Could not find method -[XCUIApplicationProcess waitForQuiescenceIncludingAnimationsIdle:]"];
+  }
+}
+
++ (void)setQuiescenceCheck:(BOOL)value;
+{
+  isWaitForQuiescence = value;
+}
+
++ (void)swizzledWaitForQuiescenceIncludingAnimationsIdle:(BOOL)includeAnimations
+{
+  if (!isWaitForQuiescence) {
+    return;
+  }
+  original_waitForQuiescenceIncludingAnimationsIdle(self, _cmd, includeAnimations);
+}
+
+@end

--- a/WebDriverAgentLib/Utilities/XCUIApplicationProcessQuiescence.m
+++ b/WebDriverAgentLib/Utilities/XCUIApplicationProcessQuiescence.m
@@ -29,7 +29,7 @@ static BOOL isWaitForQuiescence = NO;
   }
 }
 
-+ (void)setQuiescenceCheck:(BOOL)value;
++ (void)setQuiescenceCheck:(BOOL)value
 {
   isWaitForQuiescence = value;
 }


### PR DESCRIPTION
The latest changes to FBApplicationProcessProxy does not allow app reactivation due to KVO exceptions.

This PR replaces the usage of FBApplicationProcessProxy by an override of `[XCUIApplicationProcess waitForQuiescenceIncludingAnimationsIdle:]`.

Tested on Xcode 9.2, 9.4.1, 10.1 and 10.2.

Once this PR is merged we should be able to merge https://github.com/appium/WebDriverAgent/pull/134