### PR TITLE
--use-ssh is correct name  for carthage arg

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ async function fetchDependencies (useSsl = false) {
 
   let args = ['bootstrap'];
   if (useSsl) {
-    args.push('--use-ssl');
+    args.push('--use-ssh');
   }
   args.push('--platform', platforms.join(','));
   try {


### PR DESCRIPTION
```
$ carthage bootstrap --use-ssl --platform iOS\,tvOS
Unrecognized arguments: --use-ssl
```

```
$ carthage bootstrap --use-ssh --platform iOS\,tvOS
*** Checking out CocoaAsyncSocket at "7.6.3"
*** Checking out YYCache at "1.1.0"
*** Checking out RoutingHTTPServer at "v1.0.2"
*** xcodebuild output can be found in /var/folders/34/2222sh8n27d6rcp7jqlkw8km0000gn/T/carthage-xcodebuild.XjhR72.log
*** Downloading CocoaAsyncSocket.framework binary at "Version 7.6.3"
*** Building scheme "RoutingHTTPServer tvOS" in RoutingHTTPServer.xcodeproj
*** Building scheme "RoutingHTTPServer iOS" in RoutingHTTPServer.xcodeproj
*** Building scheme "YYCache tvOS" in YYCache.xcodeproj
*** Building scheme "YYCache iOS" in YYCache.xcodeproj
```