### PR TITLE
feat: add result bundle arguments

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -79,6 +79,8 @@ class WebDriverAgent {
       derivedDataPath: args.derivedDataPath,
       mjpegServerPort: this.mjpegServerPort,
       allowProvisioningDeviceRegistration: args.allowProvisioningDeviceRegistration,
+      resultBundlePath: args.resultBundlePath,
+      resultBundleVersion: args.resultBundleVersion,
     });
   }
 

--- a/lib/xcodebuild.js
+++ b/lib/xcodebuild.js
@@ -73,6 +73,9 @@ class XcodeBuild {
     this.prebuildDelay = _.isNumber(args.prebuildDelay) ? args.prebuildDelay : PREBUILD_DELAY;
 
     this.allowProvisioningDeviceRegistration = args.allowProvisioningDeviceRegistration;
+
+    this.resultBundlePath = args.resultBundlePath;
+    this.resultBundleVersion = args.resultBundleVersion;
   }
 
   async init (noSessionProxy) {
@@ -188,6 +191,14 @@ class XcodeBuild {
     if (this.allowProvisioningDeviceRegistration) {
       // To -allowProvisioningDeviceRegistration flag takes effect, -allowProvisioningUpdates needs to be passed as well.
       args.push('-allowProvisioningUpdates', '-allowProvisioningDeviceRegistration');
+    }
+
+    if (this.resultBundlePath) {
+      args.push('-resultBundlePath', this.resultBundlePath);
+    }
+
+    if (this.resultBundleVersion) {
+      args.push('-resultBundleVersion', this.resultBundleVersion);
     }
 
     if (this.useXctestrunFile) {


### PR DESCRIPTION
resultBundle has been matured. Our WDA is also getting vanilla XCTest more, so our steps also can record on the result file. It helps debug something or as a record in XCTest framework level.

We can see like below result via `.xcresult` file which is available in a log file. The log file can specify by `-resultBundlePath`. 
xcodebuild command has `-resultStreamPath`, but I could not find how it works. So, this PR only adds `resultBundlePath` and `resultBundleVersion`. `resultBundleVersion` is 3 by default (and allow only 3 so far) in recent Xcode versions. I'm not sure if the version will provide multiple versions in the future, but it should help to specify the result bundle parameter.

![image](https://user-images.githubusercontent.com/5511591/97089317-dd02dd00-1671-11eb-9edd-cf481b327cdb.png)


In the future, we can provide some options over `xcresulttool`.