### PR TITLE
fix: Make sure unique element identifier can always be extracted

### DIFF
--- a/WebDriverAgentLib/Categories/XCAccessibilityElement+FBComparison.m
+++ b/WebDriverAgentLib/Categories/XCAccessibilityElement+FBComparison.m
@@ -14,7 +14,11 @@
 
 - (BOOL)fb_isEqualToElement:(XCAccessibilityElement *)other
 {
-  return nil == other ? NO : [[FBElementUtils uidWithAccessibilityElement:self] isEqualToString:[FBElementUtils uidWithAccessibilityElement:other]];
+  if (nil == other) {
+    return NO;
+  }
+  return [[FBElementUtils uidWithAccessibilityElement:self]
+          isEqualToString:([FBElementUtils uidWithAccessibilityElement:other] ?: @"")];
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUID.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUID.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface XCUIElement (FBUID)
 
 /*! Represents unique internal element identifier, which is the same for an element and its snapshot */
-@property (nonatomic, readonly, copy) NSString *fb_uid;
+@property (nonatomic, nullable, readonly, copy) NSString *fb_uid;
 
 @end
 
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface XCElementSnapshot (FBUID)
 
 /*! Represents unique internal element identifier, which is the same for an element and its snapshot */
-@property (nonatomic, readonly, copy) NSString *fb_uid;
+@property (nonatomic, nullable, readonly, copy) NSString *fb_uid;
 
 @end
 

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -285,7 +285,7 @@
   if (focusedElement != nil) {
     FBElementCache *elementCache = request.session.elementCache;
     NSString *focusedUUID = [elementCache storeElement:focusedElement];
-    if ([focusedUUID isEqualToString:(id)request.parameters[@"uuid"]]) {
+    if (focusedUUID && [focusedUUID isEqualToString:(id)request.parameters[@"uuid"]]) {
       isFocused = YES;
     }
   }

--- a/WebDriverAgentLib/Routing/FBElementCache.h
+++ b/WebDriverAgentLib/Routing/FBElementCache.h
@@ -26,9 +26,9 @@ extern const int ELEMENT_CACHE_SIZE;
  Stores element in cache
 
  @param element element to store
- @return element's uuid
+ @return element's uuid or nil in case the element uid cannnot be extracted
  */
-- (NSString *)storeElement:(XCUIElement *)element;
+- (nullable NSString *)storeElement:(XCUIElement *)element;
 
 /**
  Returns cached element

--- a/WebDriverAgentLib/Routing/FBElementCache.m
+++ b/WebDriverAgentLib/Routing/FBElementCache.m
@@ -39,6 +39,9 @@ const int ELEMENT_CACHE_SIZE = 1024;
 - (NSString *)storeElement:(XCUIElement *)element
 {
   NSString *uuid = element.fb_uid;
+  if (nil == uuid) {
+    return nil;
+  }
   [self.elementCache setObject:element forKey:uuid];
   return uuid;
 }

--- a/WebDriverAgentLib/Routing/FBElementUtils.h
+++ b/WebDriverAgentLib/Routing/FBElementUtils.h
@@ -51,9 +51,9 @@ extern NSString *const FBUnknownAttributeException;
  Gets the unique identifier of the particular XCAccessibilityElement instance.
  
  @param element accessiblity element instance
- @return the unique element identifier
+ @return the unique element identifier or nil if it cannot be retrieved
  */
-+ (NSString *)uidWithAccessibilityElement:(XCAccessibilityElement *)element;
++ (nullable NSString *)uidWithAccessibilityElement:(XCAccessibilityElement *)element;
 
 @end
 

--- a/WebDriverAgentLib/Routing/FBElementUtils.m
+++ b/WebDriverAgentLib/Routing/FBElementUtils.m
@@ -123,6 +123,9 @@ static dispatch_once_t oncePayloadToken;
     elementId = [[element valueForKey:@"_elementID"] longLongValue];
   }
   int processId = element.processIdentifier;
+  if (elementId < 1 || processId < 1) {
+    return nil;
+  }
   uint8_t b[16] = {0};
   memcpy(b, &elementId, sizeof(long long));
   memcpy(b + sizeof(long long), &processId, sizeof(int));

--- a/WebDriverAgentLib/Routing/FBResponsePayload.m
+++ b/WebDriverAgentLib/Routing/FBResponsePayload.m
@@ -35,7 +35,9 @@ id<FBResponsePayload> FBResponseWithObject(id object)
 id<FBResponsePayload> FBResponseWithCachedElement(XCUIElement *element, FBElementCache *elementCache, BOOL compact)
 {
   NSString *elementUUID = [elementCache storeElement:element];
-  return FBResponseWithStatus([FBCommandStatus okWithValue: FBDictionaryResponseWithElement(element, elementUUID, compact)]);
+  return nil == elementUUID
+    ? FBResponseWithStatus([FBCommandStatus staleElementReferenceErrorWithMessage:nil traceback:nil])
+    : FBResponseWithStatus([FBCommandStatus okWithValue: FBDictionaryResponseWithElement(element, elementUUID, compact)]);
 }
 
 id<FBResponsePayload> FBResponseWithCachedElements(NSArray<XCUIElement *> *elements, FBElementCache *elementCache, BOOL compact)
@@ -43,7 +45,9 @@ id<FBResponsePayload> FBResponseWithCachedElements(NSArray<XCUIElement *> *eleme
   NSMutableArray *elementsResponse = [NSMutableArray array];
   for (XCUIElement *element in elements) {
     NSString *elementUUID = [elementCache storeElement:element];
-    [elementsResponse addObject:FBDictionaryResponseWithElement(element, elementUUID, compact)];
+    if (nil != elementUUID) {
+      [elementsResponse addObject:FBDictionaryResponseWithElement(element, elementUUID, compact)];
+    }
   }
   return FBResponseWithStatus([FBCommandStatus okWithValue:elementsResponse]);
 }


### PR DESCRIPTION
It turns out for some elements (usually non-existing) uuid cannot be extracted, which creates responses similar to:

```
bug [09-54-24:825] WD Proxy Proxying [POST /elements] to [POST http://127.0.0.1:8100/session/C12DF3AE-E1A7-4807-94AB-50D426A6944B/elements] with body: {"using":"class name","value":"XCUIElementTypeButton"}
dbug [09-55-07:649] WD Proxy Got response with status 200: {"value":[{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{"ELEMENT":"AF000000-0000-0000-3F1A-010000000000","element-6066-11e4-a52e-4f735466cecf":"AF000000-0000-0000-3F1A-010000000000"},{"ELEMENT":"B4000000-0000-0000-3F1A-010000000000","element-6066-11e4-a52e-4f735466cecf":"B4000000-0000-0000-3F1A-010000000000"},{"ELEMENT":"B9000000-0000-0000-3F1A-010000000000","element-6066-11e4-a52e-4f735466cecf":"B9000000-0000-0000-3F1A-010000000000"},{"ELEMENT":"BE000000-0000-0000-3F1A-010000000000","element-6066-11e4-a52e-4f735466cecf":"BE000000-0000-0000-3F1A-010000000000"},{"ELEMENT":"C3000000-0000-0000-3F1A-010000000000","element-6066-11e4-a52e-4f735466cecf":"C3000000-0000-0000-3F1A-010000000000"},{"ELEMENT":"C8000000-0000-0000-3F1A-010000000000","element-6066-11e4-a52e-4f735466cecf":"C8000000-0000-0000-3F1A-010000000000"},{"ELEMENT":"CD000000-0000-0000-3F1A-010000000000","element-6066-11e4-a52e-4f735466cecf":"CD000000-0000-0000-3F1A-010000000000"}],"sessionId":"C12DF3AE-E1A7-4807-94AB-50D426A6944B"}
dbug [09-55-07:649] MJSONWP (65a609c7) Responding to client with driver.findElements() result: [{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{"element-6066-11e4-a52e-4f735466cecf":"AF000000-0000-0000-3F1A-010000000000","ELEMENT":"AF000000-0000-0000-3F1A-010000000000"},{"element-6066-11e4-a52e-4f735466cecf":"B4000000-0000-0000-3F1A-010000000000","ELEMENT":"B4000000-0000-0000-3F1A-010000000000"},{"element-6066-11e4-a52e-4f735466cecf":"B9000000-0000-0000-3F1A-010000000000","ELEMENT":"B9000000-0000-0000-3F1A-010000000000"},{"element-6066-11e4-a52e-4f735466cecf":"BE000000-0000-0000-3F1A-010000000000","ELEMENT":"BE000000-0000-0000-3F1A-010000000000"},{"element-6066-11e4-a52e-4f735466cecf":"C3000000-0000-0000-3F1A-010000000000","ELEMENT":"C3000000-0000-0000-3F1A-010000000000"},{"element-6066-11e4-a52e-4f735466cecf":"C8000000-0000-0000-3F1A-010000000000","ELEMENT":"C8000000-0000-0000-3F1A-010000000000"},{"element-6066-11e4-a52e-4f735466cecf":"CD000000-0000-0000-3F1A-010000000000","ELEMENT":"CD000000-0000-0000-3F1A-010000000000"}]
```

In this PR we always make sure the element uid is always valid before retuning it to the client