### PR TITLE
refactor: Speed up elements lookup by using the cached snapshots

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -433,6 +433,10 @@
 		71D475C32538F5A8008D9401 /* XCUIApplicationProcess+FBQuiescence.h in Headers */ = {isa = PBXBuildFile; fileRef = 71D475C02538F5A8008D9401 /* XCUIApplicationProcess+FBQuiescence.h */; };
 		71D475C42538F5A8008D9401 /* XCUIApplicationProcess+FBQuiescence.m in Sources */ = {isa = PBXBuildFile; fileRef = 71D475C12538F5A8008D9401 /* XCUIApplicationProcess+FBQuiescence.m */; };
 		71D475C52538F5A8008D9401 /* XCUIApplicationProcess+FBQuiescence.m in Sources */ = {isa = PBXBuildFile; fileRef = 71D475C12538F5A8008D9401 /* XCUIApplicationProcess+FBQuiescence.m */; };
+		71E75E6D254824230099FC87 /* XCUIElementQuery+FBHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 71E75E6B254824230099FC87 /* XCUIElementQuery+FBHelpers.h */; };
+		71E75E6E254824230099FC87 /* XCUIElementQuery+FBHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 71E75E6B254824230099FC87 /* XCUIElementQuery+FBHelpers.h */; };
+		71E75E6F254824230099FC87 /* XCUIElementQuery+FBHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E75E6C254824230099FC87 /* XCUIElementQuery+FBHelpers.m */; };
+		71E75E70254824230099FC87 /* XCUIElementQuery+FBHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E75E6C254824230099FC87 /* XCUIElementQuery+FBHelpers.m */; };
 		71F3E7D425417FF400E0C22B /* FBSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 71F3E7D225417FF400E0C22B /* FBSettings.h */; };
 		71F3E7D525417FF400E0C22B /* FBSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 71F3E7D225417FF400E0C22B /* FBSettings.h */; };
 		71F3E7D625417FF400E0C22B /* FBSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 71F3E7D325417FF400E0C22B /* FBSettings.m */; };
@@ -1019,6 +1023,8 @@
 		71D475C02538F5A8008D9401 /* XCUIApplicationProcess+FBQuiescence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIApplicationProcess+FBQuiescence.h"; sourceTree = "<group>"; };
 		71D475C12538F5A8008D9401 /* XCUIApplicationProcess+FBQuiescence.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIApplicationProcess+FBQuiescence.m"; sourceTree = "<group>"; };
 		71E504941DF59BAD0020C32A /* XCUIElementAttributesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCUIElementAttributesTests.m; sourceTree = "<group>"; };
+		71E75E6B254824230099FC87 /* XCUIElementQuery+FBHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIElementQuery+FBHelpers.h"; sourceTree = "<group>"; };
+		71E75E6C254824230099FC87 /* XCUIElementQuery+FBHelpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIElementQuery+FBHelpers.m"; sourceTree = "<group>"; };
 		71F3E7D225417FF400E0C22B /* FBSettings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSettings.h; sourceTree = "<group>"; };
 		71F3E7D325417FF400E0C22B /* FBSettings.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSettings.m; sourceTree = "<group>"; };
 		71F5BE21252E576C00EE9EBA /* XCUIElement+FBSwiping.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIElement+FBSwiping.h"; sourceTree = "<group>"; };
@@ -1735,6 +1741,8 @@
 				EEE376481D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.m */,
 				641EE7042240CDCF00173FCB /* XCUIElement+FBTVFocuse.h */,
 				641EE7072240CDEB00173FCB /* XCUIElement+FBTVFocuse.m */,
+				71E75E6B254824230099FC87 /* XCUIElementQuery+FBHelpers.h */,
+				71E75E6C254824230099FC87 /* XCUIElementQuery+FBHelpers.m */,
 			);
 			name = Categories;
 			path = WebDriverAgentLib/Categories;
@@ -2347,6 +2355,7 @@
 				641EE6BD2240C5CA00173FCB /* FBErrorBuilder.h in Headers */,
 				641EE6BE2240C5CA00173FCB /* XCApplicationMonitor_iOS.h in Headers */,
 				641EE6BF2240C5CA00173FCB /* FBKeyboard.h in Headers */,
+				71E75E6E254824230099FC87 /* XCUIElementQuery+FBHelpers.h in Headers */,
 				641EE6C02240C5CA00173FCB /* XCUIApplication+FBHelpers.h in Headers */,
 				641EE6C12240C5CA00173FCB /* _XCTestObservationCenterImplementation.h in Headers */,
 				641EE6C22240C5CA00173FCB /* XCUIDevice+FBHelpers.h in Headers */,
@@ -2611,6 +2620,7 @@
 				EE35AD6C1E3B77D600A02D78 /* XCUIApplicationProcess.h in Headers */,
 				7140974B1FAE1B51008FB2C5 /* FBW3CActionsSynthesizer.h in Headers */,
 				EE35AD151E3B77D600A02D78 /* CDStructures.h in Headers */,
+				71E75E6D254824230099FC87 /* XCUIElementQuery+FBHelpers.h in Headers */,
 				EE35AD311E3B77D600A02D78 /* XCKeyboardLayout.h in Headers */,
 				E444DCB624913C220060D7EB /* RouteRequest.h in Headers */,
 				71F5BE23252E576C00EE9EBA /* XCUIElement+FBSwiping.h in Headers */,
@@ -3075,6 +3085,7 @@
 				641EE61D2240C5CA00173FCB /* FBElementCommands.m in Sources */,
 				641EE61E2240C5CA00173FCB /* FBExceptionHandler.m in Sources */,
 				641EE61F2240C5CA00173FCB /* FBXCodeCompatibility.m in Sources */,
+				71E75E70254824230099FC87 /* XCUIElementQuery+FBHelpers.m in Sources */,
 				641EE6202240C5CA00173FCB /* XCElementSnapshot+FBHelpers.m in Sources */,
 				641EE6212240C5CA00173FCB /* FBElementTypeTransformer.m in Sources */,
 				641EE6222240C5CA00173FCB /* FBApplication.m in Sources */,
@@ -3161,6 +3172,7 @@
 				71D475C42538F5A8008D9401 /* XCUIApplicationProcess+FBQuiescence.m in Sources */,
 				641EE7082240CDEB00173FCB /* XCUIElement+FBTVFocuse.m in Sources */,
 				EEC9EED720064FAA00BC0D5B /* XCUICoordinate+FBFix.m in Sources */,
+				71E75E6F254824230099FC87 /* XCUIElementQuery+FBHelpers.m in Sources */,
 				71D04DCA25356C43008A052C /* XCUIElement+FBCaching.m in Sources */,
 				EE158AEB1CBD456F00A3E3F0 /* FBRuntimeUtils.m in Sources */,
 				EEE376461D59F81400ED88DD /* XCUIElement+FBUtilities.m in Sources */,

--- a/WebDriverAgentLib/Categories/XCUIElement+FBCaching.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBCaching.m
@@ -13,6 +13,7 @@
 
 #import "XCUIElement+FBWebDriverAttributes.h"
 #import "XCUIElement+FBUtilities.h"
+#import "XCUIElement+FBUID.h"
 
 @implementation XCUIElement (FBCaching)
 
@@ -41,8 +42,14 @@ static char XCUIELEMENT_CACHE_ID_KEY;
     return (NSString *)result;
   }
 
-  XCElementSnapshot *snapshot = self.fb_cachedSnapshot ?: self.fb_takeSnapshot;
-  NSString *uid = snapshot.wdUID;
+  NSString *uid;
+  if ([self isKindOfClass:XCUIApplication.class]) {
+    uid = self.fb_uid;
+  } else {
+    XCElementSnapshot *snapshot = self.fb_cachedSnapshot ?: self.fb_takeSnapshot;
+    uid = snapshot.wdUID;
+  }
+
   objc_setAssociatedObject(self, &XCUIELEMENT_CACHE_ID_KEY, uid, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
   return uid;
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -37,25 +37,27 @@
   return matchedElement ? @[matchedElement] : @[];
 }
 
+- (XCElementSnapshot *)fb_cachedSnapshotWithQuery:(XCUIElementQuery *)query
+{
+  return [self isKindOfClass:XCUIApplication.class] ? query.rootElementSnapshot : self.fb_cachedSnapshot;
+}
+
 #pragma mark - Search by ClassName
 
 - (NSArray<XCUIElement *> *)fb_descendantsMatchingClassName:(NSString *)className
                                 shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
-  NSMutableArray *result = [NSMutableArray array];
   XCUIElementType type = [FBElementTypeTransformer elementTypeWithTypeName:className];
-  XCElementSnapshot *snapshot = self.fb_isResolvedFromCache.boolValue
-    ? self.lastSnapshot
-    : self.fb_takeSnapshot;
-  XCUIElementType selfType = snapshot.elementType;
-  if (selfType == type || type == XCUIElementTypeAny) {
-    [result addObject:self];
-    if (shouldReturnAfterFirstMatch) {
-      return result.copy;
-    }
-  }
   XCUIElementQuery *query = [self.fb_query descendantsMatchingType:type];
+  NSMutableArray *result = [NSMutableArray array];
   [result addObjectsFromArray:[self.class fb_extractMatchingElementsFromQuery:query shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch]];
+  XCElementSnapshot *cachedSnapshot = [self fb_cachedSnapshotWithQuery:query];
+  if (type == XCUIElementTypeAny || cachedSnapshot.elementType == type) {
+    if (shouldReturnAfterFirstMatch) {
+      return @[self];
+    }
+    [result insertObject:self atIndex:0];
+  }
   return result.copy;
 }
 
@@ -104,19 +106,18 @@
                                 shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
   NSPredicate *formattedPredicate = [NSPredicate fb_formatSearchPredicate:predicate];
-  NSMutableArray<XCUIElement *> *result = [NSMutableArray array];
-  XCElementSnapshot *selfSnapshot = self.fb_isResolvedFromCache.boolValue
-    ? self.lastSnapshot
-    : self.fb_takeSnapshot;
-  // Include self element into predicate search
-  if ([formattedPredicate evaluateWithObject:selfSnapshot]) {
-    [result addObject:self];
-    if (shouldReturnAfterFirstMatch) {
-      return result.copy;
-    }
-  }
   XCUIElementQuery *query = [[self.fb_query descendantsMatchingType:XCUIElementTypeAny] matchingPredicate:formattedPredicate];
-  [result addObjectsFromArray:[self.class fb_extractMatchingElementsFromQuery:query shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch]];
+  NSMutableArray<XCUIElement *> *result = [NSMutableArray array];
+  [result addObjectsFromArray:[self.class fb_extractMatchingElementsFromQuery:query
+                                                  shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch]];
+  XCElementSnapshot *cachedSnapshot = [self fb_cachedSnapshotWithQuery:query];
+  // Include self element into predicate search
+  if ([formattedPredicate evaluateWithObject:cachedSnapshot]) {
+    if (shouldReturnAfterFirstMatch) {
+      return @[self];
+    }
+    [result insertObject:self atIndex:0];
+  }
   return result.copy;
 }
 
@@ -147,18 +148,16 @@
 - (NSArray<XCUIElement *> *)fb_descendantsMatchingIdentifier:(NSString *)accessibilityId
                                  shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
-  NSMutableArray *result = [NSMutableArray array];
-  NSString *selfIdentifier = self.fb_isResolvedFromCache.boolValue
-    ? self.lastSnapshot.identifier
-    : self.fb_takeSnapshot.identifier;
-  if (nil != selfIdentifier && [selfIdentifier isEqualToString:accessibilityId]) {
-    [result addObject:self];
-    if (shouldReturnAfterFirstMatch) {
-      return result.copy;
-    }
-  }
   XCUIElementQuery *query = [[self.fb_query descendantsMatchingType:XCUIElementTypeAny] matchingIdentifier:accessibilityId];
+  NSMutableArray *result = [NSMutableArray array];
   [result addObjectsFromArray:[self.class fb_extractMatchingElementsFromQuery:query shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch]];
+  XCElementSnapshot *cachedSnapshot = [self fb_cachedSnapshotWithQuery:query];
+  if (nil != cachedSnapshot.wdName && [cachedSnapshot.wdName isEqualToString:accessibilityId]) {
+    if (shouldReturnAfterFirstMatch) {
+      return @[self];
+    }
+    [result insertObject:self atIndex:0];
+  }
   return result.copy;
 }
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -53,7 +53,7 @@
   [result addObjectsFromArray:[self.class fb_extractMatchingElementsFromQuery:query shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch]];
   XCElementSnapshot *cachedSnapshot = [self fb_cachedSnapshotWithQuery:query];
   if (type == XCUIElementTypeAny || cachedSnapshot.elementType == type) {
-    if (shouldReturnAfterFirstMatch) {
+    if (shouldReturnAfterFirstMatch || result.count == 0) {
       return @[self];
     }
     [result insertObject:self atIndex:0];
@@ -113,7 +113,7 @@
   XCElementSnapshot *cachedSnapshot = [self fb_cachedSnapshotWithQuery:query];
   // Include self element into predicate search
   if ([formattedPredicate evaluateWithObject:cachedSnapshot]) {
-    if (shouldReturnAfterFirstMatch) {
+    if (shouldReturnAfterFirstMatch || result.count == 0) {
       return @[self];
     }
     [result insertObject:self atIndex:0];
@@ -153,7 +153,7 @@
   [result addObjectsFromArray:[self.class fb_extractMatchingElementsFromQuery:query shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch]];
   XCElementSnapshot *cachedSnapshot = [self fb_cachedSnapshotWithQuery:query];
   if (nil != cachedSnapshot.wdName && [cachedSnapshot.wdName isEqualToString:accessibilityId]) {
-    if (shouldReturnAfterFirstMatch) {
+    if (shouldReturnAfterFirstMatch || result.count == 0) {
       return @[self];
     }
     [result insertObject:self atIndex:0];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
@@ -9,17 +9,17 @@
 
 #import "XCUIElement+FBUID.h"
 
-#import "XCUIElement+FBUtilities.h"
 #import "FBElementUtils.h"
+#import "XCUIApplication.h"
+#import "XCUIElement+FBUtilities.h"
 
 @implementation XCUIElement (FBUID)
 
 - (NSString *)fb_uid
 {
-  if ([self respondsToSelector:@selector(accessibilityElement)]) {
-    return [FBElementUtils uidWithAccessibilityElement:[self performSelector:@selector(accessibilityElement)]];
-  }
-  return self.fb_takeSnapshot.fb_uid;
+  return [self isKindOfClass:XCUIApplication.class]
+    ? [FBElementUtils uidWithAccessibilityElement:[(XCUIApplication *)self accessibilityElement]]
+    : [self fb_takeSnapshot].fb_uid;
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -33,6 +33,7 @@
 #import "XCUIElement+FBCaching.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
 #import "XCUIElementQuery.h"
+#import "XCUIElementQuery+FBHelpers.h"
 #import "XCUIScreen.h"
 #import "XCUIElement+FBUID.h"
 
@@ -68,37 +69,7 @@
 
 - (XCElementSnapshot *)fb_cachedSnapshot
 {
-  if ([self isKindOfClass:XCUIApplication.class]) {
-    return [[[(XCUIApplication *)self applicationImpl] currentProcess] lastSnapshot];
-  }
-
-  XCUIElementQuery *inputQuery = self.fb_query;
-  NSMutableArray<id<XCTElementSetTransformer>> *transformersChain = [NSMutableArray array];
-  XCElementSnapshot *rootElementSnapshot = nil;
-  while (nil != inputQuery && nil != inputQuery.transformer) {
-    [transformersChain insertObject:inputQuery.transformer atIndex:0];
-    if (nil != inputQuery.rootElementSnapshot) {
-      rootElementSnapshot = inputQuery.rootElementSnapshot;
-    }
-    inputQuery = inputQuery.inputQuery;
-  }
-  if (nil == rootElementSnapshot) {
-    return nil;
-  }
-
-  NSMutableArray *snapshots = [NSMutableArray arrayWithObject:rootElementSnapshot];
-  [snapshots addObjectsFromArray:rootElementSnapshot._allDescendants];
-  NSOrderedSet *matchingSnapshots = [NSOrderedSet orderedSetWithArray:snapshots];
-  @try {
-    for (id<XCTElementSetTransformer> transformer in transformersChain) {
-      matchingSnapshots = (NSOrderedSet *)[transformer transform:matchingSnapshots
-                                                 relatedElements:nil];
-    }
-    return matchingSnapshots.count == 1 ? matchingSnapshots.firstObject : nil;
-  } @catch (NSException *e) {
-    [FBLogger logFmt:@"Got an unexpected error while retriveing the cached snapshot: %@", e.reason];
-  }
-  return nil;
+  return [self.query fb_cachedSnapshot];
 }
 
 - (nullable XCElementSnapshot *)fb_snapshotWithAllAttributesAndMaxDepth:(NSNumber *)maxDepth

--- a/WebDriverAgentLib/Categories/XCUIElementQuery+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIElementQuery+FBHelpers.h
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+@class XCElementSnapshot;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface XCUIElementQuery (FBHelpers)
+
+/**
+ Extracts the cached element snapshot from its query.
+ No requests to the accessiblity framework is made.
+ It is only safe to use this call right after element lookup query
+ has been executed.
+
+ @return Either the cached snapshot or nil
+ */
+- (nullable XCElementSnapshot *)fb_cachedSnapshot;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIElementQuery+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIElementQuery+FBHelpers.m
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "XCUIElementQuery+FBHelpers.h"
+
+#import "FBXCodeCompatibility.h"
+#import "XCUIElementQuery.h"
+
+
+@implementation XCUIElementQuery (FBHelpers)
+
+- (nullable XCElementSnapshot *)fb_cachedSnapshot
+{
+  XCElementSnapshot *rootElementSnapshot = self.rootElementSnapshot;
+  if (nil == rootElementSnapshot) {
+    return nil;
+  }
+
+  XCUIElementQuery *inputQuery = self;
+  NSMutableArray<id<XCTElementSetTransformer>> *transformersChain = [NSMutableArray array];
+  while (nil != inputQuery && nil != inputQuery.transformer) {
+    [transformersChain insertObject:inputQuery.transformer atIndex:0];
+    inputQuery = inputQuery.inputQuery;
+  }
+
+  NSMutableArray *snapshots = [NSMutableArray arrayWithObject:rootElementSnapshot];
+  [snapshots addObjectsFromArray:rootElementSnapshot._allDescendants];
+  NSOrderedSet *matchingSnapshots = [NSOrderedSet orderedSetWithArray:snapshots];
+  @try {
+    for (id<XCTElementSetTransformer> transformer in transformersChain) {
+      matchingSnapshots = (NSOrderedSet *)[transformer transform:matchingSnapshots
+                                                 relatedElements:nil];
+    }
+    return matchingSnapshots.count == 1 ? matchingSnapshots.firstObject : nil;
+  } @catch (NSException *e) {
+    [FBLogger logFmt:@"Got an unexpected error while retriveing the cached snapshot: %@", e.reason];
+  }
+  return nil;
+}
+
+@end

--- a/WebDriverAgentLib/Routing/FBResponsePayload.m
+++ b/WebDriverAgentLib/Routing/FBResponsePayload.m
@@ -17,6 +17,7 @@
 #import "FBMacros.h"
 #import "FBProtocolHelpers.h"
 
+#import "XCUIElementQuery.h"
 #import "XCUIElement+FBUtilities.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
 
@@ -83,7 +84,13 @@ id<FBResponsePayload> FBResponseWithStatus(FBCommandStatus *status)
 
 inline NSDictionary *FBDictionaryResponseWithElement(XCUIElement *element, BOOL compact)
 {
-  XCElementSnapshot *snapshot = (element.fb_cachedSnapshot ?: element.lastSnapshot) ?: element.fb_takeSnapshot;
+  XCElementSnapshot *snapshot = nil;
+  if (nil != element.query.rootElementSnapshot) {
+    snapshot = element.fb_cachedSnapshot;
+  }
+  if (nil == snapshot) {
+    snapshot = element.lastSnapshot ?: element.fb_takeSnapshot;
+  }
   NSMutableDictionary *dictionary = FBInsertElement(@{}, (NSString *)snapshot.wdUID).mutableCopy;
   if (!compact) {
     NSArray *fields = [FBConfiguration.elementResponseAttributes componentsSeparatedByString:@","];

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
@@ -74,6 +74,8 @@
   XCTAssertEqual(matchingSnapshots.count, snapshotsCount);
   XCTAssertEqual(matchingSnapshots.firstObject.elementType, XCUIElementTypeButton);
   XCTAssertEqualObjects(matchingSnapshots.lastObject.label, @"Alerts");
+  NSArray<XCUIElement *> *selfElementsById = [matchingSnapshots.lastObject fb_descendantsMatchingIdentifier:@"Alerts" shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(selfElementsById.count, 1);
 }
 
 - (void)testSingleDescendantWithIdentifier
@@ -177,6 +179,9 @@
   XCTAssertEqual(matchingSnapshots.count, snapshotsCount);
   XCTAssertEqual(matchingSnapshots.firstObject.elementType, XCUIElementTypeButton);
   XCTAssertEqualObjects(matchingSnapshots.lastObject.label, @"Alerts");
+  NSPredicate *selfPredicate = [NSPredicate predicateWithFormat:@"label == 'Alerts'"];
+  NSArray<XCUIElement *> *selfElementsByPredicate = [matchingSnapshots.lastObject fb_descendantsMatchingPredicate:selfPredicate shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(selfElementsByPredicate.count, 1);
 }
 
 - (void)testSelfWithPredicateString


### PR DESCRIPTION
After am element query is executed it always puts the current application snapshot into the rootElementSnapshot property of the query. So lets reuse this snapshot when we need to decide whether to include self element into the search results