### PR TITLE
Changed selected alert button for dismiss/accept alert for >2 buttons

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -42,6 +42,7 @@ static NSString* const ACTIVE_APP_DETECTION_POINT = @"activeAppDetectionPoint";
 static NSString* const INCLUDE_NON_MODAL_ELEMENTS = @"includeNonModalElements";
 static NSString* const ACCEPT_ALERT_BUTTON_SELECTOR = @"acceptAlertButtonSelector";
 static NSString* const DISMISS_ALERT_BUTTON_SELECTOR = @"dismissAlertButtonSelector";
+static NSString* const LARGE_ALERT_REVERSE_ACTION = @"largeAlertReverseAction";
 
 
 @implementation FBSessionCommands
@@ -256,6 +257,7 @@ static NSString* const DISMISS_ALERT_BUTTON_SELECTOR = @"dismissAlertButtonSelec
       INCLUDE_NON_MODAL_ELEMENTS: @([FBConfiguration includeNonModalElements]),
       ACCEPT_ALERT_BUTTON_SELECTOR: FBConfiguration.acceptAlertButtonSelector,
       DISMISS_ALERT_BUTTON_SELECTOR: FBConfiguration.dismissAlertButtonSelector,
+      LARGE_ALERT_REVERSE_ACTION: @([FBConfiguration useLargeAlertReverseAction]),
     }
   );
 }
@@ -322,7 +324,10 @@ static NSString* const DISMISS_ALERT_BUTTON_SELECTOR = @"dismissAlertButtonSelec
   if (nil != [settings objectForKey:DISMISS_ALERT_BUTTON_SELECTOR]) {
     [FBConfiguration setDismissAlertButtonSelector:(NSString *)[settings objectForKey:DISMISS_ALERT_BUTTON_SELECTOR]];
   }
-
+  if (nil != [settings objectForKey:LARGE_ALERT_REVERSE_ACTION]) {
+    [FBConfiguration setuseLargeAlertReverseAction:[[settings objectForKey:LARGE_ALERT_REVERSE_ACTION] boolValue]];
+  }
+  
   return [self handleGetSettings:request];
 }
 

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -146,7 +146,7 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
   }
   if (nil == acceptButton) {
     NSArray<XCUIElement *> *buttons = [alertElement.fb_query descendantsMatchingType:XCUIElementTypeButton].allElementsBoundByAccessibilityElement;
-    acceptButton = alertElement.elementType == XCUIElementTypeAlert
+    acceptButton = alertElement.elementType == XCUIElementTypeAlert && buttons.count <= 2
       ? buttons.lastObject
       : buttons.firstObject;
   }
@@ -179,7 +179,7 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
   }
   if (nil == dismissButton) {
     NSArray<XCUIElement *> *buttons = [alertElement.fb_query descendantsMatchingType:XCUIElementTypeButton].allElementsBoundByAccessibilityElement;
-    dismissButton = alertElement.elementType == XCUIElementTypeAlert
+    dismissButton = alertElement.elementType == XCUIElementTypeAlert && buttons.count <= 2
       ? buttons.firstObject
       : buttons.lastObject;
   }

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -40,6 +40,8 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
 
 @implementation FBAlert
 
+static const int FB_LARGE_ALERT_BUTTONS_COUNT = 3;
+
 + (void)throwRequestedItemObstructedByAlertException __attribute__((noreturn))
 {
   @throw [NSException exceptionWithName:FBAlertObstructingElementException reason:@"Requested element is obstructed by alert or action sheet" userInfo:@{}];
@@ -146,9 +148,15 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
   }
   if (nil == acceptButton) {
     NSArray<XCUIElement *> *buttons = [alertElement.fb_query descendantsMatchingType:XCUIElementTypeButton].allElementsBoundByAccessibilityElement;
-    acceptButton = alertElement.elementType == XCUIElementTypeAlert && buttons.count <= 2
-      ? buttons.lastObject
-      : buttons.firstObject;
+    if (alertElement.elementType == XCUIElementTypeAlert) {
+      if (buttons.count < FB_LARGE_ALERT_BUTTONS_COUNT) {
+        acceptButton = buttons.lastObject;
+      } else {
+        acceptButton = FBConfiguration.useLargeAlertReverseAction ? buttons.firstObject : buttons.lastObject;
+      }
+    } else {
+      acceptButton = buttons.firstObject;
+    }
   }
   return nil == acceptButton
     ? [[[FBErrorBuilder builder]
@@ -179,9 +187,15 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
   }
   if (nil == dismissButton) {
     NSArray<XCUIElement *> *buttons = [alertElement.fb_query descendantsMatchingType:XCUIElementTypeButton].allElementsBoundByAccessibilityElement;
-    dismissButton = alertElement.elementType == XCUIElementTypeAlert && buttons.count <= 2
-      ? buttons.firstObject
-      : buttons.lastObject;
+    if (alertElement.elementType == XCUIElementTypeAlert) {
+      if (buttons.count < FB_LARGE_ALERT_BUTTONS_COUNT) {
+        dismissButton = buttons.firstObject;
+      } else {
+        dismissButton = FBConfiguration.useLargeAlertReverseAction ? buttons.lastObject : buttons.firstObject;
+      }
+    } else {
+      dismissButton = buttons.lastObject;
+    }
   }
   return nil == dismissButton
     ? [[[FBErrorBuilder builder]

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -187,6 +187,14 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setDismissAlertButtonSelector:(NSString *)classChainSelector;
 + (NSString *)dismissAlertButtonSelector;
 
+/**
+ Sets usage of reverse default accept/dismiss action for alerts with more than 2 buttons
+ 
+ @param enabled Turn the configuration on if the value is YES
+ */
++ (void)setuseLargeAlertReverseAction:(BOOL)enabled;
++ (BOOL)useLargeAlertReverseAction;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -44,6 +44,7 @@ static BOOL FBShouldUseFirstMatch = NO;
 static BOOL FBIncludeNonModalElements = NO;
 static NSString *FBAcceptAlertButtonSelector = @"";
 static NSString *FBDismissAlertButtonSelector = @"";
+static BOOL FBShouldUseLargeAlertReverseAction = YES;
 
 
 @implementation FBConfiguration
@@ -314,6 +315,16 @@ static NSString *FBDismissAlertButtonSelector = @"";
 + (NSString *)dismissAlertButtonSelector
 {
   return FBDismissAlertButtonSelector;
+}
+
++ (BOOL)useLargeAlertReverseAction
+{
+  return FBShouldUseLargeAlertReverseAction;
+}
+
++ (void)setuseLargeAlertReverseAction:(BOOL)enabled
+{
+  FBShouldUseLargeAlertReverseAction = enabled;
 }
 
 #pragma mark Private


### PR DESCRIPTION
Currently the logic for selecting a button to dismiss/accept an alert (if no pre-set selection query is defined) is:
For accept: 
If the type of the alert is XCUIElementTypeAlert choose the last button, if not - choose the first.
For dismiss:
If the type of the alert is XCUIElementTypeAlert choose the first button, if not - choose the last.

Through some of our test cases we've noticed that when an alert with more than 2 buttons is displayed, the more common choice for dismissing / accepting an alert is actually the other way around, (for example: location access approval and OS updates).

This PR replaces the chosen button for dismiss/accept alert if it contains more than two buttons.