### PR TITLE
fix: print error message if the method is not available

### DIFF
--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -115,10 +115,13 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)configureDefaultKeyboardPreferences;
 
 
-typedef NS_ENUM(NSInteger, FBConfigurationPreference) {
-    FBConfigurationPreferenceDisabled = 0,
-    FBConfigurationPreferenceEnabled = 1,
-    FBConfigurationPreferenceNotSupported = 2,
+/**
+Defines keyboard preference enabled status
+*/
+typedef NS_ENUM(NSInteger, FBConfigurationKeyboardPreference) {
+    FBConfigurationKeyboardPreferenceDisabled = 0,
+    FBConfigurationKeyboardPreferenceEnabled = 1,
+    FBConfigurationKeyboardPreferenceNotSupported = 2,
 };
 
 /**
@@ -127,7 +130,7 @@ typedef NS_ENUM(NSInteger, FBConfigurationPreference) {
  * @param isEnabled Turn the configuration on if the value is YES
  */
 + (void)setKeyboardAutocorrection:(BOOL)isEnabled;
-+ (FBConfigurationPreference)keyboardAutocorrection;
++ (FBConfigurationKeyboardPreference)keyboardAutocorrection;
 
 /**
  * Modify keyboard configuration of 'predictive'
@@ -135,7 +138,7 @@ typedef NS_ENUM(NSInteger, FBConfigurationPreference) {
  * @param isEnabled Turn the configuration on if the value is YES
  */
 + (void)setKeyboardPrediction:(BOOL)isEnabled;
-+ (FBConfigurationPreference)keyboardPrediction;
++ (FBConfigurationKeyboardPreference)keyboardPrediction;
 
 /**
  * The maximum time to wait until accessibility snapshot is taken

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -114,13 +114,20 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)configureDefaultKeyboardPreferences;
 
+
+typedef NS_ENUM(NSInteger, FBConfigurationPreference) {
+    FBConfigurationPreferenceDisabled = 0,
+    FBConfigurationPreferenceEnabled = 1,
+    FBConfigurationPreferenceNotSupported = 2,
+};
+
 /**
  * Modify keyboard configuration of 'auto-correction'.
  *
  * @param isEnabled Turn the configuration on if the value is YES
  */
 + (void)setKeyboardAutocorrection:(BOOL)isEnabled;
-+ (BOOL)keyboardAutocorrection;
++ (FBConfigurationPreference)keyboardAutocorrection;
 
 /**
  * Modify keyboard configuration of 'predictive'
@@ -128,7 +135,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param isEnabled Turn the configuration on if the value is YES
  */
 + (void)setKeyboardPrediction:(BOOL)isEnabled;
-+ (BOOL)keyboardPrediction;
++ (FBConfigurationPreference)keyboardPrediction;
 
 /**
  * The maximum time to wait until accessibility snapshot is taken

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -261,7 +261,7 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
   dlclose(handle);
 }
 
-+ (BOOL)keyboardAutocorrection
++ (FBConfigurationPreference)keyboardAutocorrection
 {
   return [self keyboardsPreference:FBKeyboardAutocorrectionKey];
 }
@@ -271,7 +271,7 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
   [self configureKeyboardsPreference:isEnabled forPreferenceKey:FBKeyboardAutocorrectionKey];
 }
 
-+ (BOOL)keyboardPrediction
++ (FBConfigurationPreference)keyboardPrediction
 {
   return [self keyboardsPreference:FBKeyboardPredictionKey];
 }
@@ -394,23 +394,29 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
 
 #pragma mark Private
 
-+ (BOOL)keyboardsPreference:(nonnull NSString *)key
++ (FBConfigurationPreference)keyboardsPreference:(nonnull NSString *)key
 {
   Class controllerClass = NSClassFromString(controllerClassName);
   TIPreferencesController *controller = [controllerClass sharedPreferencesController];
   if ([key isEqualToString:FBKeyboardAutocorrectionKey]) {
     if ([controller respondsToSelector:@selector(boolForPreferenceKey:)]) {
-      return [controller boolForPreferenceKey:FBKeyboardAutocorrectionKey];
+      if ([controller boolForPreferenceKey:FBKeyboardAutocorrectionKey]) {
+        return FBConfigurationPreferenceEnabled;
+      }
+      return FBConfigurationPreferenceDisabled;
     } else {
       [FBLogger log:@"Updating keyboard autocorrection preference is not supported"];
-      return nil;
+      return FBConfigurationPreferenceNotSupported;
     }
   } else if ([key isEqualToString:FBKeyboardPredictionKey]) {
     if ([controller respondsToSelector:@selector(boolForPreferenceKey:)]) {
-      return [controller boolForPreferenceKey:FBKeyboardPredictionKey];
+      if ([controller boolForPreferenceKey:FBKeyboardPredictionKey]) {
+        return FBConfigurationPreferenceEnabled;
+      }
+      return FBConfigurationPreferenceDisabled;
     } else {
       [FBLogger log:@"Updating keyboard prediction preference is not supported"];
-      return nil;
+      return FBConfigurationPreferenceNotSupported;
     }
   }
   @throw [[FBErrorBuilder.builder withDescriptionFormat:@"No available keyboardsPreferenceKey: '%@'", key] build];

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -261,7 +261,7 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
   dlclose(handle);
 }
 
-+ (FBConfigurationPreference)keyboardAutocorrection
++ (FBConfigurationKeyboardPreference)keyboardAutocorrection
 {
   return [self keyboardsPreference:FBKeyboardAutocorrectionKey];
 }
@@ -271,7 +271,7 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
   [self configureKeyboardsPreference:isEnabled forPreferenceKey:FBKeyboardAutocorrectionKey];
 }
 
-+ (FBConfigurationPreference)keyboardPrediction
++ (FBConfigurationKeyboardPreference)keyboardPrediction
 {
   return [self keyboardsPreference:FBKeyboardPredictionKey];
 }
@@ -394,29 +394,29 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
 
 #pragma mark Private
 
-+ (FBConfigurationPreference)keyboardsPreference:(nonnull NSString *)key
++ (FBConfigurationKeyboardPreference)keyboardsPreference:(nonnull NSString *)key
 {
   Class controllerClass = NSClassFromString(controllerClassName);
   TIPreferencesController *controller = [controllerClass sharedPreferencesController];
   if ([key isEqualToString:FBKeyboardAutocorrectionKey]) {
     if ([controller respondsToSelector:@selector(boolForPreferenceKey:)]) {
       if ([controller boolForPreferenceKey:FBKeyboardAutocorrectionKey]) {
-        return FBConfigurationPreferenceEnabled;
+        return FBConfigurationKeyboardPreferenceEnabled;
       }
-      return FBConfigurationPreferenceDisabled;
+      return FBConfigurationKeyboardPreferenceDisabled;
     } else {
       [FBLogger log:@"Updating keyboard autocorrection preference is not supported"];
-      return FBConfigurationPreferenceNotSupported;
+      return FBConfigurationKeyboardPreferenceNotSupported;
     }
   } else if ([key isEqualToString:FBKeyboardPredictionKey]) {
     if ([controller respondsToSelector:@selector(boolForPreferenceKey:)]) {
       if ([controller boolForPreferenceKey:FBKeyboardPredictionKey]) {
-        return FBConfigurationPreferenceEnabled;
+        return FBConfigurationKeyboardPreferenceEnabled;
       }
-      return FBConfigurationPreferenceDisabled;
+      return FBConfigurationKeyboardPreferenceDisabled;
     } else {
       [FBLogger log:@"Updating keyboard prediction preference is not supported"];
-      return FBConfigurationPreferenceNotSupported;
+      return FBConfigurationKeyboardPreferenceNotSupported;
     }
   }
   @throw [[FBErrorBuilder.builder withDescriptionFormat:@"No available keyboardsPreferenceKey: '%@'", key] build];

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -403,14 +403,14 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
       return [controller boolForPreferenceKey:FBKeyboardAutocorrectionKey];
     } else {
       [FBLogger log:@"Updating keyboard autocorrection preference is not supported"];
-      return NO;
+      return nil;
     }
   } else if ([key isEqualToString:FBKeyboardPredictionKey]) {
     if ([controller respondsToSelector:@selector(boolForPreferenceKey:)]) {
       return [controller boolForPreferenceKey:FBKeyboardPredictionKey];
     } else {
       [FBLogger log:@"Updating keyboard prediction preference is not supported"];
-      return NO;
+      return nil;
     }
   }
   @throw [[FBErrorBuilder.builder withDescriptionFormat:@"No available keyboardsPreferenceKey: '%@'", key] build];

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -400,20 +400,18 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
   TIPreferencesController *controller = [controllerClass sharedPreferencesController];
   if ([key isEqualToString:FBKeyboardAutocorrectionKey]) {
     if ([controller respondsToSelector:@selector(boolForPreferenceKey:)]) {
-      if ([controller boolForPreferenceKey:FBKeyboardAutocorrectionKey]) {
-        return FBConfigurationKeyboardPreferenceEnabled;
-      }
-      return FBConfigurationKeyboardPreferenceDisabled;
+      return [controller boolForPreferenceKey:FBKeyboardAutocorrectionKey]
+        ? FBConfigurationKeyboardPreferenceEnabled
+        : FBConfigurationKeyboardPreferenceDisabled;
     } else {
       [FBLogger log:@"Updating keyboard autocorrection preference is not supported"];
       return FBConfigurationKeyboardPreferenceNotSupported;
     }
   } else if ([key isEqualToString:FBKeyboardPredictionKey]) {
     if ([controller respondsToSelector:@selector(boolForPreferenceKey:)]) {
-      if ([controller boolForPreferenceKey:FBKeyboardPredictionKey]) {
-        return FBConfigurationKeyboardPreferenceEnabled;
-      }
-      return FBConfigurationKeyboardPreferenceDisabled;
+      return [controller boolForPreferenceKey:FBKeyboardPredictionKey]
+        ? FBConfigurationKeyboardPreferenceEnabled
+        : FBConfigurationKeyboardPreferenceDisabled;
     } else {
       [FBLogger log:@"Updating keyboard prediction preference is not supported"];
       return FBConfigurationKeyboardPreferenceNotSupported;

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -399,9 +399,19 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
   Class controllerClass = NSClassFromString(controllerClassName);
   TIPreferencesController *controller = [controllerClass sharedPreferencesController];
   if ([key isEqualToString:FBKeyboardAutocorrectionKey]) {
-    return [controller boolForPreferenceKey:FBKeyboardAutocorrectionKey];
+    if ([controller respondsToSelector:@selector(boolForPreferenceKey:)]) {
+      return [controller boolForPreferenceKey:FBKeyboardAutocorrectionKey];
+    } else {
+      [FBLogger log:@"Updating keyboard autocorrection preference is not supported"];
+      return NO;
+    }
   } else if ([key isEqualToString:FBKeyboardPredictionKey]) {
-    return [controller boolForPreferenceKey:FBKeyboardPredictionKey];
+    if ([controller respondsToSelector:@selector(boolForPreferenceKey:)]) {
+      return [controller boolForPreferenceKey:FBKeyboardPredictionKey];
+    } else {
+      [FBLogger log:@"Updating keyboard prediction preference is not supported"];
+      return NO;
+    }
   }
   @throw [[FBErrorBuilder.builder withDescriptionFormat:@"No available keyboardsPreferenceKey: '%@'", key] build];
 }


### PR DESCRIPTION
When I ran WDA via Xcode 10.1, I found selector-error here. (`nil` can work)
Over Xcode 10.2 worked without this selector check.

- server
```
[debug] [WD Proxy] Got response with status 200: {"value":{"screenshotOrientation":"auto","shouldUseCompactResponses":true,"mjpegServerFramerate":10,"snapshotMaxDepth":50,"activeAppDetectionPoint":"64.00,64.00","acceptAlertButtonSelector":"","snapshotTimeout":15,"elementResponseAttributes":"type,label","keyboardPrediction":2,"screenshotQuality":1,"keyboardAutocorrection":2,"useFirstMatch":false,"reduceMotion":true,"defaultActiveApplication":"auto","mjpegScalingFactor":100,"mjpegServerScreenshotQuality":25,"dismissAlertButtonSelector":"","includeNonModalElements":false},"sessionId":"17D1F06C-EAA2-47CD-A0BD-6984001E5DEA"}
```

`keyboardPrediction` and `keyboardAutocorrection` do not appear the result of get settings by default. It is safe to change the type.

```ruby
> @@driver.settings.get
=> {"imageMatchThreshold"=>0.4,
 "fixImageFindScreenshotDims"=>true,
 "fixImageTemplateSize"=>false,
 "fixImageTemplateScale"=>false,
 "defaultImageTemplateScale"=>1,
 "checkForImageElementStaleness"=>true,
 "autoUpdateImageElementPosition"=>false,
 "imageElementTapStrategy"=>"w3cActions",
 "getMatchedImageResult"=>false,
 "nativeWebTap"=>false,
 "useJSONSource"=>false,
 "shouldUseCompactResponses"=>true,
 "elementResponseAttributes"=>"type,label",
 "mjpegServerScreenshotQuality"=>25,
 "mjpegServerFramerate"=>10,
 "screenshotQuality"=>1,
 "mjpegScalingFactor"=>100,
 "reduceMotion"=>true}
```