### PR TITLE
feat: Bump appium/RoutingHTTPServer to 1.2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ to do this once to work on any of Facebook's open source projects.
 
 Complete your CLA here: <https://code.facebook.com/cla>
 
-## Issues  
+## Issues
 We use GitHub issues to track public bugs. Please ensure your description is
 clear and has sufficient instructions to be able to reproduce the issue.
 
@@ -26,9 +26,22 @@ Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
 disclosure of security bugs. In those cases, please go through the process
 outlined on that page and do not file a public issue.
 
-## Coding Style  
+## Coding Style
 * 2 spaces for indentation rather than tabs
 * 80 character line length
+
+## Update Carthage Dependencies
+
+1. Add a tag to the target repository
+    - e.g. https://github.com/appium/RoutingHTTPServer/releases
+2. Bump the version in `Cartfile.resolved`
+    - Please make sure the version will be downloaded and built by `carthage bootstrap` command like below
+        ```
+        *** Checking out RoutingHTTPServer at "v1.2.0"
+        *** Checking out CocoaAsyncSocket at "7.6.3"
+        *** Checking out YYCache at "1.1.0"
+        ```
+3. Create a PR to appium/WebDriverAgent repository to apply the update
 
 ## License
 By contributing to WebDriverAgent, you agree that your contributions will be licensed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ outlined on that page and do not file a public issue.
 2. Bump the version in `Cartfile.resolved`
     - Please make sure the version will be downloaded and built by `carthage bootstrap` command like below
         ```
+        $ carthage bootstrap # in appium/WebDriverAgent directory
         *** Checking out RoutingHTTPServer at "v1.2.0"
         *** Checking out CocoaAsyncSocket at "7.6.3"
         *** Checking out YYCache at "1.1.0"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,10 @@ outlined on that page and do not file a public issue.
 
 ## Update Carthage Dependencies
 
-1. Add a tag to the target repository
+1. Add a new version tag to the target repository
     - e.g. https://github.com/appium/RoutingHTTPServer/releases
+    - Please ask developers who have a permission to add the tag on the target repository
+      - The appium or appium forked repositories are Appium team members
 2. Bump the version in `Cartfile.resolved`
     - Please make sure the version will be downloaded and built by `carthage bootstrap` command like below
         ```

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "appium/RoutingHTTPServer" "v1.1.0"
+github "appium/RoutingHTTPServer" "v1.2.0"
 github "appium/YYCache" "1.1.0"
 github "robbiehanson/CocoaAsyncSocket" "7.6.3"


### PR DESCRIPTION
The 1.2.0 has a project update https://github.com/appium/RoutingHTTPServer/pull/2
I also added how to update the carthage dependency in this repo.