### PR TITLE
Get status bar from SpringBoard because that is no longer visible on iOS 13+

### DIFF
--- a/WebDriverAgentLib/Utilities/FBScreen.m
+++ b/WebDriverAgentLib/Utilities/FBScreen.m
@@ -8,6 +8,7 @@
  */
 
 #import "FBScreen.h"
+#import "FBSpringboardApplication.h"
 #import "XCUIElement+FBIsVisible.h"
 #import "FBXCodeCompatibility.h"
 #import "XCUIScreen.h"
@@ -21,8 +22,17 @@
 
 + (CGSize)statusBarSizeForApplication:(XCUIApplication *)application
 {
-  XCUIElement *mainStatusBar = application.statusBars.fb_firstMatch;
-  if (!mainStatusBar || !mainStatusBar.fb_isVisible) {
+  XCUIApplication *app = application;
+  BOOL expectVisibleBar = YES;
+
+  // Since iOS 13 the status bar is no longer part of the application, it’s part of the SpringBoard
+  if (@available(iOS 13.0, *)) {
+    app = [FBSpringboardApplication fb_springboard];
+    expectVisibleBar = NO;
+  }
+
+  XCUIElement *mainStatusBar = app.statusBars.fb_firstMatch;
+  if (!mainStatusBar || (expectVisibleBar && !mainStatusBar.fb_isVisible)) {
     return CGSizeZero;
   }
   return mainStatusBar.frame.size;

--- a/WebDriverAgentTests/IntegrationTests/FBScreenTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBScreenTests.m
@@ -32,11 +32,7 @@
 {
   CGSize statusBarSize = [FBScreen statusBarSizeForApplication:self.testedApplication];
   BOOL statusBarSizeIsZero = CGSizeEqualToSize(CGSizeZero, statusBarSize);
-  if (@available(iOS 13.0, *)) {
-    XCTAssertTrue(statusBarSizeIsZero);
-  } else {
-    XCTAssertFalse(statusBarSizeIsZero);
-  }
+  XCTAssertFalse(statusBarSizeIsZero);
 }
 
 @end


### PR DESCRIPTION
Hello, after migration to iOS 13 we faced the issue where WDA endpoint (/wda/screen) started to return 0 status bar height, and looks like it doesn't depends on app we test because the issue can be reproduced by opening any standard iOS app. I googled it a bit and found that some guys say that on iOS 13+ status bar is no loner a part of launched apps, but rather a part of SpringBoard (home screen)