### PR TITLE
fix: Only include `simulatorVersion` property for simulators

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -223,7 +223,9 @@ static NSString* const SCREENSHOT_ORIENTATION = @"screenshotOrientation";
         },
       @"ios" :
         @{
+#if TARGET_OS_SIMULATOR
           @"simulatorVersion" : [[UIDevice currentDevice] systemVersion],
+#endif
           @"ip" : [XCUIDevice sharedDevice].fb_wifiIPAddress ?: [NSNull null]
         },
       @"build" : buildInfo.copy


### PR DESCRIPTION
Currently the property is also present on real devices when requesting WDA status, which is confusing