### PR TITLE
refactor: Get rid of an unnecessary import

### DIFF
--- a/lib/check-dependencies.js
+++ b/lib/check-dependencies.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { exec } from 'teen_process';
 import path from 'path';
 import { EOL } from 'os';
-import { fileCompare } from './utils';
+import { areFilesEqual } from './utils';
 import XcodeBuild from './xcodebuild';
 import {
   BOOTSTRAP_PATH, WDA_PROJECT, WDA_SCHEME, CARTHAGE_ROOT, SDK_SIMULATOR,
@@ -53,7 +53,7 @@ function getCartfileLocations () {
 }
 
 async function needsUpdate (cartfile, installedCartfile) {
-  return !await fileCompare(cartfile, installedCartfile);
+  return !await areFilesEqual(cartfile, installedCartfile);
 }
 
 async function fetchDependencies (useSsl = false) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,7 +75,7 @@ function isTvOS (platformName) {
   return _.toLower(platformName) === _.toLower(PLATFORM_NAME_TVOS);
 }
 
-async function fileCompare (file1, file2) {
+async function areFilesEqual (file1, file2) {
   const files = [file1, file2];
   if (!_.every(await B.all(files.map((f) => fs.exists(f))))) {
     return false;
@@ -368,6 +368,6 @@ async function getPIDsListeningOnPort (port, filteringFunc = null) {
 export { updateProjectFile, resetProjectFile, setRealDeviceSecurity,
   getAdditionalRunContent, getXctestrunFileName, generateXcodeConfigFile,
   setXctestrunFile, getXctestrunFilePath, killProcess, randomInt,
-  getWDAUpgradeTimestamp, fileCompare, resetTestProcesses,
+  getWDAUpgradeTimestamp, areFilesEqual, resetTestProcesses,
   getPIDsListeningOnPort, killAppUsingPattern, isTvOS,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,6 @@
 import { fs, tempDir, plist } from 'appium-support';
 import { exec } from 'teen_process';
 import path from 'path';
-import streamEqual from 'stream-equal';
 import log from './logger';
 import _ from 'lodash';
 import { WDA_RUNNER_BUNDLE_ID, PLATFORM_NAME_TVOS, CARTHAGE_ROOT } from './constants';
@@ -77,15 +76,12 @@ function isTvOS (platformName) {
 }
 
 async function fileCompare (file1, file2) {
-  try {
-    return await streamEqual(fs.createReadStream(file1), fs.createReadStream(file2));
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      // one of the files does not exist, so they cannot be the same
-      return false;
-    }
-    throw err;
+  const files = [file1, file2];
+  if (!_.every(await B.all(files.map((f) => fs.exists(f))))) {
+    return false;
   }
+  const [hash1, hash2] = await B.all(files.map((f) => fs.hash(f, 'sha1')));
+  return hash1 === hash2;
 }
 
 async function replaceInFile (file, find, replace) {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "lodash": "^4.17.11",
     "node-simctl": "^6.0.2",
     "source-map-support": "^0.5.12",
-    "stream-equal": "^1.1.1",
     "teen_process": "^1.14.1"
   },
   "files": [

--- a/test/check-dependencies-specs.js
+++ b/test/check-dependencies-specs.js
@@ -25,7 +25,7 @@ function mockPassingResourceCreation (mocks) {
 
 function mockSkippingCarthageRun (mocks) {
   mocks.fs.expects('which').once().returns(true);
-  mocks.utils.expects('fileCompare').once()
+  mocks.utils.expects('areFilesEqual').once()
     .onFirstCall().returns(true);
   mocks.teen_process.expects('exec').never();
 }
@@ -37,7 +37,7 @@ describe('webdriveragent utils', function () {
     });
     it('should not run script if Carthage directory already present', async function () {
       mocks.fs.expects('which').once().returns(true);
-      mocks.utils.expects('fileCompare').once()
+      mocks.utils.expects('areFilesEqual').once()
         .onFirstCall().returns(true);
       mocks.teen_process.expects('exec').never();
 
@@ -47,7 +47,7 @@ describe('webdriveragent utils', function () {
     });
     it('should delete Carthage folder and throw error on script error', async function () {
       mocks.fs.expects('which').once().returns(true);
-      mocks.utils.expects('fileCompare').once()
+      mocks.utils.expects('areFilesEqual').once()
         .onFirstCall().returns(false);
       mocks.simctl.expects('getDevices')
         .once().returns([]);


### PR DESCRIPTION
File comparison could be done using internal methods only. There is no need for an additional import