### PR TITLE
chore: move node tests to macos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ branches:
 jobs:
   include:
     - stage: Node tests
-      os: linux
+      osx_image: xcode10.2
       language: node_js
       node_js: "10"
       install: npm install


### PR DESCRIPTION
Move the Nodejs unit tests to run on MacOS, which is the same as the rest of the stages. This is slower to start (since we get fewer MacOS executors), but means that the build is not started early and forced to wait when it gets to the MacOS stages. When that happens it stops Travis from being able to automatically cancel builds (when, for instance, a new commit is pushed to a branch).