### PR TITLE
chore: bump appium/RoutingHTTPServer to 1.2.2

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "appium/RoutingHTTPServer" "v1.2.1"
+github "appium/RoutingHTTPServer" "v1.2.2"
 github "appium/YYCache" "1.1.0"
 github "robbiehanson/CocoaAsyncSocket" "7.6.3"


### PR DESCRIPTION
For https://github.com/appium/RoutingHTTPServer/pull/4

```
$ ./Scripts/bootstrap.sh
Fetching dependencies
*** Checking out YYCache at "1.1.0"
*** Checking out RoutingHTTPServer at "v1.2.2"
*** Checking out CocoaAsyncSocket at "7.6.3"
*** Fetching RoutingHTTPServer
*** xcodebuild output can be found in /var/folders/34/2222sh8n27d6rcp7jqlkw8km0000gn/T/carthage-xcodebuild.m4jKrA.log
*** Downloading CocoaAsyncSocket.framework binary at "Version 7.6.3"
*** Building scheme "RoutingHTTPServer tvOS" in RoutingHTTPServer.xcodeproj
*** Building scheme "RoutingHTTPServer iOS" in RoutingHTTPServer.xcodeproj
*** Building scheme "YYCache tvOS" in YYCache.xcodeproj
*** Building scheme "YYCache iOS" in YYCache.xcodeproj
```
