### PR TITLE
[do not merge] add value in find_element by identifier

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -148,7 +148,7 @@
 - (NSArray<XCUIElement *> *)fb_descendantsMatchingIdentifier:(NSString *)accessibilityId
                                  shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
-  NSPredicate *predicate = [FBPredicate predicateWithFormat:@"name == %@", accessibilityId];
+  NSPredicate *predicate = [FBPredicate predicateWithFormat:@"name == %@ or value == %@ ", accessibilityId, accessibilityId];
   return [self fb_descendantsMatchingPredicate:predicate
                    shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
 }


### PR DESCRIPTION
This regression happened on both Xcode 11 and 12. (Haven't tested on 10, but I think Xcode 10 also had the same issue)

`find_element :name, 'hello'` in below got a regression. The value typed in a field only appeared in `value` in the page source. But current logic tied to find an element only by `name`.

```ruby
    def test_type
      w3c_scroll @@driver

      @@core.wait { @@driver.find_element :accessibility_id, 'Text Fields' }.click

      text = @@core.wait { @@driver.find_element :class, 'XCUIElementTypeTextField' }
      text.type 'hello'

      e = @@core.wait { @@driver.find_element :name, 'hello' }
      assert_equal 'hello', e.value

      @@driver.back
    end
```

https://github.com/appium/ruby_lib_core/blob/master/test/functional/ios/patch_test.rb


Current:

```
[IOSSimulatorLog] [IOS_SYSLOG_ROW] 2020-10-28 09:53:07.488 F  testmanagerd[32397:662d19] [com.apple.dt.xctest:Default] Automation type mismatch; legacy system derived element type 9 from class UIAccessibilityElementKBKey:UIAccessibilityElement, traits 8589934641, but AXAutomationType returned 20 which maps to 20
[Xcode]     t =    35.48s     Find: Descendants matching type Any
[Xcode]
[Xcode]     t =    35.48s     Find: Elements matching predicate 'wdName == "hello" AND (1 == 1 OR identifier == 0 OR frame == 0 OR value == 0 OR title == 0 OR label == 0 OR elementType == 0 OR enabled == 0 OR placeholderValue == 0 OR selected == 0)'
[Xcode]
[WD Proxy] Got response with status 404: {"value":{"error":"no such element","message":"unable to find an element using 'name', value 'hello'","traceback":"(\n\t0   WebDriverAgentLib                   0x0000000109ac6fea FBNoSuchElementErrorResponseForRequest + 298\n\t1   WebDriverAgentLib                   0x0000000109ac6da9 +[FBFindElementCommands handleFindElement:] + 409\n\t2   WebDriverAgentLib                   0x0000000109a9e7f6 -[FBRoute_TargetAction mountRequest:intoResponse:] + 182\n\t3   WebDriverAgentLib                   0x0000000109a86728 __37-[FBWebServer registerRouteHandlers:]_block_invoke + 536\n\t4   WebDriverAgentLib                   0x0000000109aac31b -[RoutingHTTPServer handleRoute:withRequest:response:] + 219\n\t5   WebDriverAgentLib                   0x0000000109aad213 __72-[RoutingHTTPServer routeMethod:withPath:parameters:request:connection:]_block_invoke + 83\n\t6   libdispatch.dylib                   0x00007fff5208e8cb _dispatch_client_callout + 8\n\t7   libdispatch.dylib                   0x00007fff5209b940 _dispatch_...
[debug] [W3C] Matched W3C error code 'no such element' to NoSuchElementError
```

Will be:

```
r privileged AX value slot attributes
[Xcode]     t =    34.96s     Find: Descendants matching type Any
[Xcode]     t =    34.97s     Find: Elements matching predicate '(wdName == "hello" OR wdValue == "hello") AND (1 == 1 OR identifier == 0 OR frame == 0 OR value == 0 OR title == 0 OR label == 0 OR elementType == 0 OR enabled == 0 OR placeholderValue == 0 OR selected == 0)'
[Xcode]     t =    34.97s     Find: Identity Binding
[Xcode]
```

1.18.3 was like below to find the `hello` element.
```
 privileged AX value slot attributes
[IOSSimulatorLog] [IOS_SYSLOG_ROW] 2020-10-28 10:22:31.504 Df testmanagerd[33949:670ef4] [com.apple.dt.xctest:Default] Checking 'numbers' for privileged AX value slot attributes
[Xcode]     t =    28.48s     Find: Descendants matching type Any
[Xcode]     t =    28.49s     Find: Elements matching predicate '"hello" IN identifiers'
[Xcode]     t =    28.49s     Find: Identity Binding
[Xcode]     t =    28.50s Requesting snapshot of accessibility hierarchy for app with pid 37267
[Xcode]
[IOSSimulatorLog] [IOS_SYSLOG_ROW] 2020-10-28 10:22:31.504 Df testmanagerd[33949:670ef4] [com.apple.dt.xctest:Default] Checking 'space' for privileged AX value slot attributes
```

The page source is https://gist.github.com/KazuCocoa/4d874d41a8dc9c2d54d1053000768361

![image](https://user-images.githubusercontent.com/5511591/97473411-4b0b1500-198e-11eb-97a2-38d078f25bea.png)