### PR TITLE
Set MJPEG server frame rate from command line arguments

### DIFF
--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -168,6 +168,11 @@ static BOOL FBIncludeNonModalElements = NO;
 
 + (NSUInteger)mjpegServerFramerate
 {
+  NSUInteger frameRate = self.mjpegServerFrameRateFromArguments;
+  if (frameRate != NSNotFound) {
+    return frameRate;
+  }
+
   return FBMjpegServerFramerate;
 }
 
@@ -347,6 +352,17 @@ static BOOL FBIncludeNonModalElements = NO;
     return NSNotFound;
   }
   return port;
+}
+
++ (NSUInteger)mjpegServerFrameRateFromArguments
+{
+  NSString *frameRateString = [self valueFromArguments: NSProcessInfo.processInfo.arguments
+                                                forKey: @"--mjpeg-server-frame-rate"];
+  NSUInteger frameRate = (NSUInteger)[frameRateString integerValue];
+  if (frameRate == 0) {
+    return NSNotFound;
+  }
+  return frameRate;
 }
 
 + (NSRange)bindingPortRangeFromArguments


### PR DESCRIPTION
Very useful if you want to start MJPEG server with different frame rate.

Currently I find 10 frames per second (default value) for modern iPhones - is too much.
4-5 frames per second seems to be good enough for auto tests.
I'd prefer not to change default value.
And the arg is more convenient than changing settings using separate request.
