### PR TITLE
configure keyboard pref

### DIFF
--- a/PrivateHeaders/TextInput/TIPreferencesController.h
+++ b/PrivateHeaders/TextInput/TIPreferencesController.h
@@ -1,0 +1,45 @@
+/**
+ * iOS-Runtime-Headers/PrivateFrameworks/TextInput.framework.
+ * Text Input preferences controller to modify the keyboard preferences for iOS 8+.
+ *
+ * Note:
+ * "autocorrection" will be PrivateFrameworks/TextInput.framework/TIKeyboardState.h in the future?
+ */
+@interface TIPreferencesController : NSObject
+
+/**
+ * Whether the autocorrection is enabled.
+ */
+@property BOOL autocorrectionEnabled;
+
+/**
+ * Whether the predication is enabled.
+ * */
+@property BOOL predictionEnabled;
+
+/**
+ The shared singleton instance.
+ */
++ (instancetype)sharedPreferencesController;
+
+/**
+ Synchronise the change to save it on disk.
+ */
+- (void)synchronizePreferences;
+
+/**
+ * Modify the preference @c value by the @c key
+ *
+ * @param value The value to set it to @c key
+ * @param key The key name to set @c value to
+ */
+- (void)setValue:(NSValue *)value forPreferenceKey:(NSString *)key;
+
+/**
+ * Get the preferenve by @c key
+ *
+ * @param key The key name to get the value
+ * @return Whether the @c key is enabled
+ */
+- (BOOL)boolForPreferenceKey:(NSString *)key;
+@end

--- a/PrivateHeaders/UIKitCore/UIKeyboardImpl.h
+++ b/PrivateHeaders/UIKitCore/UIKeyboardImpl.h
@@ -1,0 +1,17 @@
+#if TARGET_OS_SIMULATOR
+/**
+ * iOS-Runtime-Headers/PrivateFrameworks/UIKitCore.framework/UIKeyboardImpl.h
+ */
+@interface UIKeyboardImpl
++ (instancetype)sharedInstance;
+/**
+ * Modify software keyboard condition on simulators for over Xcode 6
+ * This setting is global. The change applies to all instances of UIKeyboardImpl.
+ *
+ * Idea: https://chromium.googlesource.com/chromium/src/base/+/ababb4cf8b6049a642a2f361b1006a07561c2d96/test/test_support_ios.mm#41
+ *
+ * @param enabled Whether turn setAutomaticMinimizationEnabled on
+ */
+- (void)setAutomaticMinimizationEnabled:(BOOL)enabled;
+@end
+#endif  // TARGET_IPHONE_SIMULATOR

--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -303,6 +303,10 @@
 		641EE70F2240CE4800173FCB /* FBTVNavigationTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 641EE70D2240CE4800173FCB /* FBTVNavigationTracker.m */; };
 		641EE7172240DE8C00173FCB /* RoutingHTTPServer.framework in Copy frameworks */ = {isa = PBXBuildFile; fileRef = 641EE7122240DE5E00173FCB /* RoutingHTTPServer.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		641EE7192240DFC100173FCB /* RoutingHTTPServer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 641EE7122240DE5E00173FCB /* RoutingHTTPServer.framework */; };
+		648C10AB22AAAD9C00B81B9A /* UIKeyboardImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 648C10AA22AAAD9C00B81B9A /* UIKeyboardImpl.h */; };
+		648C10AC22AAAD9C00B81B9A /* UIKeyboardImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 648C10AA22AAAD9C00B81B9A /* UIKeyboardImpl.h */; };
+		648C10AF22AAAE4000B81B9A /* TIPreferencesController.h in Headers */ = {isa = PBXBuildFile; fileRef = 648C10AE22AAAE4000B81B9A /* TIPreferencesController.h */; };
+		648C10B022AAAE4000B81B9A /* TIPreferencesController.h in Headers */ = {isa = PBXBuildFile; fileRef = 648C10AE22AAAE4000B81B9A /* TIPreferencesController.h */; };
 		64B264FE228C50E0002A5025 /* WebDriverAgentLib_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 641EE6F82240C5CA00173FCB /* WebDriverAgentLib_tvOS.framework */; };
 		64B26504228C5299002A5025 /* FBTVNavigationTrackerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 64B264F3228C5098002A5025 /* FBTVNavigationTrackerTests.m */; };
 		64B26508228C5514002A5025 /* XCUIElementDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = 64B26507228C5514002A5025 /* XCUIElementDouble.m */; };
@@ -825,6 +829,8 @@
 		641EE70D2240CE4800173FCB /* FBTVNavigationTracker.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBTVNavigationTracker.m; sourceTree = "<group>"; };
 		641EE7122240DE5E00173FCB /* RoutingHTTPServer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RoutingHTTPServer.framework; path = Carthage/Build/tvOS/RoutingHTTPServer.framework; sourceTree = "<group>"; };
 		641EE73A2240F49D00173FCB /* YYCache.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = YYCache.framework; path = Carthage/Build/tvOS/YYCache.framework; sourceTree = "<group>"; };
+		648C10AA22AAAD9C00B81B9A /* UIKeyboardImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIKeyboardImpl.h; sourceTree = "<group>"; };
+		648C10AE22AAAE4000B81B9A /* TIPreferencesController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TIPreferencesController.h; sourceTree = "<group>"; };
 		64B264EB228C4D54002A5025 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		64B264F3228C5098002A5025 /* FBTVNavigationTrackerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBTVNavigationTrackerTests.m; sourceTree = "<group>"; };
 		64B264F9228C50E0002A5025 /* UnitTests_tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests_tvOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1308,6 +1314,22 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		648C10A922AAAD7600B81B9A /* UIKitCore */ = {
+			isa = PBXGroup;
+			children = (
+				648C10AA22AAAD9C00B81B9A /* UIKeyboardImpl.h */,
+			);
+			path = UIKitCore;
+			sourceTree = "<group>";
+		};
+		648C10AD22AAAE2400B81B9A /* TextInput */ = {
+			isa = PBXGroup;
+			children = (
+				648C10AE22AAAE4000B81B9A /* TIPreferencesController.h */,
+			);
+			path = TextInput;
+			sourceTree = "<group>";
+		};
 		64B264E8228C4D54002A5025 /* UnitTests_tvOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -1394,6 +1416,8 @@
 		91F9DB731B99DDD8001349B2 /* PrivateHeaders */ = {
 			isa = PBXGroup;
 			children = (
+				648C10AD22AAAE2400B81B9A /* TextInput */,
+				648C10A922AAAD7600B81B9A /* UIKitCore */,
 				EED030DB1BFA3461007EDC1D /* XCTest */,
 			);
 			path = PrivateHeaders;
@@ -1931,6 +1955,7 @@
 				641EE6372240C5CA00173FCB /* XCSourceCodeTreeNode.h in Headers */,
 				641EE6382240C5CA00173FCB /* XCPointerEventPath.h in Headers */,
 				641EE6392240C5CA00173FCB /* FBRouteRequest.h in Headers */,
+				648C10AC22AAAD9C00B81B9A /* UIKeyboardImpl.h in Headers */,
 				641EE63A2240C5CA00173FCB /* XCTest.h in Headers */,
 				641EE63B2240C5CA00173FCB /* FBAlertsMonitor.h in Headers */,
 				641EE63C2240C5CA00173FCB /* XCAccessibilityElement.h in Headers */,
@@ -2059,6 +2084,7 @@
 				641EE6B32240C5CA00173FCB /* XCAXClient_iOS.h in Headers */,
 				641EE6B42240C5CA00173FCB /* XCTWaiterManager.h in Headers */,
 				641EE6B52240C5CA00173FCB /* XCTestDriverInterface-Protocol.h in Headers */,
+				648C10B022AAAE4000B81B9A /* TIPreferencesController.h in Headers */,
 				641EE6B62240C5CA00173FCB /* _XCTestSuiteImplementation.h in Headers */,
 				641EE6B72240C5CA00173FCB /* FBBaseActionsSynthesizer.h in Headers */,
 				641EE6B82240C5CA00173FCB /* FBAlert.h in Headers */,
@@ -2132,6 +2158,7 @@
 				EE35AD361E3B77D600A02D78 /* XCSourceCodeTreeNode.h in Headers */,
 				EE35AD341E3B77D600A02D78 /* XCPointerEventPath.h in Headers */,
 				EE158AE11CBD456F00A3E3F0 /* FBRouteRequest.h in Headers */,
+				648C10AB22AAAD9C00B81B9A /* UIKeyboardImpl.h in Headers */,
 				EE35AD401E3B77D600A02D78 /* XCTest.h in Headers */,
 				719CD8F82126C78F00C7D0C2 /* FBAlertsMonitor.h in Headers */,
 				EE35AD241E3B77D600A02D78 /* XCAccessibilityElement.h in Headers */,
@@ -2260,6 +2287,7 @@
 				EE35AD291E3B77D600A02D78 /* XCAXClient_iOS.h in Headers */,
 				EE35AD691E3B77D600A02D78 /* XCTWaiterManager.h in Headers */,
 				EE35AD481E3B77D600A02D78 /* XCTestDriverInterface-Protocol.h in Headers */,
+				648C10AF22AAAE4000B81B9A /* TIPreferencesController.h in Headers */,
 				EE35AD111E3B77D600A02D78 /* _XCTestSuiteImplementation.h in Headers */,
 				714097431FAE1B0B008FB2C5 /* FBBaseActionsSynthesizer.h in Headers */,
 				AD6C26941CF2379700F8B5FF /* FBAlert.h in Headers */,

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -217,8 +217,8 @@ static NSString* const KEYBOARD_PREDICTION = @"keyboardPrediction";
       MJPEG_SERVER_FRAMERATE: @([FBConfiguration mjpegServerFramerate]),
       MJPEG_SCALING_FACTOR: @([FBConfiguration mjpegScalingFactor]),
       SCREENSHOT_QUALITY: @([FBConfiguration screenshotQuality]),
-      KEYBOARD_AUTOCORRECTION: @([FBConfiguration keyboardAutocorrectionPreference]),
-      KEYBOARD_PREDICTION: @([FBConfiguration keyboardPredictionPreference])
+      KEYBOARD_AUTOCORRECTION: @([FBConfiguration keyboardAutocorrection]),
+      KEYBOARD_PREDICTION: @([FBConfiguration keyboardPrediction])
     }
   );
 }

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -27,6 +27,8 @@ static NSString* const MJPEG_SERVER_FRAMERATE = @"mjpegServerFramerate";
 static NSString* const MJPEG_SCALING_FACTOR = @"mjpegScalingFactor";
 static NSString* const MJPEG_COMPRESSION_FACTOR = @"mjpegCompressionFactor";
 static NSString* const SCREENSHOT_QUALITY = @"screenshotQuality";
+static NSString* const KEYBOARD_AUTOCORRECTION = @"keyboardAutocorrection";
+static NSString* const KEYBOARD_PREDICTION = @"keyboardPrediction";
 
 @implementation FBSessionCommands
 
@@ -242,6 +244,12 @@ static NSString* const SCREENSHOT_QUALITY = @"screenshotQuality";
   }
   if ([settings objectForKey:MJPEG_SCALING_FACTOR]) {
     [FBConfiguration setMjpegScalingFactor:[[settings objectForKey:MJPEG_SCALING_FACTOR] unsignedIntegerValue]];
+  }
+  if ([settings objectForKey:KEYBOARD_AUTOCORRECTION]) {
+    [FBConfiguration setKeyboardAutocorrection:[[settings objectForKey:KEYBOARD_AUTOCORRECTION] boolValue]];
+  }
+  if ([settings objectForKey:KEYBOARD_PREDICTION]) {
+    [FBConfiguration setKeyboardPrediction:[[settings objectForKey:KEYBOARD_PREDICTION] boolValue]];
   }
 
   return [self handleGetSettings:request];

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -217,6 +217,8 @@ static NSString* const KEYBOARD_PREDICTION = @"keyboardPrediction";
       MJPEG_SERVER_FRAMERATE: @([FBConfiguration mjpegServerFramerate]),
       MJPEG_SCALING_FACTOR: @([FBConfiguration mjpegScalingFactor]),
       SCREENSHOT_QUALITY: @([FBConfiguration screenshotQuality]),
+      KEYBOARD_AUTOCORRECTION: @([FBConfiguration keyboardAutocorrectionPreference]),
+      KEYBOARD_PREDICTION: @([FBConfiguration keyboardPredictionPreference])
     }
   );
 }

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -108,23 +108,23 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Configure keyboards preference to make test running stable
  */
-+ (void)configureKeyboardsPreferenceDefault;
++ (void)configureDefaultKeyboardPreferences;
 
 /**
  * Modify keyboard configuration of 'auto-correction'.
  *
- * @param value Turn the configuration on if the value is YES
+ * @param isEnabled Turn the configuration on if the value is YES
  */
-+ (void)setKeyboardAutocorrection:(BOOL)value;
-+ (BOOL)keyboardAutocorrectionPreference;
++ (void)setKeyboardAutocorrection:(BOOL)isEnabled;
++ (BOOL)keyboardAutocorrection;
 
 /**
  * Modify keyboard configuration of 'predictive'
  *
- * @param value Turn the configuration on if the value is YES
+ * @param isEnabled Turn the configuration on if the value is YES
  */
-+ (void)setKeyboardPrediction:(BOOL)value;
-+ (BOOL)keyboardPredictionPreference;
++ (void)setKeyboardPrediction:(BOOL)isEnabled;
++ (BOOL)keyboardPrediction;
 
 @end
 
@@ -171,11 +171,16 @@ NS_ASSUME_NONNULL_BEGIN
  * Get the preferenve by @c key
  *
  * @param key The key name to get the value
+ * @return Whether the @c key is enabled
  */
 - (BOOL)boolForPreferenceKey:(NSString *)key;
 @end
 
 #if TARGET_OS_SIMULATOR
+
+/**
+ * iOS-Runtime-Headers/PrivateFrameworks/UIKitCore.framework/UIKeyboardImpl.h
+ */
 @interface UIKeyboardImpl
 + (instancetype)sharedInstance;
 /**

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -106,25 +106,36 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)shouldLoadSnapshotWithAttributes;
 
 /**
- Configure keyboards preference to make test running stable
+ * Configure keyboards preference to make test running stable
  */
-+ (void)configureKeyboardPreferenceDefault;
++ (void)configureKeyboardsPreferenceDefault;
+
+/**
+ * Modify keyboard configuration.
+ *
+ * @param value Turn the configuration on if the value is YES
+ */
++ (void)setKeyboardAutocorrection:(BOOL)value;
++ (void)setKeyboardPrediction:(BOOL)value;
 
 @end
 
 
+
 /**
- * iOS-Runtime-Headers
+ * iiOS-Runtime-Headers/PrivateFrameworks/TextInput.framework
  * Text Input preferences controller to modify the keyboard preferences for iOS 8+.
  */
 @interface TIPreferencesController : NSObject
 
 /**
- Whether the autocorrection is enabled.
+ * Whether the autocorrection is enabled.
  */
 @property BOOL autocorrectionEnabled;
 
-/** Whether the predication is enabled. */
+/**
+ * Whether the predication is enabled.
+ * */
 @property BOOL predictionEnabled;
 
 /**

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -108,7 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Configure keyboards preference to make test running stable
  */
-+ (void)configureKeyboardPreference;
++ (void)configureKeyboardPreferenceDefault;
 
 @end
 
@@ -138,9 +138,27 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)synchronizePreferences;
 
 /**
- Modify the preference @c value by @c key.
+ * Modify the preference @c value by the @c key
+ *
+ * @param value The value to set it to @c key
+ * @param key The key name to set @c value to
  */
 - (void)setValue:(NSValue *)value forPreferenceKey:(NSString *)key;
 @end
+
+#if TARGET_OS_SIMULATOR
+@interface UIKeyboardImpl
++ (instancetype)sharedInstance;
+/**
+ * Modify software keyboard condition on simulators for over Xcode 6
+ * This setting is global. The change applies to all instances of UIKeyboardImpl.
+ *
+ * Idea: https://chromium.googlesource.com/chromium/src/base/+/ababb4cf8b6049a642a2f361b1006a07561c2d96/test/test_support_ios.mm#41
+ *
+ * @param enabled Whether turn setAutomaticMinimizationEnabled on
+ */
+- (void)setAutomaticMinimizationEnabled:(BOOL)enabled;
+@end
+#endif  // TARGET_IPHONE_SIMULATOR
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -9,6 +9,9 @@
 
 #import <Foundation/Foundation.h>
 
+#import "UIKeyboardImpl.h"
+#import "TIPreferencesController.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -127,72 +130,5 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)keyboardPrediction;
 
 @end
-
-
-
-/**
- * iOS-Runtime-Headers/PrivateFrameworks/TextInput.framework.
- * Text Input preferences controller to modify the keyboard preferences for iOS 8+.
- *
- * Note:
- * "autocorrection" will be PrivateFrameworks/TextInput.framework/TIKeyboardState.h in the future?
- */
-@interface TIPreferencesController : NSObject
-
-/**
- * Whether the autocorrection is enabled.
- */
-@property BOOL autocorrectionEnabled;
-
-/**
- * Whether the predication is enabled.
- * */
-@property BOOL predictionEnabled;
-
-/**
- The shared singleton instance.
- */
-+ (instancetype)sharedPreferencesController;
-
-/**
- Synchronise the change to save it on disk.
- */
-- (void)synchronizePreferences;
-
-/**
- * Modify the preference @c value by the @c key
- *
- * @param value The value to set it to @c key
- * @param key The key name to set @c value to
- */
-- (void)setValue:(NSValue *)value forPreferenceKey:(NSString *)key;
-
-/**
- * Get the preferenve by @c key
- *
- * @param key The key name to get the value
- * @return Whether the @c key is enabled
- */
-- (BOOL)boolForPreferenceKey:(NSString *)key;
-@end
-
-#if TARGET_OS_SIMULATOR
-
-/**
- * iOS-Runtime-Headers/PrivateFrameworks/UIKitCore.framework/UIKeyboardImpl.h
- */
-@interface UIKeyboardImpl
-+ (instancetype)sharedInstance;
-/**
- * Modify software keyboard condition on simulators for over Xcode 6
- * This setting is global. The change applies to all instances of UIKeyboardImpl.
- *
- * Idea: https://chromium.googlesource.com/chromium/src/base/+/ababb4cf8b6049a642a2f361b1006a07561c2d96/test/test_support_ios.mm#41
- *
- * @param enabled Whether turn setAutomaticMinimizationEnabled on
- */
-- (void)setAutomaticMinimizationEnabled:(BOOL)enabled;
-@end
-#endif  // TARGET_IPHONE_SIMULATOR
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -111,20 +111,31 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)configureKeyboardsPreferenceDefault;
 
 /**
- * Modify keyboard configuration.
+ * Modify keyboard configuration of 'auto-correction'.
  *
  * @param value Turn the configuration on if the value is YES
  */
 + (void)setKeyboardAutocorrection:(BOOL)value;
++ (BOOL)keyboardAutocorrectionPreference;
+
+/**
+ * Modify keyboard configuration of 'predictive'
+ *
+ * @param value Turn the configuration on if the value is YES
+ */
 + (void)setKeyboardPrediction:(BOOL)value;
++ (BOOL)keyboardPredictionPreference;
 
 @end
 
 
 
 /**
- * iiOS-Runtime-Headers/PrivateFrameworks/TextInput.framework
+ * iOS-Runtime-Headers/PrivateFrameworks/TextInput.framework.
  * Text Input preferences controller to modify the keyboard preferences for iOS 8+.
+ *
+ * Note:
+ * "autocorrection" will be PrivateFrameworks/TextInput.framework/TIKeyboardState.h in the future?
  */
 @interface TIPreferencesController : NSObject
 
@@ -155,6 +166,13 @@ NS_ASSUME_NONNULL_BEGIN
  * @param key The key name to set @c value to
  */
 - (void)setValue:(NSValue *)value forPreferenceKey:(NSString *)key;
+
+/**
+ * Get the preferenve by @c key
+ *
+ * @param key The key name to get the value
+ */
+- (BOOL)boolForPreferenceKey:(NSString *)key;
 @end
 
 #if TARGET_OS_SIMULATOR

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -105,6 +105,42 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)shouldLoadSnapshotWithAttributes;
 
+/**
+ Configure keyboards preference to make test running stable
+ */
++ (void)configureKeyboardPreference;
+
+@end
+
+
+/**
+ * iOS-Runtime-Headers
+ * Text Input preferences controller to modify the keyboard preferences for iOS 8+.
+ */
+@interface TIPreferencesController : NSObject
+
+/**
+ Whether the autocorrection is enabled.
+ */
+@property BOOL autocorrectionEnabled;
+
+/** Whether the predication is enabled. */
+@property BOOL predictionEnabled;
+
+/**
+ The shared singleton instance.
+ */
++ (instancetype)sharedPreferencesController;
+
+/**
+ Synchronise the change to save it on disk.
+ */
+- (void)synchronizePreferences;
+
+/**
+ Modify the preference @c value by @c key.
+ */
+- (void)setValue:(NSValue *)value forPreferenceKey:(NSString *)key;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -192,7 +192,7 @@ static NSUInteger FBMjpegScalingFactor = 100;
 }
 
 // Works for Simulator and Real devices
-+ (void)configureKeyboardsPreferenceDefault
++ (void)configureDefaultKeyboardPreferences
 {
 #if TARGET_OS_SIMULATOR
   // Force toggle software keyboard on.
@@ -232,27 +232,29 @@ static NSUInteger FBMjpegScalingFactor = 100;
   dlclose(handle);
 }
 
-+ (BOOL)keyboardAutocorrectionPreference
++ (BOOL)keyboardAutocorrection
 {
-  return [self getKeyboardsPreference:FBKeyboardAutocorrectionKey];
-}
-+ (void)setKeyboardAutocorrection: (BOOL)value
-{
-  [self configureKeyboardsPreference:@(value) forPreferenceKey:FBKeyboardAutocorrectionKey];
+  return [self keyboardsPreference:FBKeyboardAutocorrectionKey];
 }
 
-+ (BOOL)keyboardPredictionPreference
++ (void)setKeyboardAutocorrection:(BOOL)isEnabled
 {
-  return [self getKeyboardsPreference:FBKeyboardPredictionKey];
+  [self configureKeyboardsPreference:@(isEnabled) forPreferenceKey:FBKeyboardAutocorrectionKey];
 }
-+ (void)setKeyboardPrediction: (BOOL)value
+
++ (BOOL)keyboardPrediction
 {
-  [self configureKeyboardsPreference:@(value) forPreferenceKey:FBKeyboardPredictionKey];
+  return [self keyboardsPreference:FBKeyboardPredictionKey];
+}
+
++ (void)setKeyboardPrediction:(BOOL)isEnabled
+{
+  [self configureKeyboardsPreference:@(isEnabled) forPreferenceKey:FBKeyboardPredictionKey];
 }
 
 #pragma mark Private
 
-+ (BOOL)getKeyboardsPreference: (nonnull NSString *)key
++ (BOOL)keyboardsPreference:(nonnull NSString *)key
 {
   Class controllerClass = NSClassFromString(controllerClassName);
   TIPreferencesController *controller = [controllerClass sharedPreferencesController];
@@ -264,7 +266,7 @@ static NSUInteger FBMjpegScalingFactor = 100;
   @throw [[FBErrorBuilder.builder withDescriptionFormat:@"No available keyboardsPreferenceKey: '%@'", key] build];
 }
 
-+ (void)configureKeyboardsPreference: (nonnull NSValue *)value forPreferenceKey: (nonnull NSString *)key
++ (void)configureKeyboardsPreference:(nonnull NSValue *)value forPreferenceKey:(nonnull NSString *)key
 {
   void *handle = dlopen(controllerPrefBundlePath, RTLD_LAZY);
   Class controllerClass = NSClassFromString(controllerClassName);

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -186,7 +186,15 @@ static NSUInteger FBMjpegScalingFactor = 100;
 }
 
 // Works for Simulator and Real devices
-+ (void)configureKeyboardPreference {
++ (void)configureKeyboardPreferenceDefault {
+
+#if TARGET_OS_SIMULATOR
+  // Force toggle software keyboard on.
+  // This can avoid 'Keyboard is not present' error which can happen
+  // when send_keys are called by client
+  [[UIKeyboardImpl sharedInstance] setAutomaticMinimizationEnabled:NO];
+#endif
+
   static char const *const controllerPrefBundlePath = "/System/Library/PrivateFrameworks/TextInput.framework/TextInput";
   static NSString *const controllerClassName = @"TIPreferencesController";
   void *handle = dlopen(controllerPrefBundlePath, RTLD_LAZY);

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -23,6 +23,9 @@ static NSUInteger const DefaultPortRange = 100;
 
 static char const *const controllerPrefBundlePath = "/System/Library/PrivateFrameworks/TextInput.framework/TextInput";
 static NSString *const controllerClassName = @"TIPreferencesController";
+static NSString *const FBKeyboardAutocorrectionKey = @"KeyboardAutocorrection";
+static NSString *const FBKeyboardPredictionKey = @"KeyboardPrediction";
+
 
 static BOOL FBShouldUseTestManagerForVisibilityDetection = NO;
 static BOOL FBShouldUseSingletonTestManager = YES;
@@ -207,13 +210,14 @@ static NSUInteger FBMjpegScalingFactor = 100;
   if ([controller respondsToSelector:@selector(setAutocorrectionEnabled:)]) {
     controller.autocorrectionEnabled = NO;
   } else {
-    [controller setValue:@NO forPreferenceKey:@"KeyboardAutocorrection"];
+    [controller setValue:@NO forPreferenceKey:FBKeyboardAutocorrectionKey];
   }
+
   // Predictive in Keyboards
   if ([controller respondsToSelector:@selector(setPredictionEnabled:)]) {
     controller.predictionEnabled = NO;
   } else {
-    [controller setValue:@NO forPreferenceKey:@"KeyboardPrediction"];
+    [controller setValue:@NO forPreferenceKey:FBKeyboardPredictionKey];
   }
 
   // To dismiss keyboard tutorial on iOS 11+ (iPad)
@@ -228,16 +232,37 @@ static NSUInteger FBMjpegScalingFactor = 100;
   dlclose(handle);
 }
 
++ (BOOL)keyboardAutocorrectionPreference
+{
+  return [self getKeyboardsPreference:FBKeyboardAutocorrectionKey];
+}
 + (void)setKeyboardAutocorrection: (BOOL)value
 {
-  [self configureKeyboardsPreference:@(value) forPreferenceKey:@"KeyboardAutocorrection"];
+  [self configureKeyboardsPreference:@(value) forPreferenceKey:FBKeyboardAutocorrectionKey];
+}
+
++ (BOOL)keyboardPredictionPreference
+{
+  return [self getKeyboardsPreference:FBKeyboardPredictionKey];
 }
 + (void)setKeyboardPrediction: (BOOL)value
 {
-  [self configureKeyboardsPreference:@(value) forPreferenceKey:@"KeyboardPrediction"];
+  [self configureKeyboardsPreference:@(value) forPreferenceKey:FBKeyboardPredictionKey];
 }
 
 #pragma mark Private
+
++ (BOOL)getKeyboardsPreference: (nonnull NSString *)key
+{
+  Class controllerClass = NSClassFromString(controllerClassName);
+  TIPreferencesController *controller = [controllerClass sharedPreferencesController];
+  if ([key isEqualToString:FBKeyboardAutocorrectionKey]) {
+    return [controller boolForPreferenceKey:FBKeyboardAutocorrectionKey];
+  } else if ([key isEqualToString:FBKeyboardPredictionKey]) {
+    return [controller boolForPreferenceKey:FBKeyboardPredictionKey];
+  }
+  @throw [[FBErrorBuilder.builder withDescriptionFormat:@"No available keyboardsPreferenceKey: '%@'", key] build];
+}
 
 + (void)configureKeyboardsPreference: (nonnull NSValue *)value forPreferenceKey: (nonnull NSString *)key
 {
@@ -246,19 +271,19 @@ static NSUInteger FBMjpegScalingFactor = 100;
 
   TIPreferencesController *controller = [controllerClass sharedPreferencesController];
 
-  if ([key isEqualToString:@"KeyboardAutocorrection"]) {
+  if ([key isEqualToString:FBKeyboardAutocorrectionKey]) {
     // Auto-Correction in Keyboards
     if ([controller respondsToSelector:@selector(setAutocorrectionEnabled:)]) {
       controller.autocorrectionEnabled = value;
     } else {
-      [controller setValue:value forPreferenceKey:@"KeyboardAutocorrection"];
+      [controller setValue:value forPreferenceKey:FBKeyboardAutocorrectionKey];
     }
-  } else if ([key isEqualToString:@"KeyboardPrediction"]) {
+  } else if ([key isEqualToString:FBKeyboardPredictionKey]) {
     // Predictive in Keyboards
     if ([controller respondsToSelector:@selector(setPredictionEnabled:)]) {
       controller.predictionEnabled = value;
     } else {
-      [controller setValue:value forPreferenceKey:@"KeyboardPrediction"];
+      [controller setValue:value forPreferenceKey:FBKeyboardPredictionKey];
     }
   }
 

--- a/WebDriverAgentRunner/UITestingUITests.m
+++ b/WebDriverAgentRunner/UITestingUITests.m
@@ -24,7 +24,7 @@
 {
   [FBDebugLogDelegateDecorator decorateXCTestLogger];
   [FBConfiguration disableRemoteQueryEvaluation];
-  [FBConfiguration configureKeyboardPreferenceDefault];
+  [FBConfiguration configureKeyboardsPreferenceDefault];
   [super setUp];
 }
 

--- a/WebDriverAgentRunner/UITestingUITests.m
+++ b/WebDriverAgentRunner/UITestingUITests.m
@@ -24,7 +24,7 @@
 {
   [FBDebugLogDelegateDecorator decorateXCTestLogger];
   [FBConfiguration disableRemoteQueryEvaluation];
-  [FBConfiguration configureKeyboardPreference];
+  [FBConfiguration configureKeyboardPreferenceDefault];
   [super setUp];
 }
 

--- a/WebDriverAgentRunner/UITestingUITests.m
+++ b/WebDriverAgentRunner/UITestingUITests.m
@@ -24,7 +24,7 @@
 {
   [FBDebugLogDelegateDecorator decorateXCTestLogger];
   [FBConfiguration disableRemoteQueryEvaluation];
-  [FBConfiguration configureKeyboardsPreferenceDefault];
+  [FBConfiguration configureDefaultKeyboardPreferences];
   [super setUp];
 }
 

--- a/WebDriverAgentRunner/UITestingUITests.m
+++ b/WebDriverAgentRunner/UITestingUITests.m
@@ -24,6 +24,7 @@
 {
   [FBDebugLogDelegateDecorator decorateXCTestLogger];
   [FBConfiguration disableRemoteQueryEvaluation];
+  [FBConfiguration configureKeyboardPreference];
   [super setUp];
 }
 


### PR DESCRIPTION
This PR is also related to iOS 13.0


- problem

An introduction for keyboard appears if a user launch simulator on iOS 13.0. It blocks the typing keyboard.
If a user re-generate simulator every test running, for example, this blocks test cases relative to send_keys. The user must tap "continue" via find_element and click it.

<img src="https://user-images.githubusercontent.com/5511591/59036821-ff446100-88aa-11e9-80d9-b36f0d0172c8.png" width=200>

- solution

This PR sets `DidShowContinuousPathIntroduction` YES by default. It means we can make the tutorial have done. I also put some settings which might make text input flaky.
(Below animation is not clear, but I changed the preference YES/NO and show the tutorial appears/disappears.)

![My Movie](https://user-images.githubusercontent.com/5511591/59037064-77128b80-88ab-11e9-8249-22b81226504e.gif)


Interestingly, this works on real devices, too. (I tested on my iPhone)

- Discussion

As a temporary, I put this code in FBConfiuguration since this method aims to configure a test environment just after launching WDA on the device.
(I think, so far, we do not need to make this configurable by settings API til we will get any requests)
Where is best to put this kind of code? (What do you think this feature?)

---

This does not break tvOS side (no affects them). I tested it on a simulator.

----

It is enough to build/launch the module by xcuites-driver as tests since all of path through in the initial time. So, we can find issues before bumping xcuitest-driver.