### PR TITLE
chore: Change the way `retrieveDerivedDataPath` is called to avoid possible race conditions

### DIFF
--- a/lib/xcodebuild.js
+++ b/lib/xcodebuild.js
@@ -106,25 +106,33 @@ class XcodeBuild {
       return this.derivedDataPath;
     }
 
-    let stdout;
-    try {
-      ({stdout} = await exec('xcodebuild', ['-project', this.agentPath, '-showBuildSettings']));
-    } catch (err) {
-      log.warn(`Cannot retrieve WDA build settings. Original error: ${err.message}`);
-      return;
+    // avoid race conditions
+    if (this._derivedDataPathPromise) {
+      return await this._derivedDataPathPromise;
     }
 
-    const pattern = /^\s*BUILD_DIR\s+=\s+(\/.*)/m;
-    const match = pattern.exec(stdout);
-    if (!match) {
-      log.warn(`Cannot parse WDA build dir from ${_.truncate(stdout, {length: 300})}`);
-      return;
-    }
-    log.debug(`Parsed BUILD_DIR configuration value: '${match[1]}'`);
-    // Derived data root is two levels higher over the build dir
-    this.derivedDataPath = path.dirname(path.dirname(path.normalize(match[1])));
-    log.debug(`Got derived data root: '${this.derivedDataPath}'`);
-    return this.derivedDataPath;
+    this._derivedDataPathPromise = (async () => {
+      let stdout;
+      try {
+        ({stdout} = await exec('xcodebuild', ['-project', this.agentPath, '-showBuildSettings']));
+      } catch (err) {
+        log.warn(`Cannot retrieve WDA build settings. Original error: ${err.message}`);
+        return;
+      }
+
+      const pattern = /^\s*BUILD_DIR\s+=\s+(\/.*)/m;
+      const match = pattern.exec(stdout);
+      if (!match) {
+        log.warn(`Cannot parse WDA build dir from ${_.truncate(stdout, {length: 300})}`);
+        return;
+      }
+      log.debug(`Parsed BUILD_DIR configuration value: '${match[1]}'`);
+      // Derived data root is two levels higher over the build dir
+      this.derivedDataPath = path.dirname(path.dirname(path.normalize(match[1])));
+      log.debug(`Got derived data root: '${this.derivedDataPath}'`);
+      return this.derivedDataPath;
+    })();
+    return await this._derivedDataPathPromise;
   }
 
   async reset () {


### PR DESCRIPTION
Related to https://github.com/appium/appium-xcuitest-driver/pull/1212