### PR TITLE
Add useFirstMatch setting

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -30,6 +30,7 @@ static NSString* const SCREENSHOT_QUALITY = @"screenshotQuality";
 static NSString* const KEYBOARD_AUTOCORRECTION = @"keyboardAutocorrection";
 static NSString* const KEYBOARD_PREDICTION = @"keyboardPrediction";
 static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
+static NSString* const USE_FIRST_MATCH = @"useFirstMatch";
 
 @implementation FBSessionCommands
 
@@ -220,7 +221,8 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
       SCREENSHOT_QUALITY: @([FBConfiguration screenshotQuality]),
       KEYBOARD_AUTOCORRECTION: @([FBConfiguration keyboardAutocorrection]),
       KEYBOARD_PREDICTION: @([FBConfiguration keyboardPrediction]),
-      SNAPSHOT_TIMEOUT: @([FBConfiguration snapshotTimeout])
+      SNAPSHOT_TIMEOUT: @([FBConfiguration snapshotTimeout]),
+      USE_FIRST_MATCH: @([FBConfiguration useFirstMatch]),
     }
   );
 }
@@ -257,6 +259,9 @@ static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
   }
   if ([settings objectForKey:SNAPSHOT_TIMEOUT]) {
     [FBConfiguration setSnapshotTimeout:[[settings objectForKey:SNAPSHOT_TIMEOUT] doubleValue]];
+  }
+  if ([settings objectForKey:USE_FIRST_MATCH]) {
+    [FBConfiguration setUseFirstMatch:[[settings objectForKey:USE_FIRST_MATCH] boolValue]];
   }
 
   return [self handleGetSettings:request];

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -137,6 +137,16 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setSnapshotTimeout:(NSTimeInterval)timeout;
 + (NSTimeInterval)snapshotTimeout;
 
+/**
+ * Whether to use fast search result matching while searching for elements.
+ * By default this is disabled due to https://github.com/appium/appium/issues/10101
+ * but it still makes sense to enable it for views containing large counts of elements
+ *
+ * @param enabled Either YES or NO
+ */
++ (void)setUseFirstMatch:(BOOL)enabled;
++ (BOOL)useFirstMatch;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -38,6 +38,7 @@ static NSUInteger FBMjpegServerFramerate = 10;
 static NSUInteger FBScreenshotQuality = 1;
 static NSUInteger FBMjpegScalingFactor = 100;
 static NSTimeInterval FBSnapshotTimeout = 15.;
+static BOOL FBShouldUseFirstMatch = NO;
 
 @implementation FBConfiguration
 
@@ -261,6 +262,16 @@ static NSTimeInterval FBSnapshotTimeout = 15.;
 + (NSTimeInterval)snapshotTimeout
 {
   return FBSnapshotTimeout;
+}
+
++ (void)setUseFirstMatch:(BOOL)enabled
+{
+  FBShouldUseFirstMatch = enabled;
+}
+
++ (BOOL)useFirstMatch
+{
+  return FBShouldUseFirstMatch;
 }
 
 #pragma mark Private

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -9,6 +9,7 @@
 
 #import "FBXCodeCompatibility.h"
 
+#import "FBConfiguration.h"
 #import "FBErrorBuilder.h"
 #import "FBLogger.h"
 #import "XCUIElementQuery.h"
@@ -82,21 +83,11 @@ static dispatch_once_t onceAppWithPIDToken;
 @end
 
 
-static BOOL FBShouldUseFirstMatchSelector = NO;
-static dispatch_once_t onceFirstMatchToken;
-
 @implementation XCUIElementQuery (FBCompatibility)
 
 - (XCUIElement *)fb_firstMatch
 {
-  dispatch_once(&onceFirstMatchToken, ^{
-    // Unfortunately, firstMatch property does not work properly if
-    // the lookup is not executed in application context:
-    // https://github.com/appium/appium/issues/10101
-    //    FBShouldUseFirstMatchSelector = [self respondsToSelector:@selector(firstMatch)];
-    FBShouldUseFirstMatchSelector = NO;
-  });
-  if (FBShouldUseFirstMatchSelector) {
+  if (FBConfiguration.useFirstMatch) {
     XCUIElement* result = self.firstMatch;
     return result.exists ? result : nil;
   }


### PR DESCRIPTION
By default this feature is disabled due to https://github.com/appium/appium/issues/10101, but it still makes sense to enable it for views containing large counts of elements. The aim is to enable it by default after Apple fixes the problem above.