### PR TITLE
fix: Throwing excpetion when looking for active application only if element is null

### DIFF
--- a/WebDriverAgentLib/FBApplication.m
+++ b/WebDriverAgentLib/FBApplication.m
@@ -81,7 +81,7 @@ static const NSTimeInterval APP_STATE_CHANGE_TIMEOUT = 5.0;
   }
   if (nil == activeApplicationElement && activeApplicationElements.count > 0) {
     activeApplicationElement = [activeApplicationElements firstObject];
-  } else {
+  } else if (nil == activeApplicationElement) {
     NSString *errMsg = @"No applications are currently active";
     @throw [NSException exceptionWithName:FBElementNotVisibleException reason:errMsg userInfo:nil];
   }

--- a/WebDriverAgentLib/FBApplication.m
+++ b/WebDriverAgentLib/FBApplication.m
@@ -81,7 +81,8 @@ static const NSTimeInterval APP_STATE_CHANGE_TIMEOUT = 5.0;
   }
   if (nil == activeApplicationElement && activeApplicationElements.count > 0) {
     activeApplicationElement = [activeApplicationElements firstObject];
-  } else if (nil == activeApplicationElement) {
+  }
+  if (nil == activeApplicationElement) {
     NSString *errMsg = @"No applications are currently active";
     @throw [NSException exceptionWithName:FBElementNotVisibleException reason:errMsg userInfo:nil];
   }


### PR DESCRIPTION
I found cases where multiple active applications causes a failure when attempting to get the front application. This causes any command which relies on the currently active application to fail.

This PR fixes the issue with a small tweak (throwing exception only if activeApplicationElement is nil in the end).

Scenarios for example:
Scenario 1:
* Open the Weather app.
* Tap on the "The Weather Channel" icon at the lower left corner (Safari will be opened).

Scenario 2 (iPhone only):
* Swipe to the widgets page in Springboard.