### PR TITLE
feat: [Xcode 11] Call includingNonModalElements to get snapshot

### DIFF
--- a/PrivateHeaders/XCTest/XCUIElement.h
+++ b/PrivateHeaders/XCTest/XCUIElement.h
@@ -26,6 +26,10 @@
 @property(readonly) BOOL isTouchBarElement;
 @property(readonly) BOOL hasKeyboardFocus;
 @property(readonly, nonatomic) XCUIApplication *application;
+// Added since Xcode 11.0 (beta)
+@property(readonly, copy) XCUIElement *excludingNonModalElements;
+// Added since Xcode 11.0 (GM)
+@property(readonly, copy) XCUIElement *includingNonModalElements;
 
 - (id)initWithElementQuery:(id)arg1;
 

--- a/PrivateHeaders/XCTest/XCUIElementQuery.h
+++ b/PrivateHeaders/XCTest/XCUIElementQuery.h
@@ -21,6 +21,8 @@
     NSOrderedSet *_lastInput;
     NSOrderedSet *_lastOutput;
     XCElementSnapshot *_rootElementSnapshot;
+    // Added since Xcode 11.0 (beta)
+    BOOL _modalViewPruningDisabled;
 }
 
 @property(copy) NSOrderedSet *lastOutput; // @synthesize lastOutput=_lastOutput;
@@ -29,12 +31,19 @@
 @property unsigned long long expressedType; // @synthesize expressedType=_expressedType;
 @property BOOL changesScope; // @synthesize changesScope=_changesScope;
 @property(readonly, copy) CDUnknownBlockType filter; // @synthesize filter=_filter;
+// Added since Xcode 11.0 (beta)
+@property BOOL modalViewPruningDisabled; // @synthesize modalViewPruningDisabled=_modalViewPruningDisabled;
 @property(readonly) XCUIElementQuery *inputQuery; // @synthesize inputQuery=_inputQuery;
 @property(readonly, copy) NSString *queryDescription; // @synthesize queryDescription=_queryDescription;
 @property(readonly, copy) NSString *elementDescription;
 @property(readonly) XCUIApplication *application;
 @property(retain) XCElementSnapshot *rootElementSnapshot; // @synthesize rootElementSnapshot=_rootElementSnapshot;
 @property(retain) NSObject<XCTElementSetTransformer> *transformer; // @synthesize transformer = _transformer;
+
+// Added since Xcode 11.0 (beta)
+@property(readonly, copy) XCUIElementQuery *excludingNonModalElements;
+// Added since Xcode 11.0 (GM)
+@property(readonly, copy) XCUIElementQuery *includingNonModalElements;
 
 - (id)matchingSnapshotsWithError:(id *)arg1;
 - (id)matchingSnapshotsHandleUIInterruption:(BOOL)arg1 withError:(id *)arg2;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -208,7 +208,7 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
       rootQuery = rootQuery.inputQuery;
     }
     if (rootQuery != nil) {
-      if ([self respondsToSelector:@selector(includingNonModalElements)]) {
+      if ([rootQuery respondsToSelector:@selector(includingNonModalElements)]) {
         rootQuery = [rootQuery includingNonModalElements];
       }
       NSMutableArray *snapshots = [NSMutableArray arrayWithObject:rootQuery.rootElementSnapshot];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -147,9 +147,8 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
 
 - (XCAccessibilityElement *)accessibilityElementBySnapshot
 {
-  if ([self respondsToSelector:@selector(includingNonModalElements)]) {
-    XCUIElementQuery *query = self.query.includingNonModalElements;
-    return query.rootElementSnapshot.accessibilityElement;
+  if ([self.query respondsToSelector:@selector(includingNonModalElements)]) {
+    return self.query.includingNonModalElements.rootElementSnapshot.accessibilityElement;
   }
   return self.lastSnapshot.accessibilityElement;
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -151,7 +151,7 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
   @param query The XCUIElementQuery to check if it has 'includingNonModalElements'
   @return YES if includingNonModalElements is available in the query
  */
-+ (BOOL)fb_hasIncludingNonModalElements: (XCUIElementQuery *)query
++ (BOOL)fb_hasIncludingNonModalElements:(XCUIElementQuery *)query
 {
   static dispatch_once_t hasIncludingNonModalElements;
   static BOOL result;
@@ -164,11 +164,11 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
 /**
  Returns accessibility element as either rootElementSnapshot by includingNonModalElements or by lastSnapshot
 
- @return XCAccessibilityElement provided by rootElementSnapshot with includingNonModalElements or  lastSnapshot
+ @return The accessibility element with no modal elements snapshot
 */
 - (XCAccessibilityElement *)fb_accessibilityElementBySnapshot
 {
-  if ([XCUIElement fb_hasIncludingNonModalElements:self.query]) {
+  if ([self.class fb_hasIncludingNonModalElements:self.query]) {
     // 'self.query.includingNonModalElements.rootElementSnapshot' is faster than 'self.lastSnapshot' on Xcode 11.
     return self.query.includingNonModalElements.rootElementSnapshot.accessibilityElement;
   }
@@ -225,12 +225,12 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
 /**
  Returns root element query either with includingNonModalElements or no includingNonModalElements
 
- @return XCUIElementQuery with includingNonModalElements or not
+ @return The no mdal elements query
 */
-- (XCUIElementQuery *)fb_rootXCUIElementQuery
+- (XCUIElementQuery *)fb_withNoModalElementsQuery
 {
   XCUIElementQuery *query = self.query;
-  if ([XCUIElement fb_hasIncludingNonModalElements:query]) {
+  if ([self.class fb_hasIncludingNonModalElements:query]) {
     query = [query includingNonModalElements];
   }
   return query;
@@ -240,7 +240,7 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
 {
   XCElementSnapshot *snapshot = nil;
   @try {
-    XCUIElementQuery *rootQuery = [self fb_rootXCUIElementQuery];
+    XCUIElementQuery *rootQuery = [self fb_withNoModalElementsQuery];
     while (rootQuery != nil && rootQuery.rootElementSnapshot == nil) {
       rootQuery = rootQuery.inputQuery;
     }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -148,8 +148,8 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
 /**
   Whether 'includingNonModalElements' is available
 
-  @param query The XCUIElementQuery to check it has 'includingNonModalElements'
-  @return Whether includingNonModalElements is available
+  @param query The XCUIElementQuery to check if it has 'includingNonModalElements'
+  @return YES if includingNonModalElements is available in the query
  */
 + (BOOL)fb_hasIncludingNonModalElements: (XCUIElementQuery *)query
 {
@@ -164,7 +164,7 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
 /**
  Returns accessibility element as either rootElementSnapshot by includingNonModalElements or by lastSnapshot
 
- @return XCAccessibilityElement
+ @return XCAccessibilityElement provided by rootElementSnapshot with includingNonModalElements or  lastSnapshot
 */
 - (XCAccessibilityElement *)fb_accessibilityElementBySnapshot
 {
@@ -223,9 +223,9 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
 }
 
 /**
- Returns root element quert either with includingNonModalElements or no it
+ Returns root element query either with includingNonModalElements or no includingNonModalElements
 
- @return XCUIElementQuery
+ @return XCUIElementQuery with includingNonModalElements or not
 */
 - (XCUIElementQuery *)fb_rootXCUIElementQuery
 {

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -133,16 +133,25 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
   });
   id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
   if (useNewSnapshotAPI) {
-    [proxy _XCT_requestSnapshotForElement:self.lastSnapshot.accessibilityElement
+    [proxy _XCT_requestSnapshotForElement:self.accessibilityElementBySnapshot
                                attributes:axAttributes
                                parameters:defaultParameters
                                     reply:block];
   } else {
-    [proxy _XCT_snapshotForElement:self.lastSnapshot.accessibilityElement
+    [proxy _XCT_snapshotForElement:self.accessibilityElementBySnapshot
                         attributes:axAttributes
                         parameters:defaultParameters
                              reply:block];
   }
+}
+
+- (XCAccessibilityElement *)accessibilityElementBySnapshot
+{
+  if ([self respondsToSelector:@selector(includingNonModalElements)]) {
+    XCUIElementQuery *query = self.query.includingNonModalElements;
+    return query.rootElementSnapshot.accessibilityElement;
+  }
+  return self.lastSnapshot.accessibilityElement;
 }
 
 - (NSArray *)fb_createAXAttributes: (BOOL)asNumber
@@ -200,6 +209,9 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
       rootQuery = rootQuery.inputQuery;
     }
     if (rootQuery != nil) {
+      if ([self respondsToSelector:@selector(includingNonModalElements)]) {
+        rootQuery = [rootQuery includingNonModalElements];
+      }
       NSMutableArray *snapshots = [NSMutableArray arrayWithObject:rootQuery.rootElementSnapshot];
       [snapshots addObjectsFromArray:rootQuery.rootElementSnapshot._allDescendants];
       NSOrderedSet *matchingSnapshots = (NSOrderedSet *)[self.query.transformer transform:[NSOrderedSet orderedSetWithArray:snapshots] relatedElements:nil];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -227,7 +227,7 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
 
  @return The no modal elements query
 */
-- (XCUIElementQuery *)fb_withNoModalElementsQuery
+- (XCUIElementQuery *)fb_queryIncludingNoModalElements
 {
   XCUIElementQuery *query = self.query;
   if ([self.class fb_hasIncludingNonModalElements:query]) {
@@ -240,7 +240,7 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
 {
   XCElementSnapshot *snapshot = nil;
   @try {
-    XCUIElementQuery *rootQuery = [self fb_withNoModalElementsQuery];
+    XCUIElementQuery *rootQuery = [self fb_queryIncludingNoModalElements];
     while (rootQuery != nil && rootQuery.rootElementSnapshot == nil) {
       rootQuery = rootQuery.inputQuery;
     }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -148,7 +148,7 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
 /**
   Whether 'includingNonModalElements' is available
 
-  @param query The XCUIElementQuery to check if it has 'includingNonModalElements'
+  @param query The query to check if it has 'includingNonModalElements'
   @return YES if includingNonModalElements is available in the query
  */
 + (BOOL)fb_hasIncludingNonModalElements:(XCUIElementQuery *)query
@@ -225,7 +225,7 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
 /**
  Returns root element query either with includingNonModalElements or no includingNonModalElements
 
- @return The no mdal elements query
+ @return The no modal elements query
 */
 - (XCUIElementQuery *)fb_withNoModalElementsQuery
 {


### PR DESCRIPTION
Closes https://github.com/appium/appium/issues/13227

The difference is a number of elements. `includingNonModalElements` which was introduced in Xcode 11 GM returns maybe all of elements including behind the modal (Checked on the official health app). In UIKit Category case, both of them returned the same source.

I thought we should have introduced a settings API parameter to switch `includingNonModalElements` or no it. But the XML source performance also improved as below. _after_ is with _includingNonModalElements_. _before_ is no _includingNonModalElements_.
Thus, it is enough to use _includingNonModalElements_ if it is available, for now, I think.

I also ran find_element on health app in multiple modals. That also worked. (find element/s, click it)

```ruby
# test code
10.times.reduce([]) { |acc, _i|
  time = Benchmark.realtime { @driver.page_source }
  acc.push time
}
```

- After
  ```
  # UIKit catalog
  min #=> 1.178727999998955 (sec)
  max #=> 1.3325199999962933 (sec)
  avg #=> 1.2254139999990001 (sec)
  ```
  ```
  # Health app
  min #=> 1.5398520000017015 (sec)
  max #=> 1.6732320000010077 (sec)
  avg #=> 1.591718000001856 (sec)
  ```
- before
  ```
  # UIKit catalog
  min #=> 3.0453959999867948 (sec)
  max #=> 3.3232410000055097 (sec)
  avg #=> 3.114234800002305 (sec)
  ```
  ```
  # Health app
  min #=> 3.0407479999994393 (sec)
  max #=> 3.2715579999930924 (sec)
  avg #=> 3.136248699997668 (sec)
  ```

# UIKit catalog

<img src=https://user-images.githubusercontent.com/5511591/64863813-b140b580-d670-11e9-9032-a518eb58d2db.png width=200>

# Health app

<img src=https://user-images.githubusercontent.com/5511591/64863835-b867c380-d670-11e9-94fc-e6f2f52045a9.png width=200>
