### PR TITLE
refactor: Change text field cleanup algorithm

### DIFF
--- a/PrivateHeaders/XCTest/XCUIElement.h
+++ b/PrivateHeaders/XCTest/XCUIElement.h
@@ -47,6 +47,12 @@
 - (id)_pointsInFrame:(CGRect)arg1 numberOfTouches:(unsigned long long)arg2;
 - (CGPoint)_hitPointByAttemptingToScrollToVisibleSnapshot:(id)arg1;
 - (void)forcePress;
+- (void)tapWithNumberOfTaps:(unsigned long long)arg1 numberOfTouches:(unsigned long long)arg2;
+- (void)twoFingerTap;
+- (void)doubleTap;
+- (void)tap;
+- (void)pressForDuration:(double)arg1 thenDragToElement:(id)arg2;
+- (void)pressForDuration:(double)arg1;
 
 // Available since Xcode 11.0
 - (_Bool)resolveOrRaiseTestFailure:(_Bool)arg1 error:(id *)arg2;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.h
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <WebDriverAgentLib/XCUIElement.h>
+#import <XCTest/XCTest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -16,6 +16,26 @@
 #import "XCUIElement+FBTap.h"
 #import "XCUIElement+FBUtilities.h"
 
+
+#define MAX_CLEAR_RETRIES 3
+
+@interface NSString (FBRepeat)
+
+- (NSString *)fb_repeatTimes:(NSUInteger)times;
+
+@end
+
+@implementation NSString (FBRepeat)
+
+- (NSString *)fb_repeatTimes:(NSUInteger)times {
+  return [@"" stringByPaddingToLength:times * self.length
+                           withString:self
+                      startingAtIndex:0];
+}
+
+@end
+
+
 @implementation XCUIElement (FBTyping)
 
 - (BOOL)fb_prepareForTextInputWithError:(NSError **)error
@@ -72,6 +92,7 @@
 - (BOOL)fb_clearTextWithError:(NSError **)error
 {
   if (0 == [self.value fb_visualLength]) {
+    // Short circuit if the content is not present
     return YES;
   }
 
@@ -79,18 +100,37 @@
     return NO;
   }
   
+  static NSString *backspaceDeleteSequence;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    backspaceDeleteSequence = [[NSString alloc] initWithData:(NSData *)[@"\\u0008\\u007F" dataUsingEncoding:NSASCIIStringEncoding]
+                                                    encoding:NSNonLossyASCIIStringEncoding];
+  });
+  
+  NSUInteger retry = 0;
   NSUInteger preClearTextLength = 0;
-  NSData *encodedSequence = [@"\\u0008\\u007F" dataUsingEncoding:NSASCIIStringEncoding];
-  NSString *backspaceDeleteSequence = [[NSString alloc] initWithData:encodedSequence encoding:NSNonLossyASCIIStringEncoding];
-  while ([self.value fb_visualLength] != preClearTextLength) {
-    NSMutableString *textToType = @"".mutableCopy;
-    preClearTextLength = [self.value fb_visualLength];
-    for (NSUInteger i = 0 ; i < preClearTextLength ; i++) {
-      [textToType appendString:backspaceDeleteSequence];
+  while ((preClearTextLength = [self.value fb_visualLength]) > 0) {
+    NSString *textToType = [backspaceDeleteSequence fb_repeatTimes:preClearTextLength];
+    if (retry >= MAX_CLEAR_RETRIES - 1) {
+      // Last chance retry. Try to select the content of the field using the context menu
+      [self pressForDuration:1.0];
+      XCUIElement *selectAll = self.application.menuItems[@"Select All"];
+      if ([selectAll waitForExistenceWithTimeout:0.5]) {
+        [selectAll tap];
+        textToType = backspaceDeleteSequence;
+      }
     }
-    if (textToType.length > 0 && ![FBKeyboard typeText:textToType error:error]) {
+    if (![FBKeyboard typeText:textToType error:error]) {
       return NO;
     }
+    
+    if (retry >= MAX_CLEAR_RETRIES) {
+      return [[[FBErrorBuilder builder]
+                 withDescriptionFormat:@"Cannot clear the value of '%@'", self.description]
+                buildError:error];
+    }
+    
+    retry++;
   }
   return YES;
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -124,7 +124,7 @@
       return NO;
     }
     
-    if (retry >= MAX_CLEAR_RETRIES) {
+    if (retry >= MAX_CLEAR_RETRIES - 1) {
       return [[[FBErrorBuilder builder]
                  withDescriptionFormat:@"Cannot clear the value of '%@'", self.description]
                 buildError:error];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -91,14 +91,14 @@
 
 - (BOOL)fb_clearTextWithError:(NSError **)error
 {
-  id value = self.value;
-  if (nil != value && ![value isKindOfClass:NSString.class]) {
+  id currentValue = self.value;
+  if (nil != currentValue && ![currentValue isKindOfClass:NSString.class]) {
     return [[[FBErrorBuilder builder]
                withDescriptionFormat:@"The value of '%@' element is not a string and thus cannot be cleared", self.description]
               buildError:error];
   }
   
-  if (nil == value || 0 == [value fb_visualLength]) {
+  if (nil == currentValue || 0 == [currentValue fb_visualLength]) {
     // Short circuit if the content is not present
     return YES;
   }
@@ -115,7 +115,7 @@
   });
   
   NSUInteger retry = 0;
-  NSUInteger preClearTextLength = [value fb_visualLength];
+  NSUInteger preClearTextLength = [currentValue fb_visualLength];
   do {
     NSString *textToType = [backspaceDeleteSequence fb_repeatTimes:preClearTextLength];
     if (retry >= MAX_CLEAR_RETRIES - 1) {
@@ -136,8 +136,15 @@
                  withDescriptionFormat:@"Cannot clear the value of '%@'", self.description]
                 buildError:error];
     }
-    
-    preClearTextLength = [self.value fb_visualLength];
+
+    currentValue = self.value;
+    NSString *placeholderValue = self.placeholderValue;
+    if (nil != placeholderValue && [currentValue isEqualToString:placeholderValue]) {
+      // Short circuit if only the placeholder value left
+      return YES;
+    }
+    preClearTextLength = [currentValue fb_visualLength];
+
     retry++;
   } while (preClearTextLength > 0);
   return YES;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -92,13 +92,13 @@
 - (BOOL)fb_clearTextWithError:(NSError **)error
 {
   id value = self.value;
-  if (![value isKindOfClass:NSString.class]) {
+  if (nil != value && ![value isKindOfClass:NSString.class]) {
     return [[[FBErrorBuilder builder]
                withDescriptionFormat:@"The value of '%@' element is not a string and thus cannot be cleared", self.description]
               buildError:error];
   }
   
-  if (0 == [value fb_visualLength]) {
+  if (nil == value || 0 == [value fb_visualLength]) {
     // Short circuit if the content is not present
     return YES;
   }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -91,7 +91,14 @@
 
 - (BOOL)fb_clearTextWithError:(NSError **)error
 {
-  if (0 == [self.value fb_visualLength]) {
+  id value = self.value;
+  if (![value isKindOfClass:NSString.class]) {
+    return [[[FBErrorBuilder builder]
+               withDescriptionFormat:@"The value of '%@' element is not a string and thus cannot be cleared", self.description]
+              buildError:error];
+  }
+  
+  if (0 == [value fb_visualLength]) {
     // Short circuit if the content is not present
     return YES;
   }
@@ -108,8 +115,8 @@
   });
   
   NSUInteger retry = 0;
-  NSUInteger preClearTextLength = 0;
-  while ((preClearTextLength = [self.value fb_visualLength]) > 0) {
+  NSUInteger preClearTextLength = [value fb_visualLength];
+  do {
     NSString *textToType = [backspaceDeleteSequence fb_repeatTimes:preClearTextLength];
     if (retry >= MAX_CLEAR_RETRIES - 1) {
       // Last chance retry. Try to select the content of the field using the context menu
@@ -130,8 +137,9 @@
                 buildError:error];
     }
     
+    preClearTextLength = [self.value fb_visualLength];
     retry++;
-  }
+  } while (preClearTextLength > 0);
   return YES;
 }
 

--- a/WebDriverAgentTests/IntegrationTests/FBTypingTest.m
+++ b/WebDriverAgentTests/IntegrationTests/FBTypingTest.m
@@ -10,6 +10,7 @@
 #import <XCTest/XCTest.h>
 
 #import "FBIntegrationTestCase.h"
+#import "XCUIElement.h"
 #import "XCUIElement+FBTyping.h"
 
 @interface FBTypingTest : FBIntegrationTestCase


### PR DESCRIPTION
Previously there was no way to clear a text field if the cursor was not at the end of the typed text. The current solution tries to invoke the context menu on the destination text input and select the content in order to delete it as the last retry. I've also tried other approaches, like sending control chars to the edit field or "Delete" key sequences, but nothing helps, it's just too limited to understand that :( 