### PR TITLE
feat: Build with Xcode 12 beta

### DIFF
--- a/PrivateHeaders/XCTest/XCTestCase.h
+++ b/PrivateHeaders/XCTest/XCTestCase.h
@@ -72,6 +72,8 @@
 - (Class)_requiredTestRunBaseClass;
 - (void)_recordUnexpectedFailureWithDescription:(id)arg1 error:(id)arg2;
 - (void)_recordUnexpectedFailureWithDescription:(id)arg1 exception:(id)arg2;
+// Exists since Xcode 9.4.1, at least
+- (void)recordFailureWithDescription:(NSString *)arg1 inFile:(NSString *)arg2 atLine:(NSUInteger)arg3 expected:(BOOL)arg4;
 - (void)_enqueueFailureWithDescription:(NSString *)description inFile:(NSString *)filePath atLine:(NSUInteger)lineNumber expected:(BOOL)expected;
 - (void)_dequeueFailures;
 - (void)_interruptTest;

--- a/PrivateHeaders/XCTest/XCTestCaseRun.h
+++ b/PrivateHeaders/XCTest/XCTestCaseRun.h
@@ -11,6 +11,7 @@
 }
 
 - (void)_recordValues:(id)arg1 forPerformanceMetricID:(id)arg2 name:(id)arg3 unitsOfMeasurement:(id)arg4 baselineName:(id)arg5 baselineAverage:(id)arg6 maxPercentRegression:(id)arg7 maxPercentRelativeStandardDeviation:(id)arg8 maxRegression:(id)arg9 maxStandardDeviation:(id)arg10 file:(id)arg11 line:(unsigned long long)arg12;
+// Removed since Xcode 12.0
 - (void)recordFailureWithDescription:(id)arg1 inFile:(id)arg2 atLine:(unsigned long long)arg3 expected:(BOOL)arg4;
 - (void)recordFailureInTest:(id)arg1 withDescription:(id)arg2 inFile:(id)arg3 atLine:(unsigned long long)arg4 expected:(BOOL)arg5;
 - (void)stop;

--- a/PrivateHeaders/XCTest/XCTestDriver.h
+++ b/PrivateHeaders/XCTest/XCTestDriver.h
@@ -26,6 +26,7 @@
 @property(retain) NSObject<OS_dispatch_queue> *queue; // @synthesize queue=_queue;
 @property(readonly) XCTestConfiguration *testConfiguration; // @synthesize testConfiguration=_testConfiguration;
 
+// Removed since Xcode 12.0
 + (instancetype)sharedTestDriver;
 
 - (void)runTestConfiguration:(id)arg1 completionHandler:(CDUnknownBlockType)arg2;

--- a/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.m
@@ -48,7 +48,8 @@ static dispatch_once_t onceTestRunnerDaemonClass;
 
 + (id<XCTestManager_ManagerInterface>)retrieveTestRunnerProxy
 {
-  if ([[XCTestDriver sharedTestDriver] respondsToSelector:@selector(managerProxy)]) {
+  if ([XCTestDriver respondsToSelector:@selector(sharedTestDriver)] &&
+      [[XCTestDriver sharedTestDriver] respondsToSelector:@selector(managerProxy)]) {
     return [XCTestDriver sharedTestDriver].managerProxy;
   } else {
     return ((XCTRunnerDaemonSession *)[FBXCTRunnerDaemonSessionClass sharedSession]).daemonProxy;


### PR DESCRIPTION
Do not merge yet. This merge should be after 1.18.0 checkout

(Feel free to update this branch if you find other fixes)

On my local, I was able to build with Xcode 12 beta and got their page source on tvOS and iOS. Let me run this on CI.

---

note:

- XCTest.framework/XCUIElement.h
```
@property(readonly, copy) XCUIElementQuery *bannerNotifications;
@property(readonly) _Bool bannerNotificationIsSticky;
@property(readonly) _Bool hasBannerNotificationIsStickyAttribute;
```