### PR TITLE
feat: Support custom WDA URL by webDriverAgentUrl

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -147,7 +147,7 @@ class WebDriverAgent {
     const noSessionProxy = new NoSessionProxy({
       server: this.url.hostname,
       port: this.url.port,
-      base: this.url.path ? this.url.path : '',
+      base: this.url.path || '',
       timeout: 3000,
     });
     try {
@@ -313,7 +313,7 @@ class WebDriverAgent {
     const proxyOpts = {
       server: this.url.hostname,
       port: this.url.port,
-      base: this.url.path ? this.url.path : '',
+      base: this.url.path || '',
       timeout: this.wdaConnectionTimeout,
       keepAlive: true,
     };

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -147,7 +147,7 @@ class WebDriverAgent {
     const noSessionProxy = new NoSessionProxy({
       server: this.url.hostname,
       port: this.url.port,
-      base: '',
+      base: this.url.path ? this.url.path : '',
       timeout: 3000,
     });
     try {
@@ -313,7 +313,7 @@ class WebDriverAgent {
     const proxyOpts = {
       server: this.url.hostname,
       port: this.url.port,
-      base: '',
+      base: this.url.path ? this.url.path : '',
       timeout: this.wdaConnectionTimeout,
       keepAlive: true,
     };

--- a/test/unit/webdriveragent-specs.js
+++ b/test/unit/webdriveragent-specs.js
@@ -150,16 +150,12 @@ describe('launch', function () {
 
 describe('use wda proxy url', function () {
   it('should use webDriverAgentUrl wda proxy url', function () {
-    let args = Object.assign({}, {
-      device: 'some sim',
-      platformVersion: '9',
-      realDevice: false,
-      webDriverAgentUrl: 'http://mockurl:8100/aabbccdd'
-    });
+    let args = Object.assign({}, fakeConstructorArgs);
     let agent = new WebDriverAgent({}, args);
+    agent.url = 'http://127.0.0.1:8100/aabbccdd';
 
-    agent.url.port.should.eql(8100);
-    agent.url.hostname.should.eql('mockurl');
+    agent.url.port.should.eql('8100');
+    agent.url.hostname.should.eql('127.0.0.1');
     agent.url.path.should.eql('/aabbccdd');
   });
 });

--- a/test/unit/webdriveragent-specs.js
+++ b/test/unit/webdriveragent-specs.js
@@ -148,6 +148,19 @@ describe('launch', function () {
   });
 });
 
+describe('use wda proxy url', function () {
+  it('should use webDriverAgentUrl wda proxy url', async function () {
+    let override = 'http://mockurl:8100/aabbccdd';
+    let args = Object.assign({}, fakeConstructorArgs);
+    args.webDriverAgentUrl = override;
+    let agent = new WebDriverAgent({}, args);
+
+    agent.url.port.should.eql(8100);
+    agent.url.hostname.should.eql('mockurl');
+    agent.url.path.should.eql('/aabbccdd');
+  });
+});
+
 describe('get url', function () {
   it('should use default WDA listening url', function () {
     const args = Object.assign({}, fakeConstructorArgs);

--- a/test/unit/webdriveragent-specs.js
+++ b/test/unit/webdriveragent-specs.js
@@ -149,7 +149,7 @@ describe('launch', function () {
 });
 
 describe('use wda proxy url', function () {
-  it('should use webDriverAgentUrl wda proxy url', async function () {
+  it('should use webDriverAgentUrl wda proxy url', function () {
     let override = 'http://mockurl:8100/aabbccdd';
     let args = Object.assign({}, fakeConstructorArgs);
     args.webDriverAgentUrl = override;

--- a/test/unit/webdriveragent-specs.js
+++ b/test/unit/webdriveragent-specs.js
@@ -150,9 +150,12 @@ describe('launch', function () {
 
 describe('use wda proxy url', function () {
   it('should use webDriverAgentUrl wda proxy url', function () {
-    let override = 'http://mockurl:8100/aabbccdd';
-    let args = Object.assign({}, fakeConstructorArgs);
-    args.webDriverAgentUrl = override;
+    let args = Object.assign({}, {
+        device: 'some sim',
+        platformVersion: '9',
+        realDevice: false,
+        webDriverAgentUrl: 'http://mockurl:8100/aabbccdd'
+    });
     let agent = new WebDriverAgent({}, args);
 
     agent.url.port.should.eql(8100);

--- a/test/unit/webdriveragent-specs.js
+++ b/test/unit/webdriveragent-specs.js
@@ -151,10 +151,10 @@ describe('launch', function () {
 describe('use wda proxy url', function () {
   it('should use webDriverAgentUrl wda proxy url', function () {
     let args = Object.assign({}, {
-        device: 'some sim',
-        platformVersion: '9',
-        realDevice: false,
-        webDriverAgentUrl: 'http://mockurl:8100/aabbccdd'
+      device: 'some sim',
+      platformVersion: '9',
+      realDevice: false,
+      webDriverAgentUrl: 'http://mockurl:8100/aabbccdd'
     });
     let agent = new WebDriverAgent({}, args);
 


### PR DESCRIPTION
We need to support custom webDriverAgentUrl, example http://127.0.0.1:8005/08df5f4ef30445b38b5538d2c3466c94, but the wda proxy just support hostname and port, the base field have hardcode ' ', Cause the path of the url to be invalid

    const proxyOpts = {
      server: this.url.hostname,
      port: this.url.port,
      **base: '',**
      timeout: this.wdaConnectionTimeout,
      keepAlive: true
    };