### PR TITLE
refactor: move wda stuff from appium-xcuitest-driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,22 @@ branches:
 
 jobs:
   include:
-    - stage: Node tests
-      osx_image: xcode10
+    - stage:
+      name: Node unit tests
       language: node_js
       node_js: "10"
       install: npm install
       script: npm run test
+
+    - stage:
+      name: Node functional tests
+      language: node_js
+      node_js: "10"
+      install: npm install
+      env:
+        - PLATFORM_VERSION=10.0
+        - DEVICE_NAME="iPhone 6"
+      script: npm run e2e-test
 
     - stage: WDA build
       name: Generic, Xcode 11

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,11 @@ jobs:
       env:
         - PLATFORM_VERSION=10.0
         - DEVICE_NAME="iPhone 6"
+      before_script:
+        # allowing the normal method will cause rate limiting
+        - carthage bootstrap --no-use-binaries
+        - cp Cartfile.resolved Carthage
+        - mkdir -p ./Resources/WebDriverAgent.bundle
       script: npm run e2e-test
 
     - stage: WDA build

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ jobs:
       node_js: "10"
       install: npm install
       env:
-        - PLATFORM_VERSION=10.0
-        - DEVICE_NAME="iPhone 6"
+        - PLATFORM_VERSION=12.0
+        - DEVICE_NAME="iPhone X"
       before_script:
         # allowing the normal method will cause rate limiting
         - carthage bootstrap --no-use-binaries

--- a/index.js
+++ b/index.js
@@ -1,162 +1,23 @@
-import { fs, logger } from 'appium-support';
-import { getDevices } from 'node-simctl';
-import { asyncify } from 'asyncbox';
-import _ from 'lodash';
-import { exec } from 'teen_process';
-import path from 'path';
-import { EOL } from 'os';
-import { fileCompare } from './lib/utils';
+import * as dependencies from './lib/check-dependencies';
+import * as proxies from './lib/no-session-proxy';
+import * as driver from './lib/webdriveragent';
+import * as constants from './lib/constants';
+import * as utils from './lib/utils';
 
 
-const log = logger.getLogger('WebDriverAgent');
-const execLogger = {
-  // logger that gets rid of empty lines
-  logNonEmptyLines (data, fn) {
-    data = Buffer.isBuffer(data) ? data.toString() : data;
-    for (const line of data.split(EOL)) {
-      if (line) {
-        fn(line);
-      }
-    }
-  },
-  debug (data) {
-    this.logNonEmptyLines(data, log.debug.bind(log));
-  },
-  error (data) {
-    this.logNonEmptyLines(data, log.error.bind(log));
-  },
-};
+const { checkForDependencies, retrieveBuildDir, bundleWDASim } = dependencies;
+const { NoSessionProxy } = proxies;
+const { WebDriverAgent } = driver;
+const { WDA_BUNDLE_ID, BOOTSTRAP_PATH, WDA_BASE_URL, WDA_RUNNER_BUNDLE_ID, PROJECT_FILE } = constants;
+const { resetTestProcesses } = utils;
 
-const IOS = 'iOS';
-const TVOS = 'tvOS';
-
-const CARTHAGE_CMD = 'carthage';
-const CARTFILE = 'Cartfile.resolved';
-const CARTHAGE_ROOT = 'Carthage';
-
-const BOOTSTRAP_PATH = __dirname.endsWith('build')
-  ? path.resolve(__dirname, '..')
-  : __dirname;
-const WDA_BUNDLE_ID = 'com.apple.test.WebDriverAgentRunner-Runner';
-const WEBDRIVERAGENT_PROJECT = path.join(BOOTSTRAP_PATH, 'WebDriverAgent.xcodeproj');
-const WDA_RUNNER_BUNDLE_ID = 'com.facebook.WebDriverAgentRunner';
-const PROJECT_FILE = 'project.pbxproj';
-
-let buildDirPath;
-
-async function hasTvOSSims () {
-  const devices = _.flatten(Object.values(await getDevices(null, TVOS)));
-  return !_.isEmpty(devices);
-}
-
-function getCartfileLocations () {
-  const cartfile = path.resolve(BOOTSTRAP_PATH, CARTFILE);
-  const installedCartfile = path.resolve(BOOTSTRAP_PATH, CARTHAGE_ROOT, CARTFILE);
-
-  return {
-    cartfile,
-    installedCartfile,
-  };
-}
-
-async function needsUpdate (cartfile, installedCartfile) {
-  return !await fileCompare(cartfile, installedCartfile);
-}
-
-async function fetchDependencies (useSsl = false) {
-  log.info('Fetching dependencies');
-  if (!await fs.which(CARTHAGE_CMD)) {
-    log.errorAndThrow('Please make sure that you have Carthage installed (https://github.com/Carthage/Carthage)');
-  }
-
-  // check that the dependencies do not need to be updated
-  const {
-    cartfile,
-    installedCartfile,
-  } = getCartfileLocations();
-
-  if (!await needsUpdate(cartfile, installedCartfile)) {
-    // files are identical
-    log.info('Dependencies up-to-date');
-    return false;
-  }
-
-  let platforms = [IOS];
-  if (await hasTvOSSims()) {
-    platforms.push(TVOS);
-  } else {
-    log.debug('tvOS platform will not be included into Carthage bootstrap, because no Simulator devices have been created for it');
-  }
-
-  log.info(`Installing/updating dependencies for platforms ${platforms.map((p) => `'${p}'`).join(', ')}`);
-
-  let args = ['bootstrap'];
-  if (useSsl) {
-    args.push('--use-ssh');
-  }
-  args.push('--platform', platforms.join(','));
-  try {
-    await exec(CARTHAGE_CMD, args, {
-      logger: execLogger,
-      cwd: BOOTSTRAP_PATH,
-    });
-  } catch (err) {
-    // remove the carthage directory, or else subsequent runs will see it and
-    // assume the dependencies are already downloaded
-    await fs.rimraf(path.resolve(BOOTSTRAP_PATH, CARTHAGE_ROOT));
-    throw err;
-  }
-
-  // put the resolved cartfile into the Carthage directory
-  await fs.copyFile(cartfile, installedCartfile);
-
-  log.debug(`Finished fetching dependencies`);
-  return true;
-}
-
-async function buildWDASim () {
-  await exec('xcodebuild', ['-project', WEBDRIVERAGENT_PROJECT, '-scheme', 'WebDriverAgentRunner', '-sdk', 'iphonesimulator', 'CODE_SIGN_IDENTITY=""', 'CODE_SIGNING_REQUIRED="NO"']);
-}
-
-async function retrieveBuildDir () {
-  if (buildDirPath) {
-    return buildDirPath;
-  }
-
-  const {stdout} = await exec('xcodebuild', ['-project', WEBDRIVERAGENT_PROJECT, '-showBuildSettings']);
-
-  const pattern = /^\s*BUILD_DIR\s+=\s+(\/.*)/m;
-  const match = pattern.exec(stdout);
-  if (!match) {
-    throw new Error(`Cannot parse WDA build dir from ${_.truncate(stdout, {length: 300})}`);
-  }
-  buildDirPath = match[1];
-  log.debug(`Got build folder: '${buildDirPath}'`);
-  return buildDirPath;
-}
-
-async function checkForDependencies (opts = {}) {
-  return await fetchDependencies(opts.useSsl);
-}
-
-async function bundleWDASim (opts) {
-  const derivedDataPath = await retrieveBuildDir();
-  const wdaBundlePath = path.join(derivedDataPath, 'Debug-iphonesimulator', 'WebDriverAgentRunner-Runner.app');
-  if (await fs.exists(wdaBundlePath)) {
-    return wdaBundlePath;
-  }
-  await checkForDependencies(opts);
-  await buildWDASim();
-  return wdaBundlePath;
-}
-
-if (require.main === module) {
-  asyncify(checkForDependencies);
-}
 
 export {
-  checkForDependencies, retrieveBuildDir,
-  bundleWDASim,
+  WebDriverAgent,
+  NoSessionProxy,
+  checkForDependencies, retrieveBuildDir, bundleWDASim,
+  resetTestProcesses,
   BOOTSTRAP_PATH, WDA_BUNDLE_ID,
   WDA_RUNNER_BUNDLE_ID, PROJECT_FILE,
+  WDA_BASE_URL
 };

--- a/lib/check-dependencies.js
+++ b/lib/check-dependencies.js
@@ -1,0 +1,149 @@
+import { fs, logger } from 'appium-support';
+import { getDevices } from 'node-simctl';
+import { asyncify } from 'asyncbox';
+import _ from 'lodash';
+import { exec } from 'teen_process';
+import path from 'path';
+import { EOL } from 'os';
+import { fileCompare, WEBDRIVERAGENT_PROJECT } from './utils';
+import { BOOTSTRAP_PATH} from './constants';
+
+const log = logger.getLogger('WebDriverAgent');
+const execLogger = {
+  // logger that gets rid of empty lines
+  logNonEmptyLines (data, fn) {
+    data = Buffer.isBuffer(data) ? data.toString() : data;
+    for (const line of data.split(EOL)) {
+      if (line) {
+        fn(line);
+      }
+    }
+  },
+  debug (data) {
+    this.logNonEmptyLines(data, log.debug.bind(log));
+  },
+  error (data) {
+    this.logNonEmptyLines(data, log.error.bind(log));
+  },
+};
+
+const IOS = 'iOS';
+const TVOS = 'tvOS';
+
+const CARTHAGE_CMD = 'carthage';
+const CARTFILE = 'Cartfile.resolved';
+const CARTHAGE_ROOT = 'Carthage';
+
+let buildDirPath;
+
+async function hasTvOSSims () {
+  const devices = _.flatten(Object.values(await getDevices(null, TVOS)));
+  return !_.isEmpty(devices);
+}
+
+function getCartfileLocations () {
+  const cartfile = path.resolve(BOOTSTRAP_PATH, CARTFILE);
+  const installedCartfile = path.resolve(BOOTSTRAP_PATH, CARTHAGE_ROOT, CARTFILE);
+
+  return {
+    cartfile,
+    installedCartfile,
+  };
+}
+
+async function needsUpdate (cartfile, installedCartfile) {
+  return !await fileCompare(cartfile, installedCartfile);
+}
+
+async function fetchDependencies (useSsl = false) {
+  log.info('Fetching dependencies');
+  if (!await fs.which(CARTHAGE_CMD)) {
+    log.errorAndThrow('Please make sure that you have Carthage installed (https://github.com/Carthage/Carthage)');
+  }
+
+  // check that the dependencies do not need to be updated
+  const {
+    cartfile,
+    installedCartfile,
+  } = getCartfileLocations();
+
+  if (!await needsUpdate(cartfile, installedCartfile)) {
+    // files are identical
+    log.info('Dependencies up-to-date');
+    return false;
+  }
+
+  let platforms = [IOS];
+  if (await hasTvOSSims()) {
+    platforms.push(TVOS);
+  } else {
+    log.debug('tvOS platform will not be included into Carthage bootstrap, because no Simulator devices have been created for it');
+  }
+
+  log.info(`Installing/updating dependencies for platforms ${platforms.map((p) => `'${p}'`).join(', ')}`);
+
+  let args = ['bootstrap'];
+  if (useSsl) {
+    args.push('--use-ssh');
+  }
+  args.push('--platform', platforms.join(','));
+  try {
+    await exec(CARTHAGE_CMD, args, {
+      logger: execLogger,
+      cwd: BOOTSTRAP_PATH,
+    });
+  } catch (err) {
+    // remove the carthage directory, or else subsequent runs will see it and
+    // assume the dependencies are already downloaded
+    await fs.rimraf(path.resolve(BOOTSTRAP_PATH, CARTHAGE_ROOT));
+    throw err;
+  }
+
+  // put the resolved cartfile into the Carthage directory
+  await fs.copyFile(cartfile, installedCartfile);
+
+  log.debug(`Finished fetching dependencies`);
+  return true;
+}
+
+async function buildWDASim () {
+  await exec('xcodebuild', ['-project', WEBDRIVERAGENT_PROJECT, '-scheme', 'WebDriverAgentRunner', '-sdk', 'iphonesimulator', 'CODE_SIGN_IDENTITY=""', 'CODE_SIGNING_REQUIRED="NO"']);
+}
+
+async function retrieveBuildDir () {
+  if (buildDirPath) {
+    return buildDirPath;
+  }
+
+  const {stdout} = await exec('xcodebuild', ['-project', WEBDRIVERAGENT_PROJECT, '-showBuildSettings']);
+
+  const pattern = /^\s*BUILD_DIR\s+=\s+(\/.*)/m;
+  const match = pattern.exec(stdout);
+  if (!match) {
+    throw new Error(`Cannot parse WDA build dir from ${_.truncate(stdout, {length: 300})}`);
+  }
+  buildDirPath = match[1];
+  log.debug(`Got build folder: '${buildDirPath}'`);
+  return buildDirPath;
+}
+
+async function checkForDependencies (opts = {}) {
+  return await fetchDependencies(opts.useSsl);
+}
+
+async function bundleWDASim (opts) {
+  const derivedDataPath = await retrieveBuildDir();
+  const wdaBundlePath = path.join(derivedDataPath, 'Debug-iphonesimulator', 'WebDriverAgentRunner-Runner.app');
+  if (await fs.exists(wdaBundlePath)) {
+    return wdaBundlePath;
+  }
+  await checkForDependencies(opts);
+  await buildWDASim();
+  return wdaBundlePath;
+}
+
+if (require.main === module) {
+  asyncify(checkForDependencies);
+}
+
+export { checkForDependencies, retrieveBuildDir, bundleWDASim };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,21 @@
+import path from 'path';
+
+
+const BOOTSTRAP_PATH = __dirname.endsWith('build')
+  ? path.resolve(__dirname, '..', '..', '..')
+  : path.resolve(__dirname, '..', '..');
+const WDA_BUNDLE_ID = 'com.apple.test.WebDriverAgentRunner-Runner';
+const WEBDRIVERAGENT_PROJECT = path.join(BOOTSTRAP_PATH, 'WebDriverAgent.xcodeproj');
+const WDA_RUNNER_BUNDLE_ID = 'com.facebook.WebDriverAgentRunner';
+const PROJECT_FILE = 'project.pbxproj';
+
+const PLATFORM_NAME_TVOS = 'tvOS';
+const PLATFORM_NAME_IOS = 'iOS';
+
+
+export {
+  BOOTSTRAP_PATH, WDA_BUNDLE_ID,
+  WDA_RUNNER_BUNDLE_ID, PROJECT_FILE,
+  WEBDRIVERAGENT_PROJECT,
+  PLATFORM_NAME_TVOS, PLATFORM_NAME_IOS
+};

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,5 @@
+import { logger } from 'appium-support';
+
+const log = logger.getLogger('WebDriverAgent');
+
+export default log;

--- a/lib/no-session-proxy.js
+++ b/lib/no-session-proxy.js
@@ -1,0 +1,26 @@
+import { JWProxy } from 'appium-base-driver';
+
+
+class NoSessionProxy extends JWProxy {
+  constructor (opts = {}) {
+    super(opts);
+  }
+
+  getUrlForProxy (url) {
+    if (url === '') {
+      url = '/';
+    }
+    const proxyBase = `${this.scheme}://${this.server}:${this.port}${this.base}`;
+    let remainingUrl = '';
+    if ((new RegExp('^/')).test(url)) {
+      remainingUrl = url;
+    } else {
+      throw new Error(`Did not know what to do with url '${url}'`);
+    }
+    remainingUrl = remainingUrl.replace(/\/$/, ''); // can't have trailing slashes
+    return proxyBase + remainingUrl;
+  }
+}
+
+export { NoSessionProxy };
+export default NoSessionProxy;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,61 @@
+import { fs, tempDir, plist } from 'appium-support';
+import { exec } from 'teen_process';
+import path from 'path';
 import streamEqual from 'stream-equal';
-import { fs } from 'appium-support';
+import log from './logger';
+import _ from 'lodash';
+import { WDA_RUNNER_BUNDLE_ID, PLATFORM_NAME_TVOS } from './constants';
+import B from 'bluebird';
 
+
+const PROJECT_FILE = 'project.pbxproj';
+const CARTHAGE_ROOT = 'Carthage';
+
+async function getPIDsUsingPattern (pattern, opts = {}) {
+  const {
+    multi = false,
+    ignoreCase = true,
+  } = opts;
+  const args = [`-${ignoreCase ? 'i' : ''}f${multi ? '' : 'n'}`, pattern];
+  try {
+    const {stdout} = await exec('pgrep', args);
+    if (multi) {
+      const result = stdout.split('\n')
+        .filter((x) => parseInt(x, 10))
+        .map((x) => `${parseInt(x, 10)}`);
+      return _.isEmpty(result) ? null : result;
+    }
+    const pid = parseInt(stdout, 10);
+    return isNaN(pid) ? null : `${pid}`;
+  } catch (err) {
+    log.debug(`'pgrep ${args.join(' ')}' didn't detect any matching processes. Return code: ${err.code}`);
+    return null;
+  }
+}
+
+async function killAppUsingPattern (pgrepPattern) {
+  for (const signal of [2, 15, 9]) {
+    if (!await getPIDsUsingPattern(pgrepPattern)) {
+      return;
+    }
+    const args = [`-${signal}`, '-if', pgrepPattern];
+    try {
+      await exec('pkill', args);
+    } catch (err) {
+      log.debug(`pkill ${args.join(' ')} -> ${err.message}`);
+    }
+    await B.delay(100);
+  }
+}
+
+/**
+ * Return true if the platformName is tvOS
+ * @param {string} platformName The name of the platorm
+ * @returns {boolean} Return true if the platformName is tvOS
+ */
+function isTvOS (platformName) {
+  return _.toLower(platformName) === _.toLower(PLATFORM_NAME_TVOS);
+}
 
 async function fileCompare (file1, file2) {
   try {
@@ -14,4 +69,282 @@ async function fileCompare (file1, file2) {
   }
 }
 
-export { fileCompare };
+async function replaceInFile (file, find, replace) {
+  let contents = await fs.readFile(file, 'utf8');
+
+  let newContents = contents.replace(find, replace);
+  if (newContents !== contents) {
+    await fs.writeFile(file, newContents, 'utf8');
+  }
+}
+
+/**
+ * Update WebDriverAgentRunner project bundle ID with newBundleId.
+ * This method assumes project file is in the correct state.
+ * @param {string} agentPath - Path to the .xcodeproj directory.
+ * @param {string} newBundleId the new bundle ID used to update.
+ */
+async function updateProjectFile (agentPath, newBundleId) {
+  let projectFilePath = `${agentPath}/${PROJECT_FILE}`;
+  try {
+    // Assuming projectFilePath is in the correct state, create .old from projectFilePath
+    await fs.copyFile(projectFilePath, `${projectFilePath}.old`);
+    await replaceInFile(projectFilePath, new RegExp(WDA_RUNNER_BUNDLE_ID.replace('.', '\.'), 'g'), newBundleId); // eslint-disable-line no-useless-escape
+    log.debug(`Successfully updated '${projectFilePath}' with bundle id '${newBundleId}'`);
+  } catch (err) {
+    log.debug(`Error updating project file: ${err.message}`);
+    log.warn(`Unable to update project file '${projectFilePath}' with ` +
+             `bundle id '${newBundleId}'. WebDriverAgent may not start`);
+  }
+}
+
+/**
+ * Reset WebDriverAgentRunner project bundle ID to correct state.
+ * @param {string} agentPath - Path to the .xcodeproj directory.
+ */
+async function resetProjectFile (agentPath) {
+  let projectFilePath = `${agentPath}/${PROJECT_FILE}`;
+  try {
+    // restore projectFilePath from .old file
+    if (!await fs.exists(`${projectFilePath}.old`)) {
+      return; // no need to reset
+    }
+    await fs.mv(`${projectFilePath}.old`, projectFilePath);
+    log.debug(`Successfully reset '${projectFilePath}' with bundle id '${WDA_RUNNER_BUNDLE_ID}'`);
+  } catch (err) {
+    log.debug(`Error resetting project file: ${err.message}`);
+    log.warn(`Unable to reset project file '${projectFilePath}' with ` +
+             `bundle id '${WDA_RUNNER_BUNDLE_ID}'. WebDriverAgent has been ` +
+             `modified and not returned to the original state.`);
+  }
+}
+
+async function setRealDeviceSecurity (keychainPath, keychainPassword) {
+  log.debug('Setting security for iOS device');
+  await exec('security', ['-v', 'list-keychains', '-s', keychainPath]);
+  await exec('security', ['-v', 'unlock-keychain', '-p', keychainPassword, keychainPath]);
+  await exec('security', ['set-keychain-settings', '-t', '3600', '-l', keychainPath]);
+}
+
+async function generateXcodeConfigFile (orgId, signingId) {
+  log.debug(`Generating xcode config file for orgId '${orgId}' and signingId ` +
+            `'${signingId}'`);
+  const contents = `DEVELOPMENT_TEAM = ${orgId}
+CODE_SIGN_IDENTITY = ${signingId}
+`;
+  const xcconfigPath = await tempDir.path('appium-temp.xcconfig');
+  log.debug(`Writing xcode config file to ${xcconfigPath}`);
+  await fs.writeFile(xcconfigPath, contents, 'utf8');
+  return xcconfigPath;
+}
+
+/**
+ * Information of the device under test
+ * @typedef {Object} DeviceInfo
+ * @property {string} isRealDevice - Equals to true if the current device is a real device
+ * @property {string} udid - The device UDID.
+ * @property {string} platformVersion - The platform version of OS.
+ * @property {string} platformName - The platform name of iOS, tvOS
+*/
+/**
+ * Creates xctestrun file per device & platform version.
+ * We expects to have WebDriverAgentRunner_iphoneos${sdkVersion|platformVersion}-arm64.xctestrun for real device
+ * and WebDriverAgentRunner_iphonesimulator${sdkVersion|platformVersion}-x86_64.xctestrun for simulator located @bootstrapPath
+ * Newer Xcode (Xcode 10.0 at least) generate xctestrun file following sdkVersion.
+ * e.g. Xcode which has iOS SDK Version 12.2 generate WebDriverAgentRunner_iphonesimulator.2-x86_64.xctestrun
+ *      even if the cap has platform version 11.4
+ *
+ * @param {DeviceInfo} deviceInfo
+ * @param {string} sdkVersion - The Xcode SDK version of OS.
+ * @param {string} bootstrapPath - The folder path containing xctestrun file.
+ * @param {string} wdaRemotePort - The remote port WDA is listening on.
+ * @return {string} returns xctestrunFilePath for given device
+ * @throws if WebDriverAgentRunner_iphoneos${sdkVersion|platformVersion}-arm64.xctestrun for real device
+ * or WebDriverAgentRunner_iphonesimulator${sdkVersion|platformVersion}-x86_64.xctestrun for simulator is not found @bootstrapPath,
+ * then it will throw file not found exception
+ */
+async function setXctestrunFile (deviceInfo, sdkVersion, bootstrapPath, wdaRemotePort) {
+  const xctestrunFilePath = await getXctestrunFilePath(deviceInfo, sdkVersion, bootstrapPath);
+  const xctestRunContent = await plist.parsePlistFile(xctestrunFilePath);
+  const updateWDAPort = getAdditionalRunContent(deviceInfo.platformName, wdaRemotePort);
+  const newXctestRunContent = _.merge(xctestRunContent, updateWDAPort);
+  await plist.updatePlistFile(xctestrunFilePath, newXctestRunContent, true);
+
+  return xctestrunFilePath;
+}
+
+/**
+ * Return the WDA object which appends existing xctest runner content
+ * @param {string} platformName - The name of the platform
+ * @param {string} version - The Xcode SDK version of OS.
+ * @return {object} returns a runner object which has USE_PORT
+ */
+function getAdditionalRunContent (platformName, wdaRemotePort) {
+  const runner = `WebDriverAgentRunner${isTvOS(platformName) ? '_tvOS' : ''}`;
+
+  return {
+    [runner]: {
+      EnvironmentVariables: {
+        USE_PORT: wdaRemotePort
+      }
+    }
+  };
+}
+
+/**
+ * Return the path of xctestrun if it exists
+ * @param {DeviceInfo} deviceInfo
+ * @param {string} sdkVersion - The Xcode SDK version of OS.
+ * @param {string} bootstrapPath - The folder path containing xctestrun file.
+ */
+async function getXctestrunFilePath (deviceInfo, sdkVersion, bootstrapPath) {
+  // First try the SDK path, for Xcode 10 (at least)
+  const sdkBased = [
+    path.resolve(bootstrapPath, `${deviceInfo.udid}_${sdkVersion}.xctestrun`),
+    sdkVersion,
+  ];
+  // Next try Platform path, for earlier Xcode versions
+  const platformBased = [
+    path.resolve(bootstrapPath, `${deviceInfo.udid}_${deviceInfo.platformVersion}.xctestrun`),
+    deviceInfo.platformVersion,
+  ];
+
+  for (const [filePath, version] of [sdkBased, platformBased]) {
+    if (await fs.exists(filePath)) {
+      log.info(`Using '${filePath}' as xctestrun file`);
+      return filePath;
+    }
+    const originalXctestrunFile = path.resolve(bootstrapPath, getXctestrunFileName(deviceInfo, version));
+    if (await fs.exists(originalXctestrunFile)) {
+      // If this is first time run for given device, then first generate xctestrun file for device.
+      // We need to have a xctestrun file **per device** because we cant not have same wda port for all devices.
+      await fs.copyFile(originalXctestrunFile, filePath);
+      log.info(`Using '${filePath}' as xctestrun file copied by '${originalXctestrunFile}'`);
+      return filePath;
+    }
+  }
+
+  log.errorAndThrow(`If you are using 'useXctestrunFile' capability then you ` +
+                                  `need to have a xctestrun file (expected: ` +
+                                  `'${path.resolve(bootstrapPath, getXctestrunFileName(deviceInfo, sdkVersion))}')`);
+}
+
+
+/**
+ * Return the name of xctestrun file
+ * @param {DeviceInfo} deviceInfo
+ * @param {string} version - The Xcode SDK version of OS.
+ * @return {string} returns xctestrunFilePath for given device
+ */
+function getXctestrunFileName (deviceInfo, version) {
+  return isTvOS(deviceInfo.platformName)
+    ? `WebDriverAgentRunner_tvOS_appletv${deviceInfo.isRealDevice ? `os${version}-arm64` : `simulator${version}-x86_64`}.xctestrun`
+    : `WebDriverAgentRunner_iphone${deviceInfo.isRealDevice ? `os${version}-arm64` : `simulator${version}-x86_64`}.xctestrun`;
+}
+
+async function killProcess (name, proc) {
+  if (proc && proc.proc) {
+    log.info(`Shutting down ${name} process (pid ${proc.proc.pid})`);
+    try {
+      await proc.stop('SIGTERM', 1000);
+    } catch (err) {
+      if (!err.message.includes(`Process didn't end after`)) {
+        throw err;
+      }
+      log.debug(`${name} process did not end in a timely fashion: '${err.message}'. ` +
+                `Sending 'SIGKILL'...`);
+      try {
+        await proc.stop('SIGKILL');
+      } catch (err) {
+        if (err.message.includes('not currently running')) {
+          // the process ended but for some reason we were not informed
+          return;
+        }
+        throw err;
+      }
+    }
+  }
+}
+
+/**
+ * Generate a random integer.
+ *
+ * @return {number} A random integer number in range [low, hight). `low`` is inclusive and `high` is exclusive.
+ */
+function randomInt (low, high) {
+  return Math.floor(Math.random() * (high - low) + low);
+}
+
+/**
+ * Retrieves WDA upgrade timestamp
+ *
+ * @param {string} bootstrapPath The full path to the folder where WDA source is located
+ * @return {?number} The UNIX timestamp of the carthage root folder, where dependencies are downloaded.
+ * This folder is created only once on module upgrade/first install.
+ */
+async function getWDAUpgradeTimestamp (bootstrapPath) {
+  const carthageRootPath = path.resolve(bootstrapPath, CARTHAGE_ROOT);
+  if (await fs.exists(carthageRootPath)) {
+    const {mtime} = await fs.stat(carthageRootPath);
+    return mtime.getTime();
+  }
+  return null;
+}
+
+/**
+ * Kills running XCTest processes for the particular device.
+ *
+ * @param {string} udid - The device UDID.
+ * @param {boolean} isSimulator - Equals to true if the current device is a Simulator
+ */
+async function resetTestProcesses (udid, isSimulator) {
+  const processPatterns = [`xcodebuild.*${udid}`];
+  if (isSimulator) {
+    processPatterns.push(`${udid}.*XCTRunner`);
+    // The pattern to find in case idb was used
+    processPatterns.push(`xctest.*${udid}`);
+  }
+  log.debug(`Killing running processes '${processPatterns.join(', ')}' for the device ${udid}...`);
+  for (const pgrepPattern of processPatterns) {
+    await killAppUsingPattern(pgrepPattern);
+  }
+}
+
+/**
+ * Get the IDs of processes listening on the particular system port.
+ * It is also possible to apply additional filtering based on the
+ * process command line.
+ *
+ * @param {string|number} port - The port number.
+ * @param {?Function} filteringFunc - Optional lambda function, which
+ *                                    receives command line string of the particular process
+ *                                    listening on given port, and is expected to return
+ *                                    either true or false to include/exclude the corresponding PID
+ *                                    from the resulting array.
+ * @returns {Array<string>} - the list of matched process ids.
+ */
+async function getPIDsListeningOnPort (port, filteringFunc = null) {
+  const result = [];
+  try {
+    // This only works since Mac OS X El Capitan
+    const {stdout} = await exec('lsof', ['-ti', `tcp:${port}`]);
+    result.push(...(stdout.trim().split(/\n+/)));
+  } catch (e) {
+    return result;
+  }
+
+  if (!_.isFunction(filteringFunc)) {
+    return result;
+  }
+  return await B.filter(result, async (x) => {
+    const {stdout} = await exec('ps', ['-p', x, '-o', 'command']);
+    return await filteringFunc(stdout);
+  });
+}
+
+export { updateProjectFile, resetProjectFile, setRealDeviceSecurity,
+  getAdditionalRunContent, getXctestrunFileName, generateXcodeConfigFile,
+  setXctestrunFile, getXctestrunFilePath, killProcess, randomInt,
+  getWDAUpgradeTimestamp, fileCompare, CARTHAGE_ROOT, resetTestProcesses,
+  getPIDsListeningOnPort, killAppUsingPattern, isTvOS,
+};

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -1,0 +1,427 @@
+import _ from 'lodash';
+import path from 'path';
+import url from 'url';
+import { JWProxy } from 'appium-base-driver';
+import { fs, util, plist } from 'appium-support';
+import log from './logger';
+import { NoSessionProxy } from './no-session-proxy';
+import { getWDAUpgradeTimestamp, CARTHAGE_ROOT, resetTestProcesses, getPIDsListeningOnPort } from './utils';
+import XcodeBuild from './xcodebuild';
+import { exec } from 'teen_process';
+import AsyncLock from 'async-lock';
+import { checkForDependencies, bundleWDASim } from './check-dependencies';
+import { BOOTSTRAP_PATH, WDA_RUNNER_BUNDLE_ID } from './constants';
+
+const WDA_LAUNCH_TIMEOUT = 60 * 1000;
+const WDA_AGENT_PORT = 8100;
+const WDA_BASE_URL = 'http://localhost';
+const WDA_CF_BUNDLE_NAME = 'WebDriverAgentRunner-Runner';
+
+const SHARED_RESOURCES_GUARD = new AsyncLock();
+
+class WebDriverAgent {
+  constructor (xcodeVersion, args = {}) {
+    this.xcodeVersion = xcodeVersion;
+
+    this.args = _.clone(args);
+
+    this.device = args.device;
+    this.platformVersion = args.platformVersion;
+    this.platformName = args.platformName;
+    this.iosSdkVersion = args.iosSdkVersion;
+    this.host = args.host;
+    this.isRealDevice = !!args.realDevice;
+    this.idb = (args.device || {}).idb;
+
+    this.setWDAPaths(args.bootstrapPath, args.agentPath);
+
+    this.wdaLocalPort = args.wdaLocalPort;
+    this.wdaRemotePort = args.wdaLocalPort || WDA_AGENT_PORT;
+    this.wdaBaseUrl = args.wdaBaseUrl || WDA_BASE_URL;
+
+    this.prebuildWDA = args.prebuildWDA;
+
+    this.webDriverAgentUrl = args.webDriverAgentUrl;
+
+    this.started = false;
+
+    this.wdaConnectionTimeout = args.wdaConnectionTimeout;
+
+    this.useCarthageSsl = _.isBoolean(args.useCarthageSsl) && args.useCarthageSsl;
+
+    this.useXctestrunFile = args.useXctestrunFile;
+    this.usePrebuiltWDA = args.usePrebuiltWDA;
+    this.derivedDataPath = args.derivedDataPath;
+    this.mjpegServerPort = args.mjpegServerPort;
+
+    this.updatedWDABundleId = args.updatedWDABundleId;
+
+    this.xcodebuild = new XcodeBuild(this.xcodeVersion, this.device, {
+      platformVersion: this.platformVersion,
+      platformName: this.platformName,
+      iosSdkVersion: this.iosSdkVersion,
+      agentPath: this.agentPath,
+      bootstrapPath: this.bootstrapPath,
+      realDevice: this.isRealDevice,
+      showXcodeLog: args.showXcodeLog,
+      xcodeConfigFile: args.xcodeConfigFile,
+      xcodeOrgId: args.xcodeOrgId,
+      xcodeSigningId: args.xcodeSigningId,
+      keychainPath: args.keychainPath,
+      keychainPassword: args.keychainPassword,
+      useSimpleBuildTest: args.useSimpleBuildTest,
+      usePrebuiltWDA: args.usePrebuiltWDA,
+      updatedWDABundleId: this.updatedWDABundleId,
+      launchTimeout: args.wdaLaunchTimeout || WDA_LAUNCH_TIMEOUT,
+      wdaRemotePort: this.wdaRemotePort,
+      useXctestrunFile: this.useXctestrunFile,
+      derivedDataPath: args.derivedDataPath,
+      mjpegServerPort: this.mjpegServerPort,
+    });
+  }
+
+  setWDAPaths (bootstrapPath, agentPath) {
+    // allow the user to specify a place for WDA. This is undocumented and
+    // only here for the purposes of testing development of WDA
+    this.bootstrapPath = bootstrapPath || BOOTSTRAP_PATH;
+    log.info(`Using WDA path: '${this.bootstrapPath}'`);
+
+    // for backward compatibility we need to be able to specify agentPath too
+    this.agentPath = agentPath || path.resolve(this.bootstrapPath, 'WebDriverAgent.xcodeproj');
+    log.info(`Using WDA agent: '${this.agentPath}'`);
+  }
+
+  async cleanupObsoleteProcesses () {
+    const obsoletePids = await getPIDsListeningOnPort(this.url.port,
+      (cmdLine) => cmdLine.includes('/WebDriverAgentRunner') &&
+        !cmdLine.toLowerCase().includes(this.device.udid.toLowerCase()));
+
+    if (_.isEmpty(obsoletePids)) {
+      log.debug(`No obsolete cached processes from previous WDA sessions ` +
+        `listening on port ${this.url.port} have been found`);
+      return;
+    }
+
+    log.info(`Detected ${obsoletePids.length} obsolete cached process${obsoletePids.length === 1 ? '' : 'es'} ` +
+      `from previous WDA sessions. Cleaning them up`);
+    try {
+      await exec('kill', obsoletePids);
+    } catch (e) {
+      log.warn(`Failed to kill obsolete cached process${obsoletePids.length === 1 ? '' : 'es'} '${obsoletePids}'. ` +
+        `Original error: ${e.message}`);
+    }
+  }
+
+  /**
+   * Return boolean if WDA is running or not
+   * @return {boolean} True if WDA is running
+   * @throws {Error} If there was invalid response code or body
+   */
+  async isRunning () {
+    return !!(await this.getStatus());
+  }
+
+  /**
+   * Return current running WDA's status like below
+   * {
+   *   "state": "success",
+   *   "os": {
+   *     "name": "iOS",
+   *     "version": "11.4",
+   *     "sdkVersion": "11.3"
+   *   },
+   *   "ios": {
+   *     "simulatorVersion": "11.4",
+   *     "ip": "172.254.99.34"
+   *   },
+   *   "build": {
+   *     "time": "Jun 24 2018 17:08:21",
+   *     "productBundleIdentifier": "com.facebook.WebDriverAgentRunner"
+   *   }
+   * }
+   *
+   * @return {?object} State Object
+   * @throws {Error} If there was invalid response code or body
+   */
+  async getStatus () {
+    const noSessionProxy = new NoSessionProxy({
+      server: this.url.hostname,
+      port: this.url.port,
+      base: '',
+      timeout: 3000,
+    });
+    try {
+      return await noSessionProxy.command('/status', 'GET');
+    } catch (err) {
+      log.debug(`WDA is not listening at '${this.url.href}'`);
+      return null;
+    }
+  }
+
+  /**
+   * Uninstall WDAs from the test device.
+   * Over Xcode 11, multiple WDA can be in the device since Xcode 11 generates different WDA.
+   * Appium does not expect multiple WDAs are running on a device.
+   */
+  async uninstall () {
+    try {
+      const bundleIds = await this.device.getUserInstalledBundleIdsByBundleName(WDA_CF_BUNDLE_NAME);
+      if (_.isEmpty(bundleIds)) {
+        log.debug('No WDAs on the device.');
+        return;
+      }
+
+      log.debug(`Uninstalling WDAs: '${bundleIds}'`);
+      for (const bundleId of bundleIds) {
+        await this.device.removeApp(bundleId);
+      }
+    } catch (e) {
+      log.warn(`WebDriverAgent uninstall failed. Perhaps, it is already uninstalled? Original error: ${JSON.stringify(e)}`);
+    }
+  }
+
+
+  /**
+   * Return current running WDA's status like below after launching WDA
+   * {
+   *   "state": "success",
+   *   "os": {
+   *     "name": "iOS",
+   *     "version": "11.4",
+   *     "sdkVersion": "11.3"
+   *   },
+   *   "ios": {
+   *     "simulatorVersion": "11.4",
+   *     "ip": "172.254.99.34"
+   *   },
+   *   "build": {
+   *     "time": "Jun 24 2018 17:08:21",
+   *     "productBundleIdentifier": "com.facebook.WebDriverAgentRunner"
+   *   }
+   * }
+   *
+   * @param {string} sessionId Launch WDA and establish the session with this sessionId
+   * @return {?object} State Object
+   * @throws {Error} If there was invalid response code or body
+   */
+  async launch (sessionId) {
+    if (this.webDriverAgentUrl) {
+      log.info(`Using provided WebdriverAgent at '${this.webDriverAgentUrl}'`);
+      this.url = this.webDriverAgentUrl;
+      this.setupProxies(sessionId);
+      return await this.getStatus();
+    }
+
+    log.info('Launching WebDriverAgent on the device');
+
+    this.setupProxies(sessionId);
+
+    if (!this.useXctestrunFile && !await fs.exists(this.agentPath)) {
+      throw new Error(`Trying to use WebDriverAgent project at '${this.agentPath}' but the ` +
+                      'file does not exist');
+    }
+
+    // useXctestrunFile and usePrebuiltWDA use existing dependencies
+    // It depends on user side
+    if (this.idb || this.useXctestrunFile || (this.derivedDataPath && this.usePrebuiltWDA)) {
+      log.info('Skipped WDA dependencies resolution according to the provided capabilities');
+    } else {
+      // make sure that the WDA dependencies have been built
+      const synchronizationKey = path.normalize(this.bootstrapPath);
+      await SHARED_RESOURCES_GUARD.acquire(synchronizationKey, async () => {
+        const didPerformUpgrade = await checkForDependencies({useSsl: this.useCarthageSsl});
+        if (didPerformUpgrade) {
+          // Only perform the cleanup after WDA upgrade
+          await this.xcodebuild.cleanProject();
+        }
+      });
+    }
+    // We need to provide WDA local port, because it might be occupied with
+    await resetTestProcesses(this.device.udid, !this.isRealDevice);
+
+    if (this.idb) {
+      return await this.startWithIDB();
+    }
+
+    await this.xcodebuild.init(this.noSessionProxy);
+
+    // Start the xcodebuild process
+    if (this.prebuildWDA) {
+      await this.xcodebuild.prebuild();
+    }
+    return await this.xcodebuild.start();
+  }
+
+  async startWithIDB () {
+    log.info('Will launch WDA with idb instead of xcodebuild since the corresponding flag is enabled');
+    const {wdaBundleId, testBundleId} = await this.prepareWDA();
+    const env = {
+      USE_PORT: this.wdaRemotePort,
+      WDA_PRODUCT_BUNDLE_IDENTIFIER: this.updatedWDABundleId,
+    };
+    if (this.mjpegServerPort) {
+      env.MJPEG_SERVER_PORT = this.mjpegServerPort;
+    }
+
+    return await this.idb.runXCUITest(wdaBundleId, wdaBundleId, testBundleId, {env});
+  }
+
+  async parseBundleId (wdaBundlePath) {
+    const infoPlistPath = path.join(wdaBundlePath, 'Info.plist');
+    const infoPlist = await plist.parsePlist(await fs.readFile(infoPlistPath));
+    if (!infoPlist.CFBundleIdentifier) {
+      throw new Error(`Couldn't find bundle id in ${infoPlistPath}`);
+    }
+    return infoPlist.CFBundleIdentifier;
+  }
+
+  async prepareWDA () {
+    const wdaBundlePath = await this.fetchWDABundle();
+    const wdaBundleId = await this.parseBundleId(wdaBundlePath);
+    if (!await this.device.isAppInstalled(wdaBundleId)) {
+      await this.device.installApp(wdaBundlePath);
+    }
+    const testBundleId = await this.idb.installXCTestBundle(path.join(wdaBundlePath, 'PlugIns', 'WebDriverAgentRunner.xctest'));
+    return {wdaBundleId, testBundleId, wdaBundlePath};
+  }
+
+  async fetchWDABundle () {
+    if (!this.derivedDataPath) {
+      return await bundleWDASim();
+    }
+    const wdaBundlePath = await fs.walkDir(this.derivedDataPath, true, (item) => item.endsWith('WebDriverAgentRunner-Runner.app'));
+    if (!wdaBundlePath) {
+      throw new Error(`Couldn't find the WDA bundle in the ${this.derivedDataPath}`);
+    }
+    return wdaBundlePath;
+  }
+
+  async isSourceFresh () {
+    for (const subPath of [
+      CARTHAGE_ROOT,
+      'Resources',
+      `Resources${path.sep}WebDriverAgent.bundle`,
+    ]) {
+      if (!await fs.exists(path.resolve(this.bootstrapPath, subPath))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  setupProxies (sessionId) {
+    const proxyOpts = {
+      server: this.url.hostname,
+      port: this.url.port,
+      base: '',
+      timeout: this.wdaConnectionTimeout,
+      keepAlive: true,
+    };
+
+    this.jwproxy = new JWProxy(proxyOpts);
+    this.jwproxy.sessionId = sessionId;
+    this.proxyReqRes = this.jwproxy.proxyReqRes.bind(this.jwproxy);
+
+    this.noSessionProxy = new NoSessionProxy(proxyOpts);
+  }
+
+  async quit () {
+    log.info('Shutting down sub-processes');
+
+    await this.xcodebuild.quit();
+    await this.xcodebuild.reset();
+
+    if (this.jwproxy) {
+      this.jwproxy.sessionId = null;
+    }
+
+    this.started = false;
+
+    if (!this.args.webDriverAgentUrl) {
+      // if we populated the url ourselves (during `setupCaching` call, for instance)
+      // then clean that up. If the url was supplied, we want to keep it
+      this.webDriverAgentUrl = null;
+    }
+  }
+
+  get url () {
+    if (!this._url) {
+      const port = this.wdaLocalPort || WDA_AGENT_PORT;
+      const {protocol, hostname} = url.parse(this.wdaBaseUrl || WDA_BASE_URL);
+      this._url = url.parse(`${protocol}//${hostname}:${port}`);
+    }
+    return this._url;
+  }
+
+  set url (_url) {
+    this._url = url.parse(_url);
+  }
+
+  get fullyStarted () {
+    return this.started;
+  }
+
+  set fullyStarted (started = false) {
+    this.started = started;
+  }
+
+  async retrieveDerivedDataPath () {
+    return await this.xcodebuild.retrieveDerivedDataPath();
+  }
+
+  /**
+   * Reuse running WDA if it has the same bundle id with updatedWDABundleId.
+   * Or reuse it if it has the default id without updatedWDABundleId.
+   * Uninstall it if the method faces an exception for the above situation.
+   *
+   * @param {string} updatedWDABundleId BundleId you'd like to use
+   */
+  async setupCaching () {
+    const status = await this.getStatus();
+    if (!status || !status.build) {
+      log.debug('WDA is currently not running. There is nothing to cache');
+      return;
+    }
+
+    const {
+      productBundleIdentifier,
+      upgradedAt,
+    } = status.build;
+    // for real device
+    if (util.hasValue(productBundleIdentifier) && util.hasValue(this.updatedWDABundleId) && this.updatedWDABundleId !== productBundleIdentifier) {
+      log.info(`Will uninstall running WDA since it has different bundle id. The actual value is '${productBundleIdentifier}'.`);
+      return await this.uninstall();
+    }
+    // for simulator
+    if (util.hasValue(productBundleIdentifier) && !util.hasValue(this.updatedWDABundleId) && WDA_RUNNER_BUNDLE_ID !== productBundleIdentifier) {
+      log.info(`Will uninstall running WDA since its bundle id is not equal to the default value ${WDA_RUNNER_BUNDLE_ID}`);
+      return await this.uninstall();
+    }
+
+    const actualUpgradeTimestamp = await getWDAUpgradeTimestamp(this.bootstrapPath);
+    log.debug(`Upgrade timestamp of the currently bundled WDA: ${actualUpgradeTimestamp}`);
+    log.debug(`Upgrade timestamp of the WDA on the device: ${upgradedAt}`);
+    if (actualUpgradeTimestamp && upgradedAt && _.toLower(`${actualUpgradeTimestamp}`) !== _.toLower(`${upgradedAt}`)) {
+      log.info('Will uninstall running WDA since it has different version in comparison to the one ' +
+        `which is bundled with appium-xcuitest-driver module (${actualUpgradeTimestamp} != ${upgradedAt})`);
+      return await this.uninstall();
+    }
+
+    const message = util.hasValue(productBundleIdentifier)
+      ? `Will reuse previously cached WDA instance at '${this.url.href}' with '${productBundleIdentifier}'`
+      : `Will reuse previously cached WDA instance at '${this.url.href}'`;
+    log.info(`${message}. Set the wdaLocalPort capability to a value different from ${this.url.port} if this is an undesired behavior.`);
+    this.webDriverAgentUrl = this.url.href;
+  }
+
+  /**
+   * Quit and uninstall running WDA.
+   */
+  async quitAndUninstall () {
+    await this.quit();
+    await this.uninstall();
+  }
+}
+
+export default WebDriverAgent;
+export { WebDriverAgent };

--- a/lib/xcodebuild.js
+++ b/lib/xcodebuild.js
@@ -1,0 +1,387 @@
+import { retryInterval } from 'asyncbox';
+import { SubProcess, exec } from 'teen_process';
+import { fs, logger } from 'appium-support';
+import log from './logger';
+import B from 'bluebird';
+import { setRealDeviceSecurity, generateXcodeConfigFile, setXctestrunFile,
+         updateProjectFile, resetProjectFile, killProcess,
+         getWDAUpgradeTimestamp, isTvOS } from './utils';
+import _ from 'lodash';
+import path from 'path';
+import { EOL } from 'os';
+import { WDA_RUNNER_BUNDLE_ID } from './constants';
+
+
+const DEFAULT_SIGNING_ID = 'iPhone Developer';
+const BUILD_TEST_DELAY = 1000;
+const RUNNER_SCHEME_IOS = 'WebDriverAgentRunner';
+const LIB_SCHEME_IOS = 'WebDriverAgentLib';
+
+const ERROR_WRITING_ATTACHMENT = 'Error writing attachment data to file';
+const ERROR_COPYING_ATTACHMENT = 'Error copying testing attachment';
+const IGNORED_ERRORS = [
+  ERROR_WRITING_ATTACHMENT,
+  ERROR_COPYING_ATTACHMENT,
+  'Failed to remove screenshot at path',
+];
+
+const RUNNER_SCHEME_TV = 'WebDriverAgentRunner_tvOS';
+const LIB_SCHEME_TV = 'WebDriverAgentLib_tvOS';
+
+const xcodeLog = logger.getLogger('Xcode');
+
+
+class XcodeBuild {
+  constructor (xcodeVersion, device, args = {}) {
+    this.xcodeVersion = xcodeVersion;
+
+    this.device = device;
+
+    this.realDevice = args.realDevice;
+
+    this.agentPath = args.agentPath;
+    this.bootstrapPath = args.bootstrapPath;
+
+    this.platformVersion = args.platformVersion;
+    this.platformName = args.platformName;
+    this.iosSdkVersion = args.iosSdkVersion;
+
+    this.showXcodeLog = args.showXcodeLog;
+
+    this.xcodeConfigFile = args.xcodeConfigFile;
+    this.xcodeOrgId = args.xcodeOrgId;
+    this.xcodeSigningId = args.xcodeSigningId || DEFAULT_SIGNING_ID;
+    this.keychainPath = args.keychainPath;
+    this.keychainPassword = args.keychainPassword;
+
+    this.prebuildWDA = args.prebuildWDA;
+    this.usePrebuiltWDA = args.usePrebuiltWDA;
+    this.useSimpleBuildTest = args.useSimpleBuildTest;
+
+    this.useXctestrunFile = args.useXctestrunFile;
+
+    this.launchTimeout = args.launchTimeout;
+
+    this.wdaRemotePort = args.wdaRemotePort;
+
+    this.updatedWDABundleId = args.updatedWDABundleId;
+    this.derivedDataPath = args.derivedDataPath;
+
+    this.mjpegServerPort = args.mjpegServerPort;
+  }
+
+  async init (noSessionProxy) {
+    this.noSessionProxy = noSessionProxy;
+
+    if (this.useXctestrunFile) {
+      const deviveInfo = {
+        isRealDevice: this.realDevice,
+        udid: this.device.udid,
+        platformVersion: this.platformVersion,
+        platformName: this.platformName
+      };
+      this.xctestrunFilePath = await setXctestrunFile(deviveInfo, this.iosSdkVersion, this.bootstrapPath, this.wdaRemotePort);
+      return;
+    }
+
+    // if necessary, update the bundleId to user's specification
+    if (this.realDevice) {
+      // In case the project still has the user specific bundle ID, reset the project file first.
+      // - We do this reset even if updatedWDABundleId is not specified,
+      //   since the previous updatedWDABundleId test has generated the user specific bundle ID project file.
+      // - We don't call resetProjectFile for simulator,
+      //   since simulator test run will work with any user specific bundle ID.
+      await resetProjectFile(this.agentPath);
+      if (this.updatedWDABundleId) {
+        await updateProjectFile(this.agentPath, this.updatedWDABundleId);
+      }
+    }
+  }
+
+  async retrieveDerivedDataPath () {
+    if (this.derivedDataPath) {
+      return this.derivedDataPath;
+    }
+
+    let stdout;
+    try {
+      ({stdout} = await exec('xcodebuild', ['-project', this.agentPath, '-showBuildSettings']));
+    } catch (err) {
+      log.warn(`Cannot retrieve WDA build settings. Original error: ${err.message}`);
+      return;
+    }
+
+    const pattern = /^\s*BUILD_DIR\s+=\s+(\/.*)/m;
+    const match = pattern.exec(stdout);
+    if (!match) {
+      log.warn(`Cannot parse WDA build dir from ${_.truncate(stdout, {length: 300})}`);
+      return;
+    }
+    log.debug(`Parsed BUILD_DIR configuration value: '${match[1]}'`);
+    // Derived data root is two levels higher over the build dir
+    this.derivedDataPath = path.dirname(path.dirname(path.normalize(match[1])));
+    log.debug(`Got derived data root: '${this.derivedDataPath}'`);
+    return this.derivedDataPath;
+  }
+
+  async reset () {
+    // if necessary, reset the bundleId to original value
+    if (this.realDevice && this.updatedWDABundleId) {
+      await resetProjectFile(this.agentPath);
+    }
+  }
+
+  async prebuild () {
+    // first do a build phase
+    log.debug('Pre-building WDA before launching test');
+    this.usePrebuiltWDA = true;
+    await this.start(true);
+
+    this.xcodebuild = null;
+
+    // pause a moment
+    await B.delay(BUILD_TEST_DELAY);
+  }
+
+  async cleanProject () {
+    const tmpIsTvOS = isTvOS(this.platformName);
+    const libScheme = tmpIsTvOS ? LIB_SCHEME_TV : LIB_SCHEME_IOS;
+    const runnerScheme = tmpIsTvOS ? RUNNER_SCHEME_TV : RUNNER_SCHEME_IOS;
+
+    for (const scheme of [libScheme, runnerScheme]) {
+      log.debug(`Cleaning the project scheme '${scheme}' to make sure there are no leftovers from previous installs`);
+      await exec('xcodebuild', [
+        'clean',
+        '-project', this.agentPath,
+        '-scheme', scheme,
+      ]);
+    }
+  }
+
+  getCommand (buildOnly = false) {
+    let cmd = 'xcodebuild';
+    let args;
+
+    // figure out the targets for xcodebuild
+    const [buildCmd, testCmd] = this.useSimpleBuildTest ? ['build', 'test'] : ['build-for-testing', 'test-without-building'];
+    if (buildOnly) {
+      args = [buildCmd];
+    } else if (this.usePrebuiltWDA || this.useXctestrunFile) {
+      args = [testCmd];
+    } else {
+      args = [buildCmd, testCmd];
+    }
+
+    if (this.useXctestrunFile) {
+      args.push('-xctestrun', this.xctestrunFilePath);
+    } else {
+      const runnerScheme = isTvOS(this.platformName) ? RUNNER_SCHEME_TV : RUNNER_SCHEME_IOS;
+      args.push('-project', this.agentPath, '-scheme', runnerScheme);
+      if (this.derivedDataPath) {
+        args.push('-derivedDataPath', this.derivedDataPath);
+      }
+    }
+    args.push('-destination', `id=${this.device.udid}`);
+
+    const versionMatch = new RegExp(/^(\d+)\.(\d+)/).exec(this.platformVersion);
+    if (versionMatch) {
+      args.push(`IPHONEOS_DEPLOYMENT_TARGET=${versionMatch[1]}.${versionMatch[2]}`);
+    } else {
+      log.warn(`Cannot parse major and minor version numbers from platformVersion "${this.platformVersion}". ` +
+               'Will build for the default platform instead');
+    }
+
+    if (this.realDevice && this.xcodeConfigFile) {
+      log.debug(`Using Xcode configuration file: '${this.xcodeConfigFile}'`);
+      args.push('-xcconfig', this.xcodeConfigFile);
+    }
+
+    if (!process.env.APPIUM_XCUITEST_TREAT_WARNINGS_AS_ERRORS) {
+      // This sometimes helps to survive Xcode updates
+      args.push('GCC_TREAT_WARNINGS_AS_ERRORS=0');
+    }
+
+    // Below option slightly reduces build time in debug build
+    // with preventing to generate `/Index/DataStore` which is used by development
+    args.push('COMPILER_INDEX_STORE_ENABLE=NO');
+
+    return {cmd, args};
+  }
+
+  async createSubProcess (buildOnly = false) {
+    if (!this.useXctestrunFile) {
+      if (this.realDevice) {
+        if (this.keychainPath && this.keychainPassword) {
+          await setRealDeviceSecurity(this.keychainPath, this.keychainPassword);
+        }
+        if (this.xcodeOrgId && this.xcodeSigningId && !this.xcodeConfigFile) {
+          this.xcodeConfigFile = await generateXcodeConfigFile(this.xcodeOrgId, this.xcodeSigningId);
+        }
+      }
+    }
+
+    const {cmd, args} = this.getCommand(buildOnly);
+    log.debug(`Beginning ${buildOnly ? 'build' : 'test'} with command '${cmd} ${args.join(' ')}' ` +
+              `in directory '${this.bootstrapPath}'`);
+    const env = Object.assign({}, process.env, {
+      USE_PORT: this.wdaRemotePort,
+      WDA_PRODUCT_BUNDLE_IDENTIFIER: this.updatedWDABundleId || WDA_RUNNER_BUNDLE_ID,
+    });
+    if (this.mjpegServerPort) {
+      // https://github.com/appium/WebDriverAgent/pull/105
+      env.MJPEG_SERVER_PORT = this.mjpegServerPort;
+    }
+    const upgradeTimestamp = await getWDAUpgradeTimestamp(this.bootstrapPath);
+    if (upgradeTimestamp) {
+      env.UPGRADE_TIMESTAMP = upgradeTimestamp;
+    }
+    const xcodebuild = new SubProcess(cmd, args, {
+      cwd: this.bootstrapPath,
+      env,
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let logXcodeOutput = !!this.showXcodeLog;
+    const logMsg = _.isBoolean(this.showXcodeLog)
+      ? `Output from xcodebuild ${this.showXcodeLog ? 'will' : 'will not'} be logged`
+      : 'Output from xcodebuild will only be logged if any errors are present there';
+    log.debug(`${logMsg}. To change this, use 'showXcodeLog' desired capability`);
+    xcodebuild.on('output', (stdout, stderr) => {
+      let out = stdout || stderr;
+      // we want to pull out the log file that is created, and highlight it
+      // for diagnostic purposes
+      if (out.includes('Writing diagnostic log for test session to')) {
+        // pull out the first line that begins with the path separator
+        // which *should* be the line indicating the log file generated
+        xcodebuild.logLocation = _.first(_.remove(out.trim().split('\n'), (v) => v.startsWith(path.sep)));
+        log.debug(`Log file for xcodebuild test: ${xcodebuild.logLocation}`);
+      }
+
+      // if we have an error we want to output the logs
+      // otherwise the failure is inscrutible
+      // but do not log permission errors from trying to write to attachments folder
+      const ignoreError = IGNORED_ERRORS.some((x) => out.includes(x));
+      if (this.showXcodeLog !== false && out.includes('Error Domain=') && !ignoreError) {
+        logXcodeOutput = true;
+
+        // terrible hack to handle case where xcode return 0 but is failing
+        xcodebuild._wda_error_occurred = true;
+      }
+
+      // do not log permission errors from trying to write to attachments folder
+      if (logXcodeOutput && !ignoreError) {
+        for (const line of out.split(EOL)) {
+          xcodeLog.error(line);
+          if (line) {
+            xcodebuild._wda_error_message += `${EOL}${line}`;
+          }
+        }
+      }
+    });
+
+    return xcodebuild;
+  }
+
+  async start (buildOnly = false) {
+    this.xcodebuild = await this.createSubProcess(buildOnly);
+    // Store xcodebuild message
+    this.xcodebuild._wda_error_message = '';
+
+    // wrap the start procedure in a promise so that we can catch, and report,
+    // any startup errors that are thrown as events
+    return await new B((resolve, reject) => {
+      this.xcodebuild.on('exit', async (code, signal) => {
+        log.error(`xcodebuild exited with code '${code}' and signal '${signal}'`);
+        // print out the xcodebuild file if users have asked for it
+        if (this.showXcodeLog && this.xcodebuild.logLocation) {
+          xcodeLog.error(`Contents of xcodebuild log file '${this.xcodebuild.logLocation}':`);
+          try {
+            let data = await fs.readFile(this.xcodebuild.logLocation, 'utf8');
+            for (let line of data.split('\n')) {
+              xcodeLog.error(line);
+            }
+          } catch (err) {
+            log.error(`Unable to access xcodebuild log file: '${err.message}'`);
+          }
+        }
+        this.xcodebuild.processExited = true;
+        if (this.xcodebuild._wda_error_occurred || (!signal && code !== 0)) {
+          return reject(new Error(`xcodebuild failed with code ${code}${EOL}` +
+            `xcodebuild error message:${EOL}${this.xcodebuild._wda_error_message}`));
+        }
+        // in the case of just building, the process will exit and that is our finish
+        if (buildOnly) {
+          return resolve();
+        }
+      });
+
+      return (async () => {
+        try {
+          let startTime = process.hrtime();
+          await this.xcodebuild.start(true);
+          if (!buildOnly) {
+            let status = await this.waitForStart(startTime);
+            resolve(status);
+          }
+        } catch (err) {
+          let msg = `Unable to start WebDriverAgent: ${err}`;
+          log.error(msg);
+          reject(new Error(msg));
+        }
+      })();
+    });
+  }
+
+  async waitForStart (startTime) {
+    // try to connect once every 0.5 seconds, until `launchTimeout` is up
+    log.debug(`Waiting up to ${this.launchTimeout}ms for WebDriverAgent to start`);
+    let currentStatus = null;
+    try {
+      let retries = parseInt(this.launchTimeout / 500, 10);
+      await retryInterval(retries, 1000, async () => {
+        if (this.xcodebuild.processExited) {
+          // there has been an error elsewhere and we need to short-circuit
+          return;
+        }
+        const proxyTimeout = this.noSessionProxy.timeout;
+        this.noSessionProxy.timeout = 1000;
+        try {
+          currentStatus = await this.noSessionProxy.command('/status', 'GET');
+          if (currentStatus && currentStatus.ios && currentStatus.ios.ip) {
+            this.agentUrl = currentStatus.ios.ip;
+          }
+          log.debug(`WebDriverAgent information:`);
+          log.debug(JSON.stringify(currentStatus, null, 2));
+        } catch (err) {
+          throw new Error(`Unable to connect to running WebDriverAgent: ${err.message}`);
+        } finally {
+          this.noSessionProxy.timeout = proxyTimeout;
+        }
+      });
+
+      if (this.xcodebuild.processExited) {
+        // there has been an error elsewhere and we need to short-circuit
+        return currentStatus;
+      }
+
+      let endTime = process.hrtime(startTime);
+      // must get [s, ns] array into ms
+      let startupTime = parseInt((endTime[0] * 1e9 + endTime[1]) / 1e6, 10);
+      log.debug(`WebDriverAgent successfully started after ${startupTime}ms`);
+    } catch (err) {
+      // at this point, if we have not had any errors from xcode itself (reported
+      // elsewhere), we can let this go through and try to create the session
+      log.debug(err.message);
+      log.warn(`Getting status of WebDriverAgent on device timed out. Continuing`);
+    }
+    return currentStatus;
+  }
+
+  async quit () {
+    await killProcess('xcodebuild', this.xcodebuild);
+  }
+}
+
+export { XcodeBuild };
+export default XcodeBuild;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "build/index.js",
   "scripts": {
     "test": "gulp once",
+    "e2e-test": "npm run build && _FORCE_LOGS=1 npx mocha -t 0 -R spec build/test/functional --exit",
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
     "clean:carthage": "gulp clean:carthage",
     "install:dependencies": "gulp install:dependencies",
@@ -47,9 +48,14 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "gulp": "^4.0.2",
-    "pre-commit": "^1.2.2"
+    "ios-uicatalog": "^3.5.0",
+    "mocha": "^6.2.1",
+    "pre-commit": "^1.2.2",
+    "wd": "^1.11.4"
   },
   "dependencies": {
+    "appium-base-driver": "^4.0.3",
+    "appium-ios-simulator": "^3.14.0",
     "appium-support": "^2.29.0",
     "asyncbox": "^2.5.3",
     "bluebird": "^3.5.5",

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -1,0 +1,146 @@
+import _ from 'lodash';
+import path from 'path';
+import glob from 'glob';
+import fs from 'fs';
+import { system, util } from 'appium-support';
+
+
+// translate integer environment variable to a boolean 0=false, !0=true
+function checkFeatureInEnv (envArg) {
+  let feature = parseInt(process.env[envArg], 10);
+  if (isNaN(feature)) {
+    feature = process.env[envArg];
+  }
+  return !!feature;
+}
+
+const PLATFORM_VERSION = process.env.PLATFORM_VERSION ? process.env.PLATFORM_VERSION : '11.3';
+const LAUNCH_WITH_IDB = process.env.LAUNCH_WITH_IDB;
+
+// If it's real device cloud, don't set a device name. Use dynamic device allocation.
+const DEVICE_NAME = process.env.DEVICE_NAME
+  ? process.env.DEVICE_NAME
+  : process.env.SAUCE_RDC
+    ? undefined
+    : util.compareVersions(PLATFORM_VERSION, '>=', '13.0') ? 'iPhone 8' : 'iPhone 6';
+
+const SHOW_XCODE_LOG = checkFeatureInEnv('SHOW_XCODE_LOG');
+const REAL_DEVICE = checkFeatureInEnv('REAL_DEVICE');
+let XCCONFIG_FILE = process.env.XCCONFIG_FILE;
+if (REAL_DEVICE && !XCCONFIG_FILE) {
+  // no xcconfig file specified, so try to find in the root directory of the package
+  // this happens once, at the start of a test run, so using sync method is ok
+  let cwd = path.resolve(__dirname, '..', '..', '..');
+  let files = glob.sync('*.xcconfig', { cwd });
+  if (files.length) {
+    XCCONFIG_FILE = path.resolve(cwd, _.first(files));
+  }
+}
+
+// Had to make these two optional dependencies so the tests
+// can still run in linux
+let uiCatalogPath;
+if (system.isMac() && !process.env.CLOUD) {
+  // iOS 13+ need a slightly different app to be able to get the correct automation
+  uiCatalogPath = parseInt(PLATFORM_VERSION, 10) >= 13
+    ? require('ios-uicatalog').uiKitCatalog.absolute
+    : require('ios-uicatalog').uiCatalog.absolute;
+}
+
+const apps = {};
+
+const CLOUD = process.env.CLOUD;
+
+if (REAL_DEVICE) {
+  if (CLOUD) {
+    apps.testAppId = 1;
+  } else {
+    apps.uiCatalogApp = uiCatalogPath.iphoneos;
+  }
+} else {
+  if (CLOUD) {
+    apps.uiCatalogApp = 'http://appium.github.io/appium/assets/UICatalog9.4.app.zip';
+    apps.touchIdApp = null; // TODO: Upload this to appium.io
+  } else {
+    apps.uiCatalogApp = uiCatalogPath.iphonesimulator;
+    apps.touchIdApp = path.resolve('.', 'test', 'assets', 'TouchIDExample.app');
+  }
+}
+
+const REAL_DEVICE_CAPS = REAL_DEVICE ? {
+  udid: 'auto',
+  xcodeConfigFile: XCCONFIG_FILE,
+  webkitResponseTimeout: 30000,
+  testobject_app_id: apps.testAppId,
+  testobject_api_key: process.env.SAUCE_RDC_ACCESS_KEY,
+  testobject_remote_appium_url: process.env.APPIUM_STAGING_URL, // TODO: Once RDC starts supporting this again, re-insert this
+} : {};
+
+let GENERIC_CAPS = {
+  platformName: 'iOS',
+  platformVersion: PLATFORM_VERSION,
+  deviceName: DEVICE_NAME,
+  automationName: 'XCUITest',
+  launchWithIDB: !!LAUNCH_WITH_IDB,
+  noReset: true,
+  maxTypingFrequency: 30,
+  clearSystemFiles: true,
+  showXcodeLog: SHOW_XCODE_LOG,
+  wdaLaunchTimeout: (60 * 1000 * 4),
+  wdaConnectionTimeout: (60 * 1000 * 8),
+  useNewWDA: true,
+};
+
+if (process.env.CLOUD) {
+  GENERIC_CAPS.platformVersion = process.env.CLOUD_PLATFORM_VERSION;
+  GENERIC_CAPS.build = process.env.SAUCE_BUILD;
+  GENERIC_CAPS.showIOSLog = false;
+  GENERIC_CAPS[process.env.APPIUM_BUNDLE_CAP || 'appium-version'] = {'appium-url': 'sauce-storage:appium.zip'};
+  // TODO: If it's SAUCE_RDC add the appium staging URL
+
+  // `name` will be set during session initialization
+}
+
+// on Travis, when load is high, the app often fails to build,
+// and tests fail, so use static one in assets if necessary,
+// but prefer to have one build locally
+// only do this for sim, since real device one needs to be built with dev creds
+if (!REAL_DEVICE && !process.env.CLOUD) {
+  // this happens a single time, at load-time for the test suite,
+  // so sync method is not overly problematic
+  if (!fs.existsSync(apps.uiCatalogApp)) {
+    apps.uiCatalogApp = path.resolve('.', 'test', 'assets',
+      `${parseInt(PLATFORM_VERSION, 10) >= 13 ? 'UIKitCatalog' : 'UICatalog'}-iphonesimulator.app`);
+  }
+  if (!fs.existsSync(apps.iosTestApp)) {
+    apps.iosTestApp = path.resolve('.', 'test', 'assets', 'TestApp-iphonesimulator.app');
+  }
+}
+
+const UICATALOG_CAPS = _.defaults({
+  app: apps.uiCatalogApp,
+}, GENERIC_CAPS, REAL_DEVICE_CAPS);
+
+const UICATALOG_SIM_CAPS = _.defaults({
+  app: apps.uiCatalogApp,
+}, GENERIC_CAPS);
+delete UICATALOG_SIM_CAPS.noReset; // do not want to have no reset on the tests that use this
+
+const W3C_CAPS = {
+  capabilities: {
+    alwaysMatch: UICATALOG_CAPS,
+    firstMatch: [{}],
+  }
+};
+
+let TVOS_CAPS = _.defaults({
+  platformName: 'tvOS',
+  bundleId: 'com.apple.TVSettings',
+  deviceName: 'Apple TV'
+}, GENERIC_CAPS);
+
+export {
+  UICATALOG_CAPS, UICATALOG_SIM_CAPS,
+  PLATFORM_VERSION, DEVICE_NAME, W3C_CAPS,
+  TVOS_CAPS
+};

--- a/test/functional/helpers/session.js
+++ b/test/functional/helpers/session.js
@@ -1,0 +1,164 @@
+import wd from 'wd';
+import request from 'request-promise';
+import { startServer } from '../../..';
+import { util } from 'appium-support';
+import _ from 'lodash';
+
+
+const {SAUCE_RDC, SAUCE_EMUSIM, CLOUD} = process.env;
+
+function getPort () {
+  if (SAUCE_EMUSIM || SAUCE_RDC) {
+    return 80;
+  }
+  return 4994;
+}
+
+function getHost () {
+  if (SAUCE_RDC) {
+    return 'appium.staging.testobject.org';
+  } else if (SAUCE_EMUSIM) {
+    return 'ondemand.saucelabs.com';
+  }
+
+  return process.env.REAL_DEVICE ? util.localIp() : 'localhost';
+}
+
+const HOST = getHost();
+const PORT = getPort();
+// on CI the timeout needs to be long, mostly so WDA can be built the first time
+const MOCHA_TIMEOUT = 60 * 1000 * (process.env.CI ? 0 : 4);
+const WDA_PORT = 8200;
+
+let driver, server;
+
+if (CLOUD) {
+  before(function () {
+    process.env.SAUCE_JOB_NAME = `${process.env.TRAVIS_JOB_NUMBER || 'Suite'}: ${this.test.parent.suites[0].title}`;
+  });
+
+  // on Sauce Labs we need to track the status of the job
+  afterEach(function () {
+    if (driver) {
+      let fullTitle;
+      if (!driver.name) {
+        // traverse the title tree to get the whole thing
+        let titles = [];
+        const currentTest = this.currentTest;
+        titles.push(currentTest.title);
+        let parent = currentTest.parent;
+        while (parent) {
+          if (parent.title) {
+            titles.push(parent.title);
+          }
+          parent = parent.parent;
+        }
+        fullTitle = titles.reverse().join('/');
+
+        // construct the name for the job
+        driver.name = `${process.env.TRAVIS_JOB_NUMBER || 'Suite'}: ${_.first(titles)}`;
+      }
+
+      // check for the first failure
+      if (!driver.errored && this.currentTest.state !== 'passed') {
+        // add the first failed job title to the name of the job
+        driver.name += ` (${fullTitle})`;
+        // and fail the whole job
+        driver.errored = true;
+      }
+    }
+
+    // wd puts info into the error object that mocha can't display easily
+    if (this.currentTest.err) {
+      console.error('ERROR:', JSON.stringify(this.currentTest.err, null, 2)); // eslint-disable-line
+    }
+  });
+}
+
+async function initDriver () { // eslint-disable-line require-await
+  const config = {host: HOST, port: PORT};
+  driver = CLOUD
+    ? await wd.promiseChainRemote(config, process.env.SAUCE_USERNAME, process.env.SAUCE_ACCESS_KEY)
+    : await wd.promiseChainRemote(config);
+  driver.name = undefined;
+  driver.errored = false;
+  return driver;
+}
+
+async function initServer () {
+  server = await startServer(PORT, HOST);
+}
+
+function getServer () {
+  return server;
+}
+
+async function initWDA (caps) {
+  // first, see if this is necessary
+  try {
+    await request.get({url: `http://${HOST}:${WDA_PORT}/status`});
+  } catch (err) {
+    // easiest way to initialize WDA is to go through a test startup
+    // otherwise every change to the system would require a change here
+    const desiredCaps = Object.assign({
+      autoLaunch: false,
+      wdaLocalPort: WDA_PORT,
+    }, caps);
+    await driver.init(desiredCaps);
+    await driver.quit();
+  }
+}
+
+async function initSession (caps) {
+  if (!CLOUD) {
+    await initServer();
+  }
+
+  if (CLOUD) {
+    // on cloud tests, we want to set the `name` capability
+    if (!caps.name) {
+      caps.name = process.env.SAUCE_JOB_NAME || process.env.TRAVIS_JOB_NUMBER || 'unnamed';
+    }
+  }
+
+  await initDriver();
+
+  if (process.env.USE_WEBDRIVERAGENTURL) {
+    await initWDA(caps);
+    caps = Object.assign({
+      webDriverAgentUrl: `http://${HOST}:${WDA_PORT}`,
+      wdaLocalPort: WDA_PORT,
+    }, caps);
+  }
+
+  const serverRes = await driver.init(caps);
+  if (!caps.udid && !caps.fullReset && serverRes[1].udid) {
+    caps.udid = serverRes[1].udid;
+  }
+
+  return driver;
+}
+
+async function deleteSession () {
+  try {
+    if (CLOUD) {
+      await driver.sauceJobUpdate({
+        name: driver.name,
+        passed: !driver.errored,
+      });
+    }
+  } catch (ign) {}
+
+  try {
+    await driver.quit();
+  } catch (ign) {
+  } finally {
+    driver = undefined;
+  }
+
+  try {
+    await server.close();
+  } catch (ign) {}
+}
+
+export { initDriver, initSession, deleteSession, getServer, HOST, PORT, MOCHA_TIMEOUT };

--- a/test/functional/helpers/simulator.js
+++ b/test/functional/helpers/simulator.js
@@ -1,0 +1,38 @@
+import _ from 'lodash';
+import { getDevices, shutdown, deleteDevice } from 'node-simctl';
+import { retryInterval } from 'asyncbox';
+import { killAllSimulators as simKill } from 'appium-ios-simulator';
+import { resetTestProcesses } from '../../../lib/utils';
+
+
+async function killAllSimulators () {
+  if (process.env.CLOUD) {
+    return;
+  }
+
+  const allDevices = _.flatMap(_.values(await getDevices()));
+  const bootedDevices = allDevices.filter((device) => device.state === 'Booted');
+
+  for (const {udid} of bootedDevices) {
+    // It is necessary to stop the corresponding xcodebuild process before killing
+    // the simulator, otherwise it will be automatically restarted
+    await resetTestProcesses(udid, true);
+    await shutdown(udid);
+  }
+  await simKill();
+}
+
+async function shutdownSimulator (device) {
+  // stop XCTest processes if running to avoid unexpected side effects
+  await resetTestProcesses(device.udid, true);
+  await device.shutdown();
+}
+
+async function deleteDeviceWithRetry (udid) {
+  try {
+    await retryInterval(10, 1000, deleteDevice, udid);
+  } catch (ign) {}
+}
+
+
+export { killAllSimulators, shutdownSimulator, deleteDeviceWithRetry };

--- a/test/functional/webdriveragent-derived-data-path-e2e-specs.js
+++ b/test/functional/webdriveragent-derived-data-path-e2e-specs.js
@@ -1,0 +1,62 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { getSimulator } from 'appium-ios-simulator';
+import { shutdownSimulator, deleteDeviceWithRetry } from './helpers/simulator';
+import { createDevice } from 'node-simctl';
+import { MOCHA_TIMEOUT, initSession, deleteSession } from './helpers/session';
+import { UICATALOG_SIM_CAPS } from './desired';
+import path from 'path';
+import fs from 'fs';
+
+
+const SIM_DEVICE_NAME = 'xcuitestDriverTest';
+const TEMP_FOLDER = '/tmp/WebDriverAgent';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('WebDriverAgent Derived Data Path', function () {
+  this.timeout(MOCHA_TIMEOUT);
+
+  let baseCaps;
+  let caps;
+
+  let driver;
+  before(async function () {
+    const udid = await createDevice(
+      SIM_DEVICE_NAME,
+      UICATALOG_SIM_CAPS.deviceName,
+      UICATALOG_SIM_CAPS.platformVersion
+    );
+    baseCaps = Object.assign({}, UICATALOG_SIM_CAPS, {udid});
+    caps = Object.assign({
+      usePrebuiltWDA: true,
+      agentPath: path.join(TEMP_FOLDER, 'WebDriverAgent.xcodeproj'),
+      derivedDataPath: path.join(TEMP_FOLDER, 'DerivedData', 'WebDriverAgent')
+    }, baseCaps);
+    // copy existing WebDriverAgent to the selected derivedDataPath folder
+    const wda_path = path.join(process.cwd(), 'WebDriverAgent');
+    fs.symlinkSync(wda_path, TEMP_FOLDER);
+  });
+  after(async function () {
+    const sim = await getSimulator(caps.udid);
+    await shutdownSimulator(sim);
+    await deleteDeviceWithRetry(caps.udid);
+    // delete created tmp folder
+    fs.unlinkSync(TEMP_FOLDER);
+  });
+
+  afterEach(async function () {
+    // try to get rid of the driver, so if a test fails the rest of the
+    // tests aren't compromised
+    await deleteSession();
+  });
+
+  if (!process.env.REAL_DEVICE) {
+    it.skip('should start and stop a session', async function () {
+      driver = await initSession(caps, this);
+      let els = await driver.elementsByClassName('XCUIElementTypeWindow');
+      els.length.should.be.at.least(1);
+    });
+  }
+});

--- a/test/functional/webdriveragent-e2e-specs.js
+++ b/test/functional/webdriveragent-e2e-specs.js
@@ -1,0 +1,113 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { createDevice, deleteDevice } from 'node-simctl';
+import { getVersion } from 'appium-xcode';
+import { getSimulator } from 'appium-ios-simulator';
+import { killAllSimulators, shutdownSimulator } from './helpers/simulator';
+import request from 'request-promise';
+import { SubProcess } from 'teen_process';
+import { PLATFORM_VERSION, DEVICE_NAME } from './desired';
+import { retryInterval } from 'asyncbox';
+import { WebDriverAgent } from '../..';
+
+
+const SIM_DEVICE_NAME = 'webDriverAgentTest';
+
+const MOCHA_TIMEOUT = 60 * 1000 * (process.env.CI ? 0 : 4);
+
+chai.should();
+chai.use(chaiAsPromised);
+
+let testUrl = 'http://localhost:8100/tree';
+
+function getStartOpts (device) {
+  return {
+    device,
+    platformVersion: PLATFORM_VERSION,
+    host: 'localhost',
+    port: 8100,
+    realDevice: false
+  };
+}
+
+
+describe('WebDriverAgent', function () {
+  this.timeout(MOCHA_TIMEOUT);
+
+  let xcodeVersion;
+  before(async function () {
+    // Don't do these tests on Sauce Labs
+    if (process.env.CLOUD) {
+      this.skip();
+    }
+
+    xcodeVersion = await getVersion(true);
+  });
+  describe('with fresh sim', function () {
+    let device;
+    before(async function () {
+      let simUdid = await createDevice(
+        SIM_DEVICE_NAME,
+        DEVICE_NAME,
+        PLATFORM_VERSION
+      );
+      device = await getSimulator(simUdid);
+    });
+
+    after(async function () {
+      this.timeout(MOCHA_TIMEOUT);
+
+      await shutdownSimulator(device);
+
+      await deleteDevice(device.udid);
+    });
+
+    describe('with running sim', function () {
+      this.timeout(6 * 60 * 1000);
+      beforeEach(async function () {
+        await killAllSimulators();
+        await device.run();
+      });
+      afterEach(async function () {
+        try {
+          await retryInterval(5, 1000, async function () {
+            await shutdownSimulator(device);
+          });
+        } catch (ign) {}
+      });
+
+      it('should launch agent on a sim', async function () {
+        const agent = new WebDriverAgent(xcodeVersion, getStartOpts(device));
+
+        await agent.launch('sessionId');
+        await request(testUrl).should.be.eventually.rejectedWith(/unknown command/);
+        await agent.quit();
+      });
+
+      it('should fail if xcodebuild fails', async function () {
+        // short timeout
+        this.timeout(35 * 1000);
+
+        const agent = new WebDriverAgent(xcodeVersion, getStartOpts(device));
+
+        agent.xcodebuild.createSubProcess = async function () { // eslint-disable-line require-await
+          let args = [
+            '-workspace',
+            `${this.agentPath}dfgs`,
+            // '-scheme',
+            // 'XCTUITestRunner',
+            // '-destination',
+            // `id=${this.device.udid}`,
+            // 'test'
+          ];
+          return new SubProcess('xcodebuild', args, {detached: true});
+        };
+
+        await agent.launch('sessionId')
+          .should.eventually.be.rejectedWith('xcodebuild failed');
+
+        await agent.quit();
+      });
+    });
+  });
+});

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -1,0 +1,162 @@
+import { getXctestrunFilePath, getAdditionalRunContent, getXctestrunFileName } from '../../lib/utils';
+import { PLATFORM_NAME_IOS, PLATFORM_NAME_TVOS } from '../../lib/constants';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { withMocks } from 'appium-test-support';
+import { fs } from 'appium-support';
+import path from 'path';
+import { fail } from 'assert';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('utils', function () {
+  describe('#getXctestrunFilePath', withMocks({fs}, function (mocks) {
+    const platformVersion = '12.0';
+    const sdkVersion = '12.2';
+    const udid = 'xxxxxyyyyyyzzzzzz';
+    const bootstrapPath = 'path/to/data';
+    const platformName = PLATFORM_NAME_IOS;
+
+    afterEach(function () {
+      mocks.verify();
+    });
+
+    it('should return sdk based path with udid', async function () {
+      mocks.fs.expects('exists')
+        .withExactArgs(path.resolve(`${bootstrapPath}/${udid}_${sdkVersion}.xctestrun`))
+        .returns(true);
+      mocks.fs.expects('copyFile')
+        .never();
+      const deviceInfo = {isRealDevice: true, udid, platformVersion, platformName};
+      await getXctestrunFilePath(deviceInfo, sdkVersion, bootstrapPath)
+        .should.eventually.equal(path.resolve(`${bootstrapPath}/${udid}_${sdkVersion}.xctestrun`));
+    });
+
+    it('should return sdk based path without udid, copy them', async function () {
+      mocks.fs.expects('exists')
+        .withExactArgs(path.resolve(`${bootstrapPath}/${udid}_${sdkVersion}.xctestrun`))
+        .returns(false);
+      mocks.fs.expects('exists')
+        .withExactArgs(path.resolve(`${bootstrapPath}/WebDriverAgentRunner_iphoneos${sdkVersion}-arm64.xctestrun`))
+        .returns(true);
+      mocks.fs.expects('copyFile')
+        .withExactArgs(
+          path.resolve(`${bootstrapPath}/WebDriverAgentRunner_iphoneos${sdkVersion}-arm64.xctestrun`),
+          path.resolve(`${bootstrapPath}/${udid}_${sdkVersion}.xctestrun`)
+        )
+        .returns(true);
+      const deviceInfo = {isRealDevice: true, udid, platformVersion};
+      await getXctestrunFilePath(deviceInfo, sdkVersion, bootstrapPath)
+        .should.eventually.equal(path.resolve(`${bootstrapPath}/${udid}_${sdkVersion}.xctestrun`));
+    });
+
+    it('should return platform based path', async function () {
+      mocks.fs.expects('exists')
+        .withExactArgs(path.resolve(`${bootstrapPath}/${udid}_${sdkVersion}.xctestrun`))
+        .returns(false);
+      mocks.fs.expects('exists')
+        .withExactArgs(path.resolve(`${bootstrapPath}/WebDriverAgentRunner_iphonesimulator${sdkVersion}-x86_64.xctestrun`))
+        .returns(false);
+      mocks.fs.expects('exists')
+        .withExactArgs(path.resolve(`${bootstrapPath}/${udid}_${platformVersion}.xctestrun`))
+        .returns(true);
+      mocks.fs.expects('copyFile')
+        .never();
+      const deviceInfo = {isRealDevice: false, udid, platformVersion};
+      await getXctestrunFilePath(deviceInfo, sdkVersion, bootstrapPath)
+        .should.eventually.equal(path.resolve(`${bootstrapPath}/${udid}_${platformVersion}.xctestrun`));
+    });
+
+    it('should return platform based path without udid, copy them', async function () {
+      mocks.fs.expects('exists')
+        .withExactArgs(path.resolve(`${bootstrapPath}/${udid}_${sdkVersion}.xctestrun`))
+        .returns(false);
+      mocks.fs.expects('exists')
+        .withExactArgs(path.resolve(`${bootstrapPath}/WebDriverAgentRunner_iphonesimulator${sdkVersion}-x86_64.xctestrun`))
+        .returns(false);
+      mocks.fs.expects('exists')
+        .withExactArgs(path.resolve(`${bootstrapPath}/${udid}_${platformVersion}.xctestrun`))
+        .returns(false);
+      mocks.fs.expects('exists')
+        .withExactArgs(path.resolve(`${bootstrapPath}/WebDriverAgentRunner_iphonesimulator${platformVersion}-x86_64.xctestrun`))
+        .returns(true);
+      mocks.fs.expects('copyFile')
+        .withExactArgs(
+          path.resolve(`${bootstrapPath}/WebDriverAgentRunner_iphonesimulator${platformVersion}-x86_64.xctestrun`),
+          path.resolve(`${bootstrapPath}/${udid}_${platformVersion}.xctestrun`)
+        )
+        .returns(true);
+
+      const deviceInfo = {isRealDevice: false, udid, platformVersion};
+      await getXctestrunFilePath(deviceInfo, sdkVersion, bootstrapPath)
+        .should.eventually.equal(path.resolve(`${bootstrapPath}/${udid}_${platformVersion}.xctestrun`));
+    });
+
+    it('should raise an exception because of no files', async function () {
+      const expected = path.resolve(`${bootstrapPath}/WebDriverAgentRunner_iphonesimulator${sdkVersion}-x86_64.xctestrun`);
+      mocks.fs.expects('exists').exactly(4).returns(false);
+
+      const deviceInfo = {isRealDevice: false, udid, platformVersion};
+      try {
+        await getXctestrunFilePath(deviceInfo, sdkVersion, bootstrapPath);
+        fail();
+      } catch (err) {
+        err.message.should.equal(`If you are using 'useXctestrunFile' capability then you need to have a xctestrun file (expected: '${expected}')`);
+      }
+    });
+  }));
+
+  describe('#getAdditionalRunContent', function () {
+    it('should return ios format', function () {
+      const wdaPort = getAdditionalRunContent(PLATFORM_NAME_IOS, 8000);
+      wdaPort.WebDriverAgentRunner
+        .EnvironmentVariables.USE_PORT
+        .should.equal(8000);
+    });
+
+    it('should return tvos format', function () {
+      const wdaPort = getAdditionalRunContent(PLATFORM_NAME_TVOS, '9000');
+      wdaPort.WebDriverAgentRunner_tvOS
+        .EnvironmentVariables.USE_PORT
+        .should.equal('9000');
+    });
+  });
+
+  describe('#getXctestrunFileName', function () {
+    const platformVersion = '12.0';
+    const udid = 'xxxxxyyyyyyzzzzzz';
+
+    it('should return ios format, real device', function () {
+      const platformName = 'iOs';
+      const deviceInfo = {isRealDevice: true, udid, platformVersion, platformName};
+
+      getXctestrunFileName(deviceInfo, '10.2.0').should.equal(
+        'WebDriverAgentRunner_iphoneos10.2.0-arm64.xctestrun');
+    });
+
+    it('should return ios format, simulator', function () {
+      const platformName = 'ios';
+      const deviceInfo = {isRealDevice: false, udid, platformVersion, platformName};
+
+      getXctestrunFileName(deviceInfo, '10.2.0').should.equal(
+        'WebDriverAgentRunner_iphonesimulator10.2.0-x86_64.xctestrun');
+    });
+
+    it('should return tvos format, real device', function () {
+      const platformName = 'tVos';
+      const deviceInfo = {isRealDevice: true, udid, platformVersion, platformName};
+
+      getXctestrunFileName(deviceInfo, '10.2.0').should.equal(
+        'WebDriverAgentRunner_tvOS_appletvos10.2.0-arm64.xctestrun');
+    });
+
+    it('should return tvos format, simulator', function () {
+      const platformName = 'tvOS';
+      const deviceInfo = {isRealDevice: false, udid, platformVersion, platformName};
+
+      getXctestrunFileName(deviceInfo, '10.2.0').should.equal(
+        'WebDriverAgentRunner_tvOS_appletvsimulator10.2.0-x86_64.xctestrun');
+    });
+  });
+});

--- a/test/unit/webdriveragent-specs.js
+++ b/test/unit/webdriveragent-specs.js
@@ -1,0 +1,380 @@
+import { WebDriverAgent, BOOTSTRAP_PATH } from '../..';
+import * as dependencies from '../../lib/check-dependencies';
+import * as utils from '../../lib/utils';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import path from 'path';
+import _ from 'lodash';
+import sinon from 'sinon';
+import { withMocks } from 'appium-test-support';
+import { fs } from 'appium-support';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+const fakeConstructorArgs = {
+  device: 'some sim',
+  platformVersion: '9',
+  host: 'me',
+  port: '5000',
+  realDevice: false
+};
+
+const defaultAgentPath = path.resolve(BOOTSTRAP_PATH, 'WebDriverAgent.xcodeproj');
+const customBootstrapPath = '/path/to/wda';
+const customAgentPath = '/path/to/some/agent/WebDriverAgent.xcodeproj';
+const customDerivedDataPath = '/path/to/some/agent/DerivedData/';
+
+describe('Constructor', function () {
+  it('should have a default wda agent if not specified', function () {
+    let agent = new WebDriverAgent({}, fakeConstructorArgs);
+    agent.bootstrapPath.should.eql(BOOTSTRAP_PATH);
+    agent.agentPath.should.eql(defaultAgentPath);
+  });
+  it('should have custom wda bootstrap and default agent if only bootstrap specified', function () {
+    let agent = new WebDriverAgent({}, _.defaults({
+      bootstrapPath: customBootstrapPath,
+    }, fakeConstructorArgs));
+    agent.bootstrapPath.should.eql(customBootstrapPath);
+    agent.agentPath.should.eql(path.resolve(customBootstrapPath, 'WebDriverAgent.xcodeproj'));
+  });
+  it('should have custom wda bootstrap and agent if both specified', function () {
+    let agent = new WebDriverAgent({}, _.defaults({
+      bootstrapPath: customBootstrapPath,
+      agentPath: customAgentPath,
+    }, fakeConstructorArgs));
+    agent.bootstrapPath.should.eql(customBootstrapPath);
+    agent.agentPath.should.eql(customAgentPath);
+  });
+  it('should have custom derivedDataPath if specified', function () {
+    let agent = new WebDriverAgent({}, _.defaults({
+      derivedDataPath: customDerivedDataPath
+    }, fakeConstructorArgs));
+    agent.xcodebuild.derivedDataPath.should.eql(customDerivedDataPath);
+  });
+});
+
+describe('checking for dependencies', function () {
+  const wda = new WebDriverAgent('12.1');
+  const xcodebuild = wda.xcodebuild;
+  describe('#launch', withMocks({wda, fs, dependencies, xcodebuild}, function (mocks) {
+
+    afterEach(function () {
+      mocks.verify();
+    });
+
+    it('should call checkForDependencies', async function () {
+      wda.useXctestrunFile = false;
+      wda.usePrebuiltWDA = false;
+      wda.derivedDataPath = undefined;
+      wda.device = {};
+      wda.device.udid = 'udid';
+
+      mocks.wda.expects('setupProxies').once().returns();
+      mocks.fs.expects('exists').returns(true);
+      mocks.dependencies.expects('checkForDependencies').once().returns(false);
+      mocks.xcodebuild.expects('init').once().returns();
+      mocks.xcodebuild.expects('start').once().returns();
+
+      await wda.launch();
+    });
+
+    it('should call checkForDependencies since only usePrebuiltWDA', async function () {
+      wda.useXctestrunFile = false;
+      wda.usePrebuiltWDA = true;
+      wda.derivedDataPath = undefined;
+      wda.device = {};
+      wda.device.udid = 'udid';
+
+      mocks.wda.expects('setupProxies').once().returns();
+      mocks.fs.expects('exists').returns(true);
+      mocks.dependencies.expects('checkForDependencies').once().returns(false);
+      mocks.xcodebuild.expects('init').once().returns();
+      mocks.xcodebuild.expects('start').once().returns();
+
+      await wda.launch();
+    });
+
+    it('should not call checkForDependencies with usePrebuiltWDA and derivedDataPath', async function () {
+      wda.useXctestrunFile = false;
+      wda.usePrebuiltWDA = true;
+      wda.derivedDataPath = 'path/to/data';
+      wda.device = {};
+      wda.device.udid = 'udid';
+
+      mocks.wda.expects('setupProxies').once().returns();
+      mocks.fs.expects('exists').returns(true);
+      mocks.dependencies.expects('checkForDependencies').never();
+      mocks.xcodebuild.expects('init').once().returns();
+      mocks.xcodebuild.expects('start').once().returns();
+
+      await wda.launch();
+    });
+
+    it('should not call checkForDependencies with useXctestrunFile', async function () {
+      wda.useXctestrunFile = true;
+      wda.usePrebuiltWDA = false;
+      wda.derivedDataPath = undefined;
+      wda.device = {};
+      wda.device.udid = 'udid';
+
+      mocks.wda.expects('setupProxies').once().returns();
+      mocks.fs.expects('exists').returns(true);
+      mocks.dependencies.expects('checkForDependencies').never();
+      mocks.xcodebuild.expects('init').once().returns();
+      mocks.xcodebuild.expects('start').once().returns();
+
+      await wda.launch();
+    });
+  }));
+});
+
+
+describe('launch', function () {
+  it('should use webDriverAgentUrl override and return current status', async function () {
+    let override = 'http://mockurl:8100/';
+    let args = Object.assign({}, fakeConstructorArgs);
+    args.webDriverAgentUrl = override;
+    let agent = new WebDriverAgent({}, args);
+    let wdaStub = sinon.stub(agent, 'getStatus');
+    wdaStub.callsFake(function () {
+      return {build: 'data'};
+    });
+
+    await agent.launch('sessionId').should.eventually.eql({build: 'data'});
+    agent.url.href.should.eql(override);
+    wdaStub.reset();
+  });
+});
+
+describe('get url', function () {
+  it('should use default WDA listening url', function () {
+    const args = Object.assign({}, fakeConstructorArgs);
+    const agent = new WebDriverAgent({}, args);
+    agent.url.href.should.eql('http://localhost:8100/');
+  });
+  it('should use default WDA listening url with emply base url', function () {
+    const wdaLocalPort = '9100';
+    const wdaBaseUrl = '';
+
+    const args = Object.assign({}, fakeConstructorArgs);
+    args.wdaBaseUrl = wdaBaseUrl;
+    args.wdaLocalPort = wdaLocalPort;
+
+    const agent = new WebDriverAgent({}, args);
+    agent.url.href.should.eql('http://localhost:9100/');
+  });
+  it('should use customised WDA listening url', function () {
+    const wdaLocalPort = '9100';
+    const wdaBaseUrl = 'http://mockurl';
+
+    const args = Object.assign({}, fakeConstructorArgs);
+    args.wdaBaseUrl = wdaBaseUrl;
+    args.wdaLocalPort = wdaLocalPort;
+
+    const agent = new WebDriverAgent({}, args);
+    agent.url.href.should.eql('http://mockurl:9100/');
+  });
+  it('should use customised WDA listening url with slash', function () {
+    const wdaLocalPort = '9100';
+    const wdaBaseUrl = 'http://mockurl/';
+
+    const args = Object.assign({}, fakeConstructorArgs);
+    args.wdaBaseUrl = wdaBaseUrl;
+    args.wdaLocalPort = wdaLocalPort;
+
+    const agent = new WebDriverAgent({}, args);
+    agent.url.href.should.eql('http://mockurl:9100/');
+  });
+});
+
+describe('setupCaching()', function () {
+  let wda;
+  let wdaStub;
+  let wdaStubUninstall;
+  const getTimestampStub = sinon.stub(utils, 'getWDAUpgradeTimestamp');
+
+  beforeEach(function () {
+    wda = new WebDriverAgent('1');
+    wdaStub = sinon.stub(wda, 'getStatus');
+    wdaStubUninstall = sinon.stub(wda, 'uninstall');
+  });
+
+  afterEach(function () {
+    for (const stub of [wdaStub, wdaStubUninstall, getTimestampStub]) {
+      if (stub) {
+        stub.reset();
+      }
+    }
+  });
+
+  it('should not call uninstall since no Running WDA', async function () {
+    wdaStub.callsFake(function () {
+      return null;
+    });
+    wdaStubUninstall.callsFake(_.noop);
+
+    await wda.setupCaching();
+    wdaStub.calledOnce.should.be.true;
+    wdaStubUninstall.notCalled.should.be.true;
+    _.isUndefined(wda.webDriverAgentUrl).should.be.true;
+  });
+
+  it('should not call uninstall since running WDA has only time', async function () {
+    wdaStub.callsFake(function () {
+      return {build: { time: 'Jun 24 2018 17:08:21' }};
+    });
+    wdaStubUninstall.callsFake(_.noop);
+
+    await wda.setupCaching();
+    wdaStub.calledOnce.should.be.true;
+    wdaStubUninstall.notCalled.should.be.true;
+    wda.webDriverAgentUrl.should.equal('http://localhost:8100/');
+  });
+
+  it('should call uninstall once since bundle id is not default without updatedWDABundleId capability', async function () {
+    wdaStub.callsFake(function () {
+      return {build: { time: 'Jun 24 2018 17:08:21', productBundleIdentifier: 'com.example.WebDriverAgent' }};
+    });
+    wdaStubUninstall.callsFake(_.noop);
+
+    await wda.setupCaching();
+    wdaStub.calledOnce.should.be.true;
+    wdaStubUninstall.calledOnce.should.be.true;
+    _.isUndefined(wda.webDriverAgentUrl).should.be.true;
+  });
+
+  it('should call uninstall once since bundle id is different with updatedWDABundleId capability', async function () {
+    wdaStub.callsFake(function () {
+      return {build: { time: 'Jun 24 2018 17:08:21', productBundleIdentifier: 'com.example.different.WebDriverAgent' }};
+    });
+
+    wdaStubUninstall.callsFake(_.noop);
+
+    await wda.setupCaching();
+    wdaStub.calledOnce.should.be.true;
+    wdaStubUninstall.calledOnce.should.be.true;
+    _.isUndefined(wda.webDriverAgentUrl).should.be.true;
+  });
+
+  it('should not call uninstall since bundle id is equal to updatedWDABundleId capability', async function () {
+    wda = new WebDriverAgent('1', { updatedWDABundleId: 'com.example.WebDriverAgent' });
+    wdaStub = sinon.stub(wda, 'getStatus');
+    wdaStubUninstall = sinon.stub(wda, 'uninstall');
+
+    wdaStub.callsFake(function () {
+      return {build: { time: 'Jun 24 2018 17:08:21', productBundleIdentifier: 'com.example.WebDriverAgent' }};
+    });
+
+    wdaStubUninstall.callsFake(_.noop);
+
+    await wda.setupCaching();
+    wdaStub.calledOnce.should.be.true;
+    wdaStubUninstall.notCalled.should.be.true;
+    wda.webDriverAgentUrl.should.equal('http://localhost:8100/');
+  });
+
+  it('should call uninstall if current revision differs from the bundled one', async function () {
+    wdaStub.callsFake(function () {
+      return {build: { upgradedAt: '1' }};
+    });
+    getTimestampStub.callsFake(() => '2');
+    wdaStubUninstall.callsFake(_.noop);
+
+    await wda.setupCaching();
+    wdaStub.calledOnce.should.be.true;
+    wdaStubUninstall.calledOnce.should.be.true;
+  });
+
+  it('should not call uninstall if current revision is the same as the bundled one', async function () {
+    wdaStub.callsFake(function () {
+      return {build: { upgradedAt: '1' }};
+    });
+    getTimestampStub.callsFake(() => '1');
+    wdaStubUninstall.callsFake(_.noop);
+
+    await wda.setupCaching();
+    wdaStub.calledOnce.should.be.true;
+    wdaStubUninstall.notCalled.should.be.true;
+  });
+
+  it('should not call uninstall if current revision cannot be retrieved from WDA status', async function () {
+    wdaStub.callsFake(function () {
+      return {build: {}};
+    });
+    getTimestampStub.callsFake(() => '1');
+    wdaStubUninstall.callsFake(_.noop);
+
+    await wda.setupCaching();
+    wdaStub.calledOnce.should.be.true;
+    wdaStubUninstall.notCalled.should.be.true;
+  });
+
+  it('should not call uninstall if current revision cannot be retrieved from the file system', async function () {
+    wdaStub.callsFake(function () {
+      return {build: { upgradedAt: '1' }};
+    });
+    getTimestampStub.callsFake(() => null);
+    wdaStubUninstall.callsFake(_.noop);
+
+    await wda.setupCaching();
+    wdaStub.calledOnce.should.be.true;
+    wdaStubUninstall.notCalled.should.be.true;
+  });
+
+  describe('uninstall', function () {
+    let device;
+    let wda;
+    let deviceGetBundleIdsStub;
+    let deviceRemoveAppStub;
+
+    beforeEach(function () {
+      device = {
+        getUserInstalledBundleIdsByBundleName: () => {},
+        removeApp: () => {}
+      };
+      wda = new WebDriverAgent('1', {device});
+      deviceGetBundleIdsStub = sinon.stub(device, 'getUserInstalledBundleIdsByBundleName');
+      deviceRemoveAppStub = sinon.stub(device, 'removeApp');
+    });
+
+    afterEach(function () {
+      for (const stub of [deviceGetBundleIdsStub, deviceRemoveAppStub]) {
+        if (stub) {
+          stub.reset();
+        }
+      }
+    });
+
+    it('should not call uninstall', async function () {
+      deviceGetBundleIdsStub.callsFake(() => []);
+
+      await wda.uninstall();
+      deviceGetBundleIdsStub.calledOnce.should.be.true;
+      deviceRemoveAppStub.notCalled.should.be.true;
+    });
+
+    it('should call uninstall once', async function () {
+      const uninstalledBundIds = [];
+      deviceGetBundleIdsStub.callsFake(() => ['com.appium.WDA1']);
+      deviceRemoveAppStub.callsFake((id) => uninstalledBundIds.push(id));
+
+      await wda.uninstall();
+      deviceGetBundleIdsStub.calledOnce.should.be.true;
+      deviceRemoveAppStub.calledOnce.should.be.true;
+      uninstalledBundIds.should.eql(['com.appium.WDA1']);
+    });
+
+    it('should call uninstall twice', async function () {
+      const uninstalledBundIds = [];
+      deviceGetBundleIdsStub.callsFake(() => ['com.appium.WDA1', 'com.appium.WDA2']);
+      deviceRemoveAppStub.callsFake((id) => uninstalledBundIds.push(id));
+
+      await wda.uninstall();
+      deviceGetBundleIdsStub.calledOnce.should.be.true;
+      deviceRemoveAppStub.calledTwice.should.be.true;
+      uninstalledBundIds.should.eql(['com.appium.WDA1', 'com.appium.WDA2']);
+    });
+  });
+});


### PR DESCRIPTION
Move the contents of `lib/wda` from `appium-xcuitest-driver`, and associated unit and functional tests.