### PR TITLE
refactor: do not print stack trace for lsof error

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -355,7 +355,7 @@ async function getPIDsListeningOnPort (port, filteringFunc = null) {
   } catch (e) {
     if (e.code !== 1) {
       // code 1 means no processes. Other errors need reporting
-      log.debug(`Error getting processes listening on port '${port}': ${e.message}`);
+      log.debug(`Error getting processes listening on port '${port}': ${e.stderr || e.message}`);
     }
     return result;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -353,7 +353,7 @@ async function getPIDsListeningOnPort (port, filteringFunc = null) {
     const {stdout} = await exec('lsof', ['-ti', `tcp:${port}`]);
     result.push(...(stdout.trim().split(/\n+/)));
   } catch (e) {
-    log.debug(e);
+    log.debug(`Error getting processes listening on port '${port}': ${e.message}`);
     return result;
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -353,7 +353,10 @@ async function getPIDsListeningOnPort (port, filteringFunc = null) {
     const {stdout} = await exec('lsof', ['-ti', `tcp:${port}`]);
     result.push(...(stdout.trim().split(/\n+/)));
   } catch (e) {
-    log.debug(`Error getting processes listening on port '${port}': ${e.message}`);
+    if (e.code !== 1) {
+      // code 1 means no processes. Other errors need reporting
+      log.debug(`Error getting processes listening on port '${port}': ${e.message}`);
+    }
     return result;
   }
 


### PR DESCRIPTION
There is no diagnostic information to be gained from the full error being printed
```
dbug WebDriverAgent Error: Command 'lsof -ti tcp\:8100' exited with code 1
dbug WebDriverAgent     at ChildProcess.proc.on.code (/Users/travis/build/imurchie/appium-xcuitest-driver/node_modules/teen_process/lib/exec.js:113:19)
dbug WebDriverAgent     at ChildProcess.emit (events.js:198:13)
dbug WebDriverAgent     at maybeClose (internal/child_process.js:982:16)
dbug WebDriverAgent     at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)
dbug WebDriverAgent No obsolete cached processes from previous WDA sessions listening on port 8100 have been found
```
I'm not entirely convinced that _any_ error needs to be printed here, since when no processes are found `lsof` produces an error, which is an expected condition within our usage.