### PR TITLE
fix: Fix lookup by identifier

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -148,7 +148,7 @@
 - (NSArray<XCUIElement *> *)fb_descendantsMatchingIdentifier:(NSString *)accessibilityId
                                  shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
-  NSPredicate *predicate = [NSPredicate predicateWithFormat:@"name == %@", accessibilityId];
+  NSPredicate *predicate = [FBPredicate predicateWithFormat:@"name == %@", accessibilityId];
   return [self fb_descendantsMatchingPredicate:predicate
                    shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
 }


### PR DESCRIPTION
Thanks to @KazuCocoa we were able to figure out that predicate lookup does not behave similarly in different xCode versions. It is still necessary to add the predicate hack to have the necessary snapshot attributes resolved.