### PR TITLE
get current locale and timezone

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -184,7 +184,7 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
   // https://developer.apple.com/documentation/foundation/nslocale/1414388-autoupdatingcurrentlocale
   NSString *currentLocale = [[NSLocale autoupdatingCurrentLocale] localeIdentifier];
   // TZ database Time Zones format like "US/Pacific"
-  NSString *currentTimeZone = [[NSTimeZone localTimeZone] name];
+  NSString *timeZone = [[NSTimeZone localTimeZone] name];
 
   return
   FBResponseWithStatus(
@@ -202,7 +202,7 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
           @"simulatorVersion" : [[UIDevice currentDevice] systemVersion],
           @"ip" : [XCUIDevice sharedDevice].fb_wifiIPAddress ?: [NSNull null],
           @"currentLocale": currentLocale,
-          @"currentTimeZone": currentTimeZone,
+          @"timeZone": timeZone,
         },
       @"build" : buildInfo.copy
     }

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -180,7 +180,9 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
   }
 
   // Returns locale like ja_EN and zh-Hant_US. The format depends on OS
-  NSString *currentLocale = [[NSLocale currentLocale] localeIdentifier];
+  // Developers should use this locale by default
+  // https://developer.apple.com/documentation/foundation/nslocale/1414388-autoupdatingcurrentlocale
+  NSString *currentLocale = [[NSLocale autoupdatingCurrentLocale] localeIdentifier];
 
   return
   FBResponseWithStatus(
@@ -197,7 +199,7 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
         @{
           @"simulatorVersion" : [[UIDevice currentDevice] systemVersion],
           @"ip" : [XCUIDevice sharedDevice].fb_wifiIPAddress ?: [NSNull null],
-          @"locale": currentLocale,
+          @"currentLocale": currentLocale,
         },
       @"build" : buildInfo.copy
     }

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -183,6 +183,8 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
   // Developers should use this locale by default
   // https://developer.apple.com/documentation/foundation/nslocale/1414388-autoupdatingcurrentlocale
   NSString *currentLocale = [[NSLocale autoupdatingCurrentLocale] localeIdentifier];
+  // TZ database Time Zones format like "US/Pacific"
+  NSString *currentTimeZone = [[NSTimeZone localTimeZone] name];
 
   return
   FBResponseWithStatus(
@@ -200,6 +202,7 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
           @"simulatorVersion" : [[UIDevice currentDevice] systemVersion],
           @"ip" : [XCUIDevice sharedDevice].fb_wifiIPAddress ?: [NSNull null],
           @"currentLocale": currentLocale,
+          @"currentTimeZone": currentTimeZone,
         },
       @"build" : buildInfo.copy
     }

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -179,6 +179,9 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
     [buildInfo setObject:upgradeTimestamp forKey:@"upgradedAt"];
   }
 
+  // Returns locale like ja_EN and zh-Hant_US. The format depends on OS
+  NSString *currentLocale = [[NSLocale currentLocale] localeIdentifier];
+
   return
   FBResponseWithStatus(
     FBCommandStatusNoError,
@@ -194,6 +197,7 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
         @{
           @"simulatorVersion" : [[UIDevice currentDevice] systemVersion],
           @"ip" : [XCUIDevice sharedDevice].fb_wifiIPAddress ?: [NSNull null],
+          @"locale": currentLocale,
         },
       @"build" : buildInfo.copy
     }


### PR DESCRIPTION
I'm thinking to add a mobile command to get locale/device current timezone in Android and iOS
( https://github.com/appium/java-client/issues/773 )

I wait for 1.14.0 release.

e.g.
```
      "currentLocale": "en_US",
      "currentTimeZone": "Asia/Tokyo"
```

Accirding to the framework code comment, `autoupdatingCurrentLocale` is proper to get locale as general way.
```swift
@property (class, readonly, strong) NSLocale *autoupdatingCurrentLocale API_AVAILABLE(macos(10.5), ios(2.0), watchos(2.0), tvos(9.0)); // generally you should use this property

@property (class, readonly, copy) NSLocale *currentLocale;	// an object representing the user's current locale
@property (class, readonly, copy) NSLocale *systemLocale;	// the default generic root locale with little localization
```

## example

```
{
  "value": {
    "state": "success",
    "os": {
      "name": "tvOS",
      "version": "12.2",
      "sdkVersion": "12.2"
    },
    "ios": {
      "simulatorVersion": "12.2",
      "ip": "172.20.10.9",
      "currentLocale": "en_US",
      "currentTimeZone": "Asia/Tokyo"
    },
    "build": {
      "time": "Jul  1 2019 16:55:35",
      "productBundleIdentifier": "com.facebook.WebDriverAgentRunner"
    }
  },
  "sessionId": "0508FDD4-8C3C-4569-815B-A08829E05DC7",
  "status": 0
}
```

I tested iPhone sim, a real device and sim tvOS.
I googled if they return `nil`, but I could not find it...