### PR TITLE
feat: Add a possibility to provide a maximum depth to custom snapshots

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -101,7 +101,7 @@ static NSString* const FBUnknownBundleId = @"unknown";
 {
   XCElementSnapshot *snapshot = self.fb_isResolvedFromCache.boolValue
     ? self.lastSnapshot
-    : [self fb_snapshotWithAllAttributesUsingFallback:YES];
+    : [self fb_snapshotWithAllAttributesAndMaxDepth:nil];
   return [self.class dictionaryForElement:snapshot recursive:YES];
 }
 
@@ -109,7 +109,7 @@ static NSString* const FBUnknownBundleId = @"unknown";
 {
   XCElementSnapshot *snapshot = self.fb_isResolvedFromCache.boolValue
     ? self.lastSnapshot
-    : [self fb_snapshotWithAllAttributesUsingFallback:YES];
+    : [self fb_snapshotWithAllAttributesAndMaxDepth:nil];
   return [self.class accessibilityInfoForElement:snapshot];
 }
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBAccessibility.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBAccessibility.m
@@ -19,7 +19,7 @@
 - (BOOL)fb_isAccessibilityElement
 {
   return [self fb_snapshotWithAttributes:@[FB_XCAXAIsElementAttributeName]
-                             useFallback:YES].fb_isAccessibilityElement;
+                                maxDepth:@1].fb_isAccessibilityElement;
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -25,7 +25,7 @@
 - (BOOL)fb_isVisible
 {
   return [self fb_snapshotWithAttributes:@[FB_XCAXAIsVisibleAttributeName]
-                             useFallback:YES].fb_isVisible;
+                                maxDepth:@1].fb_isVisible;
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
@@ -43,13 +43,14 @@ NS_ASSUME_NONNULL_BEGIN
  Calls to this method mutate the `lastSnapshot` instance property.
  Calls to this method reset the `fb_isResolvedFromCache` property value to `NO`.
 
- @param useFallback set it to YES if a "normal" element snapshot should be returned if the one
+ @param maxDepth The maximum depth of the snapshot. nil value means to use the default depth.
  with custom attributes cannot be resolved
  
- @return The recent snapshot of the element with the attributes resolved
+ @return The recent snapshot of the element with all attributes resolved or a snapshot with default
+ attributes resolved if there was a failure while resolving additional attributes
  @throws FBStaleElementException if the element is not present in DOM and thus no snapshot could be made
  */
-- (nullable XCElementSnapshot *)fb_snapshotWithAllAttributesUsingFallback:(BOOL)useFallback;
+- (nullable XCElementSnapshot *)fb_snapshotWithAllAttributesAndMaxDepth:(nullable NSNumber *)maxDepth;
 
 /**
  Gets the most recent snapshot of the current element with given attributes resolved.
@@ -60,14 +61,14 @@ NS_ASSUME_NONNULL_BEGIN
  @param attributeNames The list of attribute names to resolve. Must be one of
  FB_...Name values exported by XCTestPrivateSymbols.h module.
  `nil` value means that only the default attributes must be extracted
- @param useFallback set it to YES if a "normal" element snapshot should be returned if the one
- with custom attributes cannot be resolved
+ @param maxDepth The maximum depth of the snapshot. nil value means to use the default depth.
 
- @return The recent snapshot of the element with the attributes resolved
+ @return The recent snapshot of the element with the given attributes resolved or a snapshot with default
+ attributes resolved if there was a failure while resolving additional attributes
  @throws FBStaleElementException if the element is not present in DOM and thus no snapshot could be made
 */
 - (nullable XCElementSnapshot *)fb_snapshotWithAttributes:(nullable NSArray<NSString *> *)attributeNames
-                                              useFallback:(BOOL)useFallback;
+                                                 maxDepth:(nullable NSNumber *)maxDepth;
 
 /**
  Filters elements by matching them to snapshots from the corresponding array

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -32,12 +32,15 @@
   // call
   if ([name isEqualToString:FBStringify(XCUIElement, isWDVisible)]) {
     return [self fb_snapshotWithAttributes:@[FB_XCAXAIsVisibleAttributeName]
-                               useFallback:YES];
+                                  maxDepth:@1];
   }
-  if ([name isEqualToString:FBStringify(XCUIElement, isWDAccessible)] ||
-      [name isEqualToString:FBStringify(XCUIElement, isWDAccessibilityContainer)]) {
+  if ([name isEqualToString:FBStringify(XCUIElement, isWDAccessible)]) {
     return [self fb_snapshotWithAttributes:@[FB_XCAXAIsElementAttributeName]
-                               useFallback:YES];
+                                  maxDepth:@1];
+  }
+  if ([name isEqualToString:FBStringify(XCUIElement, isWDAccessibilityContainer)]) {
+    return [self fb_snapshotWithAttributes:@[FB_XCAXAIsElementAttributeName]
+                                  maxDepth:nil];
   }
   
   return self.fb_takeSnapshot;

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -25,6 +25,7 @@
 #import "FBMathUtils.h"
 #import "FBRuntimeUtils.h"
 #import "NSPredicate+FBFormat.h"
+#import "XCTestPrivateSymbols.h"
 #import "XCUICoordinate.h"
 #import "XCUIDevice.h"
 #import "XCUIElement+FBIsVisible.h"
@@ -100,8 +101,7 @@
 + (id<FBResponsePayload>)handleGetEnabled:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   BOOL isEnabled = element.lastSnapshot.isWDEnabled;
   return FBResponseWithObject(isEnabled ? @YES : @NO);
 }
@@ -109,8 +109,7 @@
 + (id<FBResponsePayload>)handleGetRect:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   return FBResponseWithObject(element.lastSnapshot.wdRect);
 }
 
@@ -119,13 +118,20 @@
   FBElementCache *elementCache = request.session.elementCache;
   NSString *attributeName = request.parameters[@"name"];
   NSString *wdAttributeName = [FBElementUtils wdAttributeNameForAttributeName:attributeName];
-  BOOL shouldResolveForAdditionalAttributes = [@[
-    FBStringify(XCUIElement, isWDVisible),
-    FBStringify(XCUIElement, isWDEnabled),
-    FBStringify(XCUIElement, isWDAccessibilityContainer)
-  ] containsObject:wdAttributeName];
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:shouldResolveForAdditionalAttributes];
+  NSArray *additionalAttributes = nil;
+  NSNumber *maxDepth = nil;
+  if ([wdAttributeName isEqualToString:FBStringify(XCUIElement, isWDVisible)]) {
+    additionalAttributes = @[FB_XCAXAIsVisibleAttributeName];
+    maxDepth = @1;
+  } else if ([wdAttributeName isEqualToString:FBStringify(XCUIElement, isWDEnabled)]) {
+    additionalAttributes = @[FB_XCAXAIsElementAttributeName];
+    maxDepth = @1;
+  } else if ([wdAttributeName isEqualToString:FBStringify(XCUIElement, isWDAccessibilityContainer)]) {
+    additionalAttributes = @[FB_XCAXAIsElementAttributeName];
+  }
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]
+                       resolveForAdditionalAttributes:additionalAttributes
+                                          andMaxDepth:maxDepth];
   id attributeValue = [element.lastSnapshot fb_valueForWDAttributeName:attributeName];
   return FBResponseWithObject(attributeValue ?: [NSNull null]);
 }
@@ -133,58 +139,56 @@
 + (id<FBResponsePayload>)handleGetText:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   id text = FBFirstNonEmptyValue(element.lastSnapshot.wdValue, element.lastSnapshot.wdLabel);
-  text = text ?: @"";
-  return FBResponseWithObject(text);
+  return FBResponseWithObject(text ?: @"");
 }
 
 + (id<FBResponsePayload>)handleGetDisplayed:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:YES];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]
+                       resolveForAdditionalAttributes:@[FB_XCAXAIsVisibleAttributeName]
+                                          andMaxDepth:@1];
   return FBResponseWithObject(@(element.lastSnapshot.isWDVisible));
 }
 
 + (id<FBResponsePayload>)handleGetAccessible:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:YES];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]
+                       resolveForAdditionalAttributes:@[FB_XCAXAIsElementAttributeName]
+                                          andMaxDepth:@1];
   return FBResponseWithObject(@(element.lastSnapshot.isWDAccessible));
 }
 
 + (id<FBResponsePayload>)handleGetIsAccessibilityContainer:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:YES];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]
+                       resolveForAdditionalAttributes:@[FB_XCAXAIsElementAttributeName]
+                                          andMaxDepth:nil];
   return FBResponseWithObject(@(element.lastSnapshot.isWDAccessibilityContainer));
 }
 
 + (id<FBResponsePayload>)handleGetName:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   return FBResponseWithObject(element.lastSnapshot.wdType);
 }
 
 + (id<FBResponsePayload>)handleGetSelected:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   return FBResponseWithObject(@(element.lastSnapshot.wdSelected));
 }
 
 + (id<FBResponsePayload>)handleSetValue:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   id value = request.arguments[@"value"] ?: request.arguments[@"text"];
   if (!value) {
     return FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"Neither 'value' nor 'text' parameter is provided" traceback:nil]);
@@ -221,8 +225,7 @@
 + (id<FBResponsePayload>)handleClick:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   NSError *error = nil;
 #if TARGET_OS_IOS
   if (![element fb_tapWithError:&error]) {
@@ -237,8 +240,7 @@
 + (id<FBResponsePayload>)handleClear:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   NSError *error;
   if (![element fb_clearTextWithError:&error]) {
     return FBResponseWithStatus([FBCommandStatus invalidElementStateErrorWithMessage:error.description traceback:nil]);
@@ -269,8 +271,7 @@
 {
   NSString *elementUUID = request.parameters[@"uuid"];
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:elementUUID
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   NSError *error;
   if (![element fb_setFocusWithError:&error]) {
     return FBResponseWithStatus([FBCommandStatus invalidElementStateErrorWithMessage:error.description traceback:nil]);
@@ -281,8 +282,7 @@
 + (id<FBResponsePayload>)handleDoubleTap:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   [element doubleTap];
   return FBResponseWithOK();
 }
@@ -298,8 +298,7 @@
 + (id<FBResponsePayload>)handleTwoFingerTap:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   [element twoFingerTap];
   return FBResponseWithOK();
 }
@@ -311,8 +310,7 @@
     return FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"Both 'numberOfTaps' and 'numberOfTouches' arguments must be provided"
                                                                        traceback:nil]);
   }
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   [element tapWithNumberOfTaps:[request.arguments[@"numberOfTaps"] integerValue]
                numberOfTouches:[request.arguments[@"numberOfTouches"] integerValue]];
   return FBResponseWithOK();
@@ -321,8 +319,7 @@
 + (id<FBResponsePayload>)handleTouchAndHold:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   [element pressForDuration:[request.arguments[@"duration"] doubleValue]];
   return FBResponseWithOK();
 }
@@ -338,8 +335,7 @@
 + (id<FBResponsePayload>)handleScroll:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   // Using presence of arguments as a way to convey control flow seems like a pretty bad idea but it's
   // what ios-driver did and sadly, we must copy them.
   NSString *const name = request.arguments[@"name"];
@@ -399,8 +395,7 @@
 {
   FBSession *session = request.session;
   FBElementCache *elementCache = session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   CGRect frame = element.lastSnapshot.frame;
   CGPoint startPoint = CGPointMake((CGFloat)(frame.origin.x + [request.arguments[@"fromX"] doubleValue]), (CGFloat)(frame.origin.y + [request.arguments[@"fromY"] doubleValue]));
   CGPoint endPoint = CGPointMake((CGFloat)(frame.origin.x + [request.arguments[@"toX"] doubleValue]), (CGFloat)(frame.origin.y + [request.arguments[@"toY"] doubleValue]));
@@ -415,8 +410,7 @@
 + (id<FBResponsePayload>)handleSwipe:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   NSString *const direction = request.arguments[@"direction"];
   if (!direction) {
     return FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"Missing 'direction' parameter" traceback:nil]);
@@ -436,8 +430,7 @@
   FBElementCache *elementCache = request.session.elementCache;
   CGPoint tapPoint = CGPointMake((CGFloat)[request.arguments[@"x"] doubleValue], (CGFloat)[request.arguments[@"y"] doubleValue]);
   if ([elementCache hasElementWithUUID:request.parameters[@"uuid"]]) {
-    XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                         resolveForAdditionalAttributes:NO];
+    XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
     NSError *error;
     if (![element fb_tapCoordinate:tapPoint error:&error]) {
       return FBResponseWithStatus([FBCommandStatus invalidElementStateErrorWithMessage:error.description
@@ -455,8 +448,7 @@
 + (id<FBResponsePayload>)handlePinch:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   CGFloat scale = (CGFloat)[request.arguments[@"scale"] doubleValue];
   CGFloat velocity = (CGFloat)[request.arguments[@"velocity"] doubleValue];
   [element pinchWithScale:scale velocity:velocity];
@@ -466,8 +458,7 @@
 + (id<FBResponsePayload>)handleRotate:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   CGFloat rotation = (CGFloat)[request.arguments[@"rotation"] doubleValue];
   CGFloat velocity = (CGFloat)[request.arguments[@"velocity"] doubleValue];
   [element rotate:rotation withVelocity:velocity];
@@ -478,8 +469,7 @@
 + (id<FBResponsePayload>)handleForceTouch:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   double pressure = [request.arguments[@"pressure"] doubleValue];
   double duration = [request.arguments[@"duration"] doubleValue];
   NSError *error;
@@ -530,8 +520,7 @@
 + (id<FBResponsePayload>)handleElementScreenshot:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   NSError *error;
   NSData *screenshotData = [element fb_screenshotWithError:&error];
   if (nil == screenshotData) {
@@ -548,8 +537,7 @@ static const CGFloat DEFAULT_OFFSET = (CGFloat)0.2;
 + (id<FBResponsePayload>)handleWheelSelect:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   if (element.lastSnapshot.elementType != XCUIElementTypePickerWheel) {
     return FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:[NSString stringWithFormat:@"The element is expected to be a valid Picker Wheel control. '%@' was given instead", element.wdType] traceback:[NSString stringWithFormat:@"%@", NSThread.callStackSymbols]]);
   }

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -269,7 +269,6 @@
 
 + (id<FBResponsePayload>)handleFocuse:(FBRouteRequest *)request
 {
-  NSString *elementUUID = request.parameters[@"uuid"];
   FBElementCache *elementCache = request.session.elementCache;
   XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   NSError *error;

--- a/WebDriverAgentLib/Commands/FBFindElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBFindElementCommands.m
@@ -18,6 +18,7 @@
 #import "FBPredicate.h"
 #import "FBRouteRequest.h"
 #import "FBSession.h"
+#import "XCTestPrivateSymbols.h"
 #import "XCUIApplication+FBHelpers.h"
 #import "XCUIElement+FBClassChain.h"
 #import "XCUIElement+FBFind.h"
@@ -80,8 +81,9 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 + (id<FBResponsePayload>)handleFindVisibleCells:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:YES];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]
+                       resolveForAdditionalAttributes:@[FB_XCAXAIsVisibleAttributeName]
+                                          andMaxDepth:nil];
   NSArray<XCElementSnapshot *> *visibleCellSnapshots = [element.lastSnapshot descendantsByFilteringWithBlock:^BOOL(XCElementSnapshot *snapshot) {
     return snapshot.elementType == XCUIElementTypeCell && snapshot.wdVisible;
   }];
@@ -94,8 +96,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 + (id<FBResponsePayload>)handleFindSubElement:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                       resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   XCUIElement *foundElement = [self.class elementUsing:request.arguments[@"using"]
                                              withValue:request.arguments[@"value"]
                                                  under:element];
@@ -108,8 +109,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 + (id<FBResponsePayload>)handleFindSubElements:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]
-                              resolveForAdditionalAttributes:NO];
+  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]];
   NSArray *foundElements = [self.class elementsUsing:request.arguments[@"using"]
                                            withValue:request.arguments[@"value"]
                                                under:element

--- a/WebDriverAgentLib/Routing/FBElementCache.h
+++ b/WebDriverAgentLib/Routing/FBElementCache.h
@@ -31,17 +31,30 @@ extern const int ELEMENT_CACHE_SIZE;
 - (nullable NSString *)storeElement:(XCUIElement *)element;
 
 /**
- Returns cached element
+ Returns cached element resolved with default snapshot attributes
 
  @param uuid uuid of element to fetch
- @param resolveForAllAttributes whether to resolve the cached element for all attributes.
- This might be useful if the element is extracted from the cache for visiblity or accessbility validation
  @return element
  @throws FBStaleElementException if the found element is not present in DOM anymore
  @throws FBInvalidArgumentException if uuid is nil
  */
-- (XCUIElement *)elementForUUID:(nullable NSString *)uuid
- resolveForAdditionalAttributes:(BOOL)resolveForAllAttributes;
+- (XCUIElement *)elementForUUID:(NSString *)uuid;
+
+/**
+ Returns cached element
+
+ @param uuid uuid of element to fetch
+ @param additionalAttributes Add additonal attribute names if the snapshot should contain
+ them in `addtionalAttributes` section. nil value resolves the snapshot with standard attributes.
+ @param maxDepth The maximum depth of the snapshot. Only works if additional attributes are provided.
+ `nil` value means to use the default maximum depth value.
+ @return element
+ @throws FBStaleElementException if the found element is not present in DOM anymore
+ @throws FBInvalidArgumentException if uuid is nil
+ */
+- (XCUIElement *)elementForUUID:(NSString *)uuid
+ resolveForAdditionalAttributes:(nullable NSArray <NSString *> *)additionalAttributes
+                    andMaxDepth:(nullable NSNumber *)maxDepth;
 
 /**
  Checks element existence in the cache

--- a/WebDriverAgentLib/Routing/FBElementCache.m
+++ b/WebDriverAgentLib/Routing/FBElementCache.m
@@ -13,6 +13,7 @@
 #import "FBAlert.h"
 #import "FBExceptions.h"
 #import "FBXCodeCompatibility.h"
+#import "XCTestPrivateSymbols.h"
 #import "XCUIElement.h"
 #import "XCUIElement+FBCaching.h"
 #import "XCUIElement+FBUtilities.h"
@@ -49,7 +50,13 @@ const int ELEMENT_CACHE_SIZE = 1024;
 }
 
 - (XCUIElement *)elementForUUID:(NSString *)uuid
- resolveForAdditionalAttributes:(BOOL)resolveForAdditionalAttributes
+{
+  return [self elementForUUID:uuid resolveForAdditionalAttributes:nil andMaxDepth:nil];
+}
+
+- (XCUIElement *)elementForUUID:(NSString *)uuid
+ resolveForAdditionalAttributes:(NSArray <NSString *> *)additionalAttributes
+                    andMaxDepth:(NSNumber *)maxDepth
 {
   if (!uuid) {
     NSString *reason = [NSString stringWithFormat:@"Cannot extract cached element for UUID: %@", uuid];
@@ -59,10 +66,14 @@ const int ELEMENT_CACHE_SIZE = 1024;
   XCUIElement *element = [self.elementCache objectForKey:uuid];
   // This will throw FBStaleElementException exception if the element is stale
   // or resolve the element and set lastSnapshot property
-  if (resolveForAdditionalAttributes) {
-    [element fb_snapshotWithAllAttributesUsingFallback:YES];
-  } else {
+  if (nil == additionalAttributes) {
     [element fb_takeSnapshot];
+  } else {
+    NSMutableArray *attributes = [NSMutableArray arrayWithArray:FBStandardAttributeNames()];
+    if (nil != additionalAttributes) {
+      [attributes addObjectsFromArray:additionalAttributes];
+    }
+    [element fb_snapshotWithAttributes:attributes.copy maxDepth:maxDepth];
   }
   if (nil == element) {
     NSString *reason = [NSString stringWithFormat:@"The element identified by \"%@\" is either not present or it has expired from the internal cache. Try to find it again", uuid];

--- a/WebDriverAgentLib/Routing/FBElementCache.m
+++ b/WebDriverAgentLib/Routing/FBElementCache.m
@@ -70,9 +70,7 @@ const int ELEMENT_CACHE_SIZE = 1024;
     [element fb_takeSnapshot];
   } else {
     NSMutableArray *attributes = [NSMutableArray arrayWithArray:FBStandardAttributeNames()];
-    if (nil != additionalAttributes) {
-      [attributes addObjectsFromArray:additionalAttributes];
-    }
+    [attributes addObjectsFromArray:additionalAttributes];
     [element fb_snapshotWithAttributes:attributes.copy maxDepth:maxDepth];
   }
   if (nil == element) {

--- a/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
@@ -443,8 +443,7 @@ static const double FB_LONG_TAP_DURATION_MS = 600.0;
     if ([origin isKindOfClass:XCUIElement.class]) {
       element = origin;
     } else if ([origin isKindOfClass:NSString.class]) {
-      element = [self.elementCache elementForUUID:(NSString *)origin
-                   resolveForAdditionalAttributes:NO];
+      element = [self.elementCache elementForUUID:(NSString *)origin];
     } else {
       [result addObject:touchItem];
       continue;

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -15,6 +15,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSString *const FBSnapshotMaxDepthKey;
+
 /**
  Accessors for Global Constants.
  */

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -44,7 +44,7 @@ static BOOL FBShouldBoundElementsByIndex = NO;
 static BOOL FBIncludeNonModalElements = NO;
 static NSString *FBAcceptAlertButtonSelector = @"";
 static NSString *FBDismissAlertButtonSelector = @"";
-static NSString *FBSnapshotMaxDepthKey = @"maxDepth";
+NSString *const FBSnapshotMaxDepthKey = @"maxDepth";
 static NSMutableDictionary *FBSnapshotRequestParameters;
 static NSTimeInterval FBWaitForIdleTimeout = 10.;
 static NSTimeInterval FBAnimationCoolOffTimeout = 2.;

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -726,8 +726,7 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
     if ([origin isKindOfClass:XCUIElement.class]) {
       instance = origin;
     } else if ([origin isKindOfClass:NSString.class]) {
-      instance = [self.elementCache elementForUUID:(NSString *)origin
-                    resolveForAdditionalAttributes:NO];
+      instance = [self.elementCache elementForUUID:(NSString *)origin];
     } else {
       [result addObject:actionItem];
       continue;

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable XCElementSnapshot *)snapshotForElement:(XCAccessibilityElement *)element
                                         attributes:(nullable NSArray<NSString *> *)attributes
+                                          maxDepth:(nullable NSNumber *)maxDepth
                                              error:(NSError **)error;
 
 - (NSArray<XCAccessibilityElement *> *)activeApplications;

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
@@ -85,19 +85,25 @@ static id FBAXClient = nil;
 
 - (XCElementSnapshot *)snapshotForElement:(XCAccessibilityElement *)element
                                attributes:(NSArray<NSString *> *)attributes
+                                 maxDepth:(nullable NSNumber *)maxDepth
                                     error:(NSError **)error
 {
+  NSMutableDictionary *parameters = nil;
+  if (nil != maxDepth) {
+    parameters = self.defaultParameters.mutableCopy;
+    parameters[FBSnapshotMaxDepthKey] = maxDepth;
+  }
   if ([FBAXClient respondsToSelector:@selector(requestSnapshotForElement:attributes:parameters:error:)]) {
     id result = [FBAXClient requestSnapshotForElement:element
                                            attributes:attributes
-                                           parameters:nil
+                                           parameters:[parameters copy]
                                                 error:error];
     XCElementSnapshot *snapshot = [result valueForKey:@"_rootElementSnapshot"];
     return nil == snapshot ? result : snapshot;
   }
   return [FBAXClient snapshotForElement:element
                              attributes:attributes
-                             parameters:nil
+                             parameters:[parameters copy]
                                   error:error];
 }
 

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
@@ -118,13 +118,6 @@ extern NSString *const FBApplicationMethodNotSupportedException;
  */
 - (XCUIElementQuery *)fb_query;
 
-/**
- Determines whether Xcode 11 snapshots API is supported
-
- @return Eiter YES or NO
- */
-+ (BOOL)fb_isSdk11SnapshotApiSupported;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -178,16 +178,6 @@ static dispatch_once_t onceAppWithPIDToken;
     : self.query;
 }
 
-+ (BOOL)fb_isSdk11SnapshotApiSupported
-{
-  static dispatch_once_t newSnapshotIsSupported;
-  static BOOL result;
-  dispatch_once(&newSnapshotIsSupported, ^{
-    result = [(id)[FBXCTestDaemonsProxy testRunnerProxy] respondsToSelector:@selector(_XCT_requestSnapshotForElement:attributes:parameters:reply:)];
-  });
-  return result;
-}
-
 @end
 
 @implementation XCPointerEvent (FBXcodeCompatibility)

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -355,7 +355,7 @@ static NSString *const topNodeIndexPath = @"top";
       [element.application fb_waitUntilStableWithTimeout:FBConfiguration.animationCoolOffTimeout];
     }
     currentSnapshot = [element fb_snapshotWithAttributes:snapshotAttributes.copy
-                                             useFallback:YES];
+                                                maxDepth:nil];
     children = currentSnapshot.children;
   } else {
     currentSnapshot = (XCElementSnapshot *)root;

--- a/WebDriverAgentTests/UnitTests/FBElementCacheTests.m
+++ b/WebDriverAgentTests/UnitTests/FBElementCacheTests.m
@@ -44,16 +44,14 @@
   NSString *uuid = [self.cache storeElement:element];
   XCTAssertNotNil(uuid, @"Stored index should be higher than 0");
   XCTAssertFalse(element.fb_isResolvedFromCache.boolValue);
-  XCUIElement *cachedElement = [self.cache elementForUUID:uuid
-                           resolveForAdditionalAttributes:NO];
+  XCUIElement *cachedElement = [self.cache elementForUUID:uuid];
   XCTAssertEqual(element, cachedElement);
   XCTAssertTrue(element.fb_isResolvedFromCache.boolValue);
 }
 
 - (void)testFetchingBadIndex
 {
-  XCTAssertThrows([self.cache elementForUUID:@"random"
-              resolveForAdditionalAttributes:NO]);
+  XCTAssertThrows([self.cache elementForUUID:@"random"]);
 }
 
 - (void)testLinearCacheExpulsion
@@ -77,12 +75,10 @@
   }
   
   for(int i = 0; i < ELEMENT_COUNT - ELEMENT_CACHE_SIZE; i++) {
-    XCTAssertThrows([self.cache elementForUUID:elementIds[i]
-                resolveForAdditionalAttributes:NO]);
+    XCTAssertThrows([self.cache elementForUUID:elementIds[i]]);
   }
   for(int i = ELEMENT_COUNT - ELEMENT_CACHE_SIZE; i < ELEMENT_COUNT; i++) {
-    XCTAssertEqual(elements[i], [self.cache elementForUUID:elementIds[i]
-                            resolveForAdditionalAttributes:NO]);
+    XCTAssertEqual(elements[i], [self.cache elementForUUID:elementIds[i]]);
   }
 }
 
@@ -110,7 +106,7 @@
   }
   
   for(int i = 0; i < ACCESSED_ELEMENT_COUNT; i++) {
-    [self.cache elementForUUID:elementIds[i] resolveForAdditionalAttributes:NO];
+    [self.cache elementForUUID:elementIds[i]];
   }
      
   for(int i = ELEMENT_CACHE_SIZE; i < ELEMENT_COUNT; i++) {
@@ -118,16 +114,13 @@
   }
   
   for(int i = 0; i < ACCESSED_ELEMENT_COUNT; i++) {
-    XCTAssertEqual(elements[i], [self.cache elementForUUID:elementIds[i]
-                            resolveForAdditionalAttributes:NO]);
+    XCTAssertEqual(elements[i], [self.cache elementForUUID:elementIds[i]]);
   }
   for(int i = ACCESSED_ELEMENT_COUNT; i < ELEMENT_COUNT - ELEMENT_CACHE_SIZE + ACCESSED_ELEMENT_COUNT; i++) {
-    XCTAssertThrows([self.cache elementForUUID:elementIds[i]
-                resolveForAdditionalAttributes:NO]);
+    XCTAssertThrows([self.cache elementForUUID:elementIds[i]]);
   }
   for(int i = ELEMENT_COUNT - ELEMENT_CACHE_SIZE + ACCESSED_ELEMENT_COUNT; i < ELEMENT_COUNT; i++) {
-    XCTAssertEqual(elements[i], [self.cache elementForUUID:elementIds[i]
-                            resolveForAdditionalAttributes:NO]);
+    XCTAssertEqual(elements[i], [self.cache elementForUUID:elementIds[i]]);
   }
 }
 


### PR DESCRIPTION
Limiting the depth of a snapshot might help to avoid unexpected freezes while retrieving single visibility value from an element.