### PR TITLE
fix: Make non modal dialogs inclusion optional by default

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
@@ -86,6 +86,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable NSData *)fb_screenshotWithError:(NSError*__autoreleasing*)error;
 
+/**
+ Determines whether current iOS SDK supports non modal dialogs inlusion into snapshots
+ 
+ @return Either YES or NO
+ */
++ (BOOL)fb_supportsNonModalDialogsInclusion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -22,6 +22,7 @@
 #import "XCUIDevice+FBHealthCheck.h"
 #import "XCUIDevice+FBHelpers.h"
 #import "XCUIApplicationProcessDelay.h"
+#import "XCUIElement+FBUtilities.h"
 
 static NSString* const USE_COMPACT_RESPONSES = @"shouldUseCompactResponses";
 static NSString* const ELEMENT_RESPONSE_ATTRIBUTES = @"elementResponseAttributes";
@@ -37,6 +38,8 @@ static NSString* const USE_FIRST_MATCH = @"useFirstMatch";
 static NSString* const REDUCE_MOTION = @"reduceMotion";
 static NSString* const DEFAULT_ACTIVE_APPLICATION = @"defaultActiveApplication";
 static NSString* const ACTIVE_APP_DETECTION_POINT = @"activeAppDetectionPoint";
+static NSString* const INCLUDE_NON_MODAL_DIALOGS = @"includeNonModalDialogs";
+
 
 @implementation FBSessionCommands
 
@@ -247,6 +250,7 @@ static NSString* const ACTIVE_APP_DETECTION_POINT = @"activeAppDetectionPoint";
       REDUCE_MOTION: @([FBConfiguration reduceMotionEnabled]),
       DEFAULT_ACTIVE_APPLICATION: request.session.defaultActiveApplication,
       ACTIVE_APP_DETECTION_POINT: FBActiveAppDetectionPoint.sharedInstance.stringCoordinates,
+      INCLUDE_NON_MODAL_DIALOGS: @([FBConfiguration includeNonModalDialogs]),
     }
   );
 }
@@ -299,6 +303,10 @@ static NSString* const ACTIVE_APP_DETECTION_POINT = @"activeAppDetectionPoint";
                                                                       error:&error]) {
       return FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:error.description traceback:nil]);
     }
+  }
+  if ([settings objectForKey:INCLUDE_NON_MODAL_DIALOGS]
+      && [XCUIElement fb_supportsNonModalDialogsInclusion]) {
+    [FBConfiguration setIncludeNonModalDialogs:[[settings objectForKey:INCLUDE_NON_MODAL_DIALOGS] boolValue]];
   }
 
   return [self handleGetSettings:request];

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -158,6 +158,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setReduceMotionEnabled:(BOOL)isEnabled;
 + (BOOL)reduceMotionEnabled;
 
++ (void)setIncludeNonModalDialogs:(BOOL)isEnabled;
++ (BOOL)includeNonModalDialogs;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -39,6 +39,9 @@ static NSUInteger FBScreenshotQuality = 1;
 static NSUInteger FBMjpegScalingFactor = 100;
 static NSTimeInterval FBSnapshotTimeout = 15.;
 static BOOL FBShouldUseFirstMatch = NO;
+// This is diabled by default because enabling it prevents the accessbility snapshot to be taken
+// (it always errors with kxIllegalArgument error)
+static BOOL FBIncludeNonModalDialogs = NO;
 
 @implementation FBConfiguration
 
@@ -272,6 +275,16 @@ static BOOL FBShouldUseFirstMatch = NO;
 + (BOOL)useFirstMatch
 {
   return FBShouldUseFirstMatch;
+}
+
++ (void)setIncludeNonModalDialogs:(BOOL)isEnabled
+{
+  FBIncludeNonModalDialogs = isEnabled;
+}
+
++ (BOOL)includeNonModalDialogs
+{
+  return FBIncludeNonModalDialogs;
 }
 
 #pragma mark Private

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-webdriveragent",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Package bundling WebDriverAgent",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
It looks like enabling the includeNonModalDialogs option by default corrupts snapshots taking procedure and forces visibility detection to use fallback procedure, which is not always reliable. So I've put it under settings and made the feature disabled by default.