### PR TITLE
add menu button for tvOS

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -231,6 +231,15 @@ static bool fb_isLocked;
   [supportedButtonNames addObject:@"volumeUp"];
   [supportedButtonNames addObject:@"volumeDown"];
 #endif
+
+#if TARGET_OS_TV
+  if ([buttonName.lowercaseString isEqualToString:@"menu"]) {
+    [[XCUIRemote sharedRemote] pressButton: XCUIRemoteButtonMenu];
+    return YES;
+  }
+  [supportedButtonNames addObject:@"menu"];
+#endif
+
   if (dstButton == 0) {
     return [[[FBErrorBuilder builder]
              withDescriptionFormat:@"The button '%@' is unknown. Only the following button names are supported: %@", buttonName, supportedButtonNames]


### PR DESCRIPTION
https://developer.apple.com/design/human-interface-guidelines/tvos/remote-and-controllers/remote/

On tvOS, _menu_ button works as "back" to the previous section/view etc.
_home_ works as back to the top screen.
This _menu_ should work only for `XCUIRemote`