### PR TITLE
feat: Add a setting for elements bounding strategy selection

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
@@ -85,7 +85,7 @@ NSString *const FBClassChainQueryParseException = @"FBClassChainQueryParseExcept
     XCUIElement *result = query.fb_firstMatch;
     return result ? @[result] : @[];
   }
-  NSArray<XCUIElement *> *allMatches = query.allElementsBoundByAccessibilityElement;
+  NSArray<XCUIElement *> *allMatches = query.fb_allMatches;
   if (0 == item.position.integerValue) {
     return allMatches;
   }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -29,7 +29,7 @@
 + (NSArray<XCUIElement *> *)fb_extractMatchingElementsFromQuery:(XCUIElementQuery *)query shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
   if (!shouldReturnAfterFirstMatch) {
-    return query.allElementsBoundByAccessibilityElement;
+    return query.fb_allMatches;
   }
   XCUIElement *matchedElement = query.fb_firstMatch;
   return matchedElement ? @[matchedElement] : @[];
@@ -85,7 +85,7 @@
 
   NSPredicate *predicate = [FBPredicate predicateWithFormat:operation];
   XCUIElementQuery *query = [[self.fb_query descendantsMatchingType:XCUIElementTypeAny] matchingPredicate:predicate];
-  NSArray *childElements = query.allElementsBoundByAccessibilityElement;
+  NSArray *childElements = query.fb_allMatches;
   [results addObjectsFromArray:childElements];
 }
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -197,7 +197,7 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
   //    }
   //    return NSOrderedSame;
   //  }];
-  return query.allElementsBoundByAccessibilityElement;
+  return query.fb_allMatches;
 }
 
 - (BOOL)fb_waitUntilSnapshotIsStable

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -37,6 +37,7 @@ static NSString* const KEYBOARD_PREDICTION = @"keyboardPrediction";
 static NSString* const SNAPSHOT_TIMEOUT = @"snapshotTimeout";
 static NSString* const SNAPSHOT_MAX_DEPTH = @"snapshotMaxDepth";
 static NSString* const USE_FIRST_MATCH = @"useFirstMatch";
+static NSString* const BOUND_ELEMENTS_BY_INDEX = @"boundElementsByIndex";
 static NSString* const REDUCE_MOTION = @"reduceMotion";
 static NSString* const DEFAULT_ACTIVE_APPLICATION = @"defaultActiveApplication";
 static NSString* const ACTIVE_APP_DETECTION_POINT = @"activeAppDetectionPoint";
@@ -256,6 +257,7 @@ static NSString* const SCREENSHOT_ORIENTATION = @"screenshotOrientation";
       SNAPSHOT_TIMEOUT: @([FBConfiguration snapshotTimeout]),
       SNAPSHOT_MAX_DEPTH: @([FBConfiguration snapshotMaxDepth]),
       USE_FIRST_MATCH: @([FBConfiguration useFirstMatch]),
+      BOUND_ELEMENTS_BY_INDEX: @([FBConfiguration boundElementsByIndex]),
       REDUCE_MOTION: @([FBConfiguration reduceMotionEnabled]),
       DEFAULT_ACTIVE_APPLICATION: request.session.defaultActiveApplication,
       ACTIVE_APP_DETECTION_POINT: FBActiveAppDetectionPoint.sharedInstance.stringCoordinates,
@@ -307,6 +309,9 @@ static NSString* const SCREENSHOT_ORIENTATION = @"screenshotOrientation";
   }
   if (nil != [settings objectForKey:USE_FIRST_MATCH]) {
     [FBConfiguration setUseFirstMatch:[[settings objectForKey:USE_FIRST_MATCH] boolValue]];
+  }
+  if (nil != [settings objectForKey:BOUND_ELEMENTS_BY_INDEX]) {
+    [FBConfiguration setBoundElementsByIndex:[[settings objectForKey:BOUND_ELEMENTS_BY_INDEX] boolValue]];
   }
   if (nil != [settings objectForKey:REDUCE_MOTION]) {
     [FBConfiguration setReduceMotionEnabled:[[settings objectForKey:REDUCE_MOTION] boolValue]];

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -182,6 +182,17 @@ typedef NS_ENUM(NSInteger, FBConfigurationKeyboardPreference) {
 + (BOOL)useFirstMatch;
 
 /**
+ * Whether to bound the lookup results by index.
+ * By default this is disabled and bounding by accessibility is used.
+ * Read https://stackoverflow.com/questions/49307513/meaning-of-allelementsboundbyaccessibilityelement
+ * for more details on these two bounding methods.
+ *
+ * @param enabled Either YES or NO
+ */
++ (void)setBoundElementsByIndex:(BOOL)enabled;
++ (BOOL)boundElementsByIndex;
+
+/**
  * Modify reduce motion configuration in accessibility.
  * It works only for Simulator since Real device has security model which allows chnaging preferences
  * only from settings app.

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -39,6 +39,7 @@ static NSUInteger FBScreenshotQuality = 1;
 static NSUInteger FBMjpegScalingFactor = 100;
 static NSTimeInterval FBSnapshotTimeout = 15.;
 static BOOL FBShouldUseFirstMatch = NO;
+static BOOL FBShouldBoundElementsByIndex = NO;
 // This is diabled by default because enabling it prevents the accessbility snapshot to be taken
 // (it always errors with kxIllegalArgument error)
 static BOOL FBIncludeNonModalElements = NO;
@@ -314,6 +315,16 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
 + (BOOL)useFirstMatch
 {
   return FBShouldUseFirstMatch;
+}
+
++ (void)setBoundElementsByIndex:(BOOL)enabled
+{
+  FBShouldBoundElementsByIndex = enabled;
+}
+
++ (BOOL)boundElementsByIndex
+{
+  return FBShouldBoundElementsByIndex;
 }
 
 + (void)setIncludeNonModalElements:(BOOL)isEnabled

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
@@ -62,6 +62,13 @@ extern NSString *const FBApplicationMethodNotSupportedException;
 /* Performs short-circuit UI tree traversion in iOS 11+ to get the first element matched by the query. Equals to nil if no matching elements are found */
 @property(nullable, readonly) XCUIElement *fb_firstMatch;
 
+/*
+ This is the local wrapper for bounded elements extraction.
+ It uses either indexed or bounded binding based on the `boundElementsByIndex` configuration
+ flag value.
+ */
+@property(readonly) NSArray<XCUIElement *> *fb_allMatches;
+
 /**
  Since Xcode11 XCTest got a feature that caches intermediate query snapshots
 

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -128,8 +128,15 @@ static dispatch_once_t onceAppWithPIDToken;
 {
   XCUIElement* match = FBConfiguration.useFirstMatch
     ? self.firstMatch
-    : self.allElementsBoundByAccessibilityElement.firstObject;
+    : self.fb_allMatches.firstObject;
   return [match exists] ? match : nil;
+}
+
+- (NSArray<XCUIElement *> *)fb_allMatches
+{
+  return FBConfiguration.boundElementsByIndex
+    ? self.allElementsBoundByIndex
+    : self.allElementsBoundByAccessibilityElement;
 }
 
 - (XCElementSnapshot *)fb_elementSnapshotForDebugDescription


### PR DESCRIPTION
Adds `boundElementsByIndex` boolean setting, which allows to select the bounding strategy for elements lookup. Based on https://github.com/appium/appium/issues/14486