### PR TITLE
fix: get active app via session in get app info

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -165,7 +165,7 @@
 
 + (id<FBResponsePayload>)handleActiveAppInfo:(FBRouteRequest *)request
 {
-  XCUIApplication *app = FBApplication.fb_activeApplication;
+  XCUIApplication *app = request.session.activeApplication ?: FBApplication.fb_activeApplication;
   return FBResponseWithObject(@{
     @"pid": @(app.processID),
     @"bundleId": app.bundleID,


### PR DESCRIPTION
In a split screen, we can handle active app via `defaultActiveApplication`, but the change does not affect for `mobile: activeAppInfo` for now. So, let's refer `activeApplication` from `session` to reflect the settings. I tested on my local.

```
@driver.update_settings({ defaultActiveApplication: 'com.apple.DocumentsApp' })
```