### PR TITLE
fix: Make sure the returned screenshot is always a PNG image

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -105,9 +105,6 @@ static bool fb_isLocked;
 - (NSData *)fb_screenshotWithError:(NSError*__autoreleasing*)error
 {
   NSData* screenshotData = [self fb_rawScreenshotWithQuality:FBConfiguration.screenshotQuality error:error];
-  if (nil == screenshotData) {
-    return nil;
-  }
 #if TARGET_OS_TV
   return FBAdjustScreenshotOrientationForApplication(screenshotData);
 #else

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -230,9 +230,9 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
 
   if (@available(iOS 13.0, *)) {
     // landscape also works correctly on over iOS13 x Xcode 11
-    return [XCUIScreen.mainScreen screenshotDataForQuality:FBConfiguration.screenshotQuality
+    return FBToPngData([XCUIScreen.mainScreen screenshotDataForQuality:FBConfiguration.screenshotQuality
                                                       rect:elementRect
-                                                     error:error];
+                                                     error:error]);
   }
 
 #if !TARGET_OS_TV

--- a/WebDriverAgentLib/Utilities/FBImageUtils.h
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.h
@@ -11,9 +11,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*! Returns YES if the data contains a JPEG image */
-BOOL FBIsJpegImage(NSData *imageData);
-
 /*! Returns YES if the data contains a PNG image */
 BOOL FBIsPngImage(NSData *imageData);
 

--- a/WebDriverAgentLib/Utilities/FBImageUtils.h
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.h
@@ -9,15 +9,22 @@
 
 #import <XCTest/XCTest.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! Returns YES if the data contains a JPEG image */
 BOOL FBIsJpegImage(NSData *imageData);
 
 /*! Returns YES if the data contains a PNG image */
 BOOL FBIsPngImage(NSData *imageData);
 
+/*! Converts the given image data to a PNG representation if necessary */
+NSData *_Nullable FBToPngData(NSData *imageData);
+
 #if TARGET_OS_TV
-NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData);
+NSData *_Nullable FBAdjustScreenshotOrientationForApplication(NSData *screenshotData);
 #else
 /*! Fixes the screenshot orientation if necessary to match current screen orientation */
-NSData *FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIInterfaceOrientation orientation);
+NSData *_Nullable FBAdjustScreenshotOrientationForApplication(NSData *screenshotData, UIInterfaceOrientation orientation);
 #endif
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBImageUtils.m
+++ b/WebDriverAgentLib/Utilities/FBImageUtils.m
@@ -12,29 +12,8 @@
 #import "FBMacros.h"
 #import "FBConfiguration.h"
 
-static uint8_t JPEG_MAGIC[] = { 0xff, 0xd8 };
-static const NSUInteger JPEG_MAGIC_LEN = 2;
 static uint8_t PNG_MAGIC[] = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
 static const NSUInteger PNG_MAGIC_LEN = 8;
-
-BOOL FBIsJpegImage(NSData *imageData)
-{
-  if (nil == imageData || [imageData length] < JPEG_MAGIC_LEN) {
-    return NO;
-  }
-
-  static NSData* jpegMagicStartData = nil;
-  static dispatch_once_t onceJpegToken;
-  dispatch_once(&onceJpegToken, ^{
-    jpegMagicStartData = [NSData dataWithBytesNoCopy:(void*)JPEG_MAGIC length:JPEG_MAGIC_LEN freeWhenDone:NO];
-  });
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wassign-enum"
-  NSRange range = [imageData rangeOfData:jpegMagicStartData options:kNilOptions range:NSMakeRange(0, JPEG_MAGIC_LEN)];
-#pragma clang diagnostic pop
-  return range.location != NSNotFound;
-}
 
 BOOL FBIsPngImage(NSData *imageData)
 {


### PR DESCRIPTION
Since Xcode12 SDK the downstream XCTest calls may return HEIC images instead of JPEGs. And the client is anyway only expecting PNGs