### PR TITLE
fix: implementation of Timezone

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -344,18 +344,6 @@
 {
   NSTimeZone *localTimeZone = [NSTimeZone localTimeZone];
   // Apple timezone name like "US/New_York"
-  NSString *timeZoneAbb = [localTimeZone abbreviation];
-  if (timeZoneAbb == nil) {
-    return [localTimeZone name];
-  }
-
-  // Convert timezone name to ids like "America/New_York" as TZ database Time Zones format
-  // https://developer.apple.com/documentation/foundation/nstimezone
-  NSString *timeZoneId = [[NSTimeZone timeZoneWithAbbreviation:timeZoneAbb] name];
-  if (timeZoneId != nil) {
-    return timeZoneId;
-  }
-
   return [localTimeZone name];
 }
 


### PR DESCRIPTION

Return timezone `name` instead of `name from abbreviation`.

abbvs can sometimes clash, as observed in IST for Irish Standard time, as well as Indian Standard time.
And this leads to WDA returning incorrect timezone for that region.
So removing the logic to retrieve timezone based on abbv, and directly returning TimeZone name.

example logs where I encountered this issue,

```
local timezoneLocal Time Zone (Europe/Dublin (IST) offset 3600 (Daylight))
System timezoneEurope/Dublin (IST) offset 3600 (Daylight)
default timezoneEurope/Dublin (IST) offset 3600 (Daylight)
local timezone name Europe/Dublin
local timezone abbv IST
local timezone zoneID : Asia/Kolkata (retrieved from abbv as per current implementation)
local timezone name Europe/Dublin (What this PR will use for all)
```


Also since we already return timezone name where abbc or zoneID is nil, this will not introduce major change or mobileInfo comsumers.