### PR TITLE
fix: Only start screenshots broadcasting after the client sends some data

### DIFF
--- a/WebDriverAgentLib/Routing/FBTCPSocket.h
+++ b/WebDriverAgentLib/Routing/FBTCPSocket.h
@@ -17,16 +17,22 @@ NS_ASSUME_NONNULL_BEGIN
  The callback which is fired on new TCP client connection
 
  @param newClient The newly connected socket
- @param activeClients The actual list of connected socket clients which also includes newClient
  */
-- (void)didClientConnect:(GCDAsyncSocket *)newClient activeClients:(NSArray<GCDAsyncSocket *> *)activeClients;
+- (void)didClientConnect:(GCDAsyncSocket *)newClient;
+
+/**
+ The callback which is fired when the TCP server receives a data from a connected client
+
+ @param client The client, which sent the data
+*/
+- (void)didClientSendData:(GCDAsyncSocket *)client;
 
 /**
  The callback which is fired when TCP client disconnects
 
- @param activeClients The actual list of connected socket clients
+ @param client The actual diconnected client
  */
-- (void)didClientDisconnect:(NSArray<GCDAsyncSocket *> *)activeClients;
+- (void)didClientDisconnect:(GCDAsyncSocket *)client;
 
 @end
 

--- a/WebDriverAgentLib/Routing/FBTCPSocket.m
+++ b/WebDriverAgentLib/Routing/FBTCPSocket.m
@@ -9,7 +9,6 @@
 
 #import "FBTCPSocket.h"
 
-#import "FBLogger.h"
 
 @interface FBTCPSocket()
 @property (readonly, nonatomic) dispatch_queue_t socketQueue;
@@ -65,22 +64,23 @@
 
 - (void)socket:(GCDAsyncSocket *)sock didAcceptNewSocket:(GCDAsyncSocket *)newSocket
 {
-  NSString *host = [newSocket connectedHost];
-  UInt16 port = [newSocket connectedPort];
-  [FBLogger logFmt:@"Starting screenshots broadcast to %@:%d", host, port];
-
   @synchronized(self.connectedClients) {
     [self.connectedClients addObject:newSocket];
-    [self.delegate didClientConnect:newSocket activeClients:self.connectedClients.copy];
   }
+  [self.delegate didClientConnect:newSocket];
+}
+
+- (void)socket:(GCDAsyncSocket *)sock didReadData:(NSData *)data withTag:(long)tag
+{
+  [self.delegate didClientSendData:sock];
 }
 
 - (void)socketDidDisconnect:(GCDAsyncSocket *)sock withError:(NSError *)err
 {
   @synchronized(self.connectedClients) {
     [self.connectedClients removeObject:sock];
-    [self.delegate didClientDisconnect:self.connectedClients.copy];
   }
+  [self.delegate didClientDisconnect:sock];
 }
 
 @end


### PR DESCRIPTION
This should hopefully resolve issues like https://github.com/appium/appium/issues/13454 

The problem there is that we currently start broadcast upon new connection event. This means that  our local iproxy buffer could be too small to keep all the data before we actually start ffmpeg consumer. The PR changes the logic, so the broadcast only starts when we get the first data chunk from the client (e. g. a consumer is connected), which means no buffer overflow should happen anymore. 