### PR TITLE
feat: Add the necessary primitives to be able to automate split-screen apps

### DIFF
--- a/PrivateHeaders/XCTest/XCTestManager_ManagerInterface-Protocol.h
+++ b/PrivateHeaders/XCTest/XCTestManager_ManagerInterface-Protocol.h
@@ -9,6 +9,8 @@
 @class NSArray, NSDictionary, NSNumber, NSString, NSUUID, XCAccessibilityElement, XCDeviceEvent, XCSynthesizedEventRecord, XCTouchGesture, NSXPCListenerEndpoint, XCElementSnapshot;
 
 @protocol XCTestManager_ManagerInterface
+// since Xcode9
+- (void)_XCT_requestBundleIDForPID:(int)arg1 reply:(void (^)(NSString *, NSError *))arg2;
 - (void)_XCT_loadAccessibilityWithTimeout:(double)arg1 reply:(void (^)(BOOL, NSError *))arg2;
 - (void)_XCT_injectVoiceRecognitionAudioInputPaths:(NSArray *)arg1 completion:(void (^)(BOOL, NSError *))arg2;
 - (void)_XCT_injectAssistantRecognitionStrings:(NSArray *)arg1 completion:(void (^)(BOOL, NSError *))arg2;

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)fb_waitForAppElement:(NSTimeInterval)timeout;
 
 /**
- Retrievs the infomration about the applications the given accessiblity elements
+ Retrieves the information about the applications the given accessiblity elements
  belong to
 
  @param axElements the list of accessibility elements

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
@@ -69,6 +69,23 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)fb_waitForAppElement:(NSTimeInterval)timeout;
 
+/**
+ Retrievs the infomration about the applications the given accessiblity elements
+ belong to
+
+ @param axElements the list of accessibility elements
+ @returns The list of dictionaries. Each dictionary contains `bundleId` and `pid` items
+ */
++ (NSArray<NSDictionary<NSString *, id> *> *)fb_appsInfoWithAxElements:(NSArray<XCAccessibilityElement *> *)axElements;
+
+/**
+ Retrieves the information about the currently active apps
+
+ @returns The list of dictionaries. Each dictionary contains `bundleId` and `pid` items.
+ */
++ (NSArray<NSDictionary<NSString *, id> *> *)fb_activeAppsInfo;
+
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -40,7 +40,6 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
   dispatch_once(&oncePoint, ^{
     CGSize screenSize = [UIScreen mainScreen].bounds.size;
     // Consider the element, which is located close to the top left corner of the screen the on-screen one.
-    // FIXME: Improve this algorithm for split-screen automation
     CGFloat pointDistance = MIN(screenSize.width, screenSize.height) * 0.2;
     screenPoint = CGPointMake(pointDistance, pointDistance);
   });

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -30,6 +30,8 @@
 #import "XCTRunnerDaemonSession.h"
 
 const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
+static NSString* const FBUnknownBundleId = @"unknown";
+
 
 @implementation XCUIApplication (FBHelpers)
 
@@ -91,7 +93,7 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
                                   dispatch_semaphore_signal(sem);
                                 }];
     dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)));
-    appInfo[@"bundleId"] = bundleId ?: @"";
+    appInfo[@"bundleId"] = bundleId ?: FBUnknownBundleId;
     [result addObject:appInfo.copy];
   }
   return result.copy;

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -94,7 +94,7 @@
 + (id<FBResponsePayload>)handleDismissKeyboardCommand:(FBRouteRequest *)request
 {
 #if TARGET_OS_TV
-  if ([self isKeyboardPresent]) {
+  if ([self isKeyboardPresentForApplication:request.session.activeApplication]) {
     [[XCUIRemote sharedRemote] pressButton: XCUIRemoteButtonMenu];
   }
 #else
@@ -110,7 +110,7 @@
      timeout:5]
     timeoutErrorMessage:errorDescription]
    spinUntilTrue:^BOOL{
-     return ![self isKeyboardPresent];
+     return ![self isKeyboardPresentForApplication:request.session.activeApplication];
    }
    error:&error];
   if (!isKeyboardNotPresent) {
@@ -121,8 +121,8 @@
 
 #pragma mark - Helpers
 
-+ (BOOL)isKeyboardPresent {
-  XCUIElement *foundKeyboard = [[FBApplication fb_activeApplication].query descendantsMatchingType:XCUIElementTypeKeyboard].fb_firstMatch;
++ (BOOL)isKeyboardPresentForApplication:(XCUIApplication *)application {
+  XCUIElement *foundKeyboard = [application.query descendantsMatchingType:XCUIElementTypeKeyboard].fb_firstMatch;
   return foundKeyboard && foundKeyboard.fb_isVisible;
 }
 

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -50,7 +50,7 @@ static NSString* const DEFAULT_ACTIVE_APPLICATION = @"defaultActiveApplication";
     [[FBRoute POST:@"/wda/apps/activate"] respondWithTarget:self action:@selector(handleSessionAppActivate:)],
     [[FBRoute POST:@"/wda/apps/terminate"] respondWithTarget:self action:@selector(handleSessionAppTerminate:)],
     [[FBRoute POST:@"/wda/apps/state"] respondWithTarget:self action:@selector(handleSessionAppState:)],
-    [[FBRoute POST:@"/wda/apps/list"] respondWithTarget:self action:@selector(handleActiveAppsList:)],
+    [[FBRoute GET:@"/wda/apps/list"] respondWithTarget:self action:@selector(handleGetActiveAppsList:)],
     [[FBRoute GET:@""] respondWithTarget:self action:@selector(handleGetActiveSession:)],
     [[FBRoute DELETE:@""] respondWithTarget:self action:@selector(handleDeleteSession:)],
     [[FBRoute GET:@"/status"].withoutSession respondWithTarget:self action:@selector(handleGetStatus:)],
@@ -165,7 +165,7 @@ static NSString* const DEFAULT_ACTIVE_APPLICATION = @"defaultActiveApplication";
   return FBResponseWithObject(@(state));
 }
 
-+ (id<FBResponsePayload>)handleActiveAppsList:(FBRouteRequest *)request
++ (id<FBResponsePayload>)handleGetActiveAppsList:(FBRouteRequest *)request
 {
   return FBResponseWithObject([XCUIApplication fb_activeAppsInfo]);
 }

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -88,7 +88,7 @@ static NSString* const DEFAULT_ACTIVE_APPLICATION = @"defaultActiveApplication";
     return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:@"'capabilities' is mandatory to create a new session"
                                                               traceback:nil]);
   }
-  if (nil == (requirements = FBParseCapabilities(request.arguments[@"capabilities"], &error))) {
+  if (nil == (requirements = FBParseCapabilities((NSDictionary *)request.arguments[@"capabilities"], &error))) {
     return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:error.description traceback:nil]);
   }
   [FBConfiguration setShouldUseTestManagerForVisibilityDetection:[requirements[@"shouldUseTestManagerForVisibilityDetection"] boolValue]];
@@ -288,7 +288,7 @@ static NSString* const DEFAULT_ACTIVE_APPLICATION = @"defaultActiveApplication";
     [FBConfiguration setReduceMotionEnabled:[[settings objectForKey:REDUCE_MOTION] boolValue]];
   }
   if ([settings objectForKey:DEFAULT_ACTIVE_APPLICATION]) {
-    request.session.defaultActiveApplication = [settings objectForKey:DEFAULT_ACTIVE_APPLICATION];
+    request.session.defaultActiveApplication = (NSString *)[settings objectForKey:DEFAULT_ACTIVE_APPLICATION];
   }
 
   return [self handleGetSettings:request];

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -16,6 +16,7 @@
 #import "FBSession.h"
 #import "FBApplication.h"
 #import "FBRuntimeUtils.h"
+#import "XCUIApplication+FBHelpers.h"
 #import "XCUIDevice.h"
 #import "XCUIDevice+FBHealthCheck.h"
 #import "XCUIDevice+FBHelpers.h"
@@ -33,6 +34,7 @@ static NSString* const KEYBOARD_PREDICTION = @"keyboardPrediction";
 static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
 static NSString* const USE_FIRST_MATCH = @"useFirstMatch";
 static NSString* const REDUCE_MOTION = @"reduceMotion";
+static NSString* const DEFAULT_ACTIVE_APPLICATION = @"defaultActiveApplication";
 
 @implementation FBSessionCommands
 
@@ -48,6 +50,7 @@ static NSString* const REDUCE_MOTION = @"reduceMotion";
     [[FBRoute POST:@"/wda/apps/activate"] respondWithTarget:self action:@selector(handleSessionAppActivate:)],
     [[FBRoute POST:@"/wda/apps/terminate"] respondWithTarget:self action:@selector(handleSessionAppTerminate:)],
     [[FBRoute POST:@"/wda/apps/state"] respondWithTarget:self action:@selector(handleSessionAppState:)],
+    [[FBRoute POST:@"/wda/apps/list"] respondWithTarget:self action:@selector(handleActiveAppsList:)],
     [[FBRoute GET:@""] respondWithTarget:self action:@selector(handleGetActiveSession:)],
     [[FBRoute DELETE:@""] respondWithTarget:self action:@selector(handleDeleteSession:)],
     [[FBRoute GET:@"/status"].withoutSession respondWithTarget:self action:@selector(handleGetStatus:)],
@@ -162,6 +165,11 @@ static NSString* const REDUCE_MOTION = @"reduceMotion";
   return FBResponseWithObject(@(state));
 }
 
++ (id<FBResponsePayload>)handleActiveAppsList:(FBRouteRequest *)request
+{
+  return FBResponseWithObject([XCUIApplication fb_activeAppsInfo]);
+}
+
 + (id<FBResponsePayload>)handleGetActiveSession:(FBRouteRequest *)request
 {
   return FBResponseWithObject(FBSessionCommands.sessionInformation);
@@ -235,6 +243,7 @@ static NSString* const REDUCE_MOTION = @"reduceMotion";
       SNAPSHOT_TIMEOUT: @([FBConfiguration snapshotTimeout]),
       USE_FIRST_MATCH: @([FBConfiguration useFirstMatch]),
       REDUCE_MOTION: @([FBConfiguration reduceMotionEnabled]),
+      DEFAULT_ACTIVE_APPLICATION: request.session.defaultActiveApplication,
     }
   );
 }
@@ -277,6 +286,9 @@ static NSString* const REDUCE_MOTION = @"reduceMotion";
   }
   if ([settings objectForKey:REDUCE_MOTION]) {
     [FBConfiguration setReduceMotionEnabled:[[settings objectForKey:REDUCE_MOTION] boolValue]];
+  }
+  if ([settings objectForKey:DEFAULT_ACTIVE_APPLICATION]) {
+    request.session.defaultActiveApplication = [settings objectForKey:DEFAULT_ACTIVE_APPLICATION];
   }
 
   return [self handleGetSettings:request];

--- a/WebDriverAgentLib/FBApplication.h
+++ b/WebDriverAgentLib/FBApplication.h
@@ -19,6 +19,14 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)fb_activeApplication;
 
 /**
+ Constructor used to get current active application
+
+ @param bundleId The bundle identifier of an app, which should be selected as active by default
+ if it is present in the list of active applications
+ */
++ (instancetype)fb_activeApplicationWithDefaultBundleId:(nullable NSString *)bundleId;
+
+/**
  Constructor used to get the system application
  */
 + (instancetype)fb_systemApplication;

--- a/WebDriverAgentLib/FBApplication.m
+++ b/WebDriverAgentLib/FBApplication.m
@@ -47,11 +47,9 @@ static const NSTimeInterval APP_STATE_CHANGE_TIMEOUT = 5.0;
     if (nil != bundleId) {
       // Try to select the desired application first
       NSArray<NSDictionary *> *appsInfo = [self fb_appsInfoWithAxElements:activeApplicationElements];
-      NSUInteger index = 0;
-      for (NSDictionary *appInfo in appsInfo) {
-        index++;
-        if ([appInfo[@"bundleId"] isEqualToString:(id)bundleId]) {
-          activeApplicationElement = [activeApplicationElements objectAtIndex:index];
+      for (NSUInteger appIdx = 0; appIdx < appsInfo.count; appIdx++) {
+        if ([[[appsInfo objectAtIndex:appIdx] objectForKey:@"bundleId"] isEqualToString:(id)bundleId]) {
+          activeApplicationElement = [activeApplicationElements objectAtIndex:appIdx];
           break;
         }
       }

--- a/WebDriverAgentLib/FBSpringboardApplication.m
+++ b/WebDriverAgentLib/FBSpringboardApplication.m
@@ -9,18 +9,7 @@
 
 #import "FBSpringboardApplication.h"
 
-#import "FBErrorBuilder.h"
-#import "FBMathUtils.h"
 #import "FBRunLoopSpinner.h"
-#import "XCElementSnapshot+FBHelpers.h"
-#import "XCElementSnapshot.h"
-#import "XCUIApplication+FBHelpers.h"
-#import "XCUIElement+FBIsVisible.h"
-#import "XCUIElement+FBUtilities.h"
-#import "XCUIElement+FBTap.h"
-#import "XCUIElement+FBScrolling.h"
-#import "XCUIElement.h"
-#import "XCUIElementQuery.h"
 #import "FBXCodeCompatibility.h"
 
 #if TARGET_OS_TV

--- a/WebDriverAgentLib/Routing/FBSession.h
+++ b/WebDriverAgentLib/Routing/FBSession.h
@@ -31,6 +31,8 @@ extern NSString *const FBApplicationCrashedException;
 /*! Element cache related to that session */
 @property (nonatomic, strong, readonly) FBElementCache *elementCache;
 
+@property (nonatomic, copy) NSString *defaultActiveApplication;
+
 + (nullable instancetype)activeSession;
 
 /**

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -23,6 +23,12 @@
 #import "XCUIElement.h"
 
 NSString *const FBApplicationCrashedException = @"FBApplicationCrashedException";
+/*!
+ The intial value for the default application property.
+ Setting this value to `defaultActiveApplication` property forces WDA to use the internal
+ automated algorithm to determine the active on-screen application
+ */
+NSString *const FBDefaultApplicationAuto = @"auto";
 
 @interface FBSession ()
 @property (nonatomic) NSString *testedApplicationBundleId;
@@ -95,6 +101,7 @@ static FBSession *_activeSession;
   session.alertsMonitor = nil;
   session.defaultAlertAction = nil;
   session.identifier = [[NSUUID UUID] UUIDString];
+  session.defaultActiveApplication = FBDefaultApplicationAuto;
   session.testedApplicationBundleId = nil;
   NSMutableDictionary *apps = [NSMutableDictionary dictionary];
   if (application) {
@@ -133,7 +140,10 @@ static FBSession *_activeSession;
 
 - (FBApplication *)activeApplication
 {
-  FBApplication *application = [FBApplication fb_activeApplication];
+  NSString *defaultBundleId = [self.defaultActiveApplication isEqualToString:FBDefaultApplicationAuto]
+    ? nil
+    : self.defaultActiveApplication;
+  FBApplication *application = [FBApplication fb_activeApplicationWithDefaultBundleId:defaultBundleId];
   FBApplication *testedApplication = nil;
   if (self.testedApplicationBundleId) {
     testedApplication = [self.applications objectForKey:self.testedApplicationBundleId];

--- a/WebDriverAgentTests/IntegrationTests/XCUIApplicationHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIApplicationHelperTests.m
@@ -80,4 +80,18 @@
                         ((id<FBElement>)textField).wdUID);
 }
 
+- (void)testActiveApplicationsInfo
+{
+  NSArray *appsInfo = [XCUIApplication fb_activeAppsInfo];
+  XCTAssertTrue(appsInfo.count > 0);
+  BOOL isAppActive = NO;
+  for (NSDictionary *appInfo in appsInfo) {
+    if ([appInfo[@"bundleId"] isEqualToString:self.testedApplication.bundleID]) {
+      isAppActive = YES;
+      break;
+    }
+  }
+  XCTAssertTrue(isAppActive);
+}
+
 @end


### PR DESCRIPTION
The change is NOT breaking.

I've added the new setting called `defaultActiveApplication`. By default it is set to `auto` and only comes to play if there is more than one active application on the screen. WDA will check if this value is set to any bundle identifier, that matches with the currently active application. It will consider this particular application as active rather than one, which is located under the default screen point. If the application with the given bundle identifier is not in the list of active apps then the default algorithm is applied. The client can list the currently active applications at any time (their PIDs and bundle ids) using the newly added `apps/list` endpoint.