### PR TITLE
feat: add setSoftwareKeyboardShownByTouch to force software keyboard enable

### DIFF
--- a/PrivateHeaders/UIKitCore/UIKeyboardImpl.h
+++ b/PrivateHeaders/UIKitCore/UIKeyboardImpl.h
@@ -13,5 +13,15 @@
  * @param enabled Whether turn setAutomaticMinimizationEnabled on
  */
 - (void)setAutomaticMinimizationEnabled:(BOOL)enabled;
+
+/**
+* Modify software keyboard condition on simulators for over Xcode 6
+* This setting is global. The change applies to all instances of UIKeyboardImpl.
+*
+* Idea: https://chromium.googlesource.com/chromium/src/base/+/ababb4cf8b6049a642a2f361b1006a07561c2d96/test/test_support_ios.mm#41
+*
+* @param enabled Whether turn setSoftwareKeyboardShownByTouch on
+*/
+- (void)setSoftwareKeyboardShownByTouch:(BOOL)enabled;
 @end
 #endif  // TARGET_IPHONE_SIMULATOR

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -204,6 +204,7 @@ static BOOL FBIncludeNonModalDialogs = NO;
   // This can avoid 'Keyboard is not present' error which can happen
   // when send_keys are called by client
   [[UIKeyboardImpl sharedInstance] setAutomaticMinimizationEnabled:NO];
+  [[UIKeyboardImpl sharedInstance] setSoftwareKeyboardShownByTouch:YES];
 #endif
 
   void *handle = dlopen(controllerPrefBundlePath, RTLD_LAZY);


### PR DESCRIPTION
https://chromium.googlesource.com/chromium/src/base/+/master/test/test_support_ios.mm

This works for simulator only.

Both ` [[UIKeyboardImpl sharedInstance] setAutomaticMinimizationEnabled:NO];` and `[[UIKeyboardImpl sharedInstance] setSoftwareKeyboardShownByTouch:YES];` help to enable software keyboard to avoid no keyboard presence error.
I compared hardware keyboard/toggle software keyboard preferences. Then, I noticed `setAutomaticMinimizationEnabled:NO` was mainly for hardware keyboard and `setSoftwareKeyboardShownByTouch:YES` was mainly for the toggle software keyboard.