### PR TITLE
Enable "UseLegacyElementType" for proper Xcode 11 Functionality

### DIFF
--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -37,6 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 /*! Disables attribute key path analysis, which will cause XCTest on Xcode 9.x to ignore some elements */
 + (void)disableAttributeKeyPathAnalysis;
 
+/*! Enables usage of legacy element type, which will cause correct elementType values to be returned from XCTest on Xcode 11.x */
++ (void)enableUseLegacyElementType;
+
 /* The maximum typing frequency for all typing activities */
 + (void)setMaxTypingFrequency:(NSUInteger)value;
 + (NSUInteger)maxTypingFrequency;

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -54,6 +54,11 @@ static BOOL FBShouldUseFirstMatch = NO;
   [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"XCTDisableAttributeKeyPathAnalysis"];
 }
 
++ (void)enableUseLegacyElementType
+{
+  [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"UseLegacyElementType"];
+}
+
 + (NSRange)bindingPortRange
 {
   // 'WebDriverAgent --port 8080' can be passed via the arguments to the process

--- a/WebDriverAgentRunner/UITestingUITests.m
+++ b/WebDriverAgentRunner/UITestingUITests.m
@@ -26,6 +26,7 @@
   [FBConfiguration disableRemoteQueryEvaluation];
   [FBConfiguration configureDefaultKeyboardPreferences];
   [FBConfiguration enableUseLegacyElementType];
+  
   [super setUp];
 }
 

--- a/WebDriverAgentRunner/UITestingUITests.m
+++ b/WebDriverAgentRunner/UITestingUITests.m
@@ -25,6 +25,7 @@
   [FBDebugLogDelegateDecorator decorateXCTestLogger];
   [FBConfiguration disableRemoteQueryEvaluation];
   [FBConfiguration configureDefaultKeyboardPreferences];
+  [FBConfiguration enableUseLegacyElementType];
   [super setUp];
 }
 


### PR DESCRIPTION
On some instances (for example - Safari) an invalid element type is returned from XCTest (4096), causing findElement and getSource commands to fail since the XML cannot be parsed correctly (see `+ [FBElementTypeTransformer stringWithElementType]`.

Adding this setting causes the correct element types to be returned from XCTest.