### PR TITLE
refactor: Make snapshotting mechanism more customizable

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -96,33 +96,15 @@ static NSString* const FBUnknownBundleId = @"unknown";
   }
 
   // If getting the snapshot with attributes fails we use the snapshot with lazily initialized attributes
-  XCElementSnapshot *snapshot = self.fb_snapshotWithAttributes ?: self.fb_lastSnapshot;
-
-  NSMutableDictionary *snapshotTree = [[self.class dictionaryForElement:snapshot recursive:NO] mutableCopy];
-
-  NSArray<XCUIElement *> *children = [self fb_filterDescendantsWithSnapshots:snapshot.children];
-  NSMutableArray<NSDictionary *> *childrenTree = [NSMutableArray arrayWithCapacity:children.count];
-
-  for (XCUIElement* child in children) {
-    XCElementSnapshot *childSnapshot = child.fb_snapshotWithAttributes ?: child.fb_lastSnapshot;
-    if (nil == childSnapshot) {
-      continue;
-    }
-    [childrenTree addObject:[self.class dictionaryForElement:childSnapshot recursive:YES]];
-  }
-
-  if (childrenTree.count > 0) {
-    [snapshotTree setObject:childrenTree.copy forKey:@"children"];
-  }
-
-  return snapshotTree.copy;
+  XCElementSnapshot *snapshot = self.fb_snapshotWithAllAttributes ?: self.fb_lastSnapshot;
+  return [self.class dictionaryForElement:snapshot recursive:YES];
 }
 
 - (NSDictionary *)fb_accessibilityTree
 {
   [self fb_waitUntilSnapshotIsStable];
   // We ignore all elements except for the main window for accessibility tree
-  return [self.class accessibilityInfoForElement:(self.fb_snapshotWithAttributes ?: self.fb_lastSnapshot)];
+  return [self.class accessibilityInfoForElement:(self.fb_snapshotWithAllAttributes ?: self.fb_lastSnapshot)];
 }
 
 + (NSDictionary *)dictionaryForElement:(XCElementSnapshot *)snapshot recursive:(BOOL)recursive

--- a/WebDriverAgentLib/Categories/XCUIElement+FBAccessibility.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBAccessibility.m
@@ -18,7 +18,7 @@
 
 - (BOOL)fb_isAccessibilityElement
 {
-  return (self.fb_snapshotWithAttributes ?: self.fb_lastSnapshot).fb_isAccessibilityElement;
+  return ([self fb_snapshotWithAttributes:@[FB_XCAXAIsElementAttributeName]] ?: self.fb_lastSnapshot).fb_isAccessibilityElement;
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -122,7 +122,7 @@
     XCElementSnapshot *snapshot = matchingSnapshots.firstObject;
     matchingSnapshots = @[snapshot];
   }
-  return [self fb_filterDescendantsWithSnapshots:matchingSnapshots];
+  return [self fb_filterDescendantsWithSnapshots:matchingSnapshots onlyChildren:NO];
 }
 
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -24,7 +24,7 @@
 
 - (BOOL)fb_isVisible
 {
-  return (self.fb_snapshotWithAttributes ?: self.fb_lastSnapshot).fb_isVisible;
+  return ([self fb_snapshotWithAttributes:@[FB_XCAXAIsVisibleAttributeName]] ?: self.fb_lastSnapshot).fb_isVisible;
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
@@ -75,10 +75,11 @@ NS_ASSUME_NONNULL_BEGIN
  Filters elements by matching them to snapshots from the corresponding array
 
  @param snapshots Array of snapshots to be matched with
+ @param onlyChildren Whether to only look for direct element children
 
  @return Array of filtered elements, which have matches in snapshots array
  */
-- (NSArray<XCUIElement *> *)fb_filterDescendantsWithSnapshots:(NSArray<XCElementSnapshot *> *)snapshots;
+- (NSArray<XCUIElement *> *)fb_filterDescendantsWithSnapshots:(NSArray<XCElementSnapshot *> *)snapshots onlyChildren:(BOOL)onlyChildren;
 
 /**
  Waits until element snapshot is stable to avoid "Error copying attributes -25202 error".

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
@@ -48,7 +48,17 @@ NS_ASSUME_NONNULL_BEGIN
  
  @return The recent snapshot of the element with the attributes resolved
  */
-- (nullable XCElementSnapshot *)fb_snapshotWithAttributes;
+- (nullable XCElementSnapshot *)fb_snapshotWithAllAttributes;
+
+/**
+ Gets the most recent snapshot of the current element with given attributes resolved.
+ No additional calls to the accessibility layer are required.
+
+ @param attributeNames The list of attribute names to resolve. Must be one of
+ FB_...Name values exported by XCTestPrivateSymbols.h module
+ @return The recent snapshot of the element with the attributes resolved
+*/
+- (nullable XCElementSnapshot *)fb_snapshotWithAttributes:(NSArray<NSString *> *)attributeNames;
 
 /**
  Gets the most recent snapshot of the current element from the query snapshot that found the element.

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -75,7 +75,13 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
   return [self.query fb_elementSnapshotForDebugDescription];
 }
 
-- (nullable XCElementSnapshot *)fb_snapshotWithAttributes {
+- (nullable XCElementSnapshot *)fb_snapshotWithAllAttributes {
+  NSMutableArray *allNames = [NSMutableArray arrayWithArray:FBStandardAttributeNames().allObjects];
+  [allNames addObjectsFromArray:FBCustomAttributeNames().allObjects];
+  return [self fb_snapshotWithAttributes:allNames.copy];
+}
+
+- (nullable XCElementSnapshot *)fb_snapshotWithAttributes:(NSArray<NSString *> *)attributeNames {
   if (![FBConfiguration shouldLoadSnapshotWithAttributes]) {
     return nil;
   }
@@ -94,6 +100,7 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
                                  forProxy:proxy
                               withHandler:^(int res) {
     [self fb_requestSnapshot:axElement
+           forAttributeNames:[NSSet setWithArray:attributeNames]
                        reply:^(XCElementSnapshot *snapshot, NSError *error) {
       if (nil == error) {
         snapshotWithAttributes = snapshot;
@@ -113,85 +120,24 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
   return snapshotWithAttributes;
 }
 
-+ (BOOL)fb_isNewSnapshotAPIIsSupported
+- (void)fb_requestSnapshot:(XCAccessibilityElement *)accessibilityElement
+         forAttributeNames:(NSSet<NSString *> *)attributeNames
+                     reply:(void (^)(XCElementSnapshot *, NSError *))block
 {
-  static dispatch_once_t newSnapshotIsSupported;
-  static BOOL result;
-  dispatch_once(&newSnapshotIsSupported, ^{
-    result = [(NSObject *)[FBXCTestDaemonsProxy testRunnerProxy] respondsToSelector:@selector(_XCT_requestSnapshotForElement:attributes:parameters:reply:)];
-  });
-  return result;
-}
-
-- (void)fb_requestSnapshot:(XCAccessibilityElement *)accessibilityElement reply:(void (^)(XCElementSnapshot *, NSError *))block
-{
-  static NSDictionary *defaultParameters;
-  static dispatch_once_t initializeAttributesAndParametersToken;
-  static NSArray *axAttributes;
-  // XCode 11 has a new snapshot api and the old one will be deprecated soon
-  BOOL useNewSnapshotAPI = [XCUIElement fb_isNewSnapshotAPIIsSupported];
-  dispatch_once(&initializeAttributesAndParametersToken, ^{
-    defaultParameters = [FBXCAXClientProxy.sharedClient defaultParameters];
-    axAttributes = [self fb_createAXAttributes:!useNewSnapshotAPI];
-  });
+  NSArray *axAttributes = FBCreateAXAttributes(attributeNames);
   id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
-  if (useNewSnapshotAPI) {
+  if (XCUIElement.fb_isSdk11SnapshotApiSupported) {
+    // XCode 11 has a new snapshot api and the old one will be deprecated soon
     [proxy _XCT_requestSnapshotForElement:accessibilityElement
                                attributes:axAttributes
-                               parameters:defaultParameters
+                               parameters:FBXCAXClientProxy.sharedClient.defaultParameters
                                     reply:block];
   } else {
     [proxy _XCT_snapshotForElement:accessibilityElement
                         attributes:axAttributes
-                        parameters:defaultParameters
+                        parameters:FBXCAXClientProxy.sharedClient.defaultParameters
                              reply:block];
   }
-}
-
-- (NSArray *)fb_createAXAttributes: (BOOL)asNumber
-{
-  // Names of the properties to load. There won't be lazy loading for missing properties,
-  // thus missing properties will lead to wrong results
-  NSArray<NSString *> *propertyNames = [XCUIElement fb_defaultPropertyNames];
-  
-  SEL attributesForElementSnapshotKeyPathsSelector = [XCElementSnapshot fb_attributesForElementSnapshotKeyPathsSelector];
-  NSSet *attributes = (nil == attributesForElementSnapshotKeyPathsSelector) ? nil
-  : [XCElementSnapshot performSelector:attributesForElementSnapshotKeyPathsSelector withObject:propertyNames];
-  if (attributes == nil) {
-    @throw [NSException exceptionWithName:@"AttributesEmpty" reason:@"Couldn't build the attributes " userInfo:nil];
-  }
-  if (asNumber) {
-    NSMutableArray *axAttributes = [NSMutableArray arrayWithArray:XCAXAccessibilityAttributesForStringAttributes(attributes)];
-    if (![axAttributes containsObject:FB_XCAXAIsVisibleAttribute]) {
-      [axAttributes addObject:FB_XCAXAIsVisibleAttribute];
-    }
-    if (![axAttributes containsObject:FB_XCAXAIsVisibleAttribute]) {
-      [axAttributes addObject:FB_XCAXAIsVisibleAttribute];
-    }
-    return [axAttributes copy];
-  } else {
-    NSMutableSet *mutable = [NSMutableSet setWithSet:attributes];
-    [mutable addObject:FB_XCAXAIsVisibleAttributeName];
-    [mutable addObject:FB_XCAXAIsElementAttributeName];
-    return [mutable allObjects];
-  }
-}
-
-+ (NSArray<NSString*> *)fb_defaultPropertyNames
-{
-  static NSArray<NSString *> *propertyNames;
-  static dispatch_once_t oncePropertyNamesToken;
-  dispatch_once(&oncePropertyNamesToken, ^{
-    propertyNames = @[
-      @"identifier",
-      @"value",
-      @"label",
-      @"frame",
-      @"enabled",
-      @"elementType"
-    ];
-  });
-  return propertyNames;
 }
 
 - (XCElementSnapshot *)fb_lastSnapshotFromQuery

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -162,7 +162,7 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
   return snapshot ?: self.fb_lastSnapshot;
 }
 
-- (NSArray<XCUIElement *> *)fb_filterDescendantsWithSnapshots:(NSArray<XCElementSnapshot *> *)snapshots
+- (NSArray<XCUIElement *> *)fb_filterDescendantsWithSnapshots:(NSArray<XCElementSnapshot *> *)snapshots onlyChildren:(BOOL)onlyChildren
 {
   if (0 == snapshots.count) {
     return @[];
@@ -180,7 +180,10 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
   if (uniqueTypes && [uniqueTypes count] == 1) {
     type = [uniqueTypes.firstObject intValue];
   }
-  XCUIElementQuery *query = [[self.fb_query descendantsMatchingType:type] matchingPredicate:[FBPredicate predicateWithFormat:@"%K IN %@", FBStringify(XCUIElement, wdUID), matchedUids]];
+  XCUIElementQuery *query = onlyChildren
+    ? [self.fb_query childrenMatchingType:type]
+    : [self.fb_query descendantsMatchingType:type];
+  query = [query matchingPredicate:[FBPredicate predicateWithFormat:@"%K IN %@", FBStringify(XCUIElement, wdUID), matchedUids]];
   if (1 == snapshots.count) {
     XCUIElement *result = query.fb_firstMatch;
     return result ? @[result] : @[];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -19,6 +19,7 @@
 #import "XCUIElement.h"
 #import "XCUIElement+FBUtilities.h"
 #import "FBElementUtils.h"
+#import "XCTestPrivateSymbols.h"
 
 @implementation XCUIElement (WebDriverAttributesForwarding)
 
@@ -27,15 +28,17 @@
   if (!self.exists) {
     return [XCElementSnapshot new];
   }
-  
-  if ([name isEqualToString:FBStringify(XCUIElement, isWDVisible)]
-             || [name isEqualToString:FBStringify(XCUIElement, isWDAccessible)]
-             || [name isEqualToString:FBStringify(XCUIElement, isWDAccessibilityContainer)]) {
-    // These attrbiutes are special, because we can only retrieve them from
-    // the snapshot if we explicitly ask XCTest to include them into the query while taking it.
-    // That is why fb_snapshotWithAttributes method must be used instead of the default fb_lastSnapshot
-    // call
-    return (self.fb_snapshotWithAttributes ?: self.fb_lastSnapshot) ?: [XCElementSnapshot new];
+
+  // These attrbiutes are special, because we can only retrieve them from
+  // the snapshot if we explicitly ask XCTest to include them into the query while taking it.
+  // That is why fb_snapshotWithAllAttributes method must be used instead of the default fb_lastSnapshot
+  // call
+  if ([name isEqualToString:FBStringify(XCUIElement, isWDVisible)]) {
+    return ([self fb_snapshotWithAttributes:@[FB_XCAXAIsVisibleAttributeName]] ?: self.fb_lastSnapshot) ?: [XCElementSnapshot new];
+  }
+  if ([name isEqualToString:FBStringify(XCUIElement, isWDAccessible)] ||
+      [name isEqualToString:FBStringify(XCUIElement, isWDAccessibilityContainer)]) {
+    return ([self fb_snapshotWithAttributes:@[FB_XCAXAIsElementAttributeName]] ?: self.fb_lastSnapshot) ?: [XCElementSnapshot new];
   }
   
   return self.fb_lastSnapshot ?: [XCElementSnapshot new];

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
@@ -91,6 +91,13 @@ extern NSString *const FBApplicationMethodNotSupportedException;
  */
 - (XCUIElementQuery *)fb_query;
 
+/**
+ Determines whether Xcode 11 snapshots API is supported
+
+ @return Eiter YES or NO
+ */
++ (BOOL)fb_isSdk11SnapshotApiSupported;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -15,6 +15,8 @@
 #import "FBLogger.h"
 #import "XCUIApplication+FBHelpers.h"
 #import "XCUIElementQuery.h"
+#import "FBXCTestDaemonsProxy.h"
+#import "XCTestManager_ManagerInterface-Protocol.h"
 
 static const NSTimeInterval APP_STATE_CHANGE_TIMEOUT = 5.0;
 
@@ -161,6 +163,16 @@ static dispatch_once_t onceAppWithPIDToken;
   return FBConfiguration.includeNonModalElements && self.class.fb_supportsNonModalElementsInclusion
     ? self.query.includingNonModalElements
     : self.query;
+}
+
++ (BOOL)fb_isSdk11SnapshotApiSupported
+{
+  static dispatch_once_t newSnapshotIsSupported;
+  static BOOL result;
+  dispatch_once(&newSnapshotIsSupported, ^{
+    result = [(id)[FBXCTestDaemonsProxy testRunnerProxy] respondsToSelector:@selector(_XCT_requestSnapshotForElement:attributes:parameters:reply:)];
+  });
+  return result;
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -308,28 +308,13 @@ NSString *const FBXPathQueryEvaluationException = @"FBXPathQueryEvaluationExcept
   XCElementSnapshot *currentSnapshot;
   NSArray<XCElementSnapshot *> *children;
   if ([root isKindOfClass:XCUIElement.class]) {
+    XCUIElement *element = (XCUIElement *)root;
     if ([FBConfiguration shouldUseTestManagerForVisibilityDetection]) {
-      [((XCUIElement *)root).application fb_waitUntilSnapshotIsStable];
+      [element.application fb_waitUntilSnapshotIsStable];
     }
-    if ([root isKindOfClass:XCUIApplication.class]) {
-      XCUIApplication *application = (XCUIApplication *)root;
-      currentSnapshot = application.fb_snapshotWithAttributes ?: application.fb_lastSnapshot;
-      NSArray<XCUIElement *> *windows = [((XCUIElement *)root) fb_filterDescendantsWithSnapshots:currentSnapshot.children];
-      NSMutableArray<XCElementSnapshot *> *windowsSnapshots = [NSMutableArray array];
-      for (XCUIElement* window in windows) {
-        XCElementSnapshot *windowSnapshot = window.fb_snapshotWithAttributes ?: window.fb_lastSnapshot;
-        if (nil == windowSnapshot) {
-          [FBLogger logFmt:@"Skipping source dumping for %@ because its snapshot cannot be resolved", window.description];
-          continue;
-        }
-        [windowsSnapshots addObject:windowSnapshot];
-      }
-      children = windowsSnapshots.copy;
-    } else {
-      XCUIElement *element = (XCUIElement *)root;
-      currentSnapshot = element.fb_snapshotWithAttributes ?: element.fb_lastSnapshot;
-      children = currentSnapshot.children;
-    }
+    // TODO: Only select the attributes we actually need for xpath search
+    currentSnapshot = element.fb_snapshotWithAllAttributes ?: element.fb_lastSnapshot;
+    children = currentSnapshot.children;
   } else {
     currentSnapshot = (XCElementSnapshot *)root;
     children = currentSnapshot.children;

--- a/WebDriverAgentLib/Utilities/XCTestPrivateSymbols.h
+++ b/WebDriverAgentLib/Utilities/XCTestPrivateSymbols.h
@@ -13,11 +13,24 @@
 
 /*! Accessibility identifier for is visible attribute */
 extern NSNumber *FB_XCAXAIsVisibleAttribute;
-extern NSString* FB_XCAXAIsVisibleAttributeName;
+extern NSString *FB_XCAXAIsVisibleAttributeName;
 
 /*! Accessibility identifier for is accessible attribute */
 extern NSNumber *FB_XCAXAIsElementAttribute;
-extern NSString* FB_XCAXAIsElementAttributeName;
+extern NSString *FB_XCAXAIsElementAttributeName;
+
+/*! Accessibility identifier for identifier attribute */
+extern NSString *FB_IdentifierAttributeName;
+/*! Accessibility identifier for value attribute */
+extern NSString *FB_ValueAttributeName;
+/*! Accessibility identifier for frame attribute */
+extern NSString *FB_FrameAttributeName;
+/*! Accessibility identifier for label attribute */
+extern NSString *FB_LabelAttributeName;
+/*! Accessibility identifier for enabled attribute */
+extern NSString *FB_EnabledAttributeName;
+/*! Accessibility identifier for type attribute */
+extern NSString *FB_ElementTypeAttributeName;
 
 /*! Getter for  XCTest logger */
 extern id<XCDebugLogDelegate> (*XCDebugLogger)(void);
@@ -38,3 +51,27 @@ void *FBRetrieveXCTestSymbol(const char *name);
 
 /*! Static constructor that will retrieve XCTest private symbols */
 __attribute__((constructor)) void FBLoadXCTestSymbols(void);
+
+/**
+ Method is used to tranform attribute names into the format, which
+ is acceptable for the internal XCTest snpshoting API
+
+ @param attributeNames set of attribute names. Must be on of FB_..Name constants above
+ @returns The array of tranformed values. Unknown values are silently skipped
+ */
+NSArray *FBCreateAXAttributes(NSSet<NSString *> *attributeNames);
+
+/**
+ Retrives the set of standard attribute names
+
+ @returns Set of FB_..Name constants above, which represent standard element attributes
+ */
+NSSet<NSString*> *FBStandardAttributeNames(void);
+
+/**
+Retrives the set of custom attribute names. These attributes are normally not accessible
+ by public XCTest calls, but are still available in the accessibility framework
+
+@returns Set of FB_..Name constants above, which represent custom element attributes
+*/
+NSSet<NSString*> *FBCustomAttributeNames(void);

--- a/WebDriverAgentLib/Utilities/XCTestPrivateSymbols.m
+++ b/WebDriverAgentLib/Utilities/XCTestPrivateSymbols.m
@@ -12,11 +12,19 @@
 #import <objc/runtime.h>
 
 #import "FBRuntimeUtils.h"
+#import "FBXCodeCompatibility.h"
 
 NSNumber *FB_XCAXAIsVisibleAttribute;
 NSString *FB_XCAXAIsVisibleAttributeName = @"XC_kAXXCAttributeIsVisible";
 NSNumber *FB_XCAXAIsElementAttribute;
 NSString *FB_XCAXAIsElementAttributeName = @"XC_kAXXCAttributeIsElement";
+
+NSString *FB_IdentifierAttributeName = @"identifier";
+NSString *FB_ValueAttributeName = @"value";
+NSString *FB_FrameAttributeName = @"frame";
+NSString *FB_LabelAttributeName = @"label";
+NSString *FB_EnabledAttributeName = @"enabled";
+NSString *FB_ElementTypeAttributeName = @"elementType";
 
 void (*XCSetDebugLogger)(id <XCDebugLogDelegate>);
 id<XCDebugLogDelegate> (*XCDebugLogger)(void);
@@ -50,4 +58,71 @@ void *FBRetrieveXCTestSymbol(const char *name)
   const char *binaryPath = XCTestBinary.UTF8String;
   NSCAssert(binaryPath != nil, @"XCTest binary path should not be nil", binaryPath);
   return FBRetrieveSymbolFromBinary(binaryPath, name);
+}
+
+NSSet<NSString*> *FBStandardAttributeNames(void)
+{
+  static NSSet<NSString *> *standardNames;
+  static dispatch_once_t onceStandardAttributeNamesToken;
+  dispatch_once(&onceStandardAttributeNamesToken, ^{
+    standardNames = [NSSet setWithArray:@[
+      FB_IdentifierAttributeName,
+      FB_ValueAttributeName,
+      FB_LabelAttributeName,
+      FB_FrameAttributeName,
+      FB_EnabledAttributeName,
+      FB_ElementTypeAttributeName
+    ]];
+  });
+  return standardNames;
+}
+
+NSSet<NSString*> *FBCustomAttributeNames(void)
+{
+  static NSSet<NSString *> *customNames;
+  static dispatch_once_t onceCustomAttributeNamesToken;
+  dispatch_once(&onceCustomAttributeNamesToken, ^{
+    customNames = [NSSet setWithArray:@[
+      FB_XCAXAIsVisibleAttributeName,
+      FB_XCAXAIsElementAttributeName
+    ]];
+  });
+  return customNames;
+}
+
+NSArray *FBCreateAXAttributes(NSSet<NSString *> *attributeNames)
+{
+  NSMutableArray<NSString *> *standardAttributeNames = [NSMutableArray array];
+  for (NSString *attributeName in attributeNames) {
+    if ([FBStandardAttributeNames() containsObject:attributeName]) {
+      [standardAttributeNames addObject:attributeName];
+    }
+  }
+
+  NSSet *axAttributes = nil;
+  BOOL useSdk11Api = XCUIElement.fb_isSdk11SnapshotApiSupported;
+  if (standardAttributeNames.count > 0) {
+    SEL attributesForElementSnapshotKeyPathsSelector = [XCElementSnapshot fb_attributesForElementSnapshotKeyPathsSelector];
+    axAttributes = (nil == attributesForElementSnapshotKeyPathsSelector) ? nil
+      : [XCElementSnapshot performSelector:attributesForElementSnapshotKeyPathsSelector
+                                withObject:standardAttributeNames];
+    if (axAttributes == nil) {
+      NSString *reason = [NSString stringWithFormat:@"Couldn't build the accessbility representation for attributes %@", standardAttributeNames];
+      @throw [NSException exceptionWithName:@"AttributesEmpty" reason:reason userInfo:nil];
+    }
+  } else {
+    axAttributes = [NSSet set];
+  }
+
+  NSMutableArray* result = useSdk11Api
+    ? [NSMutableArray arrayWithArray:axAttributes.allObjects]
+    : [NSMutableArray arrayWithArray:XCAXAccessibilityAttributesForStringAttributes(axAttributes)];
+  for (NSString *attributeName in attributeNames) {
+    if ([FB_XCAXAIsVisibleAttributeName isEqualToString:attributeName]) {
+      [result addObject:(useSdk11Api ? attributeName : FB_XCAXAIsVisibleAttribute)];
+    } else if ([FB_XCAXAIsElementAttributeName isEqualToString:attributeName]) {
+      [result addObject:(useSdk11Api ? attributeName : FB_XCAXAIsElementAttribute)];
+    }
+  }
+  return [result copy];
 }

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementHelperIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementHelperIntegrationTests.m
@@ -68,7 +68,7 @@
   NSMutableArray<XCElementSnapshot *> *buttonSnapshots = [NSMutableArray array];
   [buttonSnapshots addObject:[buttons.firstObject fb_lastSnapshot]];
   
-  NSArray<XCUIElement *> *result = [self.testedApplication fb_filterDescendantsWithSnapshots:buttonSnapshots];
+  NSArray<XCUIElement *> *result = [self.testedApplication fb_filterDescendantsWithSnapshots:buttonSnapshots onlyChildren:NO];
   XCTAssertEqual(1, result.count);
   XCTAssertEqual([result.firstObject elementType], XCUIElementTypeButton);
 }

--- a/test/functional/webdriveragent-e2e-specs.js
+++ b/test/functional/webdriveragent-e2e-specs.js
@@ -26,7 +26,9 @@ function getStartOpts (device) {
     platformVersion: PLATFORM_VERSION,
     host: 'localhost',
     port: 8100,
-    realDevice: false
+    realDevice: false,
+    showXcodeLog: true,
+    wdaLaunchTimeout: 60 * 3 * 1000,
   };
 }
 


### PR DESCRIPTION
There were quite a lot ugly workarounds from Xcode9 support in the code. We need to get rid of them.
Also, such changes will allow to speed up elements lookup and the general performance.

@KazuCocoa Do you have some apps with web views? I would like to make sure with these changes the web views are still visible in the native page source. Thanks in advance for your help.