### PR TITLE
convert timezone from name form to the id form

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -55,6 +55,7 @@
 #endif
     [[FBRoute POST:@"/wda/pressButton"] respondWithTarget:self action:@selector(handlePressButtonCommand:)],
     [[FBRoute POST:@"/wda/siri/activate"] respondWithTarget:self action:@selector(handleActivateSiri:)],
+    [[FBRoute GET:@"/wda/device/info"] respondWithTarget:self action:@selector(handleGetDeviceInfo:)],
   ];
 }
 
@@ -225,6 +226,45 @@
     return FBResponseWithError(error);
   }
   return FBResponseWithOK();
+}
+
++ (id<FBResponsePayload>)handleGetDeviceInfo:(FBRouteRequest *)request
+{
+  // Returns locale like ja_EN and zh-Hant_US. The format depends on OS
+  // Developers should use this locale by default
+  // https://developer.apple.com/documentation/foundation/nslocale/1414388-autoupdatingcurrentlocale
+  NSString *currentLocale = [[NSLocale autoupdatingCurrentLocale] localeIdentifier];
+
+  return
+  FBResponseWithStatus(
+    FBCommandStatusNoError,
+    @{
+      @"currentLocale": currentLocale,
+      @"timeZone": [self getTimeZone],
+      }
+    );
+}
+
+/**
+ * @return The string of TimeZone. Returns TZ timezone id by default. Returns TimeZone name by Apple if TZ timezone id is not available.
+ */
++ (NSString *)getTimeZone
+{
+  NSTimeZone *localTimeZone = [NSTimeZone localTimeZone];
+  // Apple timezone name like "US/New_York"
+  NSString *timeZoneAbb = [localTimeZone abbreviation];
+  if (timeZoneAbb == nil) {
+    return [localTimeZone name];
+  }
+
+  // Convert timezone name to ids like "America/New_York" as TZ database Time Zones format
+  // https://developer.apple.com/documentation/foundation/nstimezone
+  NSString *timeZoneId = [[NSTimeZone timeZoneWithAbbreviation:timeZoneAbb] name];
+  if (timeZoneId != nil) {
+    return timeZoneId;
+  }
+
+  return [localTimeZone name];
 }
 
 @end

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -240,7 +240,7 @@
     FBCommandStatusNoError,
     @{
       @"currentLocale": currentLocale,
-      @"timeZone": [self getTimeZone],
+      @"timeZone": self.timeZone,
       }
     );
 }
@@ -248,7 +248,7 @@
 /**
  * @return The string of TimeZone. Returns TZ timezone id by default. Returns TimeZone name by Apple if TZ timezone id is not available.
  */
-+ (NSString *)getTimeZone
++ (NSString *)timeZone
 {
   NSTimeZone *localTimeZone = [NSTimeZone localTimeZone];
   // Apple timezone name like "US/New_York"

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -183,8 +183,11 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
   // Developers should use this locale by default
   // https://developer.apple.com/documentation/foundation/nslocale/1414388-autoupdatingcurrentlocale
   NSString *currentLocale = [[NSLocale autoupdatingCurrentLocale] localeIdentifier];
-  // TZ database Time Zones format like "US/Pacific"
-  NSString *timeZone = [[NSTimeZone localTimeZone] name];
+  // Apple timezone name like "US/New_York"
+  NSString *timeZone = [[NSTimeZone localTimeZone] abbreviation];
+  // Convert timezone name to ids like "America/New_York" as TZ database Time Zones format
+  // https://developer.apple.com/documentation/foundation/nstimezone
+  NSString *timeZoneId = [[NSTimeZone timeZoneWithAbbreviation:timeZone] name];
 
   return
   FBResponseWithStatus(
@@ -202,7 +205,7 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
           @"simulatorVersion" : [[UIDevice currentDevice] systemVersion],
           @"ip" : [XCUIDevice sharedDevice].fb_wifiIPAddress ?: [NSNull null],
           @"currentLocale": currentLocale,
-          @"timeZone": timeZone,
+          @"timeZone": timeZoneId,
         },
       @"build" : buildInfo.copy
     }

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -55,6 +55,8 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
     // Settings endpoints
     [[FBRoute GET:@"/appium/settings"] respondWithTarget:self action:@selector(handleGetSettings:)],
     [[FBRoute POST:@"/appium/settings"] respondWithTarget:self action:@selector(handleSetSettings:)],
+
+    [[FBRoute GET:@"/appium/device/info"] respondWithTarget:self action:@selector(handleGetDeviceInfo:)],
   ];
 }
 
@@ -179,11 +181,6 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
     [buildInfo setObject:upgradeTimestamp forKey:@"upgradedAt"];
   }
 
-  // Returns locale like ja_EN and zh-Hant_US. The format depends on OS
-  // Developers should use this locale by default
-  // https://developer.apple.com/documentation/foundation/nslocale/1414388-autoupdatingcurrentlocale
-  NSString *currentLocale = [[NSLocale autoupdatingCurrentLocale] localeIdentifier];
-
   return
   FBResponseWithStatus(
     FBCommandStatusNoError,
@@ -198,11 +195,26 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
       @"ios" :
         @{
           @"simulatorVersion" : [[UIDevice currentDevice] systemVersion],
-          @"ip" : [XCUIDevice sharedDevice].fb_wifiIPAddress ?: [NSNull null],
-          @"currentLocale": currentLocale,
-          @"timeZone": [self getTimeZone],
+          @"ip" : [XCUIDevice sharedDevice].fb_wifiIPAddress ?: [NSNull null]
         },
       @"build" : buildInfo.copy
+    }
+  );
+}
+
++ (id<FBResponsePayload>)handleGetDeviceInfo:(FBRouteRequest *)request
+{
+  // Returns locale like ja_EN and zh-Hant_US. The format depends on OS
+  // Developers should use this locale by default
+  // https://developer.apple.com/documentation/foundation/nslocale/1414388-autoupdatingcurrentlocale
+  NSString *currentLocale = [[NSLocale autoupdatingCurrentLocale] localeIdentifier];
+
+  return
+  FBResponseWithStatus(
+    FBCommandStatusNoError,
+    @{
+      @"currentLocale": currentLocale,
+      @"timeZone": [self getTimeZone],
     }
   );
 }

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -55,8 +55,6 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
     // Settings endpoints
     [[FBRoute GET:@"/appium/settings"] respondWithTarget:self action:@selector(handleGetSettings:)],
     [[FBRoute POST:@"/appium/settings"] respondWithTarget:self action:@selector(handleSetSettings:)],
-
-    [[FBRoute GET:@"/appium/device/info"] respondWithTarget:self action:@selector(handleGetDeviceInfo:)],
   ];
 }
 
@@ -200,45 +198,6 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
       @"build" : buildInfo.copy
     }
   );
-}
-
-+ (id<FBResponsePayload>)handleGetDeviceInfo:(FBRouteRequest *)request
-{
-  // Returns locale like ja_EN and zh-Hant_US. The format depends on OS
-  // Developers should use this locale by default
-  // https://developer.apple.com/documentation/foundation/nslocale/1414388-autoupdatingcurrentlocale
-  NSString *currentLocale = [[NSLocale autoupdatingCurrentLocale] localeIdentifier];
-
-  return
-  FBResponseWithStatus(
-    FBCommandStatusNoError,
-    @{
-      @"currentLocale": currentLocale,
-      @"timeZone": [self getTimeZone],
-    }
-  );
-}
-
-/**
- * @return The string of TimeZone. Returns TZ timezone id by default. Returns TimeZone name by Apple if TZ timezone id is not available.
- */
-+ (NSString *)getTimeZone
-{
-  NSTimeZone *localTimeZone = [NSTimeZone localTimeZone];
-  // Apple timezone name like "US/New_York"
-  NSString *timeZoneAbb = [localTimeZone abbreviation];
-  if (timeZoneAbb == nil) {
-    return [localTimeZone name];
-  }
-
-  // Convert timezone name to ids like "America/New_York" as TZ database Time Zones format
-  // https://developer.apple.com/documentation/foundation/nstimezone
-  NSString *timeZoneId = [[NSTimeZone timeZoneWithAbbreviation:timeZoneAbb] name];
-  if (timeZoneId != nil) {
-    return timeZoneId;
-  }
-
-  return [localTimeZone name];
 }
 
 + (id<FBResponsePayload>)handleGetHealthCheck:(FBRouteRequest *)request


### PR DESCRIPTION
I notied `[[NSTimeZone localTimeZone] name]` returns timezone name by Apple.
It's better to return timezone id instead of Apple name.

For example, _America/New_York_ is the id of _US/New_York_ by Apple's name.
https://stackoverflow.com/questions/2892290/where-can-i-get-a-list-of-abbreviations-for-timezonewithabbreviation

In this PR, WDA returns the id form by default. It returns the name form if it fails to convert from the name to the id.

---

Android returns the id form by default.