### PR TITLE
Fix searching elements inside WebViews for iOS 13.3

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -35,6 +35,7 @@ static NSString* const SCREENSHOT_QUALITY = @"screenshotQuality";
 static NSString* const KEYBOARD_AUTOCORRECTION = @"keyboardAutocorrection";
 static NSString* const KEYBOARD_PREDICTION = @"keyboardPrediction";
 static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
+static NSString* const SNAPSHOT_MAX_DEPTH = @"snapshotMaxDepth";
 static NSString* const USE_FIRST_MATCH = @"useFirstMatch";
 static NSString* const REDUCE_MOTION = @"reduceMotion";
 static NSString* const DEFAULT_ACTIVE_APPLICATION = @"defaultActiveApplication";
@@ -249,6 +250,7 @@ static NSString* const DISMISS_ALERT_BUTTON_SELECTOR = @"dismissAlertButtonSelec
       KEYBOARD_AUTOCORRECTION: @([FBConfiguration keyboardAutocorrection]),
       KEYBOARD_PREDICTION: @([FBConfiguration keyboardPrediction]),
       SNAPSHOT_TIMEOUT: @([FBConfiguration snapshotTimeout]),
+      SNAPSHOT_MAX_DEPTH: @([FBConfiguration snapshotMaxDepth]),
       USE_FIRST_MATCH: @([FBConfiguration useFirstMatch]),
       REDUCE_MOTION: @([FBConfiguration reduceMotionEnabled]),
       DEFAULT_ACTIVE_APPLICATION: request.session.defaultActiveApplication,
@@ -292,6 +294,9 @@ static NSString* const DISMISS_ALERT_BUTTON_SELECTOR = @"dismissAlertButtonSelec
   }
   if (nil != [settings objectForKey:SNAPSHOT_TIMEOUT]) {
     [FBConfiguration setSnapshotTimeout:[[settings objectForKey:SNAPSHOT_TIMEOUT] doubleValue]];
+  }
+  if (nil != [settings objectForKey:SNAPSHOT_MAX_DEPTH]) {
+    [FBConfiguration setSnapshotMaxDepth:[[settings objectForKey:SNAPSHOT_MAX_DEPTH] intValue]];
   }
   if (nil != [settings objectForKey:USE_FIRST_MATCH]) {
     [FBConfiguration setUseFirstMatch:[[settings objectForKey:USE_FIRST_MATCH] boolValue]];

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -139,6 +139,29 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSTimeInterval)snapshotTimeout;
 
 /**
+ Sets maximum depth for traversing elements tree from parents to children while requesting XCElementSnapshot.
+ Used to set maxDepth value in a dictionary provided by XCAXClient_iOS's method defaultParams.
+ The original XCAXClient_iOS maxDepth value is set to INT_MAX, which is too big for some queries
+ (for example: searching elements inside a WebView).
+ Reasonable values are from 15 to 100 (larger numbers make queries slower).
+
+ @param maxDepth The number of maximum depth for traversing elements tree
+ */
++ (void)setSnapshotMaxDepth:(int)maxDepth;
+
+/**
+  @return The number of maximum depth for traversing elements tree
+ */
++ (int)snapshotMaxDepth;
+
+/**
+ Returns parameters for traversing elements tree from parents to children while requesting XCElementSnapshot.
+
+ @return dictionary with parameters for element's snapshot request
+*/
++ (NSDictionary *)snapshotRequestParameters;
+
+/**
  * Whether to use fast search result matching while searching for elements.
  * By default this is disabled due to https://github.com/appium/appium/issues/10101
  * but it still makes sense to enable it for views containing large counts of elements

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -44,9 +44,21 @@ static BOOL FBShouldUseFirstMatch = NO;
 static BOOL FBIncludeNonModalElements = NO;
 static NSString *FBAcceptAlertButtonSelector = @"";
 static NSString *FBDismissAlertButtonSelector = @"";
+static NSString *FBSnapshotMaxDepthKey = @"maxDepth";
+static NSMutableDictionary *FBSnapshotRequestParameters;
 
 
 @implementation FBConfiguration
+
++ (void)initialize
+{
+  FBSnapshotRequestParameters = [NSMutableDictionary dictionaryWithDictionary:@{
+    @"maxArrayCount": @INT_MAX,
+    @"maxChildren": @INT_MAX,
+    FBSnapshotMaxDepthKey: @50, // 50 should be enough for the majority of the cases. The performance is acceptable for values up to 100.
+    @"traverseFromParentsToChildren": @1
+  }];
+}
 
 #pragma mark Public
 
@@ -276,6 +288,21 @@ static NSString *FBDismissAlertButtonSelector = @"";
   return FBSnapshotTimeout;
 }
 
++ (void)setSnapshotMaxDepth:(int)maxDepth
+{
+  FBSnapshotRequestParameters[FBSnapshotMaxDepthKey] = @(maxDepth);
+}
+
++ (int)snapshotMaxDepth
+{
+  return [FBSnapshotRequestParameters[FBSnapshotMaxDepthKey] intValue];
+}
+
++ (NSDictionary *)snapshotRequestParameters
+{
+  return FBSnapshotRequestParameters;
+}
+
 + (void)setUseFirstMatch:(BOOL)enabled
 {
   FBShouldUseFirstMatch = enabled;
@@ -411,4 +438,5 @@ static NSString *FBDismissAlertButtonSelector = @"";
   }
   return NO;
 }
+
 @end


### PR DESCRIPTION
Fixes issue with searching and interacting with elements inside WebViews for iOS 13.3

Swizzle ```defaultParameters``` of ```XCAXClient_iOS``` to set ```maxDepth``` to a meaningful level of recursion.

Original implementation of ```defaultParams``` returns this values
```
{
  maxArrayCount = 2147483647;
  maxChildren = 2147483647;
  maxDepth = 2147483647;
  traverseFromParentsToChildren = 1;
}
```

It is quite possible, that it is enough to change only the ```maxDepth``` parameter. I'm still experimenting.

Please do not merge yet, Just for verification if it does not break stuff.