### PR TITLE
Properly handle newly added element types in newer Xcode versions

### DIFF
--- a/WebDriverAgentLib/Utilities/FBElementTypeTransformer.m
+++ b/WebDriverAgentLib/Utilities/FBElementTypeTransformer.m
@@ -107,7 +107,7 @@ static NSString const *FB_ELEMENT_TYPE_PREFIX = @"XCUIElementType";
       @80 : @"XCUIElementTypeTab",
       @81 : @"XCUIElementTypeTouchBar",
       @82 : @"XCUIElementTypeStatusItem",
-      // !!! This mapping should be updated if there are changes after the new XCTest version release
+      // !!! This mapping should be updated if there are changes after each new XCTest release
       };
     NSMutableDictionary *swappedMapping = [NSMutableDictionary dictionary];
     [ElementTypeToStringMapping enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {

--- a/WebDriverAgentLib/Utilities/FBElementTypeTransformer.m
+++ b/WebDriverAgentLib/Utilities/FBElementTypeTransformer.m
@@ -10,7 +10,6 @@
 #import "FBElementTypeTransformer.h"
 
 #import "FBExceptionHandler.h"
-#import "FBLogger.h"
 
 @implementation FBElementTypeTransformer
 
@@ -124,7 +123,7 @@ static NSString const *FB_ELEMENT_TYPE_PREFIX = @"XCUIElementType";
   NSNumber *type = StringToElementTypeMapping[typeName];
   if (!type) {
     if ([typeName hasPrefix:(NSString *)FB_ELEMENT_TYPE_PREFIX] && typeName.length > FB_ELEMENT_TYPE_PREFIX.length) {
-      [FBLogger logFmt:@"Mapping an unknown element type '%@' to XCUIElementTypeOther. Consider reviewing the ElementTypeToStringMapping", typeName];
+      // Consider the element type is something new and has to be added into ElementTypeToStringMapping
       return XCUIElementTypeOther;
     }
     NSString *reason = [NSString stringWithFormat:@"Invalid argument for class used '%@'. Did you mean %@%@?", typeName, FB_ELEMENT_TYPE_PREFIX, typeName];
@@ -138,7 +137,8 @@ static NSString const *FB_ELEMENT_TYPE_PREFIX = @"XCUIElementType";
   [self createMapping];
   NSString *typeName = ElementTypeToStringMapping[@(type)];
   if (!typeName) {
-    return [NSString stringWithFormat:@"%@Unknown(%lu)", FB_ELEMENT_TYPE_PREFIX, (unsigned long)type];
+    // Consider the type name is something new and has to be added into ElementTypeToStringMapping
+    return [NSString stringWithFormat:@"%@Other", FB_ELEMENT_TYPE_PREFIX];
   }
   return typeName;
 }

--- a/WebDriverAgentLib/Utilities/FBElementTypeTransformer.m
+++ b/WebDriverAgentLib/Utilities/FBElementTypeTransformer.m
@@ -121,7 +121,7 @@ static NSString const *FB_ELEMENT_TYPE_PREFIX = @"XCUIElementType";
 {
   [self createMapping];
   NSNumber *type = StringToElementTypeMapping[typeName];
-  if (!type) {
+  if (nil == type) {
     if ([typeName hasPrefix:(NSString *)FB_ELEMENT_TYPE_PREFIX] && typeName.length > FB_ELEMENT_TYPE_PREFIX.length) {
       // Consider the element type is something new and has to be added into ElementTypeToStringMapping
       return XCUIElementTypeOther;
@@ -129,18 +129,17 @@ static NSString const *FB_ELEMENT_TYPE_PREFIX = @"XCUIElementType";
     NSString *reason = [NSString stringWithFormat:@"Invalid argument for class used '%@'. Did you mean %@%@?", typeName, FB_ELEMENT_TYPE_PREFIX, typeName];
     @throw [NSException exceptionWithName:FBInvalidArgumentException reason:reason userInfo:@{}];
   }
-  return (XCUIElementType) ( type ? type.unsignedIntegerValue : XCUIElementTypeAny);
+  return (XCUIElementType) type.unsignedIntegerValue;
 }
 
 + (NSString *)stringWithElementType:(XCUIElementType)type
 {
   [self createMapping];
   NSString *typeName = ElementTypeToStringMapping[@(type)];
-  if (!typeName) {
+  return nil == typeName
     // Consider the type name is something new and has to be added into ElementTypeToStringMapping
-    return [NSString stringWithFormat:@"%@Other", FB_ELEMENT_TYPE_PREFIX];
-  }
-  return typeName;
+    ? [NSString stringWithFormat:@"%@Other", FB_ELEMENT_TYPE_PREFIX]
+    : typeName;
 }
 
 + (NSString *)shortStringWithElementType:(XCUIElementType)type

--- a/WebDriverAgentLib/Utilities/FBElementTypeTransformer.m
+++ b/WebDriverAgentLib/Utilities/FBElementTypeTransformer.m
@@ -10,11 +10,14 @@
 #import "FBElementTypeTransformer.h"
 
 #import "FBExceptionHandler.h"
+#import "FBLogger.h"
 
 @implementation FBElementTypeTransformer
 
 static NSDictionary *ElementTypeToStringMapping;
 static NSDictionary *StringToElementTypeMapping;
+
+static NSString const *FB_ELEMENT_TYPE_PREFIX = @"XCUIElementType";
 
 + (void)createMapping
 {
@@ -103,6 +106,9 @@ static NSDictionary *StringToElementTypeMapping;
       @78 : @"XCUIElementTypeHandle",
       @79 : @"XCUIElementTypeStepper",
       @80 : @"XCUIElementTypeTab",
+      @81 : @"XCUIElementTypeTouchBar",
+      @82 : @"XCUIElementTypeStatusItem",
+      // !!! This mapping should be updated if there are changes after the new XCTest version release
       };
     NSMutableDictionary *swappedMapping = [NSMutableDictionary dictionary];
     [ElementTypeToStringMapping enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
@@ -117,7 +123,11 @@ static NSDictionary *StringToElementTypeMapping;
   [self createMapping];
   NSNumber *type = StringToElementTypeMapping[typeName];
   if (!type) {
-    NSString *reason = [NSString stringWithFormat:@"Invalid argument for class used '%@'. Did you mean XCUIElementType%@?", typeName, typeName];
+    if ([typeName hasPrefix:(NSString *)FB_ELEMENT_TYPE_PREFIX] && typeName.length > FB_ELEMENT_TYPE_PREFIX.length) {
+      [FBLogger logFmt:@"Mapping an unknown element type '%@' to XCUIElementTypeOther. Consider reviewing the ElementTypeToStringMapping", typeName];
+      return XCUIElementTypeOther;
+    }
+    NSString *reason = [NSString stringWithFormat:@"Invalid argument for class used '%@'. Did you mean %@%@?", typeName, FB_ELEMENT_TYPE_PREFIX, typeName];
     @throw [NSException exceptionWithName:FBInvalidArgumentException reason:reason userInfo:@{}];
   }
   return (XCUIElementType) ( type ? type.unsignedIntegerValue : XCUIElementTypeAny);
@@ -128,14 +138,14 @@ static NSDictionary *StringToElementTypeMapping;
   [self createMapping];
   NSString *typeName = ElementTypeToStringMapping[@(type)];
   if (!typeName) {
-    return [NSString stringWithFormat:@"Unknown(%lu)", (unsigned long)type];
+    return [NSString stringWithFormat:@"%@Unknown(%lu)", FB_ELEMENT_TYPE_PREFIX, (unsigned long)type];
   }
   return typeName;
 }
 
 + (NSString *)shortStringWithElementType:(XCUIElementType)type
 {
-  return [[self stringWithElementType:type] stringByReplacingOccurrencesOfString:@"XCUIElementType" withString:@""];
+  return [[self stringWithElementType:type] stringByReplacingOccurrencesOfString:(NSString *)FB_ELEMENT_TYPE_PREFIX withString:@""];
 }
 
 @end

--- a/WebDriverAgentTests/UnitTests/FBElementTypeTransformerTests.m
+++ b/WebDriverAgentTests/UnitTests/FBElementTypeTransformerTests.m
@@ -40,6 +40,7 @@
   XCTAssertEqual(XCUIElementTypeOther, [FBElementTypeTransformer elementTypeWithTypeName:@"XCUIElementTypeOther"]);
   XCTAssertThrows([FBElementTypeTransformer elementTypeWithTypeName:@"Whatever"]);
   XCTAssertThrows([FBElementTypeTransformer elementTypeWithTypeName:nil]);
+  XCTAssertEqual(XCUIElementTypeOther, [FBElementTypeTransformer elementTypeWithTypeName:@"XCUIElementTypeNewType"]);
 }
 
 @end


### PR DESCRIPTION
Apple keeps adding new element types to XCUIElementType enumeration. And since there is no way in Objective C to get a string representation of an enum item, we need to do such mapping on our own and also update it manually when a new element type(s) are getting added. 
This PR relaxes the logic for type number to name conversion and simply returns `XCUIElementTypeOther` for newly added unknown types, which are not in the mapping yet. This prevents WDA from unexpected crashes, although it still does not release us from adding of new type names into the mapping. 

Related to https://github.com/appium/WebDriverAgent/pull/188