### PR TITLE
chore: add script that downloads prebuilt WDA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ node_modules
 bundles/
 webdriveragent-*.tar.gz
 uncompressed/
-webdriveragents/
+prebuilt-agents/

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ node_modules
 bundles/
 webdriveragent-*.tar.gz
 uncompressed/
+webdriveragents/

--- a/Scripts/fetch-prebuilt-wda.js
+++ b/Scripts/fetch-prebuilt-wda.js
@@ -2,32 +2,75 @@ const path = require('path');
 const request = require('request-promise');
 const { asyncify } = require('asyncbox');
 const { logger, fs, mkdirp } = require('appium-support');
-const { exec } = require('teen_process');
+const _fs = require('fs');
+const B = require('bluebird');
 
 const log = logger.getLogger('WDA');
 
 async function fetchPrebuiltWebDriverAgentAssets () {
   const tag = require('../package.json').version;
+  log.info(`Getting links to webdriveragent release ${tag}`);
   const downloadUrl = `https://api.github.com/repos/appium/webdriveragent/releases/tags/v${tag}`;
   log.info(`Getting WDA release ${downloadUrl}`);
-  const releases = await request.get(downloadUrl, {
-    headers: {
-      'user-agent': 'node.js',
-    },
-    json: true,
-  });
-  const webdriveragentsDir = path.resolve(__dirname, '..', 'webdriveragents');
-  log.info(`Downloading assets to: ${webdriveragentsDir}`);
+  let releases;
+  try {
+    releases = await request.get(downloadUrl, {
+      headers: {
+        'user-agent': 'appium',
+      },
+      json: true,
+    });
+  } catch (e) {
+    throw new Error(`Could not fetch endpoint '${downloadUrl}. Reason: ${e.message}'`);
+  }
+
+  const webdriveragentsDir = path.resolve(__dirname, '..', 'prebuilt-agents');
+  log.info(`Creating webdriveragents directory at: ${webdriveragentsDir}`);
   await fs.rimraf(webdriveragentsDir);
-  await mkdirp(webdriveragentsDir);
+  try {
+    await mkdirp(webdriveragentsDir);
+  } catch (e) {
+    throw new Error(`Could not create '${webdriveragentsDir}'. Reason: ${e.message}`);
+  }
+
+  // Define a method that does a streaming download of an asset
+  async function downloadAgent (url, targetPath) {
+    try {
+      // don't use request-promise here, we need streams
+      return await new B((resolve, reject) => {
+        request(url)
+          .on('error', reject) // handle real errors, like connection errors
+          .on('response', (res) => {
+            // handle responses that fail, like 404s
+            if (res.statusCode >= 400) {
+              return reject(new Error(`${res.statusCode} - ${res.statusMessage}`));
+            }
+          })
+          .pipe(_fs.createWriteStream(targetPath))
+          .on('close', resolve);
+      });
+    } catch (err) {
+      throw new Error(`Problem downloading webdriveragent from url ${url}: ${err.message}`);
+    }
+  }
+
+  log.info(`Downloading assets to: ${webdriveragentsDir}`);
+  const agentsDownloading = [];
   for (const asset of releases.assets) {
     const url = asset.browser_download_url;
     log.info(`Downloading: ${url}`);
     // wget never seems to exit successfully so just ignore non-zero status code
     try {
-      await exec('wget', [url, '.'], {cwd: webdriveragentsDir});
+      const nameOfAgent = (function (url) {
+        const urlTokens = url.split('/');
+        return urlTokens[urlTokens.length - 1];
+      })(url);
+      agentsDownloading.push(downloadAgent(url, path.join(webdriveragentsDir, nameOfAgent)));
     } catch (ign) { }
   }
+
+  // Wait for them all to finish
+  return await B.all(agentsDownloading);
 }
 
 if (require.main === module) {

--- a/Scripts/fetch-prebuilt-wda.js
+++ b/Scripts/fetch-prebuilt-wda.js
@@ -1,0 +1,37 @@
+const path = require('path');
+const request = require('request-promise');
+const { asyncify } = require('asyncbox');
+const { logger, fs, mkdirp } = require('appium-support');
+const { exec } = require('teen_process');
+
+const log = logger.getLogger('WDA');
+
+async function fetchPrebuiltWebDriverAgentAssets () {
+  const tag = require('../package.json').version;
+  const downloadUrl = `https://api.github.com/repos/appium/webdriveragent/releases/tags/v${tag}`;
+  log.info(`Getting WDA release ${downloadUrl}`);
+  const releases = await request.get(downloadUrl, {
+    headers: {
+      'user-agent': 'node.js',
+    },
+    json: true,
+  });
+  const webdriveragentsDir = path.resolve(__dirname, '..', 'webdriveragents');
+  log.info(`Downloading assets to: ${webdriveragentsDir}`);
+  await fs.rimraf(webdriveragentsDir);
+  await mkdirp(webdriveragentsDir);
+  for (const asset of releases.assets) {
+    const url = asset.browser_download_url;
+    log.info(`Downloading: ${url}`);
+    // wget never seems to exit successfully so just ignore non-zero status code
+    try {
+      await exec('wget', [url, '.'], {cwd: webdriveragentsDir});
+    } catch (ign) { }
+  }
+}
+
+if (require.main === module) {
+  asyncify(fetchPrebuiltWebDriverAgentAssets);
+}
+
+module.exports = fetchPrebuiltWebDriverAgentAssets;

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "gulp": "^4.0.2",
-    "pre-commit": "^1.2.2",
-    "rimraf": "^3.0.0"
+    "pre-commit": "^1.2.2"
   },
   "dependencies": {
     "appium-support": "^2.29.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint:fix": "gulp eslint --fix",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "precommit-test": "gulp lint",
-    "bundle": "node ./ci-jobs/scripts/build-webdriveragent.js"
+    "bundle": "node ./ci-jobs/scripts/build-webdriveragent.js",
+    "fetch-prebuilt-wda": "node ./Scripts/fetch-prebuilt-wda"
   },
   "bin": {
     "appium-wda-bootstrap": "./build/index.js"
@@ -47,7 +48,8 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "gulp": "^4.0.2",
-    "pre-commit": "^1.2.2"
+    "pre-commit": "^1.2.2",
+    "rimraf": "^3.0.0"
   },
   "dependencies": {
     "appium-support": "^2.29.0",


### PR DESCRIPTION
This script pulls down the prebuilt webdriveragents. This is so that in future Appium versions we'll be able to download the prebuilt wda's and bypass the initial build script.