### PR TITLE
feat: return processArguments as device info

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -253,6 +253,7 @@
     @{
       @"currentLocale": currentLocale,
       @"timeZone": self.timeZone,
+      @"currentActiveApplication" : [self currentActiveApplication],
       }
     );
 }
@@ -277,6 +278,42 @@
   }
 
   return [localTimeZone name];
+}
+
+/**
+ * Returns current active app and its arguments of active session
+ *
+ * @return The dictionary of current active bundleId and its process/environment argumens
+ *
+ * @example
+ *
+ *     [self currentActiveApplication]
+ *     //=> {
+ *     //       "processArguments" : {
+ *     //       "env" : {
+ *     //           "HAPPY" : "testing"
+ *     //       },
+ *     //       "args" : [
+ *     //           "happy",
+ *     //           "tseting"
+ *     //       ]
+ *     //   },
+ *     //       "bundleId" : "com.trident.test-examples"
+ *     //   }
+ *
+ */
++ (NSDictionary *)currentActiveApplication
+{
+  FBApplication *application = [FBSession activeSession].activeApplication;
+  return
+  @{
+    @"bundleId": application.bundleID,
+    @"processArguments":
+      @{
+        @"args": application.launchArguments,
+        @"env": application.launchEnvironment
+        }
+    };
 }
 
 @end

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -168,8 +168,45 @@
   return FBResponseWithStatus(FBCommandStatusNoError, @{
     @"pid": @(app.processID),
     @"bundleId": app.bundleID,
-    @"name": app.identifier
+    @"name": app.identifier,
+    @"processArguments": [self processArguments:app],
   });
+}
+
+/**
+ * Returns current active app and its arguments of active session
+ *
+ * @return The dictionary of current active bundleId and its process/environment argumens
+ *
+ * @example
+ *
+ *     [self currentActiveApplication]
+ *     //=> {
+ *     //       "processArguments" : {
+ *     //       "env" : {
+ *     //           "HAPPY" : "testing"
+ *     //       },
+ *     //       "args" : [
+ *     //           "happy",
+ *     //           "tseting"
+ *     //       ]
+ *     //   }
+ *
+ *     [self currentActiveApplication]
+ *     //=> {}
+ */
++ (NSDictionary *)processArguments:(XCUIApplication *)app
+{
+  // Can be nil if no active activation is defined by XCTest
+  if (app == nil) {
+    return @{};
+  }
+
+  return
+  @{
+    @"args": app.launchArguments,
+    @"env": app.launchEnvironment
+  };
 }
 
 #if !TARGET_OS_TV
@@ -253,7 +290,6 @@
     @{
       @"currentLocale": currentLocale,
       @"timeZone": self.timeZone,
-      @"activeApplication" : [self activeApplicationInfo],
       }
     );
 }
@@ -278,49 +314,6 @@
   }
 
   return [localTimeZone name];
-}
-
-/**
- * Returns current active app and its arguments of active session
- *
- * @return The dictionary of current active bundleId and its process/environment argumens
- *
- * @example
- *
- *     [self currentActiveApplication]
- *     //=> {
- *     //       "processArguments" : {
- *     //       "env" : {
- *     //           "HAPPY" : "testing"
- *     //       },
- *     //       "args" : [
- *     //           "happy",
- *     //           "tseting"
- *     //       ]
- *     //   },
- *     //       "bundleId" : "com.trident.test-examples"
- *     //   }
- *
- *     [self currentActiveApplication]
- *     //=> {}
- */
-+ (NSDictionary *)activeApplicationInfo
-{
-  FBApplication *application = [FBSession activeSession].activeApplication;
-  // Can be nil if no active activation is defined by XCTest
-  if (application == nil) {
-    return @{};
-  }
-
-  return
-  @{
-    @"bundleId": application.bundleID,
-    @"processArguments":
-      @{
-        @"args": application.launchArguments,
-        @"env": application.launchEnvironment
-      }
-  };
 }
 
 @end

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -253,7 +253,7 @@
     @{
       @"currentLocale": currentLocale,
       @"timeZone": self.timeZone,
-      @"currentActiveApplication" : [self currentActiveApplication],
+      @"activeApplication" : [self currentActiveApplication],
       }
     );
 }
@@ -305,6 +305,15 @@
 + (NSDictionary *)currentActiveApplication
 {
   FBApplication *application = [FBSession activeSession].activeApplication;
+  // Can be here if no activeApplications by XCTest framework
+  if (application == nil) {
+    return
+    @{
+      @"bundleId": @"",
+      @"processArguments": @{ @"args": @[], @"env": @{} }
+    };
+  }
+
   return
   @{
     @"bundleId": application.bundleID,
@@ -312,8 +321,8 @@
       @{
         @"args": application.launchArguments,
         @"env": application.launchEnvironment
-        }
-    };
+      }
+  };
 }
 
 @end

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -253,7 +253,7 @@
     @{
       @"currentLocale": currentLocale,
       @"timeZone": self.timeZone,
-      @"activeApplication" : [self currentActiveApplication],
+      @"activeApplication" : [self activeApplicationInfo],
       }
     );
 }
@@ -301,17 +301,15 @@
  *     //       "bundleId" : "com.trident.test-examples"
  *     //   }
  *
+ *     [self currentActiveApplication]
+ *     //=> {}
  */
-+ (NSDictionary *)currentActiveApplication
++ (NSDictionary *)activeApplicationInfo
 {
   FBApplication *application = [FBSession activeSession].activeApplication;
-  // Can be here if no activeApplications by XCTest framework
+  // Can be nil if no active activation is defined by XCTest
   if (application == nil) {
-    return
-    @{
-      @"bundleId": @"",
-      @"processArguments": @{ @"args": @[], @"env": @{} }
-    };
+    return @{};
   }
 
   return


### PR DESCRIPTION
[update]
`http://localhost:8100/wda/activeAppInfo` returns some current active app info

----

Get current active application's processArguments.
It depends on the current active application, so here is probably better than `/status`
Or add a new mobile command. mm..

```ruby
# com.apple.springboard is active
> @driver.execute_script('mobile: deviceInfo', {})
=> {"currentActiveApplication"=>{"processArguments"=>{"env"=>{}, "args"=>[]}, "bundleId"=>"com.apple.springboard"}, "currentLocale"=>"en_JP", "timeZone"=>"Asia/Tokyo"}

# com.burbn.instagram is active
> @driver.execute_script('mobile: deviceInfo', {})
=> {"currentActiveApplication"=>{"processArguments"=>{"env"=>{}, "args"=>[]}, "bundleId"=>"com.burbn.instagram"}, "currentLocale"=>"en_JP", "timeZone"=>"Asia/Tokyo"}

# com.kazucocoa.test-examples is active
# I provided `processArguments` for this app
> @driver.execute_script('mobile: deviceInfo', {})
=> {"currentActiveApplication"=>{"processArguments"=>{"env"=>{"HAPPY"=>"testing"}, "args"=>["happy", "tseting"]}, "bundleId"=>"com.kazucocoa.test-examples"}, "currentLocale"=>"en_JP", "timeZone"=>"Asia/Tokyo"}
```
