### PR TITLE
fix: iOS 13.1 touch coordinates calculation in landscape mode

### DIFF
--- a/WebDriverAgentLib/Utilities/FBMathUtils.m
+++ b/WebDriverAgentLib/Utilities/FBMathUtils.m
@@ -50,9 +50,9 @@ CGPoint FBInvertPointForApplication(CGPoint point, CGSize screenSize, UIInterfac
     case UIInterfaceOrientationPortraitUpsideDown:
       return CGPointMake(screenSize.width - point.x, screenSize.height - point.y);
     case UIInterfaceOrientationLandscapeLeft:
-      return CGPointMake(point.y, screenSize.height - point.x);
+      return CGPointMake(point.y, MAX(screenSize.width, screenSize.height) - point.x);
     case UIInterfaceOrientationLandscapeRight:
-      return CGPointMake(screenSize.width - point.y, point.x);
+      return CGPointMake(MIN(screenSize.width, screenSize.height) - point.y, point.x);
   }
 }
 


### PR DESCRIPTION
It appears as if in iOS 13.1 the `frame.size` property of `XCUIApplication` is now returned in accordance to the orientation of the UI, as opposed to previously where it was always returned in a portrait orientation, causing `FBInvertPointForApplication` to return incorrect touch coordinates when the UI is in landscape (either states).

The logic of the function remains the same, however now the needed dimension is used when calculating the new point:
* Using the larger of the two screen dimensions for calculating the Y coordinate while in `UIInterfaceOrientationLandscapeLeft`.
* Using the smaller of the two screen dimensions for calculating the X coordinate while in `UIInterfaceOrientationLandscapeRight`.