### PR TITLE
refactor: Tune snapshots caching usage

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -14,7 +14,7 @@ variables:
   MAX_PLATFORM_VERSION: 13.4
   MAX_IPHONE_DEVICE_NAME: iPhone 11 Pro Max
   MAX_TV_DEVICE_NAME: Apple TV 4K
-  MAX_IPAD_DEVICE_NAME: iPad Pro (11-inch)
+  MAX_IPAD_DEVICE_NAME: iPad Pro (11-inch) (2nd generation)
   DEFAULT_NODE_VERSION: "10.x"
   DEFAULT_RUBY_VERSION: ">= 2.6"
 

--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -67,7 +67,7 @@ inline static BOOL isNilOrEmpty(id value);
     // Pure payload-based comparison sometimes yield false negatives, therefore relying on it only if all of the identifying properties are blank
   if (isNilOrEmpty(self.identifier) && isNilOrEmpty(self.title) && isNilOrEmpty(self.label) &&
       isNilOrEmpty(self.value) && isNilOrEmpty(self.placeholderValue)) {
-    return [self.wdUID isEqualToString:snapshot.wdUID];
+    return [self.wdUID isEqualToString:(snapshot.wdUID ?: @"")];
   }
   
   return self.elementType == snapshot.elementType &&

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
@@ -11,6 +11,7 @@
 
 #import "FBMacros.h"
 #import "FBXCodeCompatibility.h"
+#import "XCUIElement+FBUtilities.h"
 
 #define MAX_CENTER_DELTA 10.0
 
@@ -54,7 +55,7 @@ NSString *const FB_SAFARI_APP_NAME = @"Safari";
   // and conatins at least one text view
   __block NSUInteger buttonsCount = 0;
   __block NSUInteger textViewsCount = 0;
-  XCElementSnapshot *snapshot = [candidate.query fb_cachedSnapshot] ?: candidate.fb_lastSnapshot;
+  XCElementSnapshot *snapshot = candidate.fb_cachedSnapshot ?: candidate.fb_lastSnapshot;
   [snapshot enumerateDescendantsUsingBlock:^(XCElementSnapshot *descendant) {
     XCUIElementType curType = descendant.elementType;
     if (curType == XCUIElementTypeButton) {

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -98,7 +98,7 @@ static NSString* const FBUnknownBundleId = @"unknown";
 
 - (NSDictionary *)fb_tree
 {
-  XCElementSnapshot *snapshot = self.fb_lastSnapshot;
+  XCElementSnapshot *snapshot = self.fb_cachedSnapshot ?: self.fb_lastSnapshot;
   NSMutableDictionary *rootTree = [[self.class dictionaryForElement:snapshot recursive:NO] mutableCopy];
   NSArray<XCUIElement *> *children = [self fb_filterDescendantsWithSnapshots:snapshot.children
                                                                      selfUID:snapshot.wdUID

--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -16,6 +16,7 @@
 #import "NSPredicate+FBFormat.h"
 #import "XCElementSnapshot.h"
 #import "XCElementSnapshot+FBHelpers.h"
+#import "FBXCodeCompatibility.h"
 #import "XCUIElement+FBUtilities.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
 #import "XCUIElementQuery.h"
@@ -96,7 +97,7 @@
   NSPredicate *formattedPredicate = [NSPredicate fb_formatSearchPredicate:predicate];
   NSMutableArray<XCUIElement *> *result = [NSMutableArray array];
   // Include self element into predicate search
-  if ([formattedPredicate evaluateWithObject:self.fb_lastSnapshot]) {
+  if ([formattedPredicate evaluateWithObject:self.fb_cachedSnapshot ?: self.fb_lastSnapshot]) {
     if (shouldReturnAfterFirstMatch) {
       return @[self];
     }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
@@ -11,7 +11,6 @@
 
 #import "XCUIElement+FBUtilities.h"
 #import "FBElementUtils.h"
-#import "FBXCodeCompatibility.h"
 
 @implementation XCUIElement (FBUID)
 
@@ -20,7 +19,7 @@
   if ([self respondsToSelector:@selector(accessibilityElement)]) {
     return [FBElementUtils uidWithAccessibilityElement:[self performSelector:@selector(accessibilityElement)]];
   }
-  XCElementSnapshot *snapshot = [self.query fb_cachedSnapshot] ?: self.fb_lastSnapshot;
+  XCElementSnapshot *snapshot = self.fb_cachedSnapshot ?: self.fb_lastSnapshot;
   return snapshot.fb_uid;
 }
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
@@ -29,6 +29,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (XCElementSnapshot *)fb_lastSnapshot;
 
 /**
+ Gets the cached snapshot of the current element. nil
+ is returned if either no cached element snapshot could be retrived
+ or if the feature is not supported.
+
+@return The cached snapshot of the element
+*/
+- (nullable XCElementSnapshot *)fb_cachedSnapshot;
+
+/**
  Gets the most recent snapshot of the current element and already resolves the accessibility attributes
  needed for creating the page source of this element. No additional calls to the accessibility layer
  are required.

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -54,6 +54,11 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
   return [self.query fb_elementSnapshotForDebugDescription];
 }
 
+- (XCElementSnapshot *)fb_cachedSnapshot
+{
+  return [self.query fb_cachedSnapshot];
+}
+
 - (nullable XCElementSnapshot *)fb_snapshotWithAllAttributes {
   NSMutableArray *allNames = [NSMutableArray arrayWithArray:FBStandardAttributeNames().allObjects];
   [allNames addObjectsFromArray:FBCustomAttributeNames().allObjects];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -41,7 +41,7 @@
     return ([self fb_snapshotWithAttributes:@[FB_XCAXAIsElementAttributeName]] ?: self.fb_lastSnapshot) ?: [XCElementSnapshot new];
   }
   
-  return self.fb_lastSnapshot ?: [XCElementSnapshot new];
+  return (self.fb_cachedSnapshot ?: self.fb_lastSnapshot) ?: [XCElementSnapshot new];
 }
 
 - (id)fb_valueForWDAttributeName:(NSString *)name
@@ -65,38 +65,6 @@
 
 @implementation XCElementSnapshot (WebDriverAttributes)
 
-static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSMutableDictionary<NSString*, id> *> *> *fb_wdAttributesCache;
-
-+ (void)load
-{
-  fb_wdAttributesCache = [NSMutableDictionary dictionary];
-}
-
-- (id)fb_cachedValueWithAttributeName:(NSString *)name valueGetter:(id (^)(void))valueGetter
-{
-  NSNumber *generation = [NSNumber numberWithUnsignedLongLong:self.generation];
-  NSMutableDictionary<NSString *, NSMutableDictionary<NSString*, id> *> *cachedSnapshotsForGeneration = [fb_wdAttributesCache objectForKey:generation];
-  if (nil == cachedSnapshotsForGeneration) {
-    [fb_wdAttributesCache removeAllObjects];
-    cachedSnapshotsForGeneration = [NSMutableDictionary dictionary];
-    [fb_wdAttributesCache setObject:cachedSnapshotsForGeneration forKey:generation];
-  }
-  NSString *selfId = [NSString stringWithFormat:@"%p", (void *)self];
-  NSMutableDictionary<NSString*, id> *snapshotAttributes = [cachedSnapshotsForGeneration objectForKey:selfId];
-  if (nil == snapshotAttributes) {
-    snapshotAttributes = [NSMutableDictionary dictionary];
-    [cachedSnapshotsForGeneration setObject:snapshotAttributes forKey:selfId];
-  }
-  id cachedValue = [snapshotAttributes objectForKey:name];
-  if (nil != cachedValue) {
-    return cachedValue == [NSNull null] ? nil : cachedValue;
-  }
-  
-  id computedValue = valueGetter();
-  [snapshotAttributes setObject:(nil == computedValue ? [NSNull null] : computedValue) forKey:name];
-  return computedValue;
-}
-
 - (id)fb_valueForWDAttributeName:(NSString *)name
 {
   return [self valueForKey:[FBElementUtils wdAttributeNameForAttributeName:name]];
@@ -104,188 +72,137 @@ static NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSMutable
 
 - (NSString *)wdValue
 {
-  id (^getter)(void) = ^id(void) {
-    id value = self.value;
-    XCUIElementType elementType = self.elementType;
-    if (elementType == XCUIElementTypeStaticText) {
-      NSString *label = self.label;
-      value = FBFirstNonEmptyValue(value, label);
-    } else if (elementType == XCUIElementTypeButton) {
-      NSNumber *isSelected = self.isSelected ? @YES : nil;
-      value = FBFirstNonEmptyValue(value, isSelected);
-    } else if (elementType == XCUIElementTypeSwitch) {
-      value = @([value boolValue]);
-    } else if (elementType == XCUIElementTypeTextView ||
-               elementType == XCUIElementTypeTextField ||
-               elementType == XCUIElementTypeSecureTextField) {
-      NSString *placeholderValue = self.placeholderValue;
-      value = FBFirstNonEmptyValue(value, placeholderValue);
-    }
-    value = FBTransferEmptyStringToNil(value);
-    if (value) {
-      value = [NSString stringWithFormat:@"%@", value];
-    }
-    return value;
-  };
-  
-  return [self fb_cachedValueWithAttributeName:@"wdValue" valueGetter:getter];
-}
+  id value = self.value;
+  XCUIElementType elementType = self.elementType;
+  if (elementType == XCUIElementTypeStaticText) {
+    NSString *label = self.label;
+    value = FBFirstNonEmptyValue(value, label);
+  } else if (elementType == XCUIElementTypeButton) {
+    NSNumber *isSelected = self.isSelected ? @YES : nil;
+    value = FBFirstNonEmptyValue(value, isSelected);
+  } else if (elementType == XCUIElementTypeSwitch) {
+    value = @([value boolValue]);
+  } else if (elementType == XCUIElementTypeTextView ||
+             elementType == XCUIElementTypeTextField ||
+             elementType == XCUIElementTypeSecureTextField) {
+    NSString *placeholderValue = self.placeholderValue;
+    value = FBFirstNonEmptyValue(value, placeholderValue);
+  }
+  value = FBTransferEmptyStringToNil(value);
+  if (value) {
+    value = [NSString stringWithFormat:@"%@", value];
+  }
+  return value;
+ }
 
 - (NSString *)wdName
 {
-  id (^getter)(void) = ^id(void) {
-    NSString *identifier = self.identifier;
-    if (nil != identifier && identifier.length != 0) {
-      return identifier;
-    }
-    NSString *label = self.label;
-    return FBTransferEmptyStringToNil(label);
-  };
-  
-  return [self fb_cachedValueWithAttributeName:@"wdName" valueGetter:getter];
+  NSString *identifier = self.identifier;
+  if (nil != identifier && identifier.length != 0) {
+    return identifier;
+  }
+  NSString *label = self.label;
+  return FBTransferEmptyStringToNil(label);
 }
 
 - (NSString *)wdLabel
 {
-  id (^getter)(void) = ^id(void) {
-    NSString *label = self.label;
-    if (self.elementType == XCUIElementTypeTextField) {
-      return label;
-    }
-    return FBTransferEmptyStringToNil(label);
-  };
-  
-  return [self fb_cachedValueWithAttributeName:@"wdLabel" valueGetter:getter];
+  NSString *label = self.label;
+  XCUIElementType elementType = self.elementType;
+  if (elementType == XCUIElementTypeTextField || elementType == XCUIElementTypeSecureTextField ) {
+    return label;
+  }
+  return FBTransferEmptyStringToNil(label);
 }
 
 - (NSString *)wdType
 {
-  id (^getter)(void) = ^id(void) {
-    return [FBElementTypeTransformer stringWithElementType:self.elementType];
-  };
-  
-  return [self fb_cachedValueWithAttributeName:@"wdType" valueGetter:getter];
+  return [FBElementTypeTransformer stringWithElementType:self.elementType];
 }
 
 - (NSString *)wdUID
 {
-  id (^getter)(void) = ^id(void) {
-    return self.fb_uid;
-  };
-  
-  return [self fb_cachedValueWithAttributeName:@"wdUID" valueGetter:getter];
+  return self.fb_uid;
 }
 
 - (CGRect)wdFrame
 {
-  id (^getter)(void) = ^id(void) {
-    return [NSValue valueWithCGRect:CGRectIntegral(self.frame)];
-  };
-  
-  return [[self fb_cachedValueWithAttributeName:@"wdFrame" valueGetter:getter] CGRectValue];
+  return CGRectIntegral(self.frame);
 }
 
 - (BOOL)isWDVisible
 {
-  id (^getter)(void) = ^id(void) {
-    return @(self.fb_isVisible);
-  };
-  
-  return [[self fb_cachedValueWithAttributeName:@"isWDVisible" valueGetter:getter] boolValue];
+  return self.fb_isVisible;
 }
 
 #if TARGET_OS_TV
 - (BOOL)isWDFocused
 {
-  id (^getter)(void) = ^id(void) {
-    return @(self.hasFocus);
-  };
-
-  return [[self fb_cachedValueWithAttributeName:@"hasFocus" valueGetter:getter] boolValue];
+  return self.hasFocus;
 }
 #endif
 
 - (BOOL)isWDAccessible
 {
-  id (^getter)(void) = ^id(void) {
-    XCUIElementType elementType = self.elementType;
-    // Special cases:
-    // Table view cell: we consider it accessible if it's container is accessible
-    // Text fields: actual accessible element isn't text field itself, but nested element
-    if (elementType == XCUIElementTypeCell) {
-      if (!self.fb_isAccessibilityElement) {
-        XCElementSnapshot *containerView = [[self children] firstObject];
-        if (!containerView.fb_isAccessibilityElement) {
-          return @NO;
-        }
-      }
-    } else if (elementType != XCUIElementTypeTextField && elementType != XCUIElementTypeSecureTextField) {
-      if (!self.fb_isAccessibilityElement) {
-        return @NO;
+  XCUIElementType elementType = self.elementType;
+  // Special cases:
+  // Table view cell: we consider it accessible if it's container is accessible
+  // Text fields: actual accessible element isn't text field itself, but nested element
+  if (elementType == XCUIElementTypeCell) {
+    if (!self.fb_isAccessibilityElement) {
+      XCElementSnapshot *containerView = [[self children] firstObject];
+      if (!containerView.fb_isAccessibilityElement) {
+        return NO;
       }
     }
-    XCElementSnapshot *parentSnapshot = self.parent;
-    while (parentSnapshot) {
-      // In the scenario when table provides Search results controller, table could be marked as accessible element, even though it isn't
-      // As it is highly unlikely that table view should ever be an accessibility element itself,
-      // for now we work around that by skipping Table View in container checks
-      if (parentSnapshot.fb_isAccessibilityElement && parentSnapshot.elementType != XCUIElementTypeTable) {
-        return @NO;
-      }
-      parentSnapshot = parentSnapshot.parent;
+  } else if (elementType != XCUIElementTypeTextField && elementType != XCUIElementTypeSecureTextField) {
+    if (!self.fb_isAccessibilityElement) {
+      return NO;
     }
-    return @YES;
-  };
-  
-  return [[self fb_cachedValueWithAttributeName:@"isWDAccessible" valueGetter:getter] boolValue];
+  }
+  XCElementSnapshot *parentSnapshot = self.parent;
+  while (parentSnapshot) {
+    // In the scenario when table provides Search results controller, table could be marked as accessible element, even though it isn't
+    // As it is highly unlikely that table view should ever be an accessibility element itself,
+    // for now we work around that by skipping Table View in container checks
+    if (parentSnapshot.fb_isAccessibilityElement && parentSnapshot.elementType != XCUIElementTypeTable) {
+      return NO;
+    }
+    parentSnapshot = parentSnapshot.parent;
+  }
+  return YES;
 }
 
 - (BOOL)isWDAccessibilityContainer
 {
-  id (^getter)(void) = ^id(void) {
-    NSArray<XCElementSnapshot *> *children = self.children;
-    for (XCElementSnapshot *child in children) {
-      if (child.isWDAccessibilityContainer || child.fb_isAccessibilityElement) {
-        return @YES;
-      }
+  NSArray<XCElementSnapshot *> *children = self.children;
+  for (XCElementSnapshot *child in children) {
+    if (child.isWDAccessibilityContainer || child.fb_isAccessibilityElement) {
+      return YES;
     }
-    return @NO;
-  };
-  
-  return [[self fb_cachedValueWithAttributeName:@"isWDAccessibilityContainer" valueGetter:getter] boolValue];
+  }
+  return NO;
 }
 
 - (BOOL)isWDEnabled
 {
-  id (^getter)(void) = ^id(void) {
-    return @(self.isEnabled);
-  };
-  
-  return [[self fb_cachedValueWithAttributeName:@"isWDEnabled" valueGetter:getter] boolValue];
+  return self.isEnabled;
 }
 
 - (BOOL)isWDSelected
 {
-  id (^getter)(void) = ^id(void) {
-    return @(self.isSelected);
-  };
-
-  return [[self fb_cachedValueWithAttributeName:@"isWDSelected" valueGetter:getter] boolValue];
+  return self.isSelected;
 }
 
 - (NSDictionary *)wdRect
 {
-  id (^getter)(void) = ^id(void) {
-    CGRect frame = self.wdFrame;
-    return @{
-      @"x": @(CGRectGetMinX(frame)),
-      @"y": @(CGRectGetMinY(frame)),
-      @"width": @(CGRectGetWidth(frame)),
-      @"height": @(CGRectGetHeight(frame)),
-    };
+  CGRect frame = self.wdFrame;
+  return @{
+    @"x": @(CGRectGetMinX(frame)),
+    @"y": @(CGRectGetMinY(frame)),
+    @"width": @(CGRectGetWidth(frame)),
+    @"height": @(CGRectGetHeight(frame)),
   };
-  
-  return [self fb_cachedValueWithAttributeName:@"wdRect" valueGetter:getter];
-}
+ }
 
 @end

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -72,7 +72,7 @@
   }
 
   NSMutableArray<NSString *> *resultText = [NSMutableArray array];
-  XCElementSnapshot *snapshot = [self.alertElement.query fb_cachedSnapshot] ?: self.alertElement.fb_lastSnapshot;
+  XCElementSnapshot *snapshot = self.alertElement.fb_cachedSnapshot ?: self.alertElement.fb_lastSnapshot;
   [snapshot enumerateDescendantsUsingBlock:^(XCElementSnapshot *descendant) {
     XCUIElementType elementType = descendant.elementType;
     if (!(elementType == XCUIElementTypeTextView || elementType == XCUIElementTypeStaticText)) {
@@ -128,7 +128,7 @@
   }
 
   NSMutableArray<NSString *> *labels = [NSMutableArray array];
-  XCElementSnapshot *snapshot = [self.alertElement.query fb_cachedSnapshot] ?: self.alertElement.fb_lastSnapshot;
+  XCElementSnapshot *snapshot = self.alertElement.fb_cachedSnapshot ?: self.alertElement.fb_lastSnapshot;
   [snapshot enumerateDescendantsUsingBlock:^(XCElementSnapshot *descendant) {
     if (descendant.elementType != XCUIElementTypeButton) {
       return;

--- a/WebDriverAgentLib/Routing/FBElement.h
+++ b/WebDriverAgentLib/Routing/FBElement.h
@@ -24,10 +24,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, copy) NSDictionary *wdRect;
 
 /*! Element's name */
-@property (nonatomic, readonly, copy) NSString *wdName;
+@property (nonatomic, readonly, copy, nullable) NSString *wdName;
 
 /*! Element's label */
-@property (nonatomic, readonly, copy) NSString *wdLabel;
+@property (nonatomic, readonly, copy, nullable) NSString *wdLabel;
 
 /*! Element's selected state */
 @property (nonatomic, readonly, getter = isWDSelected) BOOL wdSelected;
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong, nullable) NSString *wdValue;
 
 /*! Element's unique identifier */
-@property (nonatomic, readonly, copy) NSString *wdUID;
+@property (nonatomic, readonly, copy, nullable) NSString *wdUID;
 
 /*! Whether element is enabled */
 @property (nonatomic, readonly, getter = isWDEnabled) BOOL wdEnabled;

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
@@ -82,7 +82,7 @@
   } else {
     // The offset relative to the element is defined
 
-    XCElementSnapshot *snapshot = element.fb_lastSnapshot;
+    XCElementSnapshot *snapshot = element.fb_cachedSnapshot ?: element.fb_lastSnapshot;
     if (nil == positionOffset) {
       NSValue *hitPointValue = snapshot.fb_hitPoint;
       if (nil != hitPointValue) {

--- a/WebDriverAgentLib/Utilities/FBTVNavigationTracker.m
+++ b/WebDriverAgentLib/Utilities/FBTVNavigationTracker.m
@@ -90,12 +90,18 @@
 #pragma mark - Utilities
 - (FBTVNavigationItem*)navigationItemWithElement:(id<FBElement>)element
 {
-  FBTVNavigationItem* item = [self.navigationItems objectForKey:element.wdUID];
+  NSString *uid = element.wdUID;
+  if (nil == uid) {
+    return nil;
+  }
+
+  FBTVNavigationItem* item = [self.navigationItems objectForKey:uid];
   if (nil != item) {
     return item;
   }
-  item = [FBTVNavigationItem itemWithUid:element.wdUID];
-  [self.navigationItems setObject:item forKey:element.wdUID];
+  
+  item = [FBTVNavigationItem itemWithUid:uid];
+  [self.navigationItems setObject:item forKey:uid];
   return item;
 }
 

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -132,7 +132,7 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   }
 
   // An offset relative to the element is defined
-  XCElementSnapshot *snapshot = element.fb_lastSnapshot;
+  XCElementSnapshot *snapshot = element.fb_cachedSnapshot ?: element.fb_lastSnapshot;
   CGRect frame = snapshot.frame;
   if (CGRectIsEmpty(frame)) {
     [FBLogger log:self.application.fb_descriptionRepresentation];

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -365,7 +365,7 @@ NSString *const FBXPathQueryEvaluationException = @"FBXPathQueryEvaluationExcept
       [element.application fb_waitUntilSnapshotIsStable];
     }
     if ([root isKindOfClass:XCUIApplication.class]) {
-      currentSnapshot = element.fb_lastSnapshot;
+      currentSnapshot = element.fb_cachedSnapshot ?: element.fb_lastSnapshot;
       NSArray<XCUIElement *> *windows = [element fb_filterDescendantsWithSnapshots:currentSnapshot.children
                                                                            selfUID:currentSnapshot.wdUID
                                                                       onlyChildren:YES];

--- a/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
@@ -150,8 +150,7 @@
   XCTAssertNil(element.wdLabel);
   XCTAssertEqualObjects(element.wdValue, @"1");
   XCTAssertFalse(element.wdSelected);
-  [element tap];
-  [element fb_nativeResolve];
+  XCTAssertTrue([element fb_tapWithError:nil]);
   XCTAssertEqualObjects(element.wdValue, @"0");
   XCTAssertFalse(element.wdSelected);
 }

--- a/test/functional/desired.js
+++ b/test/functional/desired.js
@@ -89,6 +89,7 @@ let GENERIC_CAPS = {
   wdaLaunchTimeout: (60 * 1000 * 4),
   wdaConnectionTimeout: (60 * 1000 * 8),
   useNewWDA: true,
+  simulatorStartupTimeout: 240000,
 };
 
 if (process.env.CLOUD) {


### PR DESCRIPTION
The caching logic in XCTest has been improved a lot since we deprecated Xcode9. This PR removed currently redundant attributes cache and adds the usage of cached snapshots introduced with Xcode11. The result should be better performance and reduced memory usage