### PR TITLE
chore: Add more debug output to the active application detection algorithm

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -38,14 +38,21 @@ static NSString* const FBUnknownBundleId = @"unknown";
 
 - (BOOL)fb_waitForAppElement:(NSTimeInterval)timeout
 {
-  return [[[FBRunLoopSpinner new]
+  __block BOOL canDetectAxElement = YES;
+  int currentProcessIdentifier = self.accessibilityElement.processIdentifier;
+  BOOL result = [[[FBRunLoopSpinner new]
            timeout:timeout]
           spinUntilTrue:^BOOL{
     XCAccessibilityElement *currentAppElement = FBActiveAppDetectionPoint.sharedInstance.axElement;
-    int currentProcessIdentifier = self.accessibilityElement.processIdentifier;
-    return nil != currentAppElement
-      && currentAppElement.processIdentifier == currentProcessIdentifier;
+    canDetectAxElement = nil != currentAppElement;
+    if (!canDetectAxElement) {
+      return YES;
+    }
+    return currentAppElement.processIdentifier == currentProcessIdentifier;
   }];
+  return canDetectAxElement
+    ? result
+    : [self waitForExistenceWithTimeout:timeout];
 }
 
 + (NSArray<NSDictionary<NSString *, id> *> *)fb_appsInfoWithAxElements:(NSArray<XCAccessibilityElement *> *)axElements

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -79,7 +79,7 @@ static dispatch_once_t onceAppWithPIDToken;
 - (void)fb_activate
 {
   [self activate];
-  if (![self fb_waitForAppElement:APP_STATE_CHANGE_TIMEOUT]) {
+  if (![self waitForState:XCUIApplicationStateRunningForeground timeout:APP_STATE_CHANGE_TIMEOUT / 2] || ![self fb_waitForAppElement:APP_STATE_CHANGE_TIMEOUT / 2]) {
     [FBLogger logFmt:@"The application '%@' is not running in foreground after %.2f seconds", self.bundleID, APP_STATE_CHANGE_TIMEOUT];
   }
 }


### PR DESCRIPTION
Sometimes (most likely in case of web views or third-party on-screen views) XCTest returns nil for `_XCT_requestElementAtPoint` request. We need to properly handle such cases and leave log traces, which would help us to debug such issues.