### PR TITLE
chore: Bundle WebDriverAgent-runner.app with package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ webdriveragent-*.tar.gz
 uncompressed/
 prebuilt-agents/
 WebDriverAgentRunner-Runner.app/
+WebDriverAgentRunner-Runner.app.zip

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ bundles/
 webdriveragent-*.tar.gz
 uncompressed/
 prebuilt-agents/
+WebDriverAgentRunner-Runner.app/

--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,4 @@ bundles/
 webdriveragent-*.tar.gz
 uncompressed/
 prebuilt-agents/
-WebDriverAgentRunner-Runner.app/
 WebDriverAgentRunner-Runner.app.zip

--- a/lib/check-dependencies.js
+++ b/lib/check-dependencies.js
@@ -126,7 +126,7 @@ async function checkForDependencies (opts = {}) {
 }
 
 async function bundleWDASim (xcodebuild, opts = {}) {
-  if (!_.isFunction(xcodebuild?.retrieveDerivedDataPath)) {
+  if (xcodebuild && !_.isFunction(xcodebuild.retrieveDerivedDataPath)) {
     xcodebuild = new XcodeBuild();
     opts = xcodebuild;
   }

--- a/package.json
+++ b/package.json
@@ -89,6 +89,6 @@
     "WebDriverAgentRunner",
     "WebDriverAgentTests",
     "XCTWebDriverAgentLib",
-    "WebDriverAgentRunner-Runner.app"
+    "WebDriverAgentRunner-Runner.app.zip"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean:carthage": "gulp clean:carthage",
     "install:dependencies": "gulp install:dependencies",
     "build": "gulp transpile",
-    "prepare": "gulp prepublish",
+    "prepare": "gulp prepublish && npm run bundle",
     "lint": "gulp lint",
     "lint:fix": "gulp eslint --fix",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
@@ -88,6 +88,7 @@
     "WebDriverAgentLib",
     "WebDriverAgentRunner",
     "WebDriverAgentTests",
-    "XCTWebDriverAgentLib"
+    "XCTWebDriverAgentLib",
+    "WebDriverAgentRunner-Runner.app"
   ]
 }


### PR DESCRIPTION
This bundles the WebDriverAgent-runner.app with the package

_Justification_

Using IDB, you can easily install and launch WebDriverAgent-runner.app with a couple of commands.

```
idb install /WebDriverAgentRunner-Runner.app --udid <device-udid>
idb launch com.facebook.WebDriverAgentRunner.xctrunner
```

This speeds up the installation significantly and is a huge boost for cloud providers (like myself). We won't have to build a different WDA for every single Xcode version and we'll get much faster session start times.

My next step for this is to have our CI pipeline automate the publishing of this module so that the Xcode that's used to bundle the .app is consistent.