### PR TITLE
fix proxies in #292

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -125,7 +125,7 @@ class WebDriverAgent {
     if (this.url.path === '/') {
       return '';
     }
-    return this.url.path || '';
+    return this.url.path;
   }
 
   /**

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -121,7 +121,7 @@ class WebDriverAgent {
     return !!(await this.getStatus());
   }
 
-  getBasePath () {
+  get basePath () {
     if (this.url.path === '/') {
       return '';
     }
@@ -154,7 +154,7 @@ class WebDriverAgent {
     const noSessionProxy = new NoSessionProxy({
       server: this.url.hostname,
       port: this.url.port,
-      base: this.getBasePath(),
+      base: this.basePath,
       timeout: 3000,
     });
     try {
@@ -320,7 +320,7 @@ class WebDriverAgent {
     const proxyOpts = {
       server: this.url.hostname,
       port: this.url.port,
-      base: this.getBasePath(),
+      base: this.basePath,
       timeout: this.wdaConnectionTimeout,
       keepAlive: true,
     };

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -121,6 +121,13 @@ class WebDriverAgent {
     return !!(await this.getStatus());
   }
 
+  getBasePath () {
+    if (this.url.path === '/') {
+      return '';
+    }
+    return this.url.path || '';
+  }
+
   /**
    * Return current running WDA's status like below
    * {
@@ -147,7 +154,7 @@ class WebDriverAgent {
     const noSessionProxy = new NoSessionProxy({
       server: this.url.hostname,
       port: this.url.port,
-      base: this.url.path || '',
+      base: this.getBasePath(),
       timeout: 3000,
     });
     try {
@@ -313,7 +320,7 @@ class WebDriverAgent {
     const proxyOpts = {
       server: this.url.hostname,
       port: this.url.port,
-      base: this.url.path || '',
+      base: this.getBasePath(),
       timeout: this.wdaConnectionTimeout,
       keepAlive: true,
     };

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -125,7 +125,7 @@ class WebDriverAgent {
     if (this.url.path === '/') {
       return '';
     }
-    return this.url.path;
+    return this.url.path || '';
   }
 
   /**

--- a/test/unit/webdriveragent-specs.js
+++ b/test/unit/webdriveragent-specs.js
@@ -133,30 +133,49 @@ describe('checking for dependencies', function () {
 
 describe('launch', function () {
   it('should use webDriverAgentUrl override and return current status', async function () {
-    let override = 'http://mockurl:8100/';
-    let args = Object.assign({}, fakeConstructorArgs);
+    const override = 'http://mockurl:8100/';
+    const args = Object.assign({}, fakeConstructorArgs);
     args.webDriverAgentUrl = override;
-    let agent = new WebDriverAgent({}, args);
-    let wdaStub = sinon.stub(agent, 'getStatus');
+    const agent = new WebDriverAgent({}, args);
+    const wdaStub = sinon.stub(agent, 'getStatus');
     wdaStub.callsFake(function () {
       return {build: 'data'};
     });
 
     await agent.launch('sessionId').should.eventually.eql({build: 'data'});
     agent.url.href.should.eql(override);
+    agent.jwproxy.server.should.eql('mockurl');
+    agent.jwproxy.port.should.eql('8100');
+    agent.jwproxy.base.should.eql('');
+    agent.noSessionProxy.server.should.eql('mockurl');
+    agent.noSessionProxy.port.should.eql('8100');
+    agent.noSessionProxy.base.should.eql('');
     wdaStub.reset();
   });
 });
 
 describe('use wda proxy url', function () {
-  it('should use webDriverAgentUrl wda proxy url', function () {
-    let args = Object.assign({}, fakeConstructorArgs);
-    let agent = new WebDriverAgent({}, args);
-    agent.url = 'http://127.0.0.1:8100/aabbccdd';
+  it('should use webDriverAgentUrl wda proxy url', async function () {
+    const override = 'http://127.0.0.1:8100/aabbccdd';
+    const args = Object.assign({}, fakeConstructorArgs);
+    args.webDriverAgentUrl = override;
+    const agent = new WebDriverAgent({}, args);
+    const wdaStub = sinon.stub(agent, 'getStatus');
+    wdaStub.callsFake(function () {
+      return {build: 'data'};
+    });
+
+    await agent.launch('sessionId').should.eventually.eql({build: 'data'});
 
     agent.url.port.should.eql('8100');
     agent.url.hostname.should.eql('127.0.0.1');
     agent.url.path.should.eql('/aabbccdd');
+    agent.jwproxy.server.should.eql('127.0.0.1');
+    agent.jwproxy.port.should.eql('8100');
+    agent.jwproxy.base.should.eql('/aabbccdd');
+    agent.noSessionProxy.server.should.eql('127.0.0.1');
+    agent.noSessionProxy.port.should.eql('8100');
+    agent.noSessionProxy.base.should.eql('/aabbccdd');
   });
 });
 


### PR DESCRIPTION
After https://github.com/appium/WebDriverAgent/pull/292, the default `jwproxy` and `noSessionProxy` were broken since `url.parse`'s `path` had `/` by default.
`this.url` is the result of `url.parse`