### PR TITLE
fix: Tune tap point calculation logic

### DIFF
--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
@@ -62,6 +62,7 @@
   CGPoint hitPoint;
   if (nil == element) {
     // Only absolute offset is defined
+    
     hitPoint = [positionOffset CGPointValue];
     if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
       /*
@@ -73,8 +74,18 @@
     }
   } else {
     // The offset relative to the element is defined
+
     XCElementSnapshot *snapshot = element.fb_lastSnapshot;
-    CGRect frame = snapshot.frame;
+    if (nil == positionOffset) {
+      NSValue *hitPointValue = snapshot.fb_hitPoint;
+      if (nil != hitPointValue) {
+        // short circuit element hitpoint
+        return hitPointValue;
+      }
+      [FBLogger logFmt:@"Will use the frame of '%@' for hit point calculation instead", element.debugDescription];
+    }
+    CGRect visibleFrame = snapshot.visibleFrame;
+    CGRect frame = CGRectIsEmpty(visibleFrame) ? element.frame : visibleFrame;
     if (CGRectIsEmpty(frame)) {
       [FBLogger log:self.application.fb_descriptionRepresentation];
       NSString *description = [NSString stringWithFormat:@"The element '%@' is not visible on the screen and thus is not interactable", element.description];
@@ -83,16 +94,6 @@
       }
       return nil;
     }
-    if (nil == positionOffset) {
-      NSValue *hitPointValue = snapshot.fb_hitPoint;
-      if (nil != hitPointValue) {
-        // short circuit element hitpoint
-        return hitPointValue;
-      }
-      [FBLogger logFmt:@"Failed to fetch hit point for %@. Will use element frame for hit point calculation instead", element.debugDescription];
-    }
-    CGRect visibleFrame = snapshot.visibleFrame;
-    frame = CGRectIsEmpty(visibleFrame) ? frame : visibleFrame;
     if (nil == positionOffset) {
       hitPoint = CGPointMake(frame.origin.x + frame.size.width / 2,
                              frame.origin.y + frame.size.height / 2);

--- a/WebDriverAgentTests/IntegrationTests/XCElementSnapshotHitPointTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCElementSnapshotHitPointTests.m
@@ -8,9 +8,7 @@
  */
 
 #import "FBIntegrationTestCase.h"
-#import "FBMathUtils.h"
 #import "FBTestMacros.h"
-#import "FBMacros.h"
 #import "XCElementSnapshot+FBHitpoint.h"
 #import "XCUIElement.h"
 #import "XCUIElement+FBUtilities.h"
@@ -22,18 +20,11 @@
 
 - (void)testAccessibilityActivationPoint
 {
-  if (SYSTEM_VERSION_GREATER_THAN(@"12.0")) {
-    // The test is flacky on iOS 12+ in Travis env
-    return;
-  }
-  
   [self launchApplication];
   [self goToAttributesPage];
-  FBAssertWaitTillBecomesTrue(
-    FBPointFuzzyEqualToPoint(self.testedApplication.buttons[@"not_accessible"]
-                             .fb_lastSnapshot.fb_hitPoint.CGPointValue,
-                             CGPointMake(200, 220), 0.1)
-  );
+  XCUIElement *dstBtn = self.testedApplication.buttons[@"not_accessible"];
+  CGPoint hitPoint = dstBtn.fb_lastSnapshot.fb_hitPoint.CGPointValue;
+  XCTAssertTrue(hitPoint.x > 0 && hitPoint.y > 0);
 }
 
 @end


### PR DESCRIPTION
Sometime xctest has the hit point even though the returned frame is empty. Lets try to be more flexible in such situation