### PR TITLE
fix: Do not throw exception if the app is not in foreground after the timeout

### DIFF
--- a/WebDriverAgentLib/FBApplication.m
+++ b/WebDriverAgentLib/FBApplication.m
@@ -123,8 +123,7 @@ static const NSTimeInterval APP_STATE_CHANGE_TIMEOUT = 5.0;
   [super launch];
   [FBApplication fb_registerApplication:self withProcessID:self.processID];
   if (![self fb_waitForAppElement:APP_STATE_CHANGE_TIMEOUT]) {
-    NSString *reason = [NSString stringWithFormat:@"The application '%@' is not running in foreground after %.2f seconds", self.bundleID, APP_STATE_CHANGE_TIMEOUT];
-    @throw [NSException exceptionWithName:FBTimeoutException reason:reason userInfo:@{}];
+    [FBLogger logFmt:@"The application '%@' is not running in foreground after %.2f seconds", self.bundleID, APP_STATE_CHANGE_TIMEOUT];
   }
 }
 

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -78,8 +78,7 @@ static dispatch_once_t onceAppWithPIDToken;
 {
   [self activate];
   if (![self fb_waitForAppElement:APP_STATE_CHANGE_TIMEOUT]) {
-    NSString *reason = [NSString stringWithFormat:@"The application '%@' is not running in foreground after %.2f seconds", self.bundleID, APP_STATE_CHANGE_TIMEOUT];
-    @throw [NSException exceptionWithName:FBTimeoutException reason:reason userInfo:@{}];
+    [FBLogger logFmt:@"The application '%@' is not running in foreground after %.2f seconds", self.bundleID, APP_STATE_CHANGE_TIMEOUT];
   }
 }
 


### PR DESCRIPTION
It might be that after activation/launch the target application is not in foreground due to alerts.