### PR TITLE
[do not merge] feat: Use requestSnapshotForElement instead of snapshotForElement to prevent warning

### DIFF
--- a/PrivateHeaders/XCTest/XCTestManager_ManagerInterface-Protocol.h
+++ b/PrivateHeaders/XCTest/XCTestManager_ManagerInterface-Protocol.h
@@ -6,8 +6,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class NSArray, NSDictionary, NSNumber, NSString, NSUUID, XCAccessibilityElement, XCDeviceEvent, XCSynthesizedEventRecord, XCTouchGesture, NSXPCListenerEndpoint, XCElementSnapshot, XCUIElementSnapshotRequestResult;
-// XCUIElementSnapshotRequestResult is also Xcode 11+
+@class NSArray, NSDictionary, NSNumber, NSString, NSUUID, XCAccessibilityElement, XCDeviceEvent, XCSynthesizedEventRecord, XCTouchGesture, NSXPCListenerEndpoint, XCElementSnapshot;
 
 @protocol XCTestManager_ManagerInterface
 - (void)_XCT_loadAccessibilityWithTimeout:(double)arg1 reply:(void (^)(BOOL, NSError *))arg2;
@@ -27,12 +26,13 @@
 - (void)_XCT_fetchParameterizedAttributeForElement:(XCAccessibilityElement *)arg1 attributes:(NSNumber *)arg2 parameter:(id)arg3 reply:(void (^)(id, NSError *))arg4;
 - (void)_XCT_setAttribute:(NSNumber *)arg1 value:(id)arg2 element:(XCAccessibilityElement *)arg3 reply:(void (^)(BOOL, NSError *))arg4;
 - (void)_XCT_fetchAttributesForElement:(XCAccessibilityElement *)arg1 attributes:(NSArray *)arg2 reply:(void (^)(NSDictionary *, NSError *))arg3;
-// Available  Xcode 10.3-
+// Warning from Xcode 11.0-beta
 - (void)_XCT_snapshotForElement:(XCAccessibilityElement *)arg1 attributes:(NSArray *)arg2 parameters:(NSDictionary *)arg3 reply:(void (^)(XCElementSnapshot *, NSError *))arg4;
-//=begin Available since Xcode 11+
-- (void)_XCT_fetchSnapshotForElement:(XCAccessibilityElement *)arg1 attributes:(NSArray *)arg2 parameters:(NSDictionary *)arg3 reply:(void (^)(XCUIElementSnapshotRequestResult *, NSError *))arg4;
+// Available since Xcode 9.0
 - (void)_XCT_requestSnapshotForElement:(XCAccessibilityElement *)arg1 attributes:(NSArray *)arg2 parameters:(NSDictionary *)arg3 reply:(void (^)(XCElementSnapshot *, NSError *))arg4;
-//=end Available since Xcode 11+
+// Note: Below introduced in Xcode 11 beta
+// - (void)_XCT_fetchSnapshotForElement:(XCAccessibilityElement *)arg1 attributes:(NSArray *)arg2 parameters:(NSDictionary *)arg3 reply:(void (^)(XCUIElementSnapshotRequestResult *, NSError *))arg4;
+
 
 - (void)_XCT_terminateApplicationWithBundleID:(NSString *)arg1 completion:(void (^)(NSError *))arg2;
 - (void)_XCT_performAccessibilityAction:(int)arg1 onElement:(XCAccessibilityElement *)arg2 withValue:(id)arg3 reply:(void (^)(NSError *))arg4;

--- a/PrivateHeaders/XCTest/XCTestManager_ManagerInterface-Protocol.h
+++ b/PrivateHeaders/XCTest/XCTestManager_ManagerInterface-Protocol.h
@@ -6,7 +6,8 @@
 
 #import <UIKit/UIKit.h>
 
-@class NSArray, NSDictionary, NSNumber, NSString, NSUUID, XCAccessibilityElement, XCDeviceEvent, XCSynthesizedEventRecord, XCTouchGesture, NSXPCListenerEndpoint, XCElementSnapshot;
+@class NSArray, NSDictionary, NSNumber, NSString, NSUUID, XCAccessibilityElement, XCDeviceEvent, XCSynthesizedEventRecord, XCTouchGesture, NSXPCListenerEndpoint, XCElementSnapshot, XCUIElementSnapshotRequestResult;
+// XCUIElementSnapshotRequestResult is also Xcode 11+
 
 @protocol XCTestManager_ManagerInterface
 - (void)_XCT_loadAccessibilityWithTimeout:(double)arg1 reply:(void (^)(BOOL, NSError *))arg2;
@@ -26,7 +27,13 @@
 - (void)_XCT_fetchParameterizedAttributeForElement:(XCAccessibilityElement *)arg1 attributes:(NSNumber *)arg2 parameter:(id)arg3 reply:(void (^)(id, NSError *))arg4;
 - (void)_XCT_setAttribute:(NSNumber *)arg1 value:(id)arg2 element:(XCAccessibilityElement *)arg3 reply:(void (^)(BOOL, NSError *))arg4;
 - (void)_XCT_fetchAttributesForElement:(XCAccessibilityElement *)arg1 attributes:(NSArray *)arg2 reply:(void (^)(NSDictionary *, NSError *))arg3;
+// Available  Xcode 10.3-
 - (void)_XCT_snapshotForElement:(XCAccessibilityElement *)arg1 attributes:(NSArray *)arg2 parameters:(NSDictionary *)arg3 reply:(void (^)(XCElementSnapshot *, NSError *))arg4;
+//=begin Available since Xcode 11+
+- (void)_XCT_fetchSnapshotForElement:(XCAccessibilityElement *)arg1 attributes:(NSArray *)arg2 parameters:(NSDictionary *)arg3 reply:(void (^)(XCUIElementSnapshotRequestResult *, NSError *))arg4;
+- (void)_XCT_requestSnapshotForElement:(XCAccessibilityElement *)arg1 attributes:(NSArray *)arg2 parameters:(NSDictionary *)arg3 reply:(void (^)(XCElementSnapshot *, NSError *))arg4;
+//=end Available since Xcode 11+
+
 - (void)_XCT_terminateApplicationWithBundleID:(NSString *)arg1 completion:(void (^)(NSError *))arg2;
 - (void)_XCT_performAccessibilityAction:(int)arg1 onElement:(XCAccessibilityElement *)arg2 withValue:(id)arg3 reply:(void (^)(NSError *))arg4;
 - (void)_XCT_unregisterForAccessibilityNotification:(int)arg1 withRegistrationToken:(NSNumber *)arg2 reply:(void (^)(NSError *))arg3;

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -87,6 +87,7 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
   info[@"frame"] = NSStringFromCGRect(snapshot.wdFrame);
   info[@"isEnabled"] = [@([snapshot isWDEnabled]) stringValue];
   info[@"isVisible"] = [@([snapshot isWDVisible]) stringValue];
+  info[@"accessible"] = [@([snapshot isWDAccessible]) stringValue];
 #if TARGET_OS_TV
   info[@"isFocused"] = [@([snapshot isWDFocused]) stringValue];
 #endif

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -125,17 +125,32 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
   [FBXCTestDaemonsProxy tryToSetAxTimeout:axTimeout
                                  forProxy:proxy
                               withHandler:^(int res) {
-                                [proxy _XCT_snapshotForElement:self.lastSnapshot.accessibilityElement
-                                                    attributes:axAttributes
-                                                    parameters:defaultParameters
-                                                         reply:^(XCElementSnapshot *snapshot, NSError *error) {
-                                                           if (nil == error) {
-                                                             snapshotWithAttributes = snapshot;
-                                                           } else {
-                                                             innerError = error;
-                                                           }
-                                                           dispatch_semaphore_signal(sem);
-                                                         }];
+                                Class proxyClass = NSClassFromString(@"XCTestManager_ManagerInterface");
+                                if ([proxyClass respondsToSelector:@selector(_XCT_requestSnapshotForElement)]) {
+                                  [proxy _XCT_requestSnapshotForElement:self.lastSnapshot.accessibilityElement
+                                                      attributes:axAttributes
+                                                      parameters:defaultParameters
+                                                           reply:^(XCElementSnapshot *snapshot, NSError *error) {
+                                                             if (nil == error) {
+                                                               snapshotWithAttributes = snapshot;
+                                                             } else {
+                                                               innerError = error;
+                                                             }
+                                                             dispatch_semaphore_signal(sem);
+                                                           }];
+                                } else {
+                                  [proxy _XCT_snapshotForElement:self.lastSnapshot.accessibilityElement
+                                                      attributes:axAttributes
+                                                      parameters:defaultParameters
+                                                           reply:^(XCElementSnapshot *snapshot, NSError *error) {
+                                                             if (nil == error) {
+                                                               snapshotWithAttributes = snapshot;
+                                                             } else {
+                                                               innerError = error;
+                                                             }
+                                                             dispatch_semaphore_signal(sem);
+                                                           }];
+                                }
                               }];
   dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(axTimeout * NSEC_PER_SEC)));
   if (nil == snapshotWithAttributes) {

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -125,32 +125,17 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
   [FBXCTestDaemonsProxy tryToSetAxTimeout:axTimeout
                                  forProxy:proxy
                               withHandler:^(int res) {
-                                Class proxyClass = NSClassFromString(@"XCTestManager_ManagerInterface");
-                                if ([proxyClass respondsToSelector:@selector(_XCT_requestSnapshotForElement)]) {
-                                  [proxy _XCT_requestSnapshotForElement:self.lastSnapshot.accessibilityElement
-                                                      attributes:axAttributes
-                                                      parameters:defaultParameters
-                                                           reply:^(XCElementSnapshot *snapshot, NSError *error) {
-                                                             if (nil == error) {
-                                                               snapshotWithAttributes = snapshot;
-                                                             } else {
-                                                               innerError = error;
-                                                             }
-                                                             dispatch_semaphore_signal(sem);
-                                                           }];
-                                } else {
-                                  [proxy _XCT_snapshotForElement:self.lastSnapshot.accessibilityElement
-                                                      attributes:axAttributes
-                                                      parameters:defaultParameters
-                                                           reply:^(XCElementSnapshot *snapshot, NSError *error) {
-                                                             if (nil == error) {
-                                                               snapshotWithAttributes = snapshot;
-                                                             } else {
-                                                               innerError = error;
-                                                             }
-                                                             dispatch_semaphore_signal(sem);
-                                                           }];
-                                }
+                                [proxy _XCT_requestSnapshotForElement:self.lastSnapshot.accessibilityElement
+                                                    attributes:axAttributes
+                                                    parameters:defaultParameters
+                                                         reply:^(XCElementSnapshot *snapshot, NSError *error) {
+                                                           if (nil == error) {
+                                                             snapshotWithAttributes = snapshot;
+                                                           } else {
+                                                             innerError = error;
+                                                           }
+                                                           dispatch_semaphore_signal(sem);
+                                                         }];
                               }];
   dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(axTimeout * NSEC_PER_SEC)));
   if (nil == snapshotWithAttributes) {

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -54,6 +54,10 @@
 
 @end
 
+@interface FBAccessibleAttribute : FBElementAttribute
+
+@end
+
 @interface FBDimensionAttribute : FBElementAttribute
 
 @end
@@ -429,6 +433,7 @@ static NSString *const FBAbstractMethodInvocationException = @"AbstractMethodInv
            FBLabelAttribute.class,
            FBEnabledAttribute.class,
            FBVisibleAttribute.class,
+           FBAccessibleAttribute.class,
 #if TARGET_OS_TV
            FBFocusedAttribute.class,
 #endif
@@ -526,6 +531,20 @@ static NSString *const FBAbstractMethodInvocationException = @"AbstractMethodInv
 + (NSString *)valueForElement:(id<FBElement>)element
 {
   return element.wdVisible ? @"true" : @"false";
+}
+
+@end
+
+@implementation FBAccessibleAttribute
+
++ (NSString *)name
+{
+  return @"accessible";
+}
+
++ (NSString *)valueForElement:(id<FBElement>)element
+{
+  return element.wdAccessible ? @"true" : @"false";
 }
 
 @end


### PR DESCRIPTION
`_XCT_snapshotForElement` got warning message like `[Xcode] 2019-07-24 18:16:24.545684+0900 WebDriverAgentRunner-Runner[14248:106314] Internal error: Error Domain=XCTDaemonErrorDomain Code=39 "Legacy accessibility snapshots are no longer supported" UserInfo={NSLocalizedDescription=Legacy accessibility snapshots are no longer supported}` on Xcode 11 beta 4.

`_XCT_snapshotForElement` and `_XCT_requestSnapshotForElement` has the same arguments.
Xcode 11 beta 4 and get `source` on map app in simulator iOS 13.0

## _XCT_snapshotForElement
- https://github.com/appium/appium/issues/12960#issuecomment-514553788

## _XCT_requestSnapshotForElement
(no- `Legacy accessibility snapshots ...` warning)

- https://github.com/appium/appium/issues/12960#issuecomment-514569664

I dumped headers back to Xcode 9.0. Then, I found `_XCT_requestSnapshotForElement` was already in the header. Not sure in Xcode 8, but Xcode 7 has only `_XCT_snapshotForElement`.

I think it is worth to try to switch _XCT_snapshotForElement with  _XCT_requestSnapshotForElement completely as a beta.

I also noted `_XCT_fetchSnapshotForElement` which was introduced in Xcode 11.0- beta. In the future, we can consider to use it, maybe.