### PR TITLE
feat: Allow registering your destination device on the developer portal

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -78,6 +78,7 @@ class WebDriverAgent {
       useXctestrunFile: this.useXctestrunFile,
       derivedDataPath: args.derivedDataPath,
       mjpegServerPort: this.mjpegServerPort,
+      allowProvisioningDeviceRegistration: args.allowProvisioningDeviceRegistration,
     });
   }
 

--- a/lib/xcodebuild.js
+++ b/lib/xcodebuild.js
@@ -186,6 +186,7 @@ class XcodeBuild {
     }
 
     if (this.allowProvisioningDeviceRegistration) {
+      // To -allowProvisioningDeviceRegistration flag takes effect, -allowProvisioningUpdates needs to be passed as well.
       args.push('-allowProvisioningUpdates', '-allowProvisioningDeviceRegistration');
     }
 

--- a/lib/xcodebuild.js
+++ b/lib/xcodebuild.js
@@ -71,6 +71,8 @@ class XcodeBuild {
     this.mjpegServerPort = args.mjpegServerPort;
 
     this.prebuildDelay = _.isNumber(args.prebuildDelay) ? args.prebuildDelay : PREBUILD_DELAY;
+
+    this.allowProvisioningDeviceRegistration = args.allowProvisioningDeviceRegistration;
   }
 
   async init (noSessionProxy) {
@@ -181,6 +183,10 @@ class XcodeBuild {
       args = [testCmd];
     } else {
       args = [buildCmd, testCmd];
+    }
+
+    if (this.allowProvisioningDeviceRegistration) {
+      args.push('-allowProvisioningUpdates', '-allowProvisioningDeviceRegistration');
     }
 
     if (this.useXctestrunFile) {


### PR DESCRIPTION
When you enable `allowProvisioningDeviceRegistration` in `desiredCapabilities`, it will allow xcodebuild to communicate with the Apple Developer website to automatically signed targets, xcodebuild will create and update profiles, app IDs, and certificates, register your destination device on the developer portal if necessary. Requires a developer account to have been added in Xcode's Accounts preference pane.

Related PR:  https://github.com/appium/appium-xcuitest-driver/pull/1241