### PR TITLE
fix: Allow setting compression quality and scaling factor for the mjpeg-stream

### DIFF
--- a/WebDriverAgentLib/Utilities/FBMjpegServer.m
+++ b/WebDriverAgentLib/Utilities/FBMjpegServer.m
@@ -94,18 +94,16 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
   BOOL usesScaling = fabs(FBMaxScalingFactor - scalingFactor) > DBL_EPSILON;
 
   CGFloat compressionQuality = FBConfiguration.mjpegServerScreenshotQuality / 100.0f;
-
   // If scaling is applied we perform another JPEG compression after scaling
   // To get the desired compressionQuality we need to do a lossless compression here
-  if (usesScaling) {
-    compressionQuality = FBMaxScalingFactor;
-  }
+  CGFloat screenshotCompressionQuality = usesScaling ? FBMaxCompressionQuality : compressionQuality;
+
   id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
   dispatch_semaphore_t sem = dispatch_semaphore_create(0);
   [proxy _XCT_requestScreenshotOfScreenWithID:[[XCUIScreen mainScreen] displayID]
                                        withRect:CGRectNull
                                             uti:(__bridge id)kUTTypeJPEG
-                             compressionQuality:compressionQuality
+                             compressionQuality:screenshotCompressionQuality
                                       withReply:^(NSData *data, NSError *error) {
     if (error != nil) {
       [FBLogger logFmt:@"Error taking screenshot: %@", [error description]];


### PR DESCRIPTION
The variable `compressionQuality` is overwritten with the max value for compression quality, if scaling is enabled. The result of this is that scaled images are much larger than unscaled ones (if we use the default value `25` for compression quality).