### PR TITLE
feat: Add safe area inset sizes to device info

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
@@ -100,6 +100,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)fb_activateSiriVoiceRecognitionWithText:(NSString *)text error:(NSError **)error;
 
+/**
+ Retrieves the sizes of UI edge insets. Prior to IOS 11 this API always returns zeroes for all edges
+
+ @returns String in format {top,left,bottom,right}. Each size can be a float number
+ */
+- (NSString *)fb_safeAreaInsets;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -31,6 +31,10 @@ static const NSTimeInterval FBHomeButtonCoolOffTime = 1.;
 static const NSTimeInterval FBScreenLockTimeout = 5.;
 static const NSTimeInterval SCREENSHOT_TIMEOUT = 2;
 
+NSString *formatUiEdgeInsets(UIEdgeInsets insets) {
+  return [NSString stringWithFormat:@"{%@,%@,%@,%@}", @(insets.top), @(insets.left), @(insets.bottom), @(insets.right)];
+}
+
 @implementation XCUIDevice (FBHelpers)
 
 static bool fb_isLocked;
@@ -332,5 +336,17 @@ static bool fb_isLocked;
   return YES;
 }
 #endif
+
+- (NSString *)fb_safeAreaInsets
+{
+  UIWindow* window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  if (@available(iOS 11.0, *)) {
+    return formatUiEdgeInsets(window.safeAreaInsets);
+  }
+  if (@available(tvOS 11.0, *)) {
+    return formatUiEdgeInsets(window.safeAreaInsets);
+  }
+  return @"{0,0,0,0}";
+}
 
 @end

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -291,6 +291,7 @@
     @"uuid": [UIDevice.currentDevice.identifierForVendor UUIDString] ?: @"unknown",
     // https://developer.apple.com/documentation/uikit/uiuserinterfaceidiom?language=objc
     @"userInterfaceIdiom": @(UIDevice.currentDevice.userInterfaceIdiom),
+    @"safeAreaInsets": XCUIDevice.sharedDevice.fb_safeAreaInsets,
 #if TARGET_OS_SIMULATOR
     @"isSimulator": @(YES),
 #else

--- a/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
@@ -92,4 +92,10 @@
   XCTAssertNil(error);
 }
 
+- (void)testInsetsRetrieval
+{
+  NSString *insets = XCUIDevice.sharedDevice.fb_safeAreaInsets;
+  XCTAssertTrue(insets.length > 0);
+}
+
 @end


### PR DESCRIPTION
Hardcoded values are evil: https://github.com/appium/appium-xcuitest-driver/commit/e4dac917ad53ab616b17bb5a1bb14aac87164bac#diff-3489f8b2dceb92a2d7e567be994a8984R10