### PR TITLE
feat: Add testmanagerd version as /status response

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
@@ -90,6 +90,23 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSArray<NSDictionary<NSString *, id> *> *)fb_activeAppsInfo;
 
 
+/**
+ The version of testmanagerd process  which is running on the device.
+ Potentially, we can handle proces
+
+
+ iOS 10.1 -> 6
+ iOS 11.0.1 -> 18
+ iOS 11.4 -> 22
+ iOS 12.1, 12.4 -> 26
+ iOS 13.3, 13.4.1 -> 28
+
+ tvOS 13.3 -> 28
+
+ @return The version of testmanagerd
+ */
++ (NSInteger)fb_testmanagerdVersion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
@@ -92,14 +92,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The version of testmanagerd process  which is running on the device.
- Potentially, we can handle proces
 
-
+ Potentially, we can handle processes based on this version instead of iOS versions,
  iOS 10.1 -> 6
  iOS 11.0.1 -> 18
  iOS 11.4 -> 22
  iOS 12.1, 12.4 -> 26
- iOS 13.3, 13.4.1 -> 28
+ iOS 13.0, 13.4.1 -> 28
 
  tvOS 13.3 -> 28
 

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -237,8 +237,7 @@ static NSString* const FBUnknownBundleId = @"unknown";
 + (NSInteger)fb_testmanagerdVersion
 {
   static dispatch_once_t getTestmanagerdVersion;
-  // The version is a magic number. _XCT_exchangeProtocolVersion will correct the version.
-  static NSInteger testmanagerdVersion = 6;
+  static NSInteger testmanagerdVersion;
   dispatch_once(&getTestmanagerdVersion, ^{
     id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
     dispatch_semaphore_t sem = dispatch_semaphore_create(0);

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -234,4 +234,20 @@ static NSString* const FBUnknownBundleId = @"unknown";
 }
 #endif
 
++ (NSInteger)fb_testmanagerdVersion
+{
+  static dispatch_once_t getTestmanagerdVersion;
+  static NSInteger testmanagerdVersion = 18;
+  dispatch_once(&getTestmanagerdVersion, ^{
+    id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
+    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    [proxy _XCT_exchangeProtocolVersion:testmanagerdVersion reply:^(unsigned long long code) {
+      testmanagerdVersion = (NSInteger) code;
+      dispatch_semaphore_signal(sem);
+    }];
+    dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)));
+  });
+  return testmanagerdVersion;
+}
+
 @end

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -237,7 +237,8 @@ static NSString* const FBUnknownBundleId = @"unknown";
 + (NSInteger)fb_testmanagerdVersion
 {
   static dispatch_once_t getTestmanagerdVersion;
-  static NSInteger testmanagerdVersion = 18;
+  // The version is a magic number. _XCT_exchangeProtocolVersion will correct the version.
+  static NSInteger testmanagerdVersion = 6;
   dispatch_once(&getTestmanagerdVersion, ^{
     id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
     dispatch_semaphore_t sem = dispatch_semaphore_create(0);

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -219,6 +219,7 @@ static NSString* const SCREENSHOT_ORIENTATION = @"screenshotOrientation";
           @"name" : [[UIDevice currentDevice] systemName],
           @"version" : [[UIDevice currentDevice] systemVersion],
           @"sdkVersion": FBSDKVersion() ?: @"unknown",
+          @"testmanagerdVersion": @([FBApplication fb_testmanagerdVersion]),
         },
       @"ios" :
         @{

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -219,7 +219,7 @@ static NSString* const SCREENSHOT_ORIENTATION = @"screenshotOrientation";
           @"name" : [[UIDevice currentDevice] systemName],
           @"version" : [[UIDevice currentDevice] systemVersion],
           @"sdkVersion": FBSDKVersion() ?: @"unknown",
-          @"testmanagerdVersion": @([FBApplication fb_testmanagerdVersion]),
+          @"testmanagerdVersion": @([XCUIApplication fb_testmanagerdVersion]),
         },
       @"ios" :
         @{

--- a/WebDriverAgentTests/IntegrationTests/XCUIApplicationHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIApplicationHelperTests.m
@@ -85,4 +85,9 @@
   XCTAssertTrue(isAppActive);
 }
 
+- (void)testTestmanagerdVersion
+{
+  XCTAssertGreaterThan([XCUIApplication fb_testmanagerdVersion], 0);
+}
+
 @end


### PR DESCRIPTION
Let me add the version testmanagerd as `/status`'s os section.
For now, our logic is probably enough with iOS versions, but we can handle such flow with the version of testmnagerd, too. They may help to see what version of testmanagerd was working on the device in issues.

We can add versions as Enum when we need the versions, but I haven't added them yet.