### PR TITLE
refactor: Do not check for keyboard presence before input

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -15,9 +15,16 @@
 #import "NSString+FBVisualLength.h"
 #import "XCUIElement+FBTap.h"
 #import "XCUIElement+FBUtilities.h"
-
+#import "FBXCodeCompatibility.h"
 
 #define MAX_CLEAR_RETRIES 2
+
+#if TARGET_OS_TV
+  #define MAX_PREPARE_RETRIES 1
+#else
+  #define MAX_PREPARE_RETRIES 2
+#endif
+
 
 @interface NSString (FBRepeat)
 
@@ -38,32 +45,33 @@
 
 @implementation XCUIElement (FBTyping)
 
+- (BOOL)fb_hasKeyboardFocus
+{
+  // https://developer.apple.com/documentation/xctest/xcuielement/1500968-typetext?language=objc
+  // > The element or a descendant must have keyboard focus; otherwise an error is raised.
+  return self.hasKeyboardFocus || [[[self.fb_query descendantsMatchingType:XCUIElementTypeAny]
+   matchingPredicate:[NSPredicate predicateWithFormat:@"hasKeyboardFocus == YES"]]
+  count] > 0;
+}
+
 - (BOOL)fb_prepareForTextInputWithError:(NSError **)error
 {
-  BOOL wasKeyboardAlreadyVisible = [FBKeyboard waitUntilVisibleForApplication:self.application timeout:-1 error:error];
-  if (wasKeyboardAlreadyVisible && self.hasKeyboardFocus) {
-    return YES;
-  }
+  int retries = 0;
+  do {
+    if (self.fb_hasKeyboardFocus) {
+      return YES;
+    }
 
-  BOOL isKeyboardVisible = wasKeyboardAlreadyVisible;
-  // Sometimes the keyboard is not opened after the first tap, so we need to retry
-  for (int tryNum = 0; tryNum < 2; ++tryNum) {
-    if ([self fb_tapWithError:error] && wasKeyboardAlreadyVisible) {
-      return YES;
-    }
+#if !TARGET_OS_TV
+    // There is no ability to open text field via tap in TvOS
+    [self fb_tapWithError:nil];
     // It might take some time to update the UI
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1]];
-    [self fb_waitUntilSnapshotIsStable];
-    isKeyboardVisible = [FBKeyboard waitUntilVisibleForApplication:self.application timeout:-1 error:error];
-    if (isKeyboardVisible && self.hasKeyboardFocus) {
-      return YES;
-    }
-  }
-  if (nil == error) {
-    NSString *description = [NSString stringWithFormat:@"The element '%@' is not ready for text input (hasKeyboardFocus -> %@, isKeyboardVisible -> %@)", self.description, @(self.hasKeyboardFocus), @(isKeyboardVisible)];
-    return [[[FBErrorBuilder builder] withDescription:description] buildError:error];
-  }
-  return NO;
+    [self fb_waitUntilSnapshotIsStableWithTimeout:1];
+#endif
+  } while (++retries < MAX_PREPARE_RETRIES);
+
+  NSString *description = [NSString stringWithFormat:@"The element '%@' is not ready for a text input. Neither the element itself nor its descendants have the input focus", self.description];
+  return [[[FBErrorBuilder builder] withDescription:description] buildError:error];
 }
 
 - (BOOL)fb_typeText:(NSString *)text error:(NSError **)error
@@ -73,20 +81,8 @@
 
 - (BOOL)fb_typeText:(NSString *)text frequency:(NSUInteger)frequency error:(NSError **)error
 {
-  // There is no ability to open text field via tap
-#if TARGET_OS_TV
-  if (!self.hasKeyboardFocus) {
-    return [[[FBErrorBuilder builder] withDescription:@"Keyboard is not opened."] buildError:error];
-  }
-#else
-  if (![self fb_prepareForTextInputWithError:error]) {
-    return NO;
-  }
-#endif
-  if (![FBKeyboard typeText:text frequency:frequency error:error]) {
-    return NO;
-  }
-  return YES;
+  return [self fb_prepareForTextInputWithError:error]
+    && [FBKeyboard typeText:text frequency:frequency error:error];
 }
 
 - (BOOL)fb_clearTextWithError:(NSError **)error

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -70,7 +70,7 @@
 #endif
   } while (++retries < MAX_PREPARE_RETRIES);
 
-  NSString *description = [NSString stringWithFormat:@"'%@' is not ready for a text input. Neither the accessbility element itself nor its accessible descendants have the input focus", self.description];
+  NSString *description = [NSString stringWithFormat:@"'%@' is not ready for a text input. Neither the accessibility element itself nor its accessible descendants have the input focus", self.description];
   return [[[FBErrorBuilder builder] withDescription:description] buildError:error];
 }
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -70,7 +70,7 @@
 #endif
   } while (++retries < MAX_PREPARE_RETRIES);
 
-  NSString *description = [NSString stringWithFormat:@"The element '%@' is not ready for a text input. Neither the element itself nor its descendants have the input focus", self.description];
+  NSString *description = [NSString stringWithFormat:@"'%@' is not ready for a text input. Neither the accessbility element itself nor its accessible descendants have the input focus", self.description];
   return [[[FBErrorBuilder builder] withDescription:description] buildError:error];
 }
 


### PR DESCRIPTION
The XCTest documentation for typeText does not say nothing about the keyboard presense, only about the focus. Lets follow it then