### PR TITLE
fix: Switch tap and tapByCoordinate to their native implementations for iOS 13+

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBTap.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTap.m
@@ -9,6 +9,7 @@
 
 #import "XCUIElement+FBTap.h"
 
+#import "FBMacros.h"
 #import "XCUIApplication+FBTouchAction.h"
 #import "XCUIElement+FBUtilities.h"
 
@@ -17,6 +18,13 @@
 
 - (BOOL)fb_tapWithError:(NSError **)error
 {
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"13.0")) {
+    // Tap coordinates calculation issues have been fixed
+    // for different device orientations since Xcode 11
+    [self tap];
+    return YES;
+  }
+
   NSArray<NSDictionary<NSString *, id> *> *tapGesture =
   @[
     @{@"action": @"tap",
@@ -29,6 +37,16 @@
 
 - (BOOL)fb_tapCoordinate:(CGPoint)relativeCoordinate error:(NSError **)error
 {
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"13.0")) {
+    // Coordinates calculation issues have been fixed
+    // for different device orientations since Xcode 11
+    XCUICoordinate *startCoordinate = [self coordinateWithNormalizedOffset:CGVectorMake(0, 0)];
+    CGVector offset = CGVectorMake(relativeCoordinate.x, relativeCoordinate.y);
+    XCUICoordinate *dstCoordinate = [startCoordinate coordinateWithOffset:offset];
+    [dstCoordinate tap];
+    return YES;
+  }
+
   NSArray<NSDictionary<NSString *, id> *> *tapGesture =
   @[
     @{@"action": @"tap",


### PR DESCRIPTION
It looks like there are no more coordinate calculation issues in the recent Xcode@beta, so it would be fine to use native implementations of `tap`, which are faster than our customized workarounds.