### PR TITLE
feat: Add a possibility to reset an authorization status for a protected resource

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
@@ -26,6 +26,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)fb_deactivateWithDuration:(NSTimeInterval)duration error:(NSError **)error;
 
 /**
+ Resets the authorization status for a protected resource. Available since Xcode 11.4
+
+ @param resourceId A valid resource id to reset the auth status for. See https://developer.apple.com/documentation/xctest/xcuiprotectedresource?language=objc
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return YES if the operation succeeds, otherwise NO.
+ */
+- (BOOL)fb_resetAuthorizationStatusForResource:(long long)resourceId error:(NSError **)error;
+
+/**
  Return application elements tree in form of nested dictionaries
  */
 - (NSDictionary *)fb_tree;

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -250,4 +250,15 @@ static NSString* const FBUnknownBundleId = @"unknown";
   return testmanagerdVersion;
 }
 
+- (BOOL)fb_resetAuthorizationStatusForResource:(long long)resourceId error:(NSError **)error
+{
+  if (![self respondsToSelector:@selector(resetAuthorizationStatusForResource:)]) {
+    return [[[FBErrorBuilder builder]
+             withDescription:@"'resetAuthorizationStatusForResource' API is only supported for Xcode SDK 11.4 and later"]
+            buildError:error];
+  }
+  [self performSelector:@selector(resetAuthorizationStatusForResource:) withObject:@(resourceId)];
+  return YES;
+}
+
 @end

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -252,12 +252,16 @@ static NSString* const FBUnknownBundleId = @"unknown";
 
 - (BOOL)fb_resetAuthorizationStatusForResource:(long long)resourceId error:(NSError **)error
 {
-  if (![self respondsToSelector:@selector(resetAuthorizationStatusForResource:)]) {
+  SEL selector = NSSelectorFromString(@"resetAuthorizationStatusForResource:");
+  if (![self respondsToSelector:selector]) {
     return [[[FBErrorBuilder builder]
              withDescription:@"'resetAuthorizationStatusForResource' API is only supported for Xcode SDK 11.4 and later"]
             buildError:error];
   }
-  [self performSelector:@selector(resetAuthorizationStatusForResource:) withObject:@(resourceId)];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+  [self performSelector:selector withObject:@(resourceId)];
+#pragma clang diagnostic pop
   return YES;
 }
 

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -58,6 +58,7 @@
     [[FBRoute POST:@"/wda/siri/activate"] respondWithTarget:self action:@selector(handleActivateSiri:)],
     [[FBRoute POST:@"/wda/apps/launchUnattached"].withoutSession respondWithTarget:self action:@selector(handleLaunchUnattachedApp:)],
     [[FBRoute GET:@"/wda/device/info"] respondWithTarget:self action:@selector(handleGetDeviceInfo:)],
+    [[FBRoute POST:@"/wda/resetAppAuth"] respondWithTarget:self action:@selector(handleResetAppAuth:)],
     [[FBRoute GET:@"/wda/device/info"].withoutSession respondWithTarget:self action:@selector(handleGetDeviceInfo:)],
     [[FBRoute OPTIONS:@"/*"].withoutSession respondWithTarget:self action:@selector(handlePingCommand:)],
   ];
@@ -281,6 +282,21 @@
     return FBResponseWithOK();
   }
   return FBResponseWithStatus([FBCommandStatus unknownErrorWithMessage:@"LSApplicationWorkspace failed to launch app" traceback:nil]);
+}
+
++ (id <FBResponsePayload>)handleResetAppAuth:(FBRouteRequest *)request
+{
+  NSNumber *resource = request.arguments[@"resource"];
+  if (nil == resource) {
+    NSString *errMsg = @"The 'resource' argument must be set to a valid resource identifier (numeric value). See https://developer.apple.com/documentation/xctest/xcuiprotectedresource?language=objc";
+    return FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:errMsg traceback:nil]);
+  }
+  NSError *error;
+  if (![request.session.activeApplication fb_resetAuthorizationStatusForResource:resource.longLongValue
+                                                                           error:&error]) {
+    return FBResponseWithUnknownError(error);
+  }
+  return FBResponseWithOK();
 }
 
 + (id<FBResponsePayload>)handleGetDeviceInfo:(FBRouteRequest *)request


### PR DESCRIPTION
The feature has been added since Xcode 11.4 and is quite handy for testing purposes