### PR TITLE
 refactor: Improve elements caching logic

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -428,6 +428,10 @@
 		71BD20731F86116100B36EC2 /* XCUIApplication+FBTouchAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BD20711F86116100B36EC2 /* XCUIApplication+FBTouchAction.h */; };
 		71BD20741F86116100B36EC2 /* XCUIApplication+FBTouchAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BD20721F86116100B36EC2 /* XCUIApplication+FBTouchAction.m */; };
 		71BD20781F869E0F00B36EC2 /* FBAppiumTouchActionsIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BD20771F869E0F00B36EC2 /* FBAppiumTouchActionsIntegrationTests.m */; };
+		71D04DC825356C43008A052C /* XCUIElement+FBCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 71D04DC625356C43008A052C /* XCUIElement+FBCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		71D04DC925356C43008A052C /* XCUIElement+FBCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 71D04DC625356C43008A052C /* XCUIElement+FBCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		71D04DCA25356C43008A052C /* XCUIElement+FBCaching.m in Sources */ = {isa = PBXBuildFile; fileRef = 71D04DC725356C43008A052C /* XCUIElement+FBCaching.m */; };
+		71D04DCB25356C43008A052C /* XCUIElement+FBCaching.m in Sources */ = {isa = PBXBuildFile; fileRef = 71D04DC725356C43008A052C /* XCUIElement+FBCaching.m */; };
 		71F5BE23252E576C00EE9EBA /* XCUIElement+FBSwiping.h in Headers */ = {isa = PBXBuildFile; fileRef = 71F5BE21252E576C00EE9EBA /* XCUIElement+FBSwiping.h */; };
 		71F5BE24252E576C00EE9EBA /* XCUIElement+FBSwiping.h in Headers */ = {isa = PBXBuildFile; fileRef = 71F5BE21252E576C00EE9EBA /* XCUIElement+FBSwiping.h */; };
 		71F5BE25252E576C00EE9EBA /* XCUIElement+FBSwiping.m in Sources */ = {isa = PBXBuildFile; fileRef = 71F5BE22252E576C00EE9EBA /* XCUIElement+FBSwiping.m */; };
@@ -1008,6 +1012,8 @@
 		71BD20711F86116100B36EC2 /* XCUIApplication+FBTouchAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIApplication+FBTouchAction.h"; sourceTree = "<group>"; };
 		71BD20721F86116100B36EC2 /* XCUIApplication+FBTouchAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIApplication+FBTouchAction.m"; sourceTree = "<group>"; };
 		71BD20771F869E0F00B36EC2 /* FBAppiumTouchActionsIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBAppiumTouchActionsIntegrationTests.m; sourceTree = "<group>"; };
+		71D04DC625356C43008A052C /* XCUIElement+FBCaching.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIElement+FBCaching.h"; sourceTree = "<group>"; };
+		71D04DC725356C43008A052C /* XCUIElement+FBCaching.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIElement+FBCaching.m"; sourceTree = "<group>"; };
 		71E504941DF59BAD0020C32A /* XCUIElementAttributesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCUIElementAttributesTests.m; sourceTree = "<group>"; };
 		71F5BE21252E576C00EE9EBA /* XCUIElement+FBSwiping.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIElement+FBSwiping.h"; sourceTree = "<group>"; };
 		71F5BE22252E576C00EE9EBA /* XCUIElement+FBSwiping.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIElement+FBSwiping.m"; sourceTree = "<group>"; };
@@ -1693,6 +1699,8 @@
 				EEE3763E1D59F81400ED88DD /* XCUIDevice+FBRotation.m */,
 				EE9AB7451CAEDF0C008C271F /* XCUIElement+FBAccessibility.h */,
 				EE9AB7461CAEDF0C008C271F /* XCUIElement+FBAccessibility.m */,
+				71D04DC625356C43008A052C /* XCUIElement+FBCaching.h */,
+				71D04DC725356C43008A052C /* XCUIElement+FBCaching.m */,
 				71A7EAF31E20516B001DA4F2 /* XCUIElement+FBClassChain.h */,
 				71A7EAF41E20516B001DA4F2 /* XCUIElement+FBClassChain.m */,
 				EEBBD4891D47746D00656A81 /* XCUIElement+FBFind.h */,
@@ -2381,6 +2389,7 @@
 				641EE6EB2240C5CA00173FCB /* XCTestCaseSuite.h in Headers */,
 				641EE6EC2240C5CA00173FCB /* _XCInternalTestRun.h in Headers */,
 				641EE6ED2240C5CA00173FCB /* FBXPath-Private.h in Headers */,
+				71D04DC925356C43008A052C /* XCUIElement+FBCaching.h in Headers */,
 				641EE6EE2240C5CA00173FCB /* XCKeyMappingPath.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2549,6 +2558,7 @@
 				EE35AD731E3B77D600A02D78 /* XCUIElementQuery.h in Headers */,
 				EE35AD331E3B77D600A02D78 /* XCPointerEvent.h in Headers */,
 				EE35AD351E3B77D600A02D78 /* XCSourceCodeRecording.h in Headers */,
+				71D04DC825356C43008A052C /* XCUIElement+FBCaching.h in Headers */,
 				E444DC99249131D40060D7EB /* HTTPLogging.h in Headers */,
 				E444DC9B249131D40060D7EB /* HTTPResponse.h in Headers */,
 				EEE9B4721CD02B88009D2030 /* FBRunLoopSpinner.h in Headers */,
@@ -3061,6 +3071,7 @@
 				641EE6212240C5CA00173FCB /* FBElementTypeTransformer.m in Sources */,
 				641EE6222240C5CA00173FCB /* FBApplication.m in Sources */,
 				641EE6232240C5CA00173FCB /* FBScreen.m in Sources */,
+				71D04DCB25356C43008A052C /* XCUIElement+FBCaching.m in Sources */,
 				641EE6242240C5CA00173FCB /* FBXCTestDaemonsProxy.m in Sources */,
 				641EE6252240C5CA00173FCB /* XCUIElement+FBTap.m in Sources */,
 				641EE6262240C5CA00173FCB /* FBMathUtils.m in Sources */,
@@ -3143,6 +3154,7 @@
 				EE158AC51CBD456F00A3E3F0 /* FBOrientationCommands.m in Sources */,
 				641EE7082240CDEB00173FCB /* XCUIElement+FBTVFocuse.m in Sources */,
 				EEC9EED720064FAA00BC0D5B /* XCUICoordinate+FBFix.m in Sources */,
+				71D04DCA25356C43008A052C /* XCUIElement+FBCaching.m in Sources */,
 				EE158AEB1CBD456F00A3E3F0 /* FBRuntimeUtils.m in Sources */,
 				EEE376461D59F81400ED88DD /* XCUIElement+FBUtilities.m in Sources */,
 				EE9B76A91CF7A43900275851 /* FBLogger.m in Sources */,

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -23,6 +23,7 @@
 #import "XCAccessibilityElement.h"
 #import "XCElementSnapshot+FBHelpers.h"
 #import "XCUIDevice+FBHelpers.h"
+#import "XCUIElement+FBCaching.h"
 #import "XCUIElement+FBIsVisible.h"
 #import "XCUIElement+FBUtilities.h"
 #import "XCUIElement+FBWebDriverAttributes.h"

--- a/WebDriverAgentLib/Categories/XCUIElement+FBCaching.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBCaching.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface XCUIElement (FBCaching)
+
+/*! This property is set to YES if the given element has been resolved from the cache, so it is safe to use the `lastSnapshot` property */
+@property (nullable, nonatomic) NSNumber *fb_isResolvedFromCache;
+
+@property (nonatomic, readonly) NSString *fb_cacheId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIElement+FBCaching.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBCaching.m
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "XCUIElement+FBCaching.h"
+
+#import <objc/runtime.h>
+
+#import "XCUIElement+FBWebDriverAttributes.h"
+#import "XCUIElement+FBUtilities.h"
+
+@implementation XCUIElement (FBCaching)
+
+static char XCUIELEMENT_IS_RESOLVED_FROM_CACHE_KEY;
+
+@dynamic fb_isResolvedFromCache;
+
+- (void)setFb_isResolvedFromCache:(NSNumber *)isResolvedFromCache
+{
+  objc_setAssociatedObject(self, &XCUIELEMENT_IS_RESOLVED_FROM_CACHE_KEY, isResolvedFromCache, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (NSNumber *)fb_isResolvedFromCache
+{
+  return (NSNumber *)objc_getAssociatedObject(self, &XCUIELEMENT_IS_RESOLVED_FROM_CACHE_KEY);
+}
+
+static char XCUIELEMENT_CACHE_ID_KEY;
+
+@dynamic fb_cacheId;
+
+- (NSString *)fb_cacheId
+{
+  NSString *result = (NSString *)objc_getAssociatedObject(self, &XCUIELEMENT_IS_RESOLVED_FROM_CACHE_KEY);
+  if (nil != result) {
+    return result;
+  }
+
+  XCElementSnapshot *snapshot = self.fb_cachedSnapshot ?: self.fb_takeSnapshot;
+  NSString *uid = snapshot.wdUID;
+  objc_setAssociatedObject(self, &XCUIELEMENT_CACHE_ID_KEY, uid, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+  return uid;
+}
+
+@end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
@@ -16,6 +16,7 @@
 #import "FBPredicate.h"
 #import "FBXCodeCompatibility.h"
 #import "XCUIApplication+FBTouchAction.h"
+#import "XCUIElement+FBCaching.h"
 #import "XCElementSnapshot+FBHelpers.h"
 #import "XCElementSnapshot.h"
 #import "XCUIApplication.h"

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
@@ -15,9 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface XCUIElement (FBUtilities)
 
-/*! This property is set to YES if the given element has been resolved from the cache, so it is safe to use the `lastSnapshot` property */
-@property (nullable, nonatomic) NSNumber *fb_isResolvedFromCache;
-
 /**
  Waits for receiver's frame to become stable with the default timeout
 
@@ -35,6 +32,14 @@ NS_ASSUME_NONNULL_BEGIN
  @throws FBStaleElementException if the element is not present in DOM and thus no snapshot could be made
  */
 - (XCElementSnapshot *)fb_takeSnapshot;
+
+/**
+ Extracts the cached element snapshot from its query.
+ No requests to the accessiblity framework is made.
+
+ @return Either the cached snapshot or nil
+ */
+- (nullable XCElementSnapshot *)fb_cachedSnapshot;
 
 /**
  Gets the most recent snapshot of the current element and already resolves the accessibility attributes

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -25,6 +25,7 @@
 #import "XCTestManager_ManagerInterface-Protocol.h"
 #import "XCTestPrivateSymbols.h"
 #import "XCTRunnerDaemonSession.h"
+#import "XCUIElement+FBCaching.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
 #import "XCUIElementQuery.h"
 #import "XCUIScreen.h"
@@ -62,13 +63,40 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
     [self fb_resolveWithError:&error];
   }
   if (nil == self.lastSnapshot) {
-    NSString *reason = [NSString stringWithFormat:@"The previously found element \"%@\" is not present on the current page anymore. Try to find it again", self.description];
+    NSString *hintText = @"Make sure the application UI is in the expected state";
+    if (nil != error
+        && [error.localizedDescription containsString:@"Identity Binding"]) {
+      hintText = [NSString stringWithFormat:@"%@. You could also try to switch the binding strategy using the 'boundElementsByIndex' setting for the element lookup", hintText];
+    }
+    NSString *reason = [NSString stringWithFormat:@"The previously found element \"%@\" is not present on the current page anymore. %@", self.description, hintText];
     if (nil != error) {
       reason = [NSString stringWithFormat:@"%@. Original error: %@", reason, error.localizedDescription];
     }
     @throw [NSException exceptionWithName:FBStaleElementException reason:reason userInfo:@{}];
   }
   return self.lastSnapshot;
+}
+
+- (XCElementSnapshot *)fb_cachedSnapshot
+{
+  XCElementSnapshot *snapshot = nil;
+  @try {
+    XCUIElementQuery *rootQuery = self.fb_query;
+    while (rootQuery != nil && rootQuery.rootElementSnapshot == nil) {
+      rootQuery = rootQuery.inputQuery;
+    }
+    if (rootQuery != nil) {
+      NSMutableArray *snapshots = [NSMutableArray arrayWithObject:rootQuery.rootElementSnapshot];
+      [snapshots addObjectsFromArray:rootQuery.rootElementSnapshot._allDescendants];
+      NSOrderedSet *matchingSnapshots = (NSOrderedSet *)[self.fb_query.transformer transform:[NSOrderedSet orderedSetWithArray:snapshots] relatedElements:nil];
+      if (nil != matchingSnapshots && matchingSnapshots.count == 1) {
+        snapshot = matchingSnapshots.firstObject;
+      }
+    }
+  } @catch (NSException *) {
+    snapshot = nil;
+  }
+  return snapshot;
 }
 
 - (nullable XCElementSnapshot *)fb_snapshotWithAllAttributes {
@@ -264,20 +292,6 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
 #else
   return imageData;
 #endif
-}
-
-static char XCUIELEMENT_IS_RESOLVED_FROM_CACHE_KEY;
-
-@dynamic fb_isResolvedFromCache;
-
-- (void)setFb_isResolvedFromCache:(NSNumber *)isResolvedFromCache
-{
-  objc_setAssociatedObject(self, &XCUIELEMENT_IS_RESOLVED_FROM_CACHE_KEY, isResolvedFromCache, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-- (NSNumber *)fb_isResolvedFromCache
-{
-  return (NSNumber *)objc_getAssociatedObject(self, &XCUIELEMENT_IS_RESOLVED_FROM_CACHE_KEY);
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -63,12 +63,12 @@ static const NSTimeInterval FB_ANIMATION_TIMEOUT = 5.0;
     [self fb_resolveWithError:&error];
   }
   if (nil == self.lastSnapshot) {
-    NSString *hintText = @"Make sure the application UI is in the expected state";
+    NSString *hintText = @"Make sure the application UI has the expected state";
     if (nil != error
         && [error.localizedDescription containsString:@"Identity Binding"]) {
       hintText = [NSString stringWithFormat:@"%@. You could also try to switch the binding strategy using the 'boundElementsByIndex' setting for the element lookup", hintText];
     }
-    NSString *reason = [NSString stringWithFormat:@"The previously found element \"%@\" is not present on the current page anymore. %@", self.description, hintText];
+    NSString *reason = [NSString stringWithFormat:@"The previously found element \"%@\" is not present in the current view anymore. %@", self.description, hintText];
     if (nil != error) {
       reason = [NSString stringWithFormat:@"%@. Original error: %@", reason, error.localizedDescription];
     }

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -267,7 +267,7 @@
   if (![element fb_setFocusWithError:&error]) {
     return FBResponseWithStatus([FBCommandStatus invalidElementStateErrorWithMessage:error.description traceback:nil]);
   }
-  return FBResponseWithCachedElement(element, request.session.elementCache, FBConfiguration.shouldUseCompactResponses);
+  return FBResponseWithStatus([FBCommandStatus okWithValue: FBDictionaryResponseWithElement(element, FBConfiguration.shouldUseCompactResponses)]);
 }
 #else
 + (id<FBResponsePayload>)handleDoubleTap:(FBRouteRequest *)request

--- a/WebDriverAgentLib/Routing/FBElementCache.m
+++ b/WebDriverAgentLib/Routing/FBElementCache.m
@@ -14,6 +14,7 @@
 #import "FBExceptions.h"
 #import "FBXCodeCompatibility.h"
 #import "XCUIElement.h"
+#import "XCUIElement+FBCaching.h"
 #import "XCUIElement+FBUtilities.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
 #import "XCUIElement+FBUID.h"
@@ -39,7 +40,7 @@ const int ELEMENT_CACHE_SIZE = 1024;
 
 - (NSString *)storeElement:(XCUIElement *)element
 {
-  NSString *uuid = element.fb_uid;
+  NSString *uuid = element.fb_cacheId;
   if (nil == uuid) {
     return nil;
   }

--- a/WebDriverAgentLib/Routing/FBResponsePayload.h
+++ b/WebDriverAgentLib/Routing/FBResponsePayload.h
@@ -14,6 +14,7 @@
 @class FBElementCache;
 @class RouteResponse;
 @class XCUIElement;
+@class XCElementSnapshot;
 @protocol FBResponsePayload;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -54,10 +55,10 @@ id<FBResponsePayload> FBResponseWithUnknownErrorFormat(NSString *errorFormat, ..
 id<FBResponsePayload> FBResponseWithStatus(FBCommandStatus *status);
 
 /**
- Returns a response payload as a NSDictionary for given element and elementUUID.
+ Returns a response payload as a NSDictionary for given element.
  Set compact=NO to include further attributes (defined by FBConfiguration.elementResponseAttributes)
  */
-NSDictionary *FBDictionaryResponseWithElement(XCUIElement *element, NSString *elementUUID, BOOL compact);
+NSDictionary *FBDictionaryResponseWithElement(XCUIElement *element, BOOL compact);
 
 
 /**

--- a/WebDriverAgentLib/Routing/FBResponsePayload.h
+++ b/WebDriverAgentLib/Routing/FBResponsePayload.h
@@ -14,7 +14,6 @@
 @class FBElementCache;
 @class RouteResponse;
 @class XCUIElement;
-@class XCElementSnapshot;
 @protocol FBResponsePayload;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
@@ -16,6 +16,7 @@
 #import "XCUIApplication+FBHelpers.h"
 #import "XCUIElement+FBIsVisible.h"
 #import "XCElementSnapshot.h"
+#import "XCUIElement+FBCaching.h"
 #import "XCElementSnapshot+FBHitPoint.h"
 #import "XCElementSnapshot+FBHelpers.h"
 #import "XCPointerEventPath.h"

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -21,6 +21,7 @@
 #import "FBXCTestDaemonsProxy.h"
 #import "XCElementSnapshot+FBHelpers.h"
 #import "XCUIApplication+FBHelpers.h"
+#import "XCUIElement+FBCaching.h"
 #import "XCUIElement+FBIsVisible.h"
 #import "XCUIElement+FBUtilities.h"
 #import "XCUIElement.h"

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -14,6 +14,7 @@
 #import "FBLogger.h"
 #import "NSString+FBXMLSafeString.h"
 #import "XCUIElement.h"
+#import "XCUIElement+FBCaching.h"
 #import "XCUIElement+FBUtilities.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
 #import "XCTestPrivateSymbols.h"

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementAttributesTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementAttributesTests.m
@@ -141,18 +141,18 @@
 - (void)testCompactResponseYes
 {
   XCUIElement *alertsButton = self.testedApplication.buttons[@"Alerts"];
-  NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, @"DUMMY", YES);
-  XCTAssertEqualObjects(fields[@"ELEMENT"], @"DUMMY");
-  XCTAssertEqualObjects(fields[@"element-6066-11e4-a52e-4f735466cecf"], @"DUMMY");
+  NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, YES);
+  XCTAssertNotNil(fields[@"ELEMENT"]);
+  XCTAssertNotNil(fields[@"element-6066-11e4-a52e-4f735466cecf"]);
   XCTAssertEqual(fields.count, 2);
 }
 
 - (void)testCompactResponseNo
 {
   XCUIElement *alertsButton = self.testedApplication.buttons[@"Alerts"];
-  NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, @"DUMMY", NO);
-  XCTAssertEqualObjects(fields[@"ELEMENT"], @"DUMMY");
-  XCTAssertEqualObjects(fields[@"element-6066-11e4-a52e-4f735466cecf"], @"DUMMY");
+  NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, NO);
+  XCTAssertNotNil(fields[@"ELEMENT"]);
+  XCTAssertNotNil(fields[@"element-6066-11e4-a52e-4f735466cecf"]);
   XCTAssertEqualObjects(fields[@"type"], @"XCUIElementTypeButton");
   XCTAssertEqualObjects(fields[@"label"], @"Alerts");
   XCTAssertEqual(fields.count, 4);
@@ -179,9 +179,9 @@
 {
   [FBConfiguration setElementResponseAttributes:@"name,text,enabled"];
   XCUIElement *alertsButton = self.testedApplication.buttons[@"Alerts"];
-  NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, @"DUMMY", YES);
-  XCTAssertEqualObjects(fields[@"ELEMENT"], @"DUMMY");
-  XCTAssertEqualObjects(fields[@"element-6066-11e4-a52e-4f735466cecf"], @"DUMMY");
+  NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, YES);
+  XCTAssertNotNil(fields[@"ELEMENT"]);
+  XCTAssertNotNil(fields[@"element-6066-11e4-a52e-4f735466cecf"]);
   XCTAssertEqual(fields.count, 2);
 }
 
@@ -189,9 +189,9 @@
 {
   [FBConfiguration setElementResponseAttributes:@"name,text,enabled"];
   XCUIElement *alertsButton = self.testedApplication.buttons[@"Alerts"];
-  NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, @"DUMMY", NO);
-  XCTAssertEqualObjects(fields[@"ELEMENT"], @"DUMMY");
-  XCTAssertEqualObjects(fields[@"element-6066-11e4-a52e-4f735466cecf"], @"DUMMY");
+  NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, NO);
+  XCTAssertNotNil(fields[@"ELEMENT"]);
+  XCTAssertNotNil(fields[@"element-6066-11e4-a52e-4f735466cecf"]);
   XCTAssertEqualObjects(fields[@"name"], @"XCUIElementTypeButton");
   XCTAssertEqualObjects(fields[@"text"], @"Alerts");
   XCTAssertEqualObjects(fields[@"enabled"], @(YES));
@@ -202,9 +202,9 @@
 {
   [FBConfiguration setElementResponseAttributes:@"invalid_field,name"];
   XCUIElement *alertsButton = self.testedApplication.buttons[@"Alerts"];
-  NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, @"DUMMY", NO);
-  XCTAssertEqualObjects(fields[@"ELEMENT"], @"DUMMY");
-  XCTAssertEqualObjects(fields[@"element-6066-11e4-a52e-4f735466cecf"], @"DUMMY");
+  NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, NO);
+  XCTAssertNotNil(fields[@"ELEMENT"]);
+  XCTAssertNotNil(fields[@"element-6066-11e4-a52e-4f735466cecf"]);
   XCTAssertEqualObjects(fields[@"name"], @"XCUIElementTypeButton");
   XCTAssertEqual(fields.count, 3);
 }
@@ -213,9 +213,9 @@
 {
   [FBConfiguration setElementResponseAttributes:@"name,type,label,text,rect,enabled,displayed,selected"];
   XCUIElement *alertsButton = self.testedApplication.buttons[@"Alerts"];
-  NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, @"DUMMY", NO);
-  XCTAssertEqualObjects(fields[@"ELEMENT"], @"DUMMY");
-  XCTAssertEqualObjects(fields[@"element-6066-11e4-a52e-4f735466cecf"], @"DUMMY");
+  NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, NO);
+  XCTAssertNotNil(fields[@"ELEMENT"]);
+  XCTAssertNotNil(fields[@"element-6066-11e4-a52e-4f735466cecf"]);
   XCTAssertEqualObjects(fields[@"name"], @"XCUIElementTypeButton");
   XCTAssertEqualObjects(fields[@"type"], @"XCUIElementTypeButton");
   XCTAssertEqualObjects(fields[@"label"], @"Alerts");
@@ -231,9 +231,9 @@
 {
   [FBConfiguration setElementResponseAttributes:@"attribute/name,attribute/value"];
   XCUIElement *alertsButton = self.testedApplication.buttons[@"Alerts"];
-  NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, @"DUMMY", NO);
-  XCTAssertEqualObjects(fields[@"ELEMENT"], @"DUMMY");
-  XCTAssertEqualObjects(fields[@"element-6066-11e4-a52e-4f735466cecf"], @"DUMMY");
+  NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, NO);
+  XCTAssertNotNil(fields[@"ELEMENT"]);
+  XCTAssertNotNil(fields[@"element-6066-11e4-a52e-4f735466cecf"]);
   XCTAssertEqualObjects(fields[@"attribute/name"], @"Alerts");
   XCTAssertEqualObjects(fields[@"attribute/value"], [NSNull null]);
   XCTAssertEqual(fields.count, 4);

--- a/WebDriverAgentTests/UnitTests/Doubles/XCUIElementDouble.h
+++ b/WebDriverAgentTests/UnitTests/Doubles/XCUIElementDouble.h
@@ -17,6 +17,7 @@
 @property (nonatomic, strong, nonnull) XCUIApplication *application;
 @property (nonatomic, readwrite, assign) CGRect frame;
 @property (nonatomic, assign) BOOL fb_isObstructedByAlert;
+@property (nonatomic, readonly, nonnull) NSString *fb_cacheId;
 @property (nonatomic, nullable) NSNumber *fb_isResolvedFromCache;
 @property (nonatomic, readwrite, copy, nonnull) NSDictionary *wdRect;
 @property (nonatomic, readwrite, assign) CGRect wdFrame;

--- a/WebDriverAgentTests/UnitTests/Doubles/XCUIElementDouble.m
+++ b/WebDriverAgentTests/UnitTests/Doubles/XCUIElementDouble.m
@@ -64,6 +64,11 @@
   return [self lastSnapshot];
 }
 
+- (NSString *)fb_cacheId
+{
+  return self.wdUID;
+}
+
 - (id)lastSnapshot
 {
   return self;

--- a/WebDriverAgentTests/UnitTests/FBElementCacheTests.m
+++ b/WebDriverAgentTests/UnitTests/FBElementCacheTests.m
@@ -11,6 +11,7 @@
 
 #import "FBElementCache.h"
 #import "XCUIElementDouble.h"
+#import "XCUIElement+FBCaching.h"
 #import "XCUIElement+FBUtilities.h"
 
 @interface FBElementCacheTests : XCTestCase


### PR DESCRIPTION
Now instead of making a new snapshot every time we need an element id for caching we try to extract the cached one from the element query, which saves quite a lot of time. Also, the staleness error message has been improved