### PR TITLE
fix: Avoid using element selector on query, which expects multiple matches

### DIFF
--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -104,14 +104,10 @@ static dispatch_once_t onceAppWithPIDToken;
 
 - (XCUIElement *)fb_firstMatch
 {
-  if (FBConfiguration.useFirstMatch) {
-    XCUIElement* result = self.firstMatch;
-    return result.exists ? result : nil;
-  }
-  if (!self.element.exists) {
-    return nil;
-  }
-  return self.allElementsBoundByAccessibilityElement.firstObject;
+  XCUIElement* match = FBConfiguration.useFirstMatch
+    ? self.firstMatch
+    : self.allElementsBoundByAccessibilityElement.firstObject;
+  return [match exists] ? match : nil;
 }
 
 - (XCElementSnapshot *)fb_elementSnapshotForDebugDescription

--- a/WebDriverAgentTests/IntegrationTests/FBPasteboardTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBPasteboardTests.m
@@ -41,7 +41,7 @@
   XCTAssertTrue([textField fb_clearTextWithError:&error]);
   [textField pressForDuration:2.0];
   XCUIElementQuery *pastItemsQuery = [[self.testedApplication descendantsMatchingType:XCUIElementTypeAny] matchingIdentifier:@"Paste"];
-  if (![pastItemsQuery.element waitForExistenceWithTimeout:2.0]) {
+  if (![pastItemsQuery.firstMatch waitForExistenceWithTimeout:2.0]) {
     XCTFail(@"No matched element named 'Paste'");
   }
   XCUIElement *pasteItem = pastItemsQuery.fb_firstMatch;


### PR DESCRIPTION
The Apple's documentation says 

<pre>
Use the element property to access a query’s result when you expect a single matching element for the query, but want to check for multiple ambiguous matches before accessing the result. 
The element property traverses your app’s accessibility tree to check for multiple matching elements before returning, and fails the current test if there is not a single matching element.
</pre>