### PR TITLE
fix: Remove excluded archs	

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -301,9 +301,12 @@ stages:
 
   - job: Node_Integration_Tests
     variables:
-      XCODE_VERSION: $(MAX_XCODE_VERSION)
-      DEVICE_NAME: $(MAX_IPHONE_DEVICE_NAME)
-      PLATFORM_VERSION: $(MAX_PLATFORM_VERSION)
+      # XCODE_VERSION: $(MAX_XCODE_VERSION)
+      # DEVICE_NAME: $(MAX_IPHONE_DEVICE_NAME)
+      # PLATFORM_VERSION: $(MAX_PLATFORM_VERSION)
+      XCODE_VERSION: 11.7
+      DEVICE_NAME: iPhone 11 Pro Max
+      PLATFORM_VERSION: 13.7
     steps:
     - template: azure-templates/node_setup_steps.yml
     - script: npm install

--- a/Configurations/IOSSettings.xcconfig
+++ b/Configurations/IOSSettings.xcconfig
@@ -13,8 +13,6 @@ GCC_WARN_UNUSED_VARIABLE = YES
 GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = YES
 CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES
 
-EXCLUDED_ARCHS[sdk=iphoneos*] = x86_64
-EXCLUDED_ARCHS[sdk=iphonesimulator*] = arm64
 ARCHS[sdk=iphoneos*] = arm64
 ARCHS[sdk=iphonesimulator*] = x86_64
 VALID_ARCHS[sdk=iphoneos*] = arm64

--- a/Configurations/IOSTestSettings.xcconfig
+++ b/Configurations/IOSTestSettings.xcconfig
@@ -1,5 +1,3 @@
-EXCLUDED_ARCHS[sdk=iphoneos*] = x86_64
-EXCLUDED_ARCHS[sdk=iphonesimulator*] = arm64
 ARCHS[sdk=iphoneos*] = arm64
 ARCHS[sdk=iphonesimulator*] = x86_64
 VALID_ARCHS[sdk=iphoneos*] = arm64

--- a/Configurations/TVOSSettings.xcconfig
+++ b/Configurations/TVOSSettings.xcconfig
@@ -13,8 +13,6 @@ GCC_WARN_UNUSED_VARIABLE = YES
 GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL = YES
 CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES
 
-EXCLUDED_ARCHS[sdk=appletvos*] = x86_64
-EXCLUDED_ARCHS[sdk=appletvsimulator*] = arm64
 ARCHS[sdk=appletvos*] = arm64
 ARCHS[sdk=appletvsimulator*] = x86_64
 VALID_ARCHS[sdk=appletvos*] = arm64

--- a/Configurations/TVOSTestSettings.xcconfig
+++ b/Configurations/TVOSTestSettings.xcconfig
@@ -1,5 +1,3 @@
-EXCLUDED_ARCHS[sdk=appletvos*] = x86_64
-EXCLUDED_ARCHS[sdk=appletvsimulator*] = arm64
 ARCHS[sdk=appletvos*] = arm64
 ARCHS[sdk=appletvsimulator*] = x86_64
 VALID_ARCHS[sdk=appletvos*] = arm64


### PR DESCRIPTION
Xcode 11 (and only 11) does 

```
ERR! Xcode warning: Mapping architecture arm64 to x86_64. Ensure that this target's Architectures and Valid Architectures build settings are configured correctly for the iOS Simulator platform. (in target 'WebDriverAgentRunner' from project 'WebDriverAgent')
ERR! Xcode 
ERR! Xcode warning: There are no architectures to compile for because all architectures in VALID_ARCHS (x86_64) are also in EXCLUDED_ARCHS (x86_64). (in target 'WebDriverAgentRunner' from project 'WebDriverAgent')
```