### PR TITLE
feat: make device info available for without session

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -57,7 +57,7 @@
     [[FBRoute POST:@"/wda/pressButton"] respondWithTarget:self action:@selector(handlePressButtonCommand:)],
     [[FBRoute POST:@"/wda/siri/activate"] respondWithTarget:self action:@selector(handleActivateSiri:)],
     [[FBRoute POST:@"/wda/apps/launchUnattached"].withoutSession respondWithTarget:self action:@selector(handleLaunchUnattachedApp:)],
-    [[FBRoute GET:@"/wda/device/info"] respondWithTarget:self action:@selector(handleGetDeviceInfo:)],
+    [[FBRoute GET:@"/wda/device/info"].withoutSession respondWithTarget:self action:@selector(handleGetDeviceInfo:)],
   ];
 }
 

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -57,6 +57,7 @@
     [[FBRoute POST:@"/wda/pressButton"] respondWithTarget:self action:@selector(handlePressButtonCommand:)],
     [[FBRoute POST:@"/wda/siri/activate"] respondWithTarget:self action:@selector(handleActivateSiri:)],
     [[FBRoute POST:@"/wda/apps/launchUnattached"].withoutSession respondWithTarget:self action:@selector(handleLaunchUnattachedApp:)],
+    [[FBRoute GET:@"/wda/device/info"] respondWithTarget:self action:@selector(handleGetDeviceInfo:)],
     [[FBRoute GET:@"/wda/device/info"].withoutSession respondWithTarget:self action:@selector(handleGetDeviceInfo:)],
   ];
 }


### PR DESCRIPTION
Looks like to use the `/wda/device/info` I needed to add `.withoutSession` to the command FBRoute. 

Testing with the WDA up and running on a device, and this endpoint wasn't working otherwise..

 ```
with session - 

jbrumm730 in appium-xcuitest-driver $ curl -get http://10.0.0.47:8100/wda/device/info
{
  "value" : {
    "error" : "unknown command",
    "message" : "Unhandled endpoint: \/wda\/device\/info -- http:\/\/10.0.0.47:8100\/ with parameters {\n    wildcards =     (\n        \"wda\/device\/info\"\n    );\n}",
    "traceback" : ""
  },
  "sessionId" : "D35B67A9-7C8B-4C8A-9061-74AD4E431A79"
}

without session -

jbrumm730 in appium-xcuitest-driver $ curl -get http://10.0.0.47:8100/wda/device/info
{
  "value" : {
    "timeZone" : "America\/Denver",
    "currentLocale" : "en_US",
    "model" : "iPad",
    "uuid" : "63CC7DC2-5E5D-4E15-842A-421B8D34AF8D",
    "userInterfaceIdiom" : 1,
    "userInterfaceStyle" : "light",
    "name" : "Brummet, Joshua DMPZP082KD80",
    "isSimulator" : false
  },
  "sessionId" : "02DDCF03-2C5F-48BD-B140-8559A06E3E68"
```

It's a small change, that should get us going again with getting device info from this endpoint.

Cheers