### PR TITLE
Expose hasKeyboardFocus property for using with predicates

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -276,4 +276,9 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSMutable
   return [self fb_cachedValueWithAttributeName:@"wdRect" valueGetter:getter];
 }
 
+- (BOOL)isWDHasKeyboardFocus
+{
+  return self.hasKeyboardFocus;
+}
+
 @end

--- a/WebDriverAgentLib/Routing/FBElement.h
+++ b/WebDriverAgentLib/Routing/FBElement.h
@@ -55,6 +55,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, getter = isWDFocused) BOOL wdFocused;
 #endif
 
+/*! Whether element hasKeyboardFocus */
+@property (nonatomic, readonly, getter = isWDHasKeyboardFocus) BOOL wdHasKeyboardFocus;
+
 /**
  Returns value of given property specified in WebDriver Spec
  Check the FBElement protocol to get list of supported attributes.


### PR DESCRIPTION
Useful for searches with class chains and predicates like this:

```
'hasKeyboardFocus == 1'
```