### PR TITLE
refactor: Switch search by identifier to use predicates

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -147,19 +147,9 @@
 - (NSArray<XCUIElement *> *)fb_descendantsMatchingIdentifier:(NSString *)accessibilityId
                                  shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
-  NSMutableArray *result = [NSMutableArray array];
-  NSString *selfIdentifier = self.fb_isResolvedFromCache.boolValue
-    ? self.lastSnapshot.identifier
-    : self.fb_takeSnapshot.identifier;
-  if (nil != selfIdentifier && [selfIdentifier isEqualToString:accessibilityId]) {
-    [result addObject:self];
-    if (shouldReturnAfterFirstMatch) {
-      return result.copy;
-    }
-  }
-  XCUIElementQuery *query = [[self.fb_query descendantsMatchingType:XCUIElementTypeAny] matchingIdentifier:accessibilityId];
-  [result addObjectsFromArray:[self.class fb_extractMatchingElementsFromQuery:query shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch]];
-  return result.copy;
+  NSPredicate *predicate = [NSPredicate predicateWithFormat:@"name == %@", accessibilityId];
+  return [self fb_descendantsMatchingPredicate:predicate
+                   shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
 }
 
 @end

--- a/WebDriverAgentLib/Commands/FBFindElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBFindElementCommands.m
@@ -172,8 +172,9 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
     elements = [element fb_descendantsMatchingPredicate:predicate
                             shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
   } else if (isSearchByIdentifier) {
-    elements = [element fb_descendantsMatchingIdentifier:value
-                             shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
+    NSPredicate *predicate = [FBPredicate predicateWithFormat:@"name == %@", value];
+    elements = [element fb_descendantsMatchingPredicate:predicate
+                            shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
   } else {
     [[NSException exceptionWithName:FBElementAttributeUnknownException reason:[NSString stringWithFormat:@"Invalid locator requested: %@", usingText] userInfo:nil] raise];
   }

--- a/WebDriverAgentLib/Commands/FBFindElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBFindElementCommands.m
@@ -172,9 +172,8 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
     elements = [element fb_descendantsMatchingPredicate:predicate
                             shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
   } else if (isSearchByIdentifier) {
-    NSPredicate *predicate = [FBPredicate predicateWithFormat:@"name == %@", value];
-    elements = [element fb_descendantsMatchingPredicate:predicate
-                            shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
+    elements = [element fb_descendantsMatchingIdentifier:value
+                             shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
   } else {
     [[NSException exceptionWithName:FBElementAttributeUnknownException reason:[NSString stringWithFormat:@"Invalid locator requested: %@", usingText] userInfo:nil] raise];
   }

--- a/WebDriverAgentLib/Commands/FBFindElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBFindElementCommands.m
@@ -146,38 +146,42 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
   shouldReturnAfterFirstMatch:YES] firstObject];
 }
 
-+ (NSArray *)elementsUsing:(NSString *)usingText withValue:(NSString *)value under:(XCUIElement *)element shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
++ (NSArray *)elementsUsing:(NSString *)usingText
+                 withValue:(NSString *)value
+                     under:(XCUIElement *)element
+shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
-  NSArray *elements;
-  const BOOL partialSearch = [usingText isEqualToString:@"partial link text"];
-  const BOOL isSearchByIdentifier = ([usingText isEqualToString:@"name"] || [usingText isEqualToString:@"id"] || [usingText isEqualToString:@"accessibility id"]);
-  if (partialSearch || [usingText isEqualToString:@"link text"]) {
+  if ([usingText isEqualToString:@"partial link text"]
+      || [usingText isEqualToString:@"link text"]) {
     NSArray *components = [value componentsSeparatedByString:@"="];
     NSString *propertyValue = components.lastObject;
     NSString *propertyName = (components.count < 2 ? @"name" : components.firstObject);
-    elements = [element fb_descendantsMatchingProperty:propertyName
-                                                 value:propertyValue
-                                         partialSearch:partialSearch];
+    return [element fb_descendantsMatchingProperty:propertyName
+                                             value:propertyValue
+                                     partialSearch:[usingText containsString:@"partial"]];
   } else if ([usingText isEqualToString:@"class name"]) {
-    elements = [element fb_descendantsMatchingClassName:value
-                            shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
+    return [element fb_descendantsMatchingClassName:value
+                        shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
   } else if ([usingText isEqualToString:@"class chain"]) {
-    elements = [element fb_descendantsMatchingClassChain:value
-                             shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
+    return [element fb_descendantsMatchingClassChain:value
+                         shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
   } else if ([usingText isEqualToString:@"xpath"]) {
-    elements = [element fb_descendantsMatchingXPathQuery:value
-                             shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
+    return [element fb_descendantsMatchingXPathQuery:value
+                         shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
   } else if ([usingText isEqualToString:@"predicate string"]) {
     NSPredicate *predicate = [FBPredicate predicateWithFormat:value];
-    elements = [element fb_descendantsMatchingPredicate:predicate
-                            shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
-  } else if (isSearchByIdentifier) {
-    elements = [element fb_descendantsMatchingIdentifier:value
-                             shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
+    return [element fb_descendantsMatchingPredicate:predicate
+                        shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
+  } else if ([usingText isEqualToString:@"name"]
+             || [usingText isEqualToString:@"id"]
+             || [usingText isEqualToString:@"accessibility id"]) {
+    return [element fb_descendantsMatchingIdentifier:value
+                         shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
   } else {
-    [[NSException exceptionWithName:FBElementAttributeUnknownException reason:[NSString stringWithFormat:@"Invalid locator requested: %@", usingText] userInfo:nil] raise];
+    @throw [NSException exceptionWithName:FBElementAttributeUnknownException
+                                   reason:[NSString stringWithFormat:@"Invalid locator requested: %@", usingText]
+                                 userInfo:nil];
   }
-  return elements;
 }
 
 @end


### PR DESCRIPTION
Internally search by identifier is anyway changed to predicate search. Also, the current implementation might sometimes be confusing, because the value we show in the page source for `name` is `wdName`, which is calculated as

```
  NSString *identifier = self.identifier;
  if (nil != identifier && identifier.length != 0) {
    return identifier;
  }
  NSString *label = self.label;
  return FBTransferEmptyStringToNil(label);
```