### PR TITLE
fix: typo, 'XCTest/XcTest.h' file not found

### DIFF
--- a/WebDriverAgentLib/Routing/FBExceptions.h
+++ b/WebDriverAgentLib/Routing/FBExceptions.h
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <XCTest/XcTest.h>
+#import <XCTest/XCTest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
This will happen on a Case-senstive APFS formatted system