### PR TITLE
feat: Add a possibility to request page source with particular attributes excluded

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
@@ -41,6 +41,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)fb_xmlRepresentation;
 
 /**
+ Return application elements tree in form of xml string exluding the given attribute names.
+
+ @param excludedAttributes the list of XML attribute names to be excluded from the resulting document.
+ Invalid attribute names are silently skipped
+ @returns The XML representation of the current element as a string
+ */
+- (NSString *)fb_xmlRepresentationWithoutAttributes:(NSArray<NSString *> *)excludedAttributes;
+
+/**
  Return application elements tree in form of internal XCTest debugDescription string
  */
 - (NSString *)fb_descriptionRepresentation;

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -188,7 +188,15 @@ static NSString* const FBUnknownBundleId = @"unknown";
 
 - (NSString *)fb_xmlRepresentation
 {
-  return [FBXPath xmlStringWithRootElement:self];
+  return [FBXPath xmlStringWithRootElement:self excludingAttributes:nil];
+}
+
+- (NSString *)fb_xmlRepresentationWithoutAttributes:(NSArray<NSString *> *)excludedAttributes
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullable-to-nonnull-conversion"
+  return [FBXPath xmlStringWithRootElement:self excludingAttributes:excludedAttributes];
+#pragma clang diagnostic pop
 }
 
 - (NSString *)fb_descriptionRepresentation

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -190,7 +190,7 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
     XCUIElement *result = query.fb_firstMatch;
     return result ? @[result] : @[];
   }
-  // Rely here on the fact, that XPath always returns query resulsts in the same
+  // Rely here on the fact, that XPath always returns query results in the same
   // order they appear in the document, which means we don't need to resort the resulting
   // array. Although, if it turns out this is still not the case then we could always
   // uncomment the sorting procedure below:

--- a/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -45,7 +45,12 @@ static NSString *const SOURCE_FORMAT_DESCRIPTION = @"description";
   NSString *sourceType = request.parameters[@"format"] ?: SOURCE_FORMAT_XML;
   id result;
   if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_XML] == NSOrderedSame) {
-    result = application.fb_xmlRepresentation;
+    NSArray<NSString *> *excludedAttributes = nil == request.parameters[@"excluded_attributes"]
+      ? nil
+      : [request.parameters[@"excluded_attributes"] componentsSeparatedByString:@","];
+    result = nil == excludedAttributes
+      ? application.fb_xmlRepresentation
+      : [application fb_xmlRepresentationWithoutAttributes:(NSArray<NSString *> *)excludedAttributes];
   } else if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_JSON] == NSOrderedSame) {
     result = application.fb_tree;
   } else if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_DESCRIPTION] == NSOrderedSame) {

--- a/WebDriverAgentLib/Utilities/FBXPath-Private.h
+++ b/WebDriverAgentLib/Utilities/FBXPath-Private.h
@@ -20,9 +20,16 @@ NS_ASSUME_NONNULL_BEGIN
  @param writer the correspondig libxml2 writer object
  @param elementStore an empty dictionary to store indexes mapping or nil if no mappings should be stored
  @param query Optional XPath query value. By analyzing this query we may optimize the lookup speed.
+ @param excludedAttributes The list of XML attribute names to be excluded from the generated XML representation.
+ Setting nil to this argument means that none of the known attributes must be excluded.
+ If `query` argument is assigned then `excludedAttributes` argument is effectively ignored.
  @return zero if the method has completed successfully
  */
-+ (int)xmlRepresentationWithRootElement:(XCElementSnapshot *)root writer:(xmlTextWriterPtr)writer elementStore:(nullable NSMutableDictionary *)elementStore query:(nullable NSString*)query;
++ (int)xmlRepresentationWithRootElement:(XCElementSnapshot *)root
+                                 writer:(xmlTextWriterPtr)writer
+                           elementStore:(nullable NSMutableDictionary *)elementStore
+                                  query:(nullable NSString*)query
+                    excludingAttributes:(nullable NSArray<NSString *> *)excludedAttributes;
 
 /**
  Gets the list of matched snapshots from xmllib2-compatible xmlNodeSetPtr structure

--- a/WebDriverAgentLib/Utilities/FBXPath.h
+++ b/WebDriverAgentLib/Utilities/FBXPath.h
@@ -48,16 +48,20 @@ extern NSString *const FBXPathQueryEvaluationException;
  @return an array of descendants matching the given xpath query or an empty array if no matches were found
  @throws NSException if there is an unexpected internal error during xml parsing
  */
-+ (NSArray<XCElementSnapshot *> *)matchesWithRootElement:(id<FBElement>)root forQuery:(NSString *)xpathQuery;
++ (NSArray<XCElementSnapshot *> *)matchesWithRootElement:(id<FBElement>)root
+                                                forQuery:(NSString *)xpathQuery;
 
 /**
  Gets XML representation of XCElementSnapshot with all its descendants. This method generates the same
  representation, which is used for XPath search
  
  @param root the root element
+ @param excludedAttributes the list of attribute names to exclude from the resulting document.
+ Passing nil means all the available attributes should be included
  @return valid XML document as string or nil in case of failure
  */
-+ (nullable NSString *)xmlStringWithRootElement:(id<FBElement>)root;
++ (nullable NSString *)xmlStringWithRootElement:(id<FBElement>)root
+                            excludingAttributes:(nullable NSArray<NSString *> *)excludedAttributes;
 
 @end
 

--- a/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
@@ -38,7 +38,7 @@
   FBAssertWaitTillBecomesTrue(self.testedView.buttons.count > 0);
 }
 
-- (void)testSingleDescendantXMLRepresentation
+- (XCElementSnapshot *)destinationSnpshot
 {
   XCUIElement *matchingElement = self.testedView.buttons.fb_firstMatch;
   FBAssertWaitTillBecomesTrue(nil != matchingElement.fb_lastSnapshot);
@@ -47,9 +47,24 @@
   // Over iOS13, snapshot returns a child.
   // The purpose of here is return a single element so replace children with nil for testing.
   snapshot.children = nil;
-  NSString *xmlStr = [FBXPath xmlStringWithRootElement:snapshot];
+  return snapshot;
+}
+
+- (void)testSingleDescendantXMLRepresentation
+{
+  XCElementSnapshot *snapshot = self.destinationSnpshot;
+  NSString *xmlStr = [FBXPath xmlStringWithRootElement:snapshot excludingAttributes:nil];
   XCTAssertNotNil(xmlStr);
   NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\"/>\n", snapshot.wdType, snapshot.wdType, snapshot.wdName, snapshot.wdLabel, snapshot.wdEnabled ? @"true" : @"false", snapshot.wdVisible ? @"true" : @"false", [snapshot.wdRect[@"x"] stringValue], [snapshot.wdRect[@"y"] stringValue], [snapshot.wdRect[@"width"] stringValue], [snapshot.wdRect[@"height"] stringValue]];
+  XCTAssertEqualObjects(xmlStr, expectedXml);
+}
+
+- (void)testSingleDescendantXMLRepresentationWithoutAttributes
+{
+  XCElementSnapshot *snapshot = self.destinationSnpshot;
+  NSString *xmlStr = [FBXPath xmlStringWithRootElement:snapshot excludingAttributes:@[@"visible", @"enabled", @"blabla"]];
+  XCTAssertNotNil(xmlStr);
+  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" name=\"%@\" label=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\"/>\n", snapshot.wdType, snapshot.wdType, snapshot.wdName, snapshot.wdLabel, [snapshot.wdRect[@"x"] stringValue], [snapshot.wdRect[@"y"] stringValue], [snapshot.wdRect[@"width"] stringValue], [snapshot.wdRect[@"height"] stringValue]];
   XCTAssertEqualObjects(xmlStr, expectedXml);
 }
 

--- a/WebDriverAgentTests/UnitTests/FBXPathTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXPathTests.m
@@ -18,7 +18,9 @@
 
 @implementation FBXPathTests
 
-- (NSString *)xmlStringWithElement:(id<FBElement>)element xpathQuery:(nullable NSString *)query
+- (NSString *)xmlStringWithElement:(id<FBElement>)element
+                        xpathQuery:(nullable NSString *)query
+               excludingAttributes:(nullable NSArray<NSString *> *)excludedAttributes
 {
   xmlDocPtr doc;
   
@@ -26,7 +28,11 @@
   NSMutableDictionary *elementStore = [NSMutableDictionary dictionary];
   int buffersize;
   xmlChar *xmlbuff;
-  int rc = [FBXPath xmlRepresentationWithRootElement:(XCElementSnapshot *)element writer:writer elementStore:elementStore query:query];
+  int rc = [FBXPath xmlRepresentationWithRootElement:(XCElementSnapshot *)element
+                                              writer:writer
+                                        elementStore:elementStore
+                                               query:query
+                                 excludingAttributes:excludedAttributes];
   if (0 == rc) {
     xmlDocDumpFormatMemory(doc, &xmlbuff, &buffersize, 1);
   }
@@ -42,15 +48,29 @@
 - (void)testDefaultXPathPresentation
 {
   XCUIElementDouble *element = [XCUIElementDouble new];
-  NSString *resultXml = [self xmlStringWithElement:element xpathQuery:nil];
+  NSString *resultXml = [self xmlStringWithElement:element
+                                        xpathQuery:nil
+                               excludingAttributes:nil];
   NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" value=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" private_indexPath=\"top\"/>\n", element.wdType, element.wdType, element.wdValue, element.wdName, element.wdLabel,  element.wdEnabled ? @"true" : @"false", element.wdVisible ? @"true" : @"false", element.wdRect[@"x"], element.wdRect[@"y"], element.wdRect[@"width"], element.wdRect[@"height"]];
   XCTAssertTrue([resultXml isEqualToString: expectedXml]);
+}
+
+- (void)testtXPathPresentationWithSomeAttributesExcluded
+{
+  XCUIElementDouble *element = [XCUIElementDouble new];
+  NSString *resultXml = [self xmlStringWithElement:element
+                                        xpathQuery:nil
+                               excludingAttributes:@[@"type", @"visible", @"value"]];
+  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ name=\"%@\" label=\"%@\" enabled=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" private_indexPath=\"top\"/>\n", element.wdType, element.wdName, element.wdLabel,  element.wdEnabled ? @"true" : @"false", element.wdRect[@"x"], element.wdRect[@"y"], element.wdRect[@"width"], element.wdRect[@"height"]];
+  XCTAssertEqualObjects(resultXml, expectedXml);
 }
 
 - (void)testXPathPresentationBasedOnQueryMatchingAllAttributes
 {
   XCUIElementDouble *element = [XCUIElementDouble new];
-  NSString *resultXml = [self xmlStringWithElement:element xpathQuery:[NSString stringWithFormat:@"//%@[@*]", element.wdType]];
+  NSString *resultXml = [self xmlStringWithElement:element
+                                        xpathQuery:[NSString stringWithFormat:@"//%@[@*]", element.wdType]
+                               excludingAttributes:@[@"visible"]];
   NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" value=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" private_indexPath=\"top\"/>\n", element.wdType, element.wdType, element.wdValue, element.wdName, element.wdLabel,  element.wdEnabled ? @"true" : @"false", element.wdVisible ? @"true" : @"false", element.wdRect[@"x"], element.wdRect[@"y"], element.wdRect[@"width"], element.wdRect[@"height"]];
   XCTAssertTrue([resultXml isEqualToString: expectedXml]);
 }
@@ -58,7 +78,9 @@
 - (void)testXPathPresentationBasedOnQueryMatchingSomeAttributes
 {
   XCUIElementDouble *element = [XCUIElementDouble new];
-  NSString *resultXml = [self xmlStringWithElement:element xpathQuery:[NSString stringWithFormat:@"//%@[@%@ and contains(@%@, 'blabla')]", element.wdType, @"value", @"name"]];
+  NSString *resultXml = [self xmlStringWithElement:element
+                                        xpathQuery:[NSString stringWithFormat:@"//%@[@%@ and contains(@%@, 'blabla')]", element.wdType, @"value", @"name"]
+                               excludingAttributes:nil];
   NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ value=\"%@\" name=\"%@\" private_indexPath=\"top\"/>\n", element.wdType, element.wdValue, element.wdName];
   XCTAssertTrue([resultXml isEqualToString: expectedXml]);
 }
@@ -71,7 +93,11 @@
   NSMutableDictionary *elementStore = [NSMutableDictionary dictionary];
   XCUIElementDouble *root = [XCUIElementDouble new];
   NSString *query = [NSString stringWithFormat:@"//%@", root.wdType];
-  int rc = [FBXPath xmlRepresentationWithRootElement:(XCElementSnapshot *)root writer:writer elementStore:elementStore query:query];
+  int rc = [FBXPath xmlRepresentationWithRootElement:(XCElementSnapshot *)root
+                                              writer:writer
+                                        elementStore:elementStore
+                                               query:query
+                                 excludingAttributes:nil];
   if (rc < 0) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);


### PR DESCRIPTION
Sometimes it might be handy to request the page source without some attributes (especially the `visible` one), which could potentially seriously slow down the xml retrieval process.