### PR TITLE
Allow Cross-Origin resource sharing

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -58,6 +58,7 @@
     [[FBRoute POST:@"/wda/siri/activate"] respondWithTarget:self action:@selector(handleActivateSiri:)],
     [[FBRoute POST:@"/wda/apps/launchUnattached"].withoutSession respondWithTarget:self action:@selector(handleLaunchUnattachedApp:)],
     [[FBRoute GET:@"/wda/device/info"] respondWithTarget:self action:@selector(handleGetDeviceInfo:)],
+    [[FBRoute OPTIONS:@"/*"].withoutSession respondWithTarget:self action:@selector(handlePingCommand:)],
   ];
 }
 
@@ -116,6 +117,11 @@
   if (!isKeyboardNotPresent) {
     return FBResponseWithStatus([FBCommandStatus elementNotVisibleErrorWithMessage:error.description traceback:[NSString stringWithFormat:@"%@", NSThread.callStackSymbols]]);
   }
+  return FBResponseWithOK();
+}
+
++ (id<FBResponsePayload>)handlePingCommand:(FBRouteRequest *)request
+{
   return FBResponseWithOK();
 }
 

--- a/WebDriverAgentLib/Routing/FBRoute.h
+++ b/WebDriverAgentLib/Routing/FBRoute.h
@@ -49,6 +49,11 @@ typedef __nonnull id<FBResponsePayload> (^FBRouteSyncHandler)(FBRouteRequest *re
 + (instancetype)DELETE:(NSString *)pathPattern;
 
 /**
+ Convenience constructor for OPTIONS route with given pathPattern
+*/
++ (instancetype)OPTIONS:(NSString *)pathPattern;
+
+/**
  Chain-able constructor that handles response with given FBRouteSyncHandler block
  */
 - (instancetype)respondWithBlock:(FBRouteSyncHandler)handler;

--- a/WebDriverAgentLib/Routing/FBRoute.m
+++ b/WebDriverAgentLib/Routing/FBRoute.m
@@ -74,6 +74,11 @@ static NSString *const FBRouteSessionPrefix = @"/session/:sessionID";
   return route;
 }
 
++ (instancetype)OPTIONS:(NSString *)pathPattern
+{
+  return [self withVerb:@"OPTIONS" path:pathPattern requiresSession:NO];
+}
+
 + (instancetype)GET:(NSString *)pathPattern
 {
   return [self withVerb:@"GET" path:pathPattern requiresSession:YES];

--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -85,6 +85,8 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   self.server = [[RoutingHTTPServer alloc] init];
   [self.server setRouteQueue:dispatch_get_main_queue()];
   [self.server setDefaultHeader:@"Server" value:@"WebDriverAgent/1.0"];
+  [self.server setDefaultHeader:@"Access-Control-Allow-Origin" value:@"*"];
+  [self.server setDefaultHeader:@"Access-Control-Allow-Headers" value:@"Content-Type, X-Requested-With"];
   [self.server setConnectionClass:[FBHTTPConnection self]];
 
   [self registerRouteHandlers:[self.class collectCommandHandlerClasses]];


### PR DESCRIPTION
Allowing Cross-Origin resource sharing makes it possible to use a web-based UI elements inspector