### PR TITLE
fix: make adjusting screenshot coordinate configurable - screenshotOrientation settings api

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -259,7 +259,9 @@ static NSString* const SCREENSHOT_ORIENTATION = @"screenshotOrientation";
       INCLUDE_NON_MODAL_ELEMENTS: @([FBConfiguration includeNonModalElements]),
       ACCEPT_ALERT_BUTTON_SELECTOR: FBConfiguration.acceptAlertButtonSelector,
       DISMISS_ALERT_BUTTON_SELECTOR: FBConfiguration.dismissAlertButtonSelector,
-      SCREENSHOT_ORIENTATION: [FBConfiguration screenshotOrientationForUser],
+#if !TARGET_OS_TV
+      SCREENSHOT_ORIENTATION: [FBConfiguration humanReadableScreenshotOrientation],
+#endif
     }
   );
 }
@@ -332,7 +334,13 @@ static NSString* const SCREENSHOT_ORIENTATION = @"screenshotOrientation";
 
 #if !TARGET_OS_TV
   if (nil != [settings objectForKey:SCREENSHOT_ORIENTATION]) {
-    [FBConfiguration setScreenshotOrientation:(NSString *)[settings objectForKey:SCREENSHOT_ORIENTATION]];
+    NSError *error;
+    if (![FBConfiguration setScreenshotOrientation:(NSString *)[settings objectForKey:SCREENSHOT_ORIENTATION]
+                                             error:&error]) {
+      return FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:error.description traceback:nil]);
+    }
+
+
   }
 #endif
 

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -259,6 +259,7 @@ static NSString* const SCREENSHOT_ORIENTATION = @"screenshotOrientation";
       INCLUDE_NON_MODAL_ELEMENTS: @([FBConfiguration includeNonModalElements]),
       ACCEPT_ALERT_BUTTON_SELECTOR: FBConfiguration.acceptAlertButtonSelector,
       DISMISS_ALERT_BUTTON_SELECTOR: FBConfiguration.dismissAlertButtonSelector,
+      SCREENSHOT_ORIENTATION: [FBConfiguration screenshotOrientationForUser],
     }
   );
 }

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -43,7 +43,7 @@ static NSString* const ACTIVE_APP_DETECTION_POINT = @"activeAppDetectionPoint";
 static NSString* const INCLUDE_NON_MODAL_ELEMENTS = @"includeNonModalElements";
 static NSString* const ACCEPT_ALERT_BUTTON_SELECTOR = @"acceptAlertButtonSelector";
 static NSString* const DISMISS_ALERT_BUTTON_SELECTOR = @"dismissAlertButtonSelector";
-static NSString* const SKIP_ADJUSTING_SCREENSHOT_ORIENTATION = @"skipAdjustingScreenshotOrientation";
+static NSString* const AUTO_ADJUST_SCREENSHOT_ORIENTATION = @"autoAdjustScreenshotOrientation";
 
 
 @implementation FBSessionCommands
@@ -328,8 +328,8 @@ static NSString* const SKIP_ADJUSTING_SCREENSHOT_ORIENTATION = @"skipAdjustingSc
   if (nil != [settings objectForKey:DISMISS_ALERT_BUTTON_SELECTOR]) {
     [FBConfiguration setDismissAlertButtonSelector:(NSString *)[settings objectForKey:DISMISS_ALERT_BUTTON_SELECTOR]];
   }
-  if (nil != [settings objectForKey:SKIP_ADJUSTING_SCREENSHOT_ORIENTATION]) {
-    [FBConfiguration setSkipAdjustingScreenshotOrientation:[[settings objectForKey:SKIP_ADJUSTING_SCREENSHOT_ORIENTATION] boolValue]];
+  if (nil != [settings objectForKey:AUTO_ADJUST_SCREENSHOT_ORIENTATION]) {
+    [FBConfiguration setAutoAdjustScreenshotOrientation:[[settings objectForKey:AUTO_ADJUST_SCREENSHOT_ORIENTATION] boolValue]];
   }
 
   return [self handleGetSettings:request];

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -43,7 +43,7 @@ static NSString* const ACTIVE_APP_DETECTION_POINT = @"activeAppDetectionPoint";
 static NSString* const INCLUDE_NON_MODAL_ELEMENTS = @"includeNonModalElements";
 static NSString* const ACCEPT_ALERT_BUTTON_SELECTOR = @"acceptAlertButtonSelector";
 static NSString* const DISMISS_ALERT_BUTTON_SELECTOR = @"dismissAlertButtonSelector";
-static NSString* const AUTO_ADJUST_SCREENSHOT_ORIENTATION = @"autoAdjustScreenshotOrientation";
+static NSString* const SCREENSHOT_ORIENTATION = @"screenshotOrientation";
 
 
 @implementation FBSessionCommands
@@ -328,8 +328,8 @@ static NSString* const AUTO_ADJUST_SCREENSHOT_ORIENTATION = @"autoAdjustScreensh
   if (nil != [settings objectForKey:DISMISS_ALERT_BUTTON_SELECTOR]) {
     [FBConfiguration setDismissAlertButtonSelector:(NSString *)[settings objectForKey:DISMISS_ALERT_BUTTON_SELECTOR]];
   }
-  if (nil != [settings objectForKey:AUTO_ADJUST_SCREENSHOT_ORIENTATION]) {
-    [FBConfiguration setAutoAdjustScreenshotOrientation:[[settings objectForKey:AUTO_ADJUST_SCREENSHOT_ORIENTATION] boolValue]];
+  if (nil != [settings objectForKey:SCREENSHOT_ORIENTATION]) {
+    [FBConfiguration setScreenshotOrientation:(NSString *)[settings objectForKey:SCREENSHOT_ORIENTATION]];
   }
 
   return [self handleGetSettings:request];

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -328,9 +328,12 @@ static NSString* const SCREENSHOT_ORIENTATION = @"screenshotOrientation";
   if (nil != [settings objectForKey:DISMISS_ALERT_BUTTON_SELECTOR]) {
     [FBConfiguration setDismissAlertButtonSelector:(NSString *)[settings objectForKey:DISMISS_ALERT_BUTTON_SELECTOR]];
   }
+
+#if !TARGET_OS_TV
   if (nil != [settings objectForKey:SCREENSHOT_ORIENTATION]) {
     [FBConfiguration setScreenshotOrientation:(NSString *)[settings objectForKey:SCREENSHOT_ORIENTATION]];
   }
+#endif
 
   return [self handleGetSettings:request];
 }

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -43,7 +43,7 @@ static NSString* const ACTIVE_APP_DETECTION_POINT = @"activeAppDetectionPoint";
 static NSString* const INCLUDE_NON_MODAL_ELEMENTS = @"includeNonModalElements";
 static NSString* const ACCEPT_ALERT_BUTTON_SELECTOR = @"acceptAlertButtonSelector";
 static NSString* const DISMISS_ALERT_BUTTON_SELECTOR = @"dismissAlertButtonSelector";
-static NSString* const SKIP_ADJUSTING_SCREENSHOT_COORDINATE = @"skipAdjustingScreenshotCoordinate";
+static NSString* const SKIP_ADJUSTING_SCREENSHOT_ORIENTATION = @"skipAdjustingScreenshotOrientation";
 
 
 @implementation FBSessionCommands
@@ -328,8 +328,8 @@ static NSString* const SKIP_ADJUSTING_SCREENSHOT_COORDINATE = @"skipAdjustingScr
   if (nil != [settings objectForKey:DISMISS_ALERT_BUTTON_SELECTOR]) {
     [FBConfiguration setDismissAlertButtonSelector:(NSString *)[settings objectForKey:DISMISS_ALERT_BUTTON_SELECTOR]];
   }
-  if (nil != [settings objectForKey:SKIP_ADJUSTING_SCREENSHOT_COORDINATE]) {
-    [FBConfiguration setSkipAdjustingScreenshotCoordinate:[[settings objectForKey:SKIP_ADJUSTING_SCREENSHOT_COORDINATE] boolValue]];
+  if (nil != [settings objectForKey:SKIP_ADJUSTING_SCREENSHOT_ORIENTATION]) {
+    [FBConfiguration setSkipAdjustingScreenshotOrientation:[[settings objectForKey:SKIP_ADJUSTING_SCREENSHOT_ORIENTATION] boolValue]];
   }
 
   return [self handleGetSettings:request];

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -43,6 +43,7 @@ static NSString* const ACTIVE_APP_DETECTION_POINT = @"activeAppDetectionPoint";
 static NSString* const INCLUDE_NON_MODAL_ELEMENTS = @"includeNonModalElements";
 static NSString* const ACCEPT_ALERT_BUTTON_SELECTOR = @"acceptAlertButtonSelector";
 static NSString* const DISMISS_ALERT_BUTTON_SELECTOR = @"dismissAlertButtonSelector";
+static NSString* const SKIP_ADJUSTING_SCREENSHOT_COORDINATE = @"skipAdjustingScreenshotCoordinate";
 
 
 @implementation FBSessionCommands
@@ -326,6 +327,9 @@ static NSString* const DISMISS_ALERT_BUTTON_SELECTOR = @"dismissAlertButtonSelec
   }
   if (nil != [settings objectForKey:DISMISS_ALERT_BUTTON_SELECTOR]) {
     [FBConfiguration setDismissAlertButtonSelector:(NSString *)[settings objectForKey:DISMISS_ALERT_BUTTON_SELECTOR]];
+  }
+  if (nil != [settings objectForKey:SKIP_ADJUSTING_SCREENSHOT_COORDINATE]) {
+    [FBConfiguration setSkipAdjustingScreenshotCoordinate:[[settings objectForKey:SKIP_ADJUSTING_SCREENSHOT_COORDINATE] boolValue]];
   }
 
   return [self handleGetSettings:request];

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -221,7 +221,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param orientation Set the orientation to adjust the screenshot.
  Case insensitive "portrait", "portraitUpsideDown", "landscapeRight" and "landscapeLeft"  are available
- to force the coodinate adjust. Other wards are handled as "auto", which handles
+ to force the coodinate adjust. Other words are handled as "auto", which handles
  the adjustment automatically. Defaults to "auto".
  @param error If no availale orientation strategy was given, it returns an NSError object that describes the problem.
  */

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -220,11 +220,12 @@ NS_ASSUME_NONNULL_BEGIN
  Xcode versions, OS versions or device models and simulator or real device could influence it.
 
  @param orientation Set the orientation to adjust the screenshot.
- Case insensitive "Portrait", "PortraitUpsideDown", "LandscapeRight" and "LandscapeLeft"  are available
+ Case insensitive "portrait", "portraitUpsideDown", "landscapeRight" and "landscapeLeft"  are available
  to force the coodinate adjust. Other wards are handled as "auto", which handles
  the adjustment automatically. Defaults to "auto".
+ @param error If no availale orientation strategy was given, it returns an NSError object that describes the problem.
  */
-+ (void)setScreenshotOrientation:(NSString *)orientation;
++ (BOOL)setScreenshotOrientation:(NSString *)orientation error:(NSError **)error;
 
 /**
 @return The value of UIInterfaceOrientation
@@ -234,7 +235,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 @return The orientation as String for human read
 */
-+ (NSString *)screenshotOrientationForUser;
++ (NSString *)humanReadableScreenshotOrientation;
 
 #endif
 

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -216,11 +216,10 @@ NS_ASSUME_NONNULL_BEGIN
  But the logic sometimes cannot set the screenshot orientation properly. Skiping the logic can fix it.
  Xcode versions, OS versions or device models and simulator or real device could influence this logic.
 
- @param isEnabled Set to NO in order to skip adjusting screenshot coordinate. Defaults to YES.
+ @param orientation Set to NO in order to skip adjusting screenshot coordinate. Defaults to YES.
  */
-+ (void)setAutoAdjustScreenshotOrientation:(BOOL)isEnabled;
-+ (BOOL)autoAdjustScreenshotOrientation;
-
++ (void)setScreenshotOrientation:(NSString *)orientation;
++ (NSString *)screenshotOrientation;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -212,15 +212,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if !TARGET_OS_TV
 /**
- Adjust the screenshot orientation for iOS
- The adjustment helps to fix the screenshot coordinate when a user change the device orientation.
- But the logic sometimes cannot set the screenshot orientation properly. Skiping the logic can fix it.
- Xcode versions, OS versions or device models and simulator or real device could influence this logic.
+ Set the screenshot orientation for iOS
 
- @param orientation Set to NO in order to skip adjusting screenshot coordinate. Defaults to YES.
+ It helps to fix the screenshot orientation when the device under test's orientation changes.
+ For example, when a device changes to the landscape, the screenshot orientation could be wrong.
+ Then, this setting can force change the screenshot orientation.
+ Xcode versions, OS versions or device models and simulator or real device could influence it.
+
+ @param orientation Set the orientation to adjust the screenshot.
+ Case insensitive "Portrait", "PortraitUpsideDown", "LandscapeRight" and "LandscapeLeft"  are available
+ to force the coodinate adjust. Other wards are handled as "auto", which handles
+ the adjustment automatically. Defaults to "auto".
  */
 + (void)setScreenshotOrientation:(NSString *)orientation;
+
+/**
+@return The value of UIInterfaceOrientation
+*/
 + (NSInteger)screenshotOrientation;
+
+/**
+@return The orientation as String for human read
+*/
++ (NSString *)screenshotOrientationForUser;
+
 #endif
 
 @end

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -211,15 +211,15 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)dismissAlertButtonSelector;
 
 /**
- Skip adjusting the screenshot orientation.
+ Auto adjust the screenshot orientation.
  The adjustment helps to fix the screenshot coordinate when a user change the device orientation.
  But the logic sometimes cannot set the screenshot orientation properly. Skiping the logic can fix it.
  Xcode versions, OS versions or device models and simulator or real device could influence this logic.
 
- @param isEnabled Set to YES in order to skip adjusting screenshot coordinate. Defaults to false.
+ @param isEnabled Set to NO in order to skip adjusting screenshot coordinate. Defaults to YES.
  */
-+ (void)setSkipAdjustingScreenshotOrientation:(BOOL)isEnabled;
-+ (BOOL)skipAdjustingScreenshotOrientation;
++ (void)setAutoAdjustScreenshotOrientation:(BOOL)isEnabled;
++ (BOOL)autoAdjustScreenshotOrientation;
 
 
 @end

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -211,15 +211,15 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)dismissAlertButtonSelector;
 
 /**
- Skip adjusting the screenshot coordinate.
+ Skip adjusting the screenshot orientation.
  The adjustment helps to fix the screenshot coordinate when a user change the device orientation.
  But the logic sometimes cannot set the screenshot orientation properly. Skiping the logic can fix it.
- Xcode versions, OS versions or device models and simulator or real device could be related.
+ Xcode versions, OS versions or device models and simulator or real device could influence this logic.
 
  @param isEnabled Set to YES in order to skip adjusting screenshot coordinate. Defaults to false.
  */
-+ (void)setSkipAdjustingScreenshotCoordinate:(BOOL)isEnabled;
-+ (BOOL)skipAdjustingScreenshotCoordinate;
++ (void)setSkipAdjustingScreenshotOrientation:(BOOL)isEnabled;
++ (BOOL)skipAdjustingScreenshotOrientation;
 
 
 @end

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -210,8 +210,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setDismissAlertButtonSelector:(NSString *)classChainSelector;
 + (NSString *)dismissAlertButtonSelector;
 
+#if !TARGET_OS_TV
 /**
- Auto adjust the screenshot orientation.
+ Adjust the screenshot orientation for iOS
  The adjustment helps to fix the screenshot coordinate when a user change the device orientation.
  But the logic sometimes cannot set the screenshot orientation properly. Skiping the logic can fix it.
  Xcode versions, OS versions or device models and simulator or real device could influence this logic.
@@ -219,7 +220,8 @@ NS_ASSUME_NONNULL_BEGIN
  @param orientation Set to NO in order to skip adjusting screenshot coordinate. Defaults to YES.
  */
 + (void)setScreenshotOrientation:(NSString *)orientation;
-+ (NSString *)screenshotOrientation;
++ (NSInteger)screenshotOrientation;
+#endif
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -210,6 +210,18 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setDismissAlertButtonSelector:(NSString *)classChainSelector;
 + (NSString *)dismissAlertButtonSelector;
 
+/**
+ Skip adjusting the screenshot coordinate.
+ The adjustment helps to fix the screenshot coordinate when a user change the device orientation.
+ But the logic sometimes cannot set the screenshot orientation properly. Skiping the logic can fix it.
+ Xcode versions, OS versions or device models and simulator or real device could be related.
+
+ @param isEnabled Set to YES in order to skip adjusting screenshot coordinate. Defaults to false.
+ */
++ (void)setSkipAdjustingScreenshotCoordinate:(BOOL)isEnabled;
++ (BOOL)skipAdjustingScreenshotCoordinate;
+
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -347,7 +347,7 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
 }
 
 #if !TARGET_OS_TV
-+ (void)setScreenshotOrientation:(NSString *)orientation
++ (BOOL)setScreenshotOrientation:(NSString *)orientation error:(NSError **)error
 {
   // Only UIInterfaceOrientationUnknown is over iOS 8. Others are over iOS 2.
   // https://developer.apple.com/documentation/uikit/uiinterfaceorientation/uiinterfaceorientationunknown
@@ -357,11 +357,17 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
     FBScreenshotOrientation = UIInterfaceOrientationPortraitUpsideDown;
   } else if ([orientation.lowercaseString isEqualToString:@"landscaperight"]) {
     FBScreenshotOrientation = UIInterfaceOrientationLandscapeRight;
-  }else if ([orientation.lowercaseString isEqualToString:@"landscapeleft"]) {
+  } else if ([orientation.lowercaseString isEqualToString:@"landscapeleft"]) {
     FBScreenshotOrientation = UIInterfaceOrientationLandscapeLeft;
-  } else {
+  } else if ([orientation.lowercaseString isEqualToString:@"auto"]) {
     FBScreenshotOrientation = UIInterfaceOrientationUnknown;
+  } else {
+    return [[FBErrorBuilder.builder withDescriptionFormat:
+             @"No available orientation strategies. Available strategies are 'auto', 'portrate', " \
+             "'portraitUpsideDown', 'landscapeRight' and 'landscapeLeft'"]
+            buildError:error];
   }
+  return YES;
 }
 
 + (NSInteger)screenshotOrientation
@@ -369,18 +375,18 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
   return FBScreenshotOrientation;
 }
 
-+ (NSString *)screenshotOrientationForUser
++ (NSString *)humanReadableScreenshotOrientation
 {
   if (FBScreenshotOrientation == UIInterfaceOrientationPortrait) {
-    return @"Portrait";
+    return @"portrait";
   } else if (FBScreenshotOrientation == UIInterfaceOrientationPortraitUpsideDown) {
-     return @"PortraitUpsideDown";
+     return @"portraitUpsideDown";
   } else if (FBScreenshotOrientation == UIInterfaceOrientationLandscapeRight) {
-     return @"LandscapeRight";
+     return @"landscapeRight";
   } else if (FBScreenshotOrientation == UIInterfaceOrientationLandscapeLeft) {
-     return @"LandscapeLeft";
+     return @"landscapeLeft";
   }
-  return @"Auto";
+  return @"auto";
 }
 #endif
 

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -377,16 +377,18 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
 
 + (NSString *)humanReadableScreenshotOrientation
 {
-  if (FBScreenshotOrientation == UIInterfaceOrientationPortrait) {
-    return @"portrait";
-  } else if (FBScreenshotOrientation == UIInterfaceOrientationPortraitUpsideDown) {
-     return @"portraitUpsideDown";
-  } else if (FBScreenshotOrientation == UIInterfaceOrientationLandscapeRight) {
-     return @"landscapeRight";
-  } else if (FBScreenshotOrientation == UIInterfaceOrientationLandscapeLeft) {
-     return @"landscapeLeft";
+  switch (FBScreenshotOrientation) {
+    case UIInterfaceOrientationPortrait:
+      return @"portrait";
+    case UIInterfaceOrientationPortraitUpsideDown:
+      return @"portraitUpsideDown";
+    case UIInterfaceOrientationLandscapeRight:
+      return @"landscapeRight";
+    case UIInterfaceOrientationLandscapeLeft:
+      return @"landscapeLeft";
+    case UIInterfaceOrientationUnknown:
+      return @"auto";
   }
-  return @"auto";
 }
 #endif
 

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -363,8 +363,8 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
     FBScreenshotOrientation = UIInterfaceOrientationUnknown;
   } else {
     return [[FBErrorBuilder.builder withDescriptionFormat:
-             @"No available orientation strategies. Available strategies are 'auto', 'portrate', " \
-             "'portraitUpsideDown', 'landscapeRight' and 'landscapeLeft'"]
+             @"The orientation value '%@' is not known. Only the following orientation values are supported: " \
+             "'auto', 'portrate', 'portraitUpsideDown', 'landscapeRight' and 'landscapeLeft'", orientation]
             buildError:error];
   }
   return YES;

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -344,7 +344,7 @@ static BOOL FBSkipAdjustingScreenshotOrientation = NO;
   return FBDismissAlertButtonSelector;
 }
 
-+ (void)setSkipAdjustingScreenshotOrientation:(BOOL)isEnabled:(BOOL)isEnabled
++ (void)setSkipAdjustingScreenshotOrientation:(BOOL)isEnabled
 {
   FBSkipAdjustingScreenshotOrientation = isEnabled;
 }

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -351,9 +351,7 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
 {
   // Only UIInterfaceOrientationUnknown is over iOS 8. Others are over iOS 2.
   // https://developer.apple.com/documentation/uikit/uiinterfaceorientation/uiinterfaceorientationunknown
-  if (orientation == nil) {
-    FBScreenshotOrientation = UIInterfaceOrientationUnknown;
-  } else if ([orientation.lowercaseString isEqualToString:@"portrait"]) {
+  if ([orientation.lowercaseString isEqualToString:@"portrait"]) {
     FBScreenshotOrientation = UIInterfaceOrientationPortrait;
   } else if ([orientation.lowercaseString isEqualToString:@"portraitupsidedown"]) {
     FBScreenshotOrientation = UIInterfaceOrientationPortraitUpsideDown;
@@ -369,6 +367,20 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
 + (NSInteger)screenshotOrientation
 {
   return FBScreenshotOrientation;
+}
+
++ (NSString *)screenshotOrientationForUser
+{
+  if (FBScreenshotOrientation == UIInterfaceOrientationPortrait) {
+    return @"Portrait";
+  } else if (FBScreenshotOrientation == UIInterfaceOrientationPortraitUpsideDown) {
+     return @"PortraitUpsideDown";
+  } else if (FBScreenshotOrientation == UIInterfaceOrientationLandscapeRight) {
+     return @"LandscapeRight";
+  } else if (FBScreenshotOrientation == UIInterfaceOrientationLandscapeLeft) {
+     return @"LandscapeLeft";
+  }
+  return @"Auto";
 }
 #endif
 

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -46,7 +46,7 @@ static NSString *FBAcceptAlertButtonSelector = @"";
 static NSString *FBDismissAlertButtonSelector = @"";
 static NSString *FBSnapshotMaxDepthKey = @"maxDepth";
 static NSMutableDictionary *FBSnapshotRequestParameters;
-static BOOL FBSkipAdjustingScreenshotCoordinate = NO;
+static BOOL FBSkipAdjustingScreenshotOrientation = NO;
 
 
 @implementation FBConfiguration
@@ -344,14 +344,14 @@ static BOOL FBSkipAdjustingScreenshotCoordinate = NO;
   return FBDismissAlertButtonSelector;
 }
 
-+ (void)setSkipAdjustingScreenshotCoordinate:(BOOL)isEnabled
++ (void)setSkipAdjustingScreenshotOrientation:(BOOL)isEnabled:(BOOL)isEnabled
 {
-  FBSkipAdjustingScreenshotCoordinate = isEnabled;
+  FBSkipAdjustingScreenshotOrientation = isEnabled;
 }
 
-+ (BOOL)skipAdjustingScreenshotCoordinate
++ (BOOL)skipAdjustingScreenshotOrientation
 {
-  return FBSkipAdjustingScreenshotCoordinate;
+  return FBSkipAdjustingScreenshotOrientation;
 }
 
 #pragma mark Private

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -46,8 +46,7 @@ static NSString *FBAcceptAlertButtonSelector = @"";
 static NSString *FBDismissAlertButtonSelector = @"";
 static NSString *FBSnapshotMaxDepthKey = @"maxDepth";
 static NSMutableDictionary *FBSnapshotRequestParameters;
-static BOOL FBAutoAdjustScreenshotOrientation = YES;
-
+static NSString *FBScreenshotOrientation = @"Auto";
 
 @implementation FBConfiguration
 
@@ -344,14 +343,26 @@ static BOOL FBAutoAdjustScreenshotOrientation = YES;
   return FBDismissAlertButtonSelector;
 }
 
-+ (void)setAutoAdjustScreenshotOrientation:(BOOL)isEnabled
++ (void)setScreenshotOrientation:(NSString *)orientation
 {
-  FBAutoAdjustScreenshotOrientation = isEnabled;
+  if (orientation == nil) {
+    FBScreenshotOrientation = @"Auto";
+  } else if ([orientation.lowercaseString isEqualToString:@"portrait"]) {
+    FBScreenshotOrientation = @"Portrait";
+  } else if ([orientation.lowercaseString isEqualToString:@"portraitupsidedown"]) {
+    FBScreenshotOrientation = @"PortraitUpsideDown";
+  } else if ([orientation.lowercaseString isEqualToString:@"landscaperight"]) {
+    FBScreenshotOrientation = @"LandscapeRight";
+  }else if ([orientation.lowercaseString isEqualToString:@"landscapeleft"]) {
+    FBScreenshotOrientation = @"LandscapeLeft";
+  } else {
+    FBScreenshotOrientation = @"Auto";
+  }
 }
 
-+ (BOOL)autoAdjustScreenshotOrientation
++ (NSString *)screenshotOrientation
 {
-  return FBAutoAdjustScreenshotOrientation;
+  return FBScreenshotOrientation;
 }
 
 #pragma mark Private

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -46,7 +46,10 @@ static NSString *FBAcceptAlertButtonSelector = @"";
 static NSString *FBDismissAlertButtonSelector = @"";
 static NSString *FBSnapshotMaxDepthKey = @"maxDepth";
 static NSMutableDictionary *FBSnapshotRequestParameters;
-static NSString *FBScreenshotOrientation = @"Auto";
+
+#if !TARGET_OS_TV
+static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUnknown;
+#endif
 
 @implementation FBConfiguration
 
@@ -343,27 +346,31 @@ static NSString *FBScreenshotOrientation = @"Auto";
   return FBDismissAlertButtonSelector;
 }
 
+#if !TARGET_OS_TV
 + (void)setScreenshotOrientation:(NSString *)orientation
 {
+  // Only UIInterfaceOrientationUnknown is over iOS 8. Others are over iOS 2.
+  // https://developer.apple.com/documentation/uikit/uiinterfaceorientation/uiinterfaceorientationunknown
   if (orientation == nil) {
-    FBScreenshotOrientation = @"Auto";
+    FBScreenshotOrientation = UIInterfaceOrientationUnknown;
   } else if ([orientation.lowercaseString isEqualToString:@"portrait"]) {
-    FBScreenshotOrientation = @"Portrait";
+    FBScreenshotOrientation = UIInterfaceOrientationPortrait;
   } else if ([orientation.lowercaseString isEqualToString:@"portraitupsidedown"]) {
-    FBScreenshotOrientation = @"PortraitUpsideDown";
+    FBScreenshotOrientation = UIInterfaceOrientationPortraitUpsideDown;
   } else if ([orientation.lowercaseString isEqualToString:@"landscaperight"]) {
-    FBScreenshotOrientation = @"LandscapeRight";
+    FBScreenshotOrientation = UIInterfaceOrientationLandscapeRight;
   }else if ([orientation.lowercaseString isEqualToString:@"landscapeleft"]) {
-    FBScreenshotOrientation = @"LandscapeLeft";
+    FBScreenshotOrientation = UIInterfaceOrientationLandscapeLeft;
   } else {
-    FBScreenshotOrientation = @"Auto";
+    FBScreenshotOrientation = UIInterfaceOrientationUnknown;
   }
 }
 
-+ (NSString *)screenshotOrientation
++ (NSInteger)screenshotOrientation
 {
   return FBScreenshotOrientation;
 }
+#endif
 
 #pragma mark Private
 

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -46,7 +46,7 @@ static NSString *FBAcceptAlertButtonSelector = @"";
 static NSString *FBDismissAlertButtonSelector = @"";
 static NSString *FBSnapshotMaxDepthKey = @"maxDepth";
 static NSMutableDictionary *FBSnapshotRequestParameters;
-static BOOL FBSkipAdjustingScreenshotOrientation = NO;
+static BOOL FBAutoAdjustScreenshotOrientation = YES;
 
 
 @implementation FBConfiguration
@@ -344,14 +344,14 @@ static BOOL FBSkipAdjustingScreenshotOrientation = NO;
   return FBDismissAlertButtonSelector;
 }
 
-+ (void)setSkipAdjustingScreenshotOrientation:(BOOL)isEnabled
++ (void)setAutoAdjustScreenshotOrientation:(BOOL)isEnabled
 {
-  FBSkipAdjustingScreenshotOrientation = isEnabled;
+  FBAutoAdjustScreenshotOrientation = isEnabled;
 }
 
-+ (BOOL)skipAdjustingScreenshotOrientation
++ (BOOL)autoAdjustScreenshotOrientation
 {
-  return FBSkipAdjustingScreenshotOrientation;
+  return FBAutoAdjustScreenshotOrientation;
 }
 
 #pragma mark Private

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -46,6 +46,7 @@ static NSString *FBAcceptAlertButtonSelector = @"";
 static NSString *FBDismissAlertButtonSelector = @"";
 static NSString *FBSnapshotMaxDepthKey = @"maxDepth";
 static NSMutableDictionary *FBSnapshotRequestParameters;
+static BOOL FBSkipAdjustingScreenshotCoordinate = NO;
 
 
 @implementation FBConfiguration
@@ -341,6 +342,16 @@ static NSMutableDictionary *FBSnapshotRequestParameters;
 + (NSString *)dismissAlertButtonSelector
 {
   return FBDismissAlertButtonSelector;
+}
+
++ (void)setSkipAdjustingScreenshotCoordinate:(BOOL)isEnabled
+{
+  FBSkipAdjustingScreenshotCoordinate = isEnabled;
+}
+
++ (BOOL)skipAdjustingScreenshotCoordinate
+{
+  return FBSkipAdjustingScreenshotCoordinate;
 }
 
 #pragma mark Private

--- a/WebDriverAgentLib/Utilities/FBImageUtils.m
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.m
@@ -67,10 +67,12 @@ NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData)
 #else
 NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIInterfaceOrientation orientation)
 {
-
   UIImageOrientation imageOrientation;
   if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationUnknown) {
-    if (orientation == UIInterfaceOrientationLandscapeRight) {
+    if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+      // In iOS < 11.0 screenshots are already adjusted properly
+      imageOrientation = UIImageOrientationUp;
+    } else if (orientation == UIInterfaceOrientationLandscapeRight) {
       imageOrientation = UIImageOrientationLeft;
     } else if (orientation == UIInterfaceOrientationLandscapeLeft) {
       imageOrientation = UIImageOrientationRight;
@@ -88,7 +90,7 @@ NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIIn
       imageOrientation = UIImageOrientationDown;
     } else if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationLandscapeRight) {
       imageOrientation = UIImageOrientationLeft;
-    }else if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationLandscapeLeft) {
+    } else if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationLandscapeLeft) {
       imageOrientation = UIImageOrientationRight;
     } else {
       imageOrientation = UIImageOrientationUp;

--- a/WebDriverAgentLib/Utilities/FBImageUtils.m
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.m
@@ -86,14 +86,19 @@ NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIIn
       return (NSData *)UIImagePNGRepresentation(image);
     }
   } else {
-    if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationPortraitUpsideDown) {
-      imageOrientation = UIImageOrientationDown;
-    } else if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationLandscapeRight) {
-      imageOrientation = UIImageOrientationLeft;
-    } else if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationLandscapeLeft) {
-      imageOrientation = UIImageOrientationRight;
-    } else {
-      imageOrientation = UIImageOrientationUp;
+    switch (FBConfiguration.screenshotOrientation) {
+      case UIInterfaceOrientationPortraitUpsideDown:
+        imageOrientation = UIImageOrientationDown;
+        break;
+      case UIInterfaceOrientationLandscapeRight:
+        imageOrientation = UIImageOrientationLeft;
+        break;
+      case UIInterfaceOrientationLandscapeLeft:
+        imageOrientation = UIImageOrientationRight;
+        break;
+      default:
+        imageOrientation = UIImageOrientationUp;
+        break;
     }
   }
 

--- a/WebDriverAgentLib/Utilities/FBImageUtils.m
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.m
@@ -67,9 +67,10 @@ NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData)
 #else
 NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIInterfaceOrientation orientation)
 {
+
   UIImageOrientation imageOrientation;
   // Apply auto rotation by default for iOS >= 11.0. In iOS < 11.0 screenshots are already adjusted properly.
-  if (FBConfiguration.autoAdjustScreenshotOrientation && SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+  if ([FBConfiguration.screenshotOrientation isEqualToString:@"Auto"] && SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
     if (orientation == UIInterfaceOrientationLandscapeRight) {
       imageOrientation = UIImageOrientationLeft;
     } else if (orientation == UIInterfaceOrientationLandscapeLeft) {
@@ -84,7 +85,15 @@ NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIIn
       return (NSData *)UIImagePNGRepresentation(image);
     }
   } else {
-    imageOrientation = UIImageOrientationUp;
+    if ([FBConfiguration.screenshotOrientation isEqualToString:@"PortraitUpsideDown"]) {
+      imageOrientation = UIImageOrientationDown;
+    } else if ([FBConfiguration.screenshotOrientation isEqualToString:@"LandscapeRight"]) {
+      imageOrientation = UIImageOrientationLeft;
+    }else if ([FBConfiguration.screenshotOrientation isEqualToString:@"LandscapeLeft"]) {
+      imageOrientation = UIImageOrientationRight;
+    } else {
+      imageOrientation = UIImageOrientationUp;
+    }
   }
 
   UIImage *image = [UIImage imageWithData:screenshotData];

--- a/WebDriverAgentLib/Utilities/FBImageUtils.m
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.m
@@ -70,7 +70,7 @@ NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIIn
 
   UIImageOrientation imageOrientation;
   // Apply auto rotation by default for iOS >= 11.0. In iOS < 11.0 screenshots are already adjusted properly.
-  if ([FBConfiguration.screenshotOrientation isEqualToString:@"Auto"] && SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+  if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationUnknown && SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
     if (orientation == UIInterfaceOrientationLandscapeRight) {
       imageOrientation = UIImageOrientationLeft;
     } else if (orientation == UIInterfaceOrientationLandscapeLeft) {
@@ -85,11 +85,11 @@ NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIIn
       return (NSData *)UIImagePNGRepresentation(image);
     }
   } else {
-    if ([FBConfiguration.screenshotOrientation isEqualToString:@"PortraitUpsideDown"]) {
+    if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationPortraitUpsideDown) {
       imageOrientation = UIImageOrientationDown;
-    } else if ([FBConfiguration.screenshotOrientation isEqualToString:@"LandscapeRight"]) {
+    } else if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationLandscapeRight) {
       imageOrientation = UIImageOrientationLeft;
-    }else if ([FBConfiguration.screenshotOrientation isEqualToString:@"LandscapeLeft"]) {
+    }else if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationLandscapeLeft) {
       imageOrientation = UIImageOrientationRight;
     } else {
       imageOrientation = UIImageOrientationUp;

--- a/WebDriverAgentLib/Utilities/FBImageUtils.m
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.m
@@ -68,7 +68,7 @@ NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData)
 NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIInterfaceOrientation orientation)
 {
   UIImageOrientation imageOrientation;
-  if (SYSTEM_VERSION_LESS_THAN(@"11.0") || FBConfiguration.skipAdjustingScreenshotCoordinate) {
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0") || FBConfiguration.skipAdjustingScreenshotOrientation) {
     // In iOS < 11.0 screenshots are already adjusted properly
     imageOrientation = UIImageOrientationUp;
   } else if (orientation == UIInterfaceOrientationLandscapeRight) {

--- a/WebDriverAgentLib/Utilities/FBImageUtils.m
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.m
@@ -69,8 +69,7 @@ NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIIn
 {
 
   UIImageOrientation imageOrientation;
-  // Apply auto rotation by default for iOS >= 11.0. In iOS < 11.0 screenshots are already adjusted properly.
-  if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationUnknown && SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+  if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationUnknown) {
     if (orientation == UIInterfaceOrientationLandscapeRight) {
       imageOrientation = UIImageOrientationLeft;
     } else if (orientation == UIInterfaceOrientationLandscapeLeft) {

--- a/WebDriverAgentLib/Utilities/FBImageUtils.m
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.m
@@ -10,6 +10,7 @@
 #import "FBImageUtils.h"
 
 #import "FBMacros.h"
+#import "FBConfiguration.h"
 
 static uint8_t JPEG_MAGIC[] = { 0xff, 0xd8 };
 static const NSUInteger JPEG_MAGIC_LEN = 2;
@@ -67,7 +68,7 @@ NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData)
 NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIInterfaceOrientation orientation)
 {
   UIImageOrientation imageOrientation;
-  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0") || FBConfiguration.skipAdjustingScreenshotCoordinate) {
     // In iOS < 11.0 screenshots are already adjusted properly
     imageOrientation = UIImageOrientationUp;
   } else if (orientation == UIInterfaceOrientationLandscapeRight) {

--- a/WebDriverAgentLib/Utilities/FBImageUtils.m
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.m
@@ -68,21 +68,23 @@ NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData)
 NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIInterfaceOrientation orientation)
 {
   UIImageOrientation imageOrientation;
-  if (SYSTEM_VERSION_LESS_THAN(@"11.0") || FBConfiguration.skipAdjustingScreenshotOrientation) {
-    // In iOS < 11.0 screenshots are already adjusted properly
-    imageOrientation = UIImageOrientationUp;
-  } else if (orientation == UIInterfaceOrientationLandscapeRight) {
-    imageOrientation = UIImageOrientationLeft;
-  } else if (orientation == UIInterfaceOrientationLandscapeLeft) {
-    imageOrientation = UIImageOrientationRight;
-  } else if (orientation == UIInterfaceOrientationPortraitUpsideDown) {
-    imageOrientation = UIImageOrientationDown;
-  } else {
-    if (FBIsPngImage(screenshotData)) {
-      return screenshotData;
+  // Apply auto rotation by default for iOS >= 11.0. In iOS < 11.0 screenshots are already adjusted properly.
+  if (FBConfiguration.autoAdjustScreenshotOrientation && SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    if (orientation == UIInterfaceOrientationLandscapeRight) {
+      imageOrientation = UIImageOrientationLeft;
+    } else if (orientation == UIInterfaceOrientationLandscapeLeft) {
+      imageOrientation = UIImageOrientationRight;
+    } else if (orientation == UIInterfaceOrientationPortraitUpsideDown) {
+      imageOrientation = UIImageOrientationDown;
+    } else {
+      if (FBIsPngImage(screenshotData)) {
+        return screenshotData;
+      }
+      UIImage *image = [UIImage imageWithData:screenshotData];
+      return (NSData *)UIImagePNGRepresentation(image);
     }
-    UIImage *image = [UIImage imageWithData:screenshotData];
-    return (NSData *)UIImagePNGRepresentation(image);
+  } else {
+    imageOrientation = UIImageOrientationUp;
   }
 
   UIImage *image = [UIImage imageWithData:screenshotData];


### PR DESCRIPTION
I found the screenshot coordination should be handled as `SYSTEM_VERSION_LESS_THAN(@"11.0")` case, but it looked depending on the device under test environment.

I found landscape screenshot should follow `SYSTEM_VERSION_LESS_THAN(@"11.0")`  logic on various Xcode, iOS and model versions. It meant it was difficult to say only `SYSTEM_VERSION_LESS_THAN(@"11.0")` or `SYSTEM_VERSION_LESS_THAN(@"12.0")` etc was always true in all Xcode 10, 11 environments for us (and in the future). It also could include on simulator/devices situations.

So, let me add a setting to be able to configure the coordination on the user side when they face the screenshot orientation issue.


I tested on my local.

e.g.:
On Xcode 11.3 and iPhone 11 simulator,
- iOS 13 simulators returned correct screenshot coordinate without this setting 
- iOS 12 simulators needed this setting