### PR TITLE
Bundle webdriveragent pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ node_modules
 
 # webdriveragent zip bundles
 bundles/
+webdriveragent-*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ node_modules
 # webdriveragent zip bundles
 bundles/
 webdriveragent-*.tar.gz
+uncompressed/

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ Modules/module.modulemap
 
 # node stuff
 node_modules
+
+# webdriveragent zip bundles
+bundles/

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -20,5 +20,10 @@ jobs:
       displayName: Build WebDriverAgents
     - script: ls ./bundles
       displayName: List WDA Bundles
-    - script: echo "UPLOAD EM NOW"
-      displayName: Upload to GitHub Releases
+    - task: GithubRelease@0
+      displayName: Publish to GitHub Release
+      inputs:
+        githubConnection: appium
+        repositoryName: appium/WebDriverAgent
+        tag: $(Build.BuildNumber)
+        assets: bundles/

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,4 +1,12 @@
 jobs:
+  - job: create_github_release
+    steps:
+      - task: GithubRelease@0
+        inputs:
+          action: create
+          githubConnection: appiumbot
+          repositoryName: appium/WebDriverAgent
+          tag: $(Build.BuildNumber)
   - template: ./templates/build.yml
     parameters:
       name: 'macOS_10_14'

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -6,7 +6,6 @@ jobs:
           action: create
           githubConnection: appiumbot
           repositoryName: appium/WebDriverAgent
-          tag: $(Build.BuildNumber)
   - template: ./templates/build.yml
     parameters:
       name: 'macOS_10_14'

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -4,3 +4,7 @@ jobs:
     parameters:
       vmImage: 'macOS-10.13'
       name: 'macOS_10_13'
+  - template: ./templates/build.yml
+    parameters:
+      vmImage: 'macOS-10.12'
+      name: 'macOS_10_12'

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -2,6 +2,6 @@ jobs:
   - template: ./templates/build.yml
   - template: ./templates/build.yml
     parameters:
-      excludeXcode: '10.1, 10.2.1, 10.2, 10, 9.4.1'
+      excludeXcode: '10.1, 10.2.1, 10.2, 10, 9.4.1, 8.3.3'
       vmImage: 'macOS-10.13'
       name: 'macOS_10_13'

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -13,7 +13,7 @@ jobs:
         versionSpec: '12.x' 
     - script: npm install
       displayName: Install Node Modules
-    - script: ./Scripts/build.sh
+    - script: mkdir Resources && ./Scripts/build.sh
       displayName: BUILD SH
     - script: node ./ci-jobs/scripts/build-webdriveragents.js
       displayName: Build WebDriverAgents

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -14,8 +14,9 @@ jobs:
         versionSpec: '12.x' 
     - script: npm install
       displayName: Install Node Modules
-    - script: ./Scripts/bootstrap.sh
-      displayName: Make Resources Folder
+    #- script: ./Scripts/bootstrap.sh
+      #displayName: Make Resources Folder
+    - script: mkdir -p Resources/WebDriverAgent.bundle
     - script: ./Scripts/build.sh
       displayName: BUILD SH
     - script: node ./ci-jobs/scripts/build-webdriveragents.js

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -9,15 +9,13 @@ jobs:
     steps:
     - script: ls /Applications/
       displayName: List Installed Applications
-    - script: |
-        pwd
-        mkdir ./Resources
-      displayName: Make Resources Folder
     - task: NodeTool@0
       inputs:
         versionSpec: '12.x' 
     - script: npm install
       displayName: Install Node Modules
+    - script: ./Scripts/bootstrap.sh -d
+      displayName: Make Resources Folder
     - script: ./Scripts/build.sh
       displayName: BUILD SH
     - script: node ./ci-jobs/scripts/build-webdriveragents.js

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,4 +1,5 @@
 jobs:
   - template: ./templates/build.yml
   - template: ./templates/build.yml
-    vmImage: 'macOS-10.13'
+    parameters:
+      vmImage: 'macOS-10.13'

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -3,6 +3,7 @@ jobs:
     variables:
       SDK: sim
       TARGET: runner
+      USE_SSH: true
     pool:
       vmImage: 'macOS-10.14'
     steps:

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -13,7 +13,7 @@ jobs:
         versionSpec: '12.x' 
     - script: npm install
       displayName: Install Node Modules
-    - script: mkdir Resources && ./Scripts/build.sh
+    - script: ./Scripts/build.sh
       displayName: BUILD SH
     - script: node ./ci-jobs/scripts/build-webdriveragents.js
       displayName: Build WebDriverAgents

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -12,10 +12,12 @@ jobs:
     - macOS_10_13
     - macOS_10_14
     steps:
+      - script: ls -R $(Build.ArtifactStagingDirectory)
+        displayName: List Artifacts
       - task: GithubRelease@0
         inputs:
           action: create
           githubConnection: appiumbot
           repositoryName: appium/WebDriverAgent
-          assets: '$(Build.ArtifactStagingDirectory)/*'
+          assets: '$(Build.ArtifactStagingDirectory)/**'
           addChangeLog: false

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,6 +1,7 @@
 jobs:
   - template: ./templates/build.yml
-  #- template: ./templates/build.yml
-    #parameters:
-      #vmImage: 'macOS-10.13'
-      #name: 'macOS_10_13'
+  - template: ./templates/build.yml
+    parameters:
+      excludeXcode: '10.1, 10.2.1, 10.2, 10, 9.4.1'
+      vmImage: 'macOS-10.13'
+      name: 'macOS_10_13'

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -14,7 +14,7 @@ jobs:
         versionSpec: '12.x' 
     - script: npm install
       displayName: Install Node Modules
-    - script: ./Scripts/bootstrap.sh -d
+    - script: ./Scripts/bootstrap.sh
       displayName: Make Resources Folder
     - script: ./Scripts/build.sh
       displayName: BUILD SH

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -3,3 +3,4 @@ jobs:
   - template: ./templates/build.yml
     parameters:
       vmImage: 'macOS-10.13'
+      name: 'macOS_10_13'

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,10 +1,6 @@
 jobs:
   - template: ./templates/build.yml
-  - template: ./templates/build.yml
-    parameters:
-      vmImage: 'macOS-10.13'
-      name: 'macOS_10_13'
-  - template: ./templates/build.yml
-    parameters:
-      vmImage: 'macOS-10.12'
-      name: 'macOS_10_12'
+  #- template: ./templates/build.yml
+    #parameters:
+      #vmImage: 'macOS-10.13'
+      #name: 'macOS_10_13'

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,16 +1,5 @@
 jobs:
-  - template: ./templates/build.yml
-    parameters:
-      name: 'macOS_10_14'
-  - template: ./templates/build.yml
-    parameters:
-      excludeXcode: '10.1, 10.2.1, 10.2, 10, 9.4.1, 8.3.3'
-      vmImage: 'macOS-10.13'
-      name: 'macOS_10_13'
   - job: create_github_release
-    dependsOn:
-    - macOS_10_13
-    - macOS_10_14
     steps:
       - script: ls -R $(Build.ArtifactStagingDirectory)
         displayName: List Artifacts
@@ -21,3 +10,11 @@ jobs:
           repositoryName: appium/WebDriverAgent
           assets: '$(Build.ArtifactStagingDirectory)/**'
           addChangeLog: false
+  - template: ./templates/build.yml
+    parameters:
+      name: 'macOS_10_14'
+  - template: ./templates/build.yml
+    parameters:
+      excludeXcode: '10.1, 10.2.1, 10.2, 10, 9.4.1, 8.3.3'
+      vmImage: 'macOS-10.13'
+      name: 'macOS_10_13'

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -23,7 +23,7 @@ jobs:
     - task: GithubRelease@0
       displayName: Publish to GitHub Release
       inputs:
-        githubConnection: appium
+        githubConnection: appiumbot
         repositoryName: appium/WebDriverAgent
         tag: $(Build.BuildNumber)
         assets: bundles/

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,5 +1,8 @@
 jobs:
   - job: build_and_upload_bundles
+    variables:
+      SDK: sim
+      TARGET: runner
     pool:
       vmImage: 'macOS-10.14'
     steps:

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,5 +1,7 @@
 jobs:
   - template: ./templates/build.yml
+    parameters:
+      name: 'macOS_10_14'
   - template: ./templates/build.yml
     parameters:
       excludeXcode: '10.1, 10.2.1, 10.2, 10, 9.4.1, 8.3.3'

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,29 +1,4 @@
 jobs:
-  - job: build_and_upload_bundles
-    variables:
-      SDK: sim
-      TARGET: runner
-      #USE_SSH: true
-    pool:
-      vmImage: 'macOS-10.14'
-    steps:
-    - script: ls /Applications/
-      displayName: List Installed Applications
-    - task: NodeTool@0
-      inputs:
-        versionSpec: '12.x' 
-    - script: npm install
-      displayName: Install Node Modules
-    - script: mkdir -p Resources/WebDriverAgent.bundle
-      displayName: Make Resources Folder
-    - script: node ./ci-jobs/scripts/build-webdriveragents.js
-      displayName: Build WebDriverAgents
-    - script: ls ./bundles
-      displayName: List WDA Bundles
-    - task: GithubRelease@0
-      displayName: Publish to GitHub Release
-      inputs:
-        githubConnection: appiumbot
-        repositoryName: appium/WebDriverAgent
-        tag: $(Build.BuildNumber)
-        assets: bundles/
+  - template: ./templates/build.yml
+  - template: ./templates/build.yml
+    vmImage: 'macOS-10.13'

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -8,6 +8,10 @@ jobs:
     steps:
     - script: ls /Applications/
       displayName: List Installed Applications
+    - script: |
+        pwd
+        mkdir ./Resources
+      displayName: Make Resources Folder
     - task: NodeTool@0
       inputs:
         versionSpec: '12.x' 

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,14 +1,11 @@
 jobs:
   - job: create_github_release
     steps:
-      - script: ls -R $(Build.ArtifactStagingDirectory)
-        displayName: List Artifacts
       - task: GithubRelease@0
         inputs:
           action: create
           githubConnection: appiumbot
           repositoryName: appium/WebDriverAgent
-          assets: '$(Build.ArtifactStagingDirectory)/**'
           addChangeLog: false
   - template: ./templates/build.yml
     parameters:

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -14,11 +14,8 @@ jobs:
         versionSpec: '12.x' 
     - script: npm install
       displayName: Install Node Modules
-    #- script: ./Scripts/bootstrap.sh
-      #displayName: Make Resources Folder
     - script: mkdir -p Resources/WebDriverAgent.bundle
-    - script: ./Scripts/build.sh
-      displayName: BUILD SH
+      displayName: Make Resources Folder
     - script: node ./ci-jobs/scripts/build-webdriveragents.js
       displayName: Build WebDriverAgents
     - script: ls ./bundles

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,11 +1,4 @@
 jobs:
-  - job: create_github_release
-    steps:
-      - task: GithubRelease@0
-        inputs:
-          action: create
-          githubConnection: appiumbot
-          repositoryName: appium/WebDriverAgent
   - template: ./templates/build.yml
     parameters:
       name: 'macOS_10_14'
@@ -14,3 +7,15 @@ jobs:
       excludeXcode: '10.1, 10.2.1, 10.2, 10, 9.4.1, 8.3.3'
       vmImage: 'macOS-10.13'
       name: 'macOS_10_13'
+  - job: create_github_release
+    dependsOn:
+    - macOS_10_13
+    - macOS_10_14
+    steps:
+      - task: GithubRelease@0
+        inputs:
+          action: create
+          githubConnection: appiumbot
+          repositoryName: appium/WebDriverAgent
+          assets: '$(Build.ArtifactStagingDirectory)/*'
+          addChangeLog: false

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -3,7 +3,7 @@ jobs:
     variables:
       SDK: sim
       TARGET: runner
-      USE_SSH: true
+      #USE_SSH: true
     pool:
       vmImage: 'macOS-10.14'
     steps:

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -13,6 +13,8 @@ jobs:
         versionSpec: '12.x' 
     - script: npm install
       displayName: Install Node Modules
+    - script: ./Scripts/build.sh
+      displayName: BUILD SH
     - script: node ./ci-jobs/scripts/build-webdriveragents.js
       displayName: Build WebDriverAgents
     - script: ls ./bundles

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: build_and_upload_bundles
     steps:
-    - script: node ./ci-jobs/scripts/build-and-upload-webdriveragents.js
+    - script: node ./ci-jobs/scripts/build-webdriveragents.js
       displayName: Build WebDriverAgents
     - script: echo "UPLOAD EM NOW"
       displayName: Upload to GitHub Releases

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,6 +1,8 @@
 jobs:
   - job: build_and_upload_bundles
     steps:
+    - script: npm install
+      displayName: Install Node Modules
     - script: node ./ci-jobs/scripts/build-webdriveragents.js
       displayName: Build WebDriverAgents
     - script: echo "UPLOAD EM NOW"

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -12,5 +12,7 @@ jobs:
       displayName: Install Node Modules
     - script: node ./ci-jobs/scripts/build-webdriveragents.js
       displayName: Build WebDriverAgents
+    - script: ls ./bundles
+      displayName: List WDA Bundles
     - script: echo "UPLOAD EM NOW"
       displayName: Upload to GitHub Releases

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,0 +1,7 @@
+jobs:
+  - job: Build and Upload WebDriverAgent Bundles
+    step:
+    - script: node ./ci-jobs/scripts/build-and-upload-webdriveragents.js
+      displayName: Build WebDriverAgents
+    - script: echo "UPLOAD EM NOW"
+      displayName: Upload to GitHub Releases

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -5,6 +5,9 @@ jobs:
     steps:
     - script: ls /Applications/
       displayName: List Installed Applications
+    - task: NodeTool@0
+      inputs:
+        versionSpec: '12.x' 
     - script: npm install
       displayName: Install Node Modules
     - script: node ./ci-jobs/scripts/build-webdriveragents.js

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,6 +1,6 @@
 jobs:
   - job: Build and Upload WebDriverAgent Bundles
-    step:
+    steps:
     - script: node ./ci-jobs/scripts/build-and-upload-webdriveragents.js
       displayName: Build WebDriverAgents
     - script: echo "UPLOAD EM NOW"

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,5 +1,7 @@
 jobs:
   - job: build_and_upload_bundles
+    pool:
+      vmImage: 'macOS-10.14'
     steps:
     - script: ls /Applications/
       displayName: List Installed Applications

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,5 +1,5 @@
 jobs:
-  - job: Build and Upload WebDriverAgent Bundles
+  - job: build_and_upload_bundles
     steps:
     - script: node ./ci-jobs/scripts/build-and-upload-webdriveragents.js
       displayName: Build WebDriverAgents

--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -1,6 +1,8 @@
 jobs:
   - job: build_and_upload_bundles
     steps:
+    - script: ls /Applications/
+      displayName: List Installed Applications
     - script: npm install
       displayName: Install Node Modules
     - script: node ./ci-jobs/scripts/build-webdriveragents.js

--- a/ci-jobs/scripts/azure-print-tag-name.js
+++ b/ci-jobs/scripts/azure-print-tag-name.js
@@ -1,0 +1,3 @@
+
+const branch = process.env.BUILD_SOURCEBRANCH || '';
+console.log(branch.replace(/^refs\/tags\//, '')); // eslint-disable-line no-console

--- a/ci-jobs/scripts/build-webdriveragent.js
+++ b/ci-jobs/scripts/build-webdriveragent.js
@@ -39,6 +39,7 @@ async function buildWebDriverAgent (xcodeVersion) {
   // Re-compress the tarball
   await exec('tar', ['-cvjf', pathToTar, '-C', uncompressedDir, '.']);
   await fs.rimraf(uncompressedDir);
+  log.info(`Tarball bundled at "${pathToTar}"`);
 }
 
 if (require.main === module) {

--- a/ci-jobs/scripts/build-webdriveragent.js
+++ b/ci-jobs/scripts/build-webdriveragent.js
@@ -6,6 +6,7 @@ const { exec } = require('teen_process');
 const xcode = require('appium-xcode');
 
 const log = new logger.getLogger('WDABuild');
+const rootDir = path.resolve(__dirname, '..', '..');
 
 async function buildWebDriverAgent (xcodeVersion) {
   // Get Xcode version
@@ -16,14 +17,14 @@ async function buildWebDriverAgent (xcodeVersion) {
   await exec('npx', ['gulp', 'clean:carthage']);
   log.info('Running ./Scripts/build.sh');
   let env = {TARGET: 'runner', SDK: 'sim'};
-  await exec('/bin/bash', ['./Scripts/build.sh'], {env});
+  await exec('/bin/bash', ['./Scripts/build.sh'], {env, cwd: rootDir});
 
   // Create bundles folder
   await mkdirp('bundles');
-  const pathToBundles = path.resolve('bundles');
+  const pathToBundles = path.resolve(rootDir, 'bundles');
 
   // Start creating tarball
-  const uncompressedDir = path.resolve('uncompressed');
+  const uncompressedDir = path.resolve(rootDir, 'uncompressed');
   await fs.rimraf(uncompressedDir);
   await mkdirp(uncompressedDir);
   log.info('Creating tarball');
@@ -37,7 +38,7 @@ async function buildWebDriverAgent (xcodeVersion) {
   // Compress the tarball
   const pathToTar = path.resolve(pathToBundles, `webdriveragent-xcode_${xcodeVersion}.tar.gz`);
   env = {COPYFILE_DISABLE: 1};
-  await exec('tar', ['-czf', pathToTar, '-C', uncompressedDir, '.'], {env});
+  await exec('tar', ['-czf', pathToTar, '-C', uncompressedDir, '.'], {env, cwd: rootDir});
   await fs.rimraf(uncompressedDir);
   log.info(`Tarball bundled at "${pathToTar}"`);
 }

--- a/ci-jobs/scripts/build-webdriveragent.js
+++ b/ci-jobs/scripts/build-webdriveragent.js
@@ -1,25 +1,44 @@
+const path = require('path');
+const os = require('os');
 const { asyncify } = require('asyncbox');
-const { logger, fs } = require('appium-support');
+const { logger, fs, mkdirp } = require('appium-support');
 const { exec } = require('teen_process');
 const xcode = require('appium-xcode');
 
-const log = new logger.getLogger('WDA Build');
+const log = new logger.getLogger('WDABuild');
 
 async function buildWebDriverAgent (xcodeVersion) {
   // Get Xcode version
   xcodeVersion = xcodeVersion || await xcode.getVersion();
   log.info(`Building bundle for Xcode version '${xcodeVersion}'`);
 
-  // Clean and build the dependencies
+  // Clean and build
   await exec('npx', ['gulp', 'clean:carthage']);
-  log.info('Running ./Scripts/bootstrap.sh');
-  await exec('./Scripts/bootstrap.sh', ['-d']);
+  log.info('Running ./Scripts/build.sh');
+  await exec('./Scripts/build.sh');
 
-  // Create a bundle
-  await fs.mkdir('bundles');
-  const bundleName = `bundles/webdriveragent-xcode_${xcodeVersion}.zip`;
-  log.info(`Creating bundle '${bundleName}'`);
-  await exec('zip', ['-r', bundleName, '.']);
+  // Create tarball using NPM Pack and move to '/bundles' folder
+  const pathToBundles = path.resolve('bundles');
+  const pathToTar = path.resolve(pathToBundles, `webdriveragent-xcode_${xcodeVersion}.tar.gz`);
+  log.info('Running "npm pack" to bundle tarball');
+  await mkdirp('bundles');
+  await exec('npm', ['pack']);
+  const originalPathToTar = (await fs.glob(path.resolve('.', 'appium-webdriveragent-*.tgz')))[0];
+  fs.rename(originalPathToTar, pathToTar);
+
+  // Uncompress the tarball
+  await exec('tar', ['xvzf', pathToTar, '-C', pathToBundles]);
+  const uncompressedDir = path.resolve(pathToBundles, 'package');
+
+  // Add DerivedData to it
+  const derivedDataPath = path.resolve(os.homedir(), 'Library', 'Developer', 'Xcode', 'DerivedData');
+  const wdaPath = (await fs.glob(`${derivedDataPath}/WebDriverAgent-*`))[0];
+  await mkdirp(path.resolve(uncompressedDir, 'DerivedData'));
+  await fs.rename(wdaPath, path.resolve(uncompressedDir, 'DerivedData', 'WebDriverAgent'));
+
+  // Re-compress the tarball
+  await exec('tar', ['-cvjf', pathToTar, '-C', uncompressedDir, '.']);
+  await fs.rimraf(uncompressedDir);
 }
 
 if (require.main === module) {

--- a/ci-jobs/scripts/build-webdriveragent.js
+++ b/ci-jobs/scripts/build-webdriveragent.js
@@ -1,0 +1,29 @@
+const { asyncify } = require('asyncbox');
+const { logger, fs } = require('appium-support');
+const { exec } = require('teen_process');
+const xcode = require('appium-xcode');
+
+const log = new logger.getLogger('WDA Build');
+
+async function buildWebDriverAgent () {
+  // Get Xcode version
+  const xcodeVersion = await xcode.getVersion();
+  log.info(`Building bundle for Xcode version '${xcodeVersion}'`);
+
+  // Clean and build the dependencies
+  await exec('npx', ['gulp', 'clean:carthage']);
+  log.info('Running ./Scripts/bootstrap.sh');
+  await exec('./Scripts/bootstrap.sh', ['-d']);
+
+  // Create a bundle
+  await fs.mkdir('bundles');
+  const bundleName = `bundles/webdriveragent-xcode_${xcodeVersion}.zip`;
+  log.info(`Creating bundle '${bundleName}'`);
+  await exec('zip', ['-r', bundleName, '.']);
+}
+
+if (require.main === module) {
+  asyncify(buildWebDriverAgent);
+}
+
+module.exports = buildWebDriverAgent;

--- a/ci-jobs/scripts/build-webdriveragent.js
+++ b/ci-jobs/scripts/build-webdriveragent.js
@@ -5,9 +5,9 @@ const xcode = require('appium-xcode');
 
 const log = new logger.getLogger('WDA Build');
 
-async function buildWebDriverAgent () {
+async function buildWebDriverAgent (xcodeVersion) {
   // Get Xcode version
-  const xcodeVersion = await xcode.getVersion();
+  xcodeVersion = xcodeVersion || await xcode.getVersion();
   log.info(`Building bundle for Xcode version '${xcodeVersion}'`);
 
   // Clean and build the dependencies

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -10,6 +10,9 @@ async function buildAndUploadWebDriverAgents () {
   const xcodePaths = (await fs.readdir('/Applications/'))
     .filter((file) => file.toLowerCase().startsWith('xcode_'));
 
+  // Determine which xcodes need to be skipped
+  let excludedXcodeArr = (process.env.EXCLUDE_XCODE || '').split(',');
+
   for (let xcodePath of xcodePaths) {
     if (xcodePath.includes('_beta')) {
       continue;
@@ -18,6 +21,11 @@ async function buildAndUploadWebDriverAgents () {
     log.info(`Running xcode-select for '${xcodePath}'`);
     await exec('sudo', ['xcode-select', '-s', `/Applications/${xcodePath}/Contents/Developer`]);
     const xcodeVersion = xcodePath.replace('.app', '').split('_', 2)[1];
+    
+    if (excludedXcodeArr.includes(xcodeVersion)) {
+      continue;
+    }
+
     log.info('Building webdriveragent for xcode version', xcodeVersion);
     await buildWebDriverAgent(xcodeVersion);
   }

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -11,7 +11,7 @@ async function buildAndUploadWebDriverAgents () {
     .filter((file) => file.toLowerCase().startsWith('xcode_'));
 
   for (let xcodePath of xcodePaths) {
-    if (xcodePath.endsWith('_beta')) {
+    if (xcodePath.contains('_beta')) {
       continue;
     }
     // Build webdriveragent for this xcode version

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -3,7 +3,7 @@ const { asyncify } = require('asyncbox');
 const { fs, logger } = require('appium-support');
 const { exec } = require('teen_process');
 
-const log = new logger.getLogger('WDA Build');
+const log = new logger.getLogger('WDABuild');
 
 async function buildAndUploadWebDriverAgents () {
   // Get all xcode paths from /Applications/

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -12,6 +12,7 @@ async function buildAndUploadWebDriverAgents () {
 
   // Determine which xcodes need to be skipped
   let excludedXcodeArr = (process.env.EXCLUDE_XCODE || '').split(',');
+  log.info(`Will skip xcode versions: '${excludedXcodeArr}'`)
 
   for (let xcodePath of xcodePaths) {
     if (xcodePath.includes('_beta')) {
@@ -23,6 +24,7 @@ async function buildAndUploadWebDriverAgents () {
     const xcodeVersion = xcodePath.replace('.app', '').split('_', 2)[1];
 
     if (excludedXcodeArr.includes(xcodeVersion)) {
+      log.info(`Skipping xcode version '${xcodeVersion}'`);
       continue;
     }
 

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -22,7 +22,7 @@ async function buildAndUploadWebDriverAgents () {
     // Build webdriveragent for this xcode version
     log.info(`Running xcode-select for '${xcodePath}'`);
     await exec('sudo', ['xcode-select', '-s', `/Applications/${xcodePath}/Contents/Developer`]);
-    const xcodeVersion = path.parse(xcodePath).split('_', 2)[1];
+    const xcodeVersion = path.parse(xcodePath).name.split('_', 2)[1];
 
     if (excludedXcodeArr.includes(xcodeVersion)) {
       log.info(`Skipping xcode version '${xcodeVersion}'`);

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -2,6 +2,7 @@ const buildWebDriverAgent = require('./build-webdriveragent');
 const { asyncify } = require('asyncbox');
 const { fs, logger } = require('appium-support');
 const { exec } = require('teen_process');
+const path = require('path');
 
 const log = new logger.getLogger('WDABuild');
 
@@ -21,7 +22,7 @@ async function buildAndUploadWebDriverAgents () {
     // Build webdriveragent for this xcode version
     log.info(`Running xcode-select for '${xcodePath}'`);
     await exec('sudo', ['xcode-select', '-s', `/Applications/${xcodePath}/Contents/Developer`]);
-    const xcodeVersion = xcodePath.replace('.app', '').split('_', 2)[1];
+    const xcodeVersion = path.parse(xcodePath).split('_', 2)[1];
 
     if (excludedXcodeArr.includes(xcodeVersion)) {
       log.info(`Skipping xcode version '${xcodeVersion}'`);

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -12,7 +12,7 @@ async function buildAndUploadWebDriverAgents () {
 
   // Determine which xcodes need to be skipped
   let excludedXcodeArr = (process.env.EXCLUDE_XCODE || '').split(',');
-  log.info(`Will skip xcode versions: '${excludedXcodeArr}'`)
+  log.info(`Will skip xcode versions: '${excludedXcodeArr}'`);
 
   for (let xcodePath of xcodePaths) {
     if (xcodePath.includes('_beta')) {
@@ -29,7 +29,11 @@ async function buildAndUploadWebDriverAgents () {
     }
 
     log.info('Building webdriveragent for xcode version', xcodeVersion);
-    await buildWebDriverAgent(xcodeVersion);
+    try {
+      await buildWebDriverAgent(xcodeVersion);
+    } catch (e) {
+      log.error(`Skipping build for '${xcodeVersion} due to error: ${e}'`);
+    }
   }
 
   // Divider log line

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -11,7 +11,7 @@ async function buildAndUploadWebDriverAgents () {
     .filter((file) => file.toLowerCase().startsWith('xcode_'));
 
   for (let xcodePath of xcodePaths) {
-    if (xcodePath.contains('_beta')) {
+    if (xcodePath.includes('_beta')) {
       continue;
     }
     // Build webdriveragent for this xcode version

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -11,6 +11,9 @@ async function buildAndUploadWebDriverAgents () {
     .filter((file) => file.toLowerCase().startsWith('xcode_'));
 
   for (let xcodePath of xcodePaths) {
+    if (xcodePath.endsWith('_beta')) {
+      continue;
+    }
     // Build webdriveragent for this xcode version
     log.info(`Running xcode-select for '${xcodePath}'`);
     await exec('sudo', ['xcode-select', '-s', `/Applications/${xcodePath}/Contents/Developer`]);

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -21,7 +21,7 @@ async function buildAndUploadWebDriverAgents () {
     log.info(`Running xcode-select for '${xcodePath}'`);
     await exec('sudo', ['xcode-select', '-s', `/Applications/${xcodePath}/Contents/Developer`]);
     const xcodeVersion = xcodePath.replace('.app', '').split('_', 2)[1];
-    
+
     if (excludedXcodeArr.includes(xcodeVersion)) {
       continue;
     }

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -11,11 +11,11 @@ async function buildAndUploadWebDriverAgents () {
     .filter((file) => file.toLowerCase().startsWith('xcode_'));
 
   // Determine which xcodes need to be skipped
-  let excludedXcodeArr = (process.env.EXCLUDE_XCODE || '').split(',');
+  let excludedXcodeArr = (process.env.EXCLUDE_XCODE || '').replace(/\s/g, '').split(',');
   log.info(`Will skip xcode versions: '${excludedXcodeArr}'`);
 
   for (let xcodePath of xcodePaths) {
-    if (xcodePath.includes('_beta')) {
+    if (xcodePath.includes('beta')) {
       continue;
     }
     // Build webdriveragent for this xcode version

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -8,7 +8,7 @@ const log = new logger.getLogger('WDA Build');
 async function buildAndUploadWebDriverAgents () {
   // Get all xcode paths from /Applications/
   const xcodePaths = (await fs.readdir('/Applications/'))
-    .filter((file) => file.toLowerCase().startsWith('xcode'));
+    .filter((file) => file.toLowerCase().startsWith('xcode_'));
 
   for (let xcodePath of xcodePaths) {
     // Build webdriveragent for this xcode version
@@ -16,6 +16,9 @@ async function buildAndUploadWebDriverAgents () {
     await exec('sudo', ['xcode-select', '-s', `/Applications/${xcodePath}/Contents/Developer`]);
     await buildWebDriverAgent();
   }
+
+  // Divider log line
+  log.info('\n');
 }
 
 if (require.main === module) {

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -13,7 +13,7 @@ async function buildAndUploadWebDriverAgents () {
   for (let xcodePath of xcodePaths) {
     // Build webdriveragent for this xcode version
     log.info(`Running xcode-select for '${xcodePath}'`);
-    await exec('sudo',  ['xcode-select', '-s', xcodePath]);
+    await exec('sudo', ['xcode-select', '-s', xcodePath]);
     await buildWebDriverAgent();
   }
 }

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -14,7 +14,9 @@ async function buildAndUploadWebDriverAgents () {
     // Build webdriveragent for this xcode version
     log.info(`Running xcode-select for '${xcodePath}'`);
     await exec('sudo', ['xcode-select', '-s', `/Applications/${xcodePath}/Contents/Developer`]);
-    await buildWebDriverAgent();
+    const xcodeVersion = xcodePath.replace('.app', '').split('_', 2)[1];
+    log.info('Building webdriveragent for xcode version', xcodeVersion);
+    await buildWebDriverAgent(xcodeVersion);
   }
 
   // Divider log line

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -13,7 +13,7 @@ async function buildAndUploadWebDriverAgents () {
   for (let xcodePath of xcodePaths) {
     // Build webdriveragent for this xcode version
     log.info(`Running xcode-select for '${xcodePath}'`);
-    await exec('sudo', ['xcode-select', '-s', xcodePath]);
+    await exec('sudo', ['xcode-select', '-s', `/Applications/${xcodePath}/Contents/Developer`]);
     await buildWebDriverAgent();
   }
 }

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -8,12 +8,12 @@ const log = new logger.getLogger('WDA Build');
 async function buildAndUploadWebDriverAgents () {
   // Get all xcode paths from /Applications/
   const xcodePaths = (await fs.readdir('/Applications/'))
-    .filter((file) => file.toLowerCase().startsWith('xcode_'));
+    .filter((file) => file.toLowerCase().startsWith('xcode'));
 
   for (let xcodePath of xcodePaths) {
     // Build webdriveragent for this xcode version
     log.info(`Running xcode-select for '${xcodePath}'`);
-    await exec('xcode-select', ['-s', xcodePath]);
+    await exec('sudo xcode-select', ['-s', xcodePath]);
 
     await buildWebDriverAgent();
   }

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -13,8 +13,7 @@ async function buildAndUploadWebDriverAgents () {
   for (let xcodePath of xcodePaths) {
     // Build webdriveragent for this xcode version
     log.info(`Running xcode-select for '${xcodePath}'`);
-    await exec('sudo xcode-select', ['-s', xcodePath]);
-
+    await exec('sudo',  ['xcode-select', '-s', xcodePath]);
     await buildWebDriverAgent();
   }
 }

--- a/ci-jobs/scripts/build-webdriveragents.js
+++ b/ci-jobs/scripts/build-webdriveragents.js
@@ -1,0 +1,26 @@
+const buildWebDriverAgent = require('./build-webdriveragent');
+const { asyncify } = require('asyncbox');
+const { fs, logger } = require('appium-support');
+const { exec } = require('teen_process');
+
+const log = new logger.getLogger('WDA Build');
+
+async function buildAndUploadWebDriverAgents () {
+  // Get all xcode paths from /Applications/
+  const xcodePaths = (await fs.readdir('/Applications/'))
+    .filter((file) => file.toLowerCase().startsWith('xcode_'));
+
+  for (let xcodePath of xcodePaths) {
+    // Build webdriveragent for this xcode version
+    log.info(`Running xcode-select for '${xcodePath}'`);
+    await exec('xcode-select', ['-s', xcodePath]);
+
+    await buildWebDriverAgent();
+  }
+}
+
+if (require.main === module) {
+  asyncify(buildAndUploadWebDriverAgents);
+}
+
+module.exports = buildAndUploadWebDriverAgents;

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -8,6 +8,7 @@ jobs:
       EXCLUDE_XCODE: ${{ parameters.excludeXcode }}
     pool:
       vmImage: ${{ parameters.vmImage }}
+    dependsOn: create_github_release
     steps:
     - script: ls /Applications/
       displayName: List Installed Applications

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -33,5 +33,4 @@ jobs:
         action: edit
         githubConnection: appiumbot
         repositoryName: appium/WebDriverAgent
-        tag: $(Build.BuildNumber)
         assets: bundles/*

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -8,7 +8,6 @@ jobs:
       EXCLUDE_XCODE: ${{ parameters.excludeXcode }}
     pool:
       vmImage: ${{ parameters.vmImage }}
-    dependsOn: create_github_release
     steps:
     - script: ls /Applications/
       displayName: List Installed Applications

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -6,7 +6,6 @@ jobs:
   - job: ${{ parameters.name }}
     variables:
       EXCLUDE_XCODE: ${{ parameters.excludeXcode }}
-      GITHUB_TOKEN: $(GITHUB_TOKEN)
     pool:
       vmImage: ${{ parameters.vmImage }}
     dependsOn: create_github_release
@@ -31,6 +30,7 @@ jobs:
         targetPath: bundles/
         artifactName: ${{ parameters.name }}
     - script: |
+        export GITHUB_TOKEN=$(GITHUB_TOKEN)
         brew install ghr
         ghr $(node ./ci-jobs/scripts/azure-print-tag-name) bundles/
       displayName: Upload to GitHub Releases

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -5,10 +5,7 @@ parameters:
 jobs:
   - job: ${{ parameters.name }}
     variables:
-      SDK: sim
-      TARGET: runner
       EXCLUDE_XCODE: ${{ parameters.excludeXcode }}
-      #USE_SSH: true
     pool:
       vmImage: ${{ parameters.vmImage }}
     steps:

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -33,4 +33,6 @@ jobs:
         export GITHUB_TOKEN=$(GITHUB_TOKEN)
         brew install ghr
         ghr $(node ./ci-jobs/scripts/azure-print-tag-name) bundles/
+      env:
+        GITHUB_TOKEN: $(GITHUB_TOKEN)
       displayName: Upload to GitHub Releases

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -7,7 +7,7 @@ jobs:
       TARGET: runner
       #USE_SSH: true
     pool:
-      vmImage: ${{ paramters.vmImage }}
+      vmImage: ${{ parameters.vmImage }}
     steps:
     - script: ls /Applications/
       displayName: List Installed Applications

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -1,7 +1,7 @@
 parameters:
   vmImage: 'macOS-10.14'
 jobs:
-  - job: build_and_upload_bundles
+  - job: build_and_upload_bundles_${{ parameters.vmImage }}
     variables:
       SDK: sim
       TARGET: runner

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -30,7 +30,6 @@ jobs:
         targetPath: bundles/
         artifactName: ${{ parameters.name }}
     - script: |
-        export GITHUB_TOKEN=$(GITHUB_TOKEN)
         brew install ghr
         ghr $(node ./ci-jobs/scripts/azure-print-tag-name) bundles/
       env:

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -6,6 +6,7 @@ jobs:
   - job: ${{ parameters.name }}
     variables:
       EXCLUDE_XCODE: ${{ parameters.excludeXcode }}
+      GITHUB_TOKEN: $(GITHUB_TOKEN)
     pool:
       vmImage: ${{ parameters.vmImage }}
     dependsOn: create_github_release

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -1,7 +1,8 @@
 parameters:
   vmImage: 'macOS-10.14'
+  name: macOS_10_14
 jobs:
-  - job: build_and_upload_bundles_${{ parameters.vmImage }}
+  - job: ${{ parameters.name }}
     variables:
       SDK: sim
       TARGET: runner

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -10,6 +10,8 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
     dependsOn: create_github_release
     steps:
+    - script: node ./ci-jobs/scripts/azure-print-tag-name
+      displayName: Print Tag Name
     - script: ls /Applications/
       displayName: List Installed Applications
     - task: NodeTool@0
@@ -27,3 +29,7 @@ jobs:
       inputs:
         targetPath: bundles/
         artifactName: ${{ parameters.name }}
+    - script: |
+        brew install ghr
+        ghr $(node ./ci-jobs/scripts/azure-print-tag-name) bundles/
+      displayName: Upload to GitHub Releases

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -25,6 +25,7 @@ jobs:
     - task: PublishPipelineArtifact@0
       inputs:
         targetPath: bundles/
+        artifactName: ${{ parameters.name }}
     - task: GithubRelease@0
       displayName: Publish to GitHub Release
       inputs:

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -27,10 +27,3 @@ jobs:
       inputs:
         targetPath: bundles/
         artifactName: ${{ parameters.name }}
-    - task: GithubRelease@0
-      displayName: Publish to GitHub Release
-      inputs:
-        action: edit
-        githubConnection: appiumbot
-        repositoryName: appium/WebDriverAgent
-        assets: bundles/*

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -8,6 +8,7 @@ jobs:
       EXCLUDE_XCODE: ${{ parameters.excludeXcode }}
     pool:
       vmImage: ${{ parameters.vmImage }}
+    dependsOn: create_github_release
     steps:
     - script: ls /Applications/
       displayName: List Installed Applications
@@ -29,7 +30,8 @@ jobs:
     - task: GithubRelease@0
       displayName: Publish to GitHub Release
       inputs:
+        action: edit
         githubConnection: appiumbot
         repositoryName: appium/WebDriverAgent
         tag: $(Build.BuildNumber)
-        assets: bundles/
+        assets: bundles/*

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -1,0 +1,31 @@
+parameters:
+  vmImage: 'macOS-10.14'
+jobs:
+  - job: build_and_upload_bundles
+    variables:
+      SDK: sim
+      TARGET: runner
+      #USE_SSH: true
+    pool:
+      vmImage: ${{ paramters.vmImage }}
+    steps:
+    - script: ls /Applications/
+      displayName: List Installed Applications
+    - task: NodeTool@0
+      inputs:
+        versionSpec: '12.x' 
+    - script: npm install
+      displayName: Install Node Modules
+    - script: mkdir -p Resources/WebDriverAgent.bundle
+      displayName: Make Resources Folder
+    - script: node ./ci-jobs/scripts/build-webdriveragents.js
+      displayName: Build WebDriverAgents
+    - script: ls ./bundles
+      displayName: List WDA Bundles
+    - task: GithubRelease@0
+      displayName: Publish to GitHub Release
+      inputs:
+        githubConnection: appiumbot
+        repositoryName: appium/WebDriverAgent
+        tag: $(Build.BuildNumber)
+        assets: bundles/

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -1,11 +1,13 @@
 parameters:
   vmImage: 'macOS-10.14'
   name: macOS_10_14
+  excludeXcode: $(excludeXcode)
 jobs:
   - job: ${{ parameters.name }}
     variables:
       SDK: sim
       TARGET: runner
+      EXCLUDE_XCODE: ${{ parameters.excludeXcode }}
       #USE_SSH: true
     pool:
       vmImage: ${{ parameters.vmImage }}

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -25,6 +25,9 @@ jobs:
       displayName: Build WebDriverAgents
     - script: ls ./bundles
       displayName: List WDA Bundles
+    - task: PublishPipelineArtifact@0
+      inputs:
+        targetPath: bundles/
     - task: GithubRelease@0
       displayName: Publish to GitHub Release
       inputs:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "gulp lint",
     "lint:fix": "gulp eslint --fix",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
-    "precommit-test": "gulp lint"
+    "precommit-test": "gulp lint",
+    "bundle": "node ./ci-jobs/scripts/build-webdriveragent.js"
   },
   "pre-commit": [
     "precommit-msg",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "gulp": "^4.0.2",
-    "pre-commit": "^1.2.2"
+    "pre-commit": "^1.2.2",
+    "release": "^6.0.1"
   },
   "dependencies": {
     "appium-support": "^2.29.0",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "gulp": "^4.0.2",
-    "pre-commit": "^1.2.2",
-    "release": "^6.0.1"
+    "pre-commit": "^1.2.2"
   },
   "dependencies": {
     "appium-support": "^2.29.0",

--- a/package.json
+++ b/package.json
@@ -38,16 +38,16 @@
   "homepage": "https://github.com/appium/WebDriverAgent#readme",
   "devDependencies": {
     "appium-gulp-plugins": "^4.1.0",
-    "appium-support": "^2.29.0",
     "appium-test-support": "^1.3.1",
     "appium-xcode": "^3.8.0",
-    "asyncbox": "^2.5.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "gulp": "^4.0.2",
     "pre-commit": "^1.2.2"
   },
   "dependencies": {
+    "appium-support": "^2.29.0",
+    "asyncbox": "^2.5.3",
     "bluebird": "^3.5.5",
     "lodash": "^4.17.11",
     "node-simctl": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -38,15 +38,16 @@
   "homepage": "https://github.com/appium/WebDriverAgent#readme",
   "devDependencies": {
     "appium-gulp-plugins": "^4.1.0",
+    "appium-support": "^2.29.0",
     "appium-test-support": "^1.3.1",
+    "appium-xcode": "^3.8.0",
+    "asyncbox": "^2.5.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "gulp": "^4.0.2",
     "pre-commit": "^1.2.2"
   },
   "dependencies": {
-    "appium-support": "^2.29.0",
-    "asyncbox": "^2.5.3",
     "bluebird": "^3.5.5",
     "lodash": "^4.17.11",
     "node-simctl": "^5.0.1",


### PR DESCRIPTION
Added a pipeline that bundles WebDriverAgents for every xcode version [see here](https://dev.azure.com/AppiumCI/Appium%20CI/_build/results?buildId=3365).

Runs build.sh for every version of Xcode that Azure makes available (betas excluded), copies the `DerivedData` directory into the same directory as WebDriverAgent, creates a .tgz bundle, publishes the .tgz bundle to GitHub Releases.