### PR TITLE
chore: Remove the unused alert obstruction checks

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
@@ -22,8 +22,7 @@
   if (nil == alert) {
     return nil;
   }
-  BOOL isPhone = [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone;
-  if (!isPhone
+  if ([UIDevice currentDevice].userInterfaceIdiom != UIUserInterfaceIdiomPhone
       && alert.elementType != XCUIElementTypeAlert
       && nil == [self.query matchingIdentifier:@"PopoverDismissRegion"].fb_firstMatch) {
     // In case of iPad we want to check if sheet isn't contained by popover.

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
@@ -15,25 +15,22 @@
 
 - (XCUIElement *)fb_alertElement
 {
-  XCUIElement *alert = self.alerts.element;
-  if (alert.exists) {
-    return alert;
+  NSPredicate *alertCollectorPredicate = [NSPredicate predicateWithFormat:@"elementType IN {%lu,%lu}",
+                                          XCUIElementTypeAlert, XCUIElementTypeSheet];
+  XCUIElement *alert = [[self descendantsMatchingType:XCUIElementTypeAny]
+                      matchingPredicate:alertCollectorPredicate].fb_firstMatch;
+  if (nil == alert) {
+    return nil;
   }
-
-  alert = self.sheets.element;
-  if (alert.exists) {
-    if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
-      return alert;
-    }
+  BOOL isPhone = [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone;
+  if (!isPhone
+      && alert.elementType != XCUIElementTypeAlert
+      && nil == [self.query matchingIdentifier:@"PopoverDismissRegion"].fb_firstMatch) {
     // In case of iPad we want to check if sheet isn't contained by popover.
     // In that case we ignore it.
-    NSPredicate *predicateString = [NSPredicate predicateWithFormat:@"identifier == 'PopoverDismissRegion'"];
-    XCUIElementQuery *query = [[self.fb_query descendantsMatchingType:XCUIElementTypeAny] matchingPredicate:predicateString];
-    if (!query.fb_firstMatch) {
-      return alert;
-    }
+    return nil;
   }
-  return nil;
+  return alert;
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
@@ -17,14 +17,14 @@
 {
   NSPredicate *alertCollectorPredicate = [NSPredicate predicateWithFormat:@"elementType IN {%lu,%lu}",
                                           XCUIElementTypeAlert, XCUIElementTypeSheet];
-  XCUIElement *alert = [[self descendantsMatchingType:XCUIElementTypeAny]
+  XCUIElement *alert = [[self.fb_query descendantsMatchingType:XCUIElementTypeAny]
                       matchingPredicate:alertCollectorPredicate].fb_firstMatch;
   if (nil == alert) {
     return nil;
   }
   if ([UIDevice currentDevice].userInterfaceIdiom != UIUserInterfaceIdiomPhone
       && alert.elementType != XCUIElementTypeAlert
-      && nil == [self.query matchingIdentifier:@"PopoverDismissRegion"].fb_firstMatch) {
+      && nil == [self.fb_query matchingIdentifier:@"PopoverDismissRegion"].fb_firstMatch) {
     // In case of iPad we want to check if sheet isn't contained by popover.
     // In that case we ignore it.
     return nil;

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
@@ -23,8 +23,8 @@
     return nil;
   }
   if ([UIDevice currentDevice].userInterfaceIdiom != UIUserInterfaceIdiomPhone
-      && alert.elementType != XCUIElementTypeAlert
-      && nil == [self.fb_query matchingIdentifier:@"PopoverDismissRegion"].fb_firstMatch) {
+      && alert.elementType == XCUIElementTypeSheet
+      && nil != [self.fb_query matchingIdentifier:@"PopoverDismissRegion"].fb_firstMatch) {
     // In case of iPad we want to check if sheet isn't contained by popover.
     // In that case we ignore it.
     return nil;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
@@ -21,19 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)fb_waitUntilFrameIsStable;
 
 /**
- Checks if receiver is obstructed by alert
- */
-- (BOOL)fb_isObstructedByAlert;
-
-/**
- Checks if receiver obstructs given element
-
- @param element tested element
- @return YES if receiver obstructs 'element', otherwise NO
- */
-- (BOOL)fb_obstructsElement:(XCUIElement *)element;
-
-/**
  Gets the most recent snapshot of the current element. The element will be
  automatically resolved if the snapshot is not available yet
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -11,7 +11,6 @@
 
 #import <objc/runtime.h>
 
-#import "FBAlert.h"
 #import "FBConfiguration.h"
 #import "FBLogger.h"
 #import "FBImageUtils.h"
@@ -48,27 +47,6 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
     frame = newFrame;
     return isSameFrame;
   }];
-}
-
-- (BOOL)fb_isObstructedByAlert
-{
-  return [[FBAlert alertWithApplication:self.application].alertElement fb_obstructsElement:self];
-}
-
-- (BOOL)fb_obstructsElement:(XCUIElement *)element
-{
-  if (!self.exists) {
-    return NO;
-  }
-  XCElementSnapshot *snapshot = self.fb_lastSnapshot;
-  XCElementSnapshot *elementSnapshot = element.fb_lastSnapshot;
-  if ([snapshot _isAncestorOfElement:elementSnapshot]) {
-    return NO;
-  }
-  if ([snapshot _matchesElement:elementSnapshot]) {
-    return NO;
-  }
-  return YES;
 }
 
 - (XCElementSnapshot *)fb_lastSnapshot

--- a/WebDriverAgentLib/FBAlert.h
+++ b/WebDriverAgentLib/FBAlert.h
@@ -14,18 +14,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*! Notification used to notify about requested element being obstructed by alert */
-extern NSString *const FBAlertObstructingElementException;
-
 /**
  Alert helper class that abstracts alert handling
  */
 @interface FBAlert : NSObject
-
-/**
- Throws FBAlertObstructingElementException
- */
-+ (void)throwRequestedItemObstructedByAlertException __attribute__((noreturn));
 
 /**
  Creates alert helper for given application
@@ -80,14 +72,6 @@ extern NSString *const FBAlertObstructingElementException;
  @return YES if the operation suceeds, otherwise NO.
  */
 - (BOOL)clickAlertButton:(NSString *)label error:(NSError **)error;
-
-/**
- Filters out elements obstructed by alert
-
- @param elements array of elements we want to filter
- @return elements not obstructed by alert
- */
-- (NSArray<XCUIElement *> *)filterObstructedElements:(NSArray<XCUIElement *> *)elements;
 
 /**
  XCUElement that represents alert

--- a/WebDriverAgentLib/Routing/FBExceptionHandler.m
+++ b/WebDriverAgentLib/Routing/FBExceptionHandler.m
@@ -38,9 +38,6 @@ NSString *const FBTimeoutException = @"FBTimeoutException";
              || [exception.name isEqualToString:FBElementAttributeUnknownException]) {
     commandStatus = [FBCommandStatus invalidArgumentErrorWithMessage:exception.reason
                                                            traceback:traceback];
-  } else if ([exception.name isEqualToString:FBAlertObstructingElementException]) {
-    commandStatus =[FBCommandStatus unexpectedAlertOpenErrorWithMessage:nil
-                                                              traceback:traceback];
   } else if ([exception.name isEqualToString:FBApplicationCrashedException]
              || [exception.name isEqualToString:FBApplicationDeadlockDetectedException]) {
     commandStatus = [FBCommandStatus invalidElementStateErrorWithMessage:exception.reason

--- a/WebDriverAgentTests/IntegrationTests/FBAlertTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBAlertTests.m
@@ -51,11 +51,6 @@
   FBAssertWaitTillBecomesTrue(self.testedApplication.sheets.count != 0);
 }
 
-- (void)testAlertException
-{
-  XCTAssertThrowsSpecificNamed([FBAlert throwRequestedItemObstructedByAlertException], NSException, FBAlertObstructingElementException);
-}
-
 - (void)testAlertPresence
 {
   FBAlert *alert = [FBAlert alertWithApplication:self.testedApplication];
@@ -146,17 +141,6 @@
   XCTAssertTrue(alertElement.elementType == XCUIElementTypeAlert);
 }
 
-- (void)testFilteringObstructedElements
-{
-  FBAlert *alert = [FBAlert alertWithApplication:self.testedApplication];
-  XCUIElement *showAlertButton = self.testedApplication.buttons[FBShowAlertButtonName];
-  XCUIElement *acceptAlertButton = self.testedApplication.buttons[@"Will do"];
-  [self showApplicationAlert];
-
-  NSArray *filteredElements = [alert filterObstructedElements:@[showAlertButton, acceptAlertButton]];
-  XCTAssertEqualObjects(filteredElements, @[acceptAlertButton]);
-}
-
 - (void)testNotificationAlert
 {
   FBAlert *alert = [FBAlert alertWithApplication:self.testedApplication];
@@ -189,25 +173,6 @@
 
   XCTAssertTrue([alert.text containsString:@"to access your location"]);
   XCTAssertTrue([alert.text containsString:@"Yo Yo"]);
-}
-
-- (void)testSheetAlert
-{
-  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
-    // This test is unstable under Xcode8
-    return;
-  }
-  FBAlert *alert = [FBAlert alertWithApplication:self.testedApplication];
-  BOOL isIpad = [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad;
-  [self showApplicationSheet];
-  XCUIElement *showSheetButton = self.testedApplication.buttons[FBShowSheetAlertButtonName];
-  //On iphone this filterObstructedElements will throw an exception.
-  if (isIpad) {
-    NSArray *filteredElements = [alert filterObstructedElements:@[showSheetButton]];
-    XCTAssertEqualObjects(filteredElements, @[showSheetButton]);
-  } else {
-    XCTAssertThrowsSpecificNamed([alert filterObstructedElements:@[showSheetButton]], NSException, FBAlertObstructingElementException, @"should throw FBAlertObstructingElementException");
-  }
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementHelperIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementHelperIntegrationTests.m
@@ -28,32 +28,6 @@
   [self goToAlertsPage];
 }
 
-- (void)testObstructionByAlert
-{
-  XCUIElement *showAlertButton = self.testedApplication.buttons[FBShowAlertButtonName];
-  XCTAssertTrue(showAlertButton.exists);
-  XCTAssertFalse(showAlertButton.fb_isObstructedByAlert);
-  [showAlertButton tap];
-  FBAssertWaitTillBecomesTrue(self.testedApplication.alerts.count > 0);
-  XCTAssertTrue(showAlertButton.fb_isObstructedByAlert);
-}
-
-- (void)testElementObstruction
-{
-  XCUIElement *showAlertButton = self.testedApplication.buttons[FBShowAlertButtonName];
-  XCTAssertTrue(showAlertButton.exists);
-  [showAlertButton tap];
-  FBAssertWaitTillBecomesTrue(self.testedApplication.alerts.count > 0);
-
-  XCUIElement *alert = self.testedApplication.alerts.element;
-  XCUIElement *acceptAlertButton = self.testedApplication.buttons[@"Will do"];
-  XCTAssertTrue(alert.exists);
-  XCTAssertTrue(acceptAlertButton.exists);
-
-  XCTAssertTrue([alert fb_obstructsElement:showAlertButton]);
-  XCTAssertFalse([alert fb_obstructsElement:acceptAlertButton]);
-}
-
 - (void)testDescendantsFiltering
 {
   NSArray<XCUIElement *> *buttons = self.testedApplication.buttons.allElementsBoundByAccessibilityElement;

--- a/WebDriverAgentTests/UnitTests/FBExceptionHandlerTests.m
+++ b/WebDriverAgentTests/UnitTests/FBExceptionHandlerTests.m
@@ -46,15 +46,6 @@
                              forResponse:(RouteResponse *)[RouteResponseDouble new]];
 }
 
-- (void)testMatchingErrorHandlingWithCustomDescription
-{
-  NSException *exception = [NSException exceptionWithName:FBAlertObstructingElementException
-                                                   reason:@"reason"
-                                                 userInfo:@{}];
-  [self.exceptionHandler handleException:exception
-                             forResponse:(RouteResponse *)[RouteResponseDouble new]];
-}
-
 - (void)testNonMatchingErrorHandling
 {
   NSException *exception = [NSException exceptionWithName:@"something"


### PR DESCRIPTION
The client code for alert obstruction verification has been removed a while ago (because of its slowness), although the related helpers are still present without being used anywhere except of tests. This PR cleans up the unnecessary code.