### PR TITLE
Add bootstrap.sh to the package, and a bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "precommit-test": "gulp lint",
     "bundle": "node ./ci-jobs/scripts/build-webdriveragent.js"
   },
+  "bin": {
+    "appium-wda-bootstrap": "./build/index.js"
+  },
   "pre-commit": [
     "precommit-msg",
     "precommit-test"
@@ -61,6 +64,7 @@
     "lib",
     "build/index.js",
     "build/lib",
+    "Scripts/bootstrap.sh",
     "Cartfile",
     "Cartfile.resolved",
     "Configurations",


### PR DESCRIPTION
1. Add `./Scripts/bootstrap.sh` to the published package.
1. Add a binary link to the JS dependency script. I am _very_ open to a different name of the binary.