### PR TITLE
fix: Compile error by GCFloat in generic configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ jobs:
 
     - stage: WDA build
       name: Generic build for build-for-testing, Xcode 11
+      osx_image: xcode11
       script:
         - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
         - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner_tvOS -target WebDriverAgentRunner_tvOS -destination 'generic/platform=tvOS'
@@ -48,7 +49,7 @@ jobs:
     - name: iPhone 11, Xcode 11
       osx_image: xcode11
       env: IPHONE_MODEL="Apple TV 4K" TV_VERSION="13.0" ACTION=build TARGET=tv_runner SDK=tv_sim
-    - name: Generic build for build-for-testing, Xcode 11
+    - name: Generic build for build-for-testing, Xcode 10
       script: xcodebuild build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
         - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
         - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner_tvOS -target WebDriverAgentRunner_tvOS -destination 'generic/platform=tvOS'

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,9 @@ jobs:
 
     - stage: WDA build
       name: Generic build for build-for-testing, Xcode 11
-      script: xcodebuild build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
+      script:
+        - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
+        - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner_tvOS -target WebDriverAgentRunner_tvOS -destination 'generic/platform=tvOS'
     - name: iPhone 11, Xcode 11
       osx_image: xcode11
       env: IPHONE_MODEL="iPhone 11" IPAD_MODEL="iPad Pro (11-inch)" IOS_VERSION="13.0" ACTION=build TARGET=runner
@@ -48,6 +50,8 @@ jobs:
       env: IPHONE_MODEL="Apple TV 4K" TV_VERSION="13.0" ACTION=build TARGET=tv_runner SDK=tv_sim
     - name: Generic build for build-for-testing, Xcode 11
       script: xcodebuild build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
+        - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
+        - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner_tvOS -target WebDriverAgentRunner_tvOS -destination 'generic/platform=tvOS'
     - name: iPhone X, Xcode 10
       env: IPHONE_MODEL="iPhone X" IPAD_MODEL="iPad Air 2" IOS_VERSION="12.0" ACTION=build TARGET=runner
     - name: apple tv, Xcode 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ jobs:
       name: Generic build for build-for-testing, Xcode 11
       osx_image: xcode11
       script:
+        - ./Scripts/bootstrap.sh -d
         - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
         - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner_tvOS -target WebDriverAgentRunner_tvOS -destination 'generic/platform=tvOS'
     - name: iPhone 11, Xcode 11
@@ -50,7 +51,8 @@ jobs:
       osx_image: xcode11
       env: IPHONE_MODEL="Apple TV 4K" TV_VERSION="13.0" ACTION=build TARGET=tv_runner SDK=tv_sim
     - name: Generic build for build-for-testing, Xcode 10
-      script: xcodebuild build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
+      script:
+        - ./Scripts/bootstrap.sh -d
         - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
         - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner_tvOS -target WebDriverAgentRunner_tvOS -destination 'generic/platform=tvOS'
     - name: iPhone X, Xcode 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,32 +38,26 @@ jobs:
       script: npm run test
 
     - stage: WDA build
-      name: iPhone 11, Xcode 11
+      name: Generic, Xcode 11
+      osx_image: xcode11
+      env: ACTION=build TARGET=runner DEST=generic CODE_SIGNING_ALLOWED=NO
+    - name: Generic tvOS, Xcode 11
+      osx_image: xcode11
+      env: ACTION=build TARGET=tv_runner DEST=tv_generic CODE_SIGNING_ALLOWED=NO
+    - name: iPhone 11, Xcode 11
       osx_image: xcode11
       env: IPHONE_MODEL="iPhone 11" IPAD_MODEL="iPad Pro (11-inch)" IOS_VERSION="13.0" ACTION=build TARGET=runner
-      script:
-        - npm run test
-        # Generic build
-        - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
     - name: iPhone 11, Xcode 11
       osx_image: xcode11
       env: IPHONE_MODEL="Apple TV 4K" TV_VERSION="13.0" ACTION=build TARGET=tv_runner SDK=tv_sim
-      script:
-        - npm run test
-        # Generic build
-        - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner_tvOS -target WebDriverAgentRunner_tvOS -destination 'generic/platform=tvOS'
+    - name: Generic, Xcode 10
+      env: ACTION=build TARGET=runner DEST=generic CODE_SIGNING_ALLOWED=NO
+    - name: Generic tvOS, Xcode 10
+      env: ACTION=build TARGET=tv_runner DEST=tv_generic CODE_SIGNING_ALLOWED=NO
     - name: iPhone X, Xcode 10
       env: IPHONE_MODEL="iPhone X" IPAD_MODEL="iPad Air 2" IOS_VERSION="12.0" ACTION=build TARGET=runner
-      script:
-        - npm run test
-        # Generic build
-        - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
     - name: apple tv, Xcode 10
       env: DEST=tv TV_MODEL="Apple TV" TV_VERSION="12.0" ACTION=build TARGET=tv_runner SDK=tv_sim
-      script:
-        - npm run test
-        # Generic build
-        - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner_tvOS -target WebDriverAgentRunner_tvOS -destination 'generic/platform=tvOS'
 
     - stage: WDA Analysis
       name: iPhone 11, Xcode 11, lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,27 +38,32 @@ jobs:
       script: npm run test
 
     - stage: WDA build
-      name: Generic build for build-for-testing, Xcode 11
-      osx_image: xcode11
-      script:
-        - ./Scripts/bootstrap.sh -d
-        - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
-        - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner_tvOS -target WebDriverAgentRunner_tvOS -destination 'generic/platform=tvOS'
-    - name: iPhone 11, Xcode 11
+      name: iPhone 11, Xcode 11
       osx_image: xcode11
       env: IPHONE_MODEL="iPhone 11" IPAD_MODEL="iPad Pro (11-inch)" IOS_VERSION="13.0" ACTION=build TARGET=runner
+      script:
+        - npm run test
+        # Generic build
+        - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
     - name: iPhone 11, Xcode 11
       osx_image: xcode11
       env: IPHONE_MODEL="Apple TV 4K" TV_VERSION="13.0" ACTION=build TARGET=tv_runner SDK=tv_sim
-    - name: Generic build for build-for-testing, Xcode 10
       script:
-        - ./Scripts/bootstrap.sh -d
-        - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
+        - npm run test
+        # Generic build
         - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner_tvOS -target WebDriverAgentRunner_tvOS -destination 'generic/platform=tvOS'
     - name: iPhone X, Xcode 10
       env: IPHONE_MODEL="iPhone X" IPAD_MODEL="iPad Air 2" IOS_VERSION="12.0" ACTION=build TARGET=runner
+      script:
+        - npm run test
+        # Generic build
+        - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
     - name: apple tv, Xcode 10
       env: DEST=tv TV_MODEL="Apple TV" TV_VERSION="12.0" ACTION=build TARGET=tv_runner SDK=tv_sim
+      script:
+        - npm run test
+        # Generic build
+        - xcodebuild CODE_SIGNING_ALLOWED=NO build-for-testing -scheme WebDriverAgentRunner_tvOS -target WebDriverAgentRunner_tvOS -destination 'generic/platform=tvOS'
 
     - stage: WDA Analysis
       name: iPhone 11, Xcode 11, lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,16 @@ jobs:
       script: npm run test
 
     - stage: WDA build
-      name: iPhone 11, Xcode 11
+      name: Generic build for build-for-testing, Xcode 11
+      script: xcodebuild build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
+    - name: iPhone 11, Xcode 11
       osx_image: xcode11
       env: IPHONE_MODEL="iPhone 11" IPAD_MODEL="iPad Pro (11-inch)" IOS_VERSION="13.0" ACTION=build TARGET=runner
     - name: iPhone 11, Xcode 11
       osx_image: xcode11
       env: IPHONE_MODEL="Apple TV 4K" TV_VERSION="13.0" ACTION=build TARGET=tv_runner SDK=tv_sim
+    - name: Generic build for build-for-testing, Xcode 11
+      script: xcodebuild build-for-testing -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination 'generic/platform=iOS'
     - name: iPhone X, Xcode 10
       env: IPHONE_MODEL="iPhone X" IPAD_MODEL="iPad Air 2" IOS_VERSION="12.0" ACTION=build TARGET=runner
     - name: apple tv, Xcode 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,10 @@ jobs:
     - stage: WDA build
       name: Generic, Xcode 11
       osx_image: xcode11
-      env: ACTION=build TARGET=runner DEST=generic CODE_SIGNING_ALLOWED=NO
+      env: ACTION=build TARGET=runner DEST=generic CODE_SIGN=no
     - name: Generic tvOS, Xcode 11
       osx_image: xcode11
-      env: ACTION=build TARGET=tv_runner DEST=tv_generic CODE_SIGNING_ALLOWED=NO
+      env: ACTION=build TARGET=tv_runner DEST=tv_generic CODE_SIGN=no
     - name: iPhone 11, Xcode 11
       osx_image: xcode11
       env: IPHONE_MODEL="iPhone 11" IPAD_MODEL="iPad Pro (11-inch)" IOS_VERSION="13.0" ACTION=build TARGET=runner
@@ -51,9 +51,9 @@ jobs:
       osx_image: xcode11
       env: IPHONE_MODEL="Apple TV 4K" TV_VERSION="13.0" ACTION=build TARGET=tv_runner SDK=tv_sim
     - name: Generic, Xcode 10
-      env: ACTION=build TARGET=runner DEST=generic CODE_SIGNING_ALLOWED=NO
+      env: ACTION=build TARGET=runner DEST=generic CODE_SIGN=no
     - name: Generic tvOS, Xcode 10
-      env: ACTION=build TARGET=tv_runner DEST=tv_generic CODE_SIGNING_ALLOWED=NO
+      env: ACTION=build TARGET=tv_runner DEST=tv_generic CODE_SIGN=no
     - name: iPhone X, Xcode 10
       env: IPHONE_MODEL="iPhone X" IPAD_MODEL="iPad Air 2" IOS_VERSION="12.0" ACTION=build TARGET=runner
     - name: apple tv, Xcode 10

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -26,7 +26,7 @@ function define_xc_macros() {
     "ipad" ) XC_DESTINATION="name=$IPAD_MODEL,OS=$IOS_VERSION";;
     "tv" ) XC_DESTINATION="name=$TV_MODEL,OS=$TV_VERSION";;
     "generic" ) XC_DESTINATION="generic/platform=iOS";;
-    "tv_generic" ) XC_DESTINATION="generic/platform=tvOS" XC_MACROS="${XC_MACROS} ARCHS=arm64";; # tvOS only support arm64
+    "tv_generic" ) XC_DESTINATION="generic/platform=tvOS" XC_MACROS="${XC_MACROS} ARCHS=arm64";; # tvOS only supports arm64
   esac
 
   case "$ACTION" in

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -26,7 +26,7 @@ function define_xc_macros() {
     "ipad" ) XC_DESTINATION="name=$IPAD_MODEL,OS=$IOS_VERSION";;
     "tv" ) XC_DESTINATION="name=$TV_MODEL,OS=$TV_VERSION";;
     "generic" ) XC_DESTINATION="generic/platform=iOS";;
-    "tv_generic" ) XC_DESTINATION="generic/platform=tvOS";;
+    "tv_generic" ) XC_DESTINATION="generic/platform=tvOS" XC_MACROS="${XC_MACROS} ARCHS=arm64";; # tvOS only support arm64
   esac
 
   case "$ACTION" in

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -48,7 +48,7 @@ function define_xc_macros() {
   esac
 
   case "${CODE_SIGN:-}" in
-    "no" ) XC_CODE_SIGN="${XC_MACROS} CODE_SIGNING_ALLOWED=NO";;
+    "no" ) XC_MACROS="${XC_MACROS} CODE_SIGNING_ALLOWED=NO";;
   esac
 }
 

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -25,6 +25,8 @@ function define_xc_macros() {
     "iphone" ) XC_DESTINATION="name=$IPHONE_MODEL,OS=$IOS_VERSION";;
     "ipad" ) XC_DESTINATION="name=$IPAD_MODEL,OS=$IOS_VERSION";;
     "tv" ) XC_DESTINATION="name=$TV_MODEL,OS=$TV_VERSION";;
+    "generic" ) XC_DESTINATION="generic/platform=iOS";;
+    "tv_generic" ) XC_DESTINATION="generic/platform=tvOS";;
   esac
 
   case "$ACTION" in

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -46,6 +46,10 @@ function define_xc_macros() {
     "tv_device" ) XC_SDK="appletvos";;
     *) echo "Unknown SDK"; exit 1 ;;
   esac
+
+  case "${CODE_SIGN:-}" in
+    "no" ) XC_CODE_SIGN="${XC_MACROS} CODE_SIGNING_ALLOWED=NO";;
+  esac
 }
 
 function analyze() {

--- a/WebDriverAgentLib/Utilities/FBActiveAppDetectionPoint.m
+++ b/WebDriverAgentLib/Utilities/FBActiveAppDetectionPoint.m
@@ -20,7 +20,7 @@
   if ((self = [super init])) {
     CGSize screenSize = [UIScreen mainScreen].bounds.size;
     // Consider the element, which is located close to the top left corner of the screen the on-screen one.
-    CGFloat pointDistance = MIN(screenSize.width, screenSize.height) * 0.2;
+    CGFloat pointDistance = MIN(screenSize.width, screenSize.height) * (CGFloat) 0.2;
     _coordinates = CGPointMake(pointDistance, pointDistance);
   }
   return self;
@@ -76,7 +76,7 @@
              withDescriptionFormat:@"Both screen point coordinates should be valid numbers. Got '%@' instead", coordinatesStr]
             buildError:error];
   }
-  self.coordinates = CGPointMake(strX.doubleValue, strY.doubleValue);
+  self.coordinates = CGPointMake((CGFloat) strX.doubleValue, (CGFloat) strY.doubleValue);
   return YES;
 }
 


### PR DESCRIPTION
closes https://github.com/appium/appium/issues/13360

I could reproduce the error with xcodebuild. (I've added the build command as CI)

We can install the generic build to various real devices.