### PR TITLE
fix: Target iOS 10.2

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -3788,7 +3788,7 @@
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = WebDriverAgentLib/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3846,7 +3846,7 @@
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = WebDriverAgentLib/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
This aligns the iOS deployment target with the tvOS deployment target.

The iOS deployment target was set to 12.2 in #404 (618b0906d64d843413f2f2dd13b465d2f03c523e), but I'm not sure that was intentional, as the commit message reads: _the minimum supported Xcode SDK version is bumped to **10.2**_.

For some reason, WebDriverAgent will fail to launch on iOS 9.3.5 devices with the following code signing error in syslog:

```
Dec  2 15:57:00 x-iPad securityd[89] <Error>:  secTaskDiagnoseEntitlements MISSING keychain entitlements: no stored taskRef found
Dec  2 15:57:00 x-iPad securityd[89] <Error>:  secTaskDiagnoseEntitlements MISSING keychain entitlements: no stored taskRef found
Dec  2 15:57:00 x-iPad amfid[200] <Error>:  SecTrustEvaluate  [leaf IssuerCommonName SubjectCommonName]
Dec  2 15:57:00 x-iPad kernel[0] <Notice>: AMFI: WebDriverAgentRu(pid 276) - [deny-mmap] mapped executable file has no team identifier in its signature: /private/var/containers/Bundle/Application/9A92B401-8E65-4E19-89DB-6B124EB7690B/WebDriverAgentRunner-Runner.app/PlugIns/WebDriverAgentRunner.xctest/Frameworks/WebDriverAgentLib.framework/WebDriverAgentLib
Dec  2 15:57:00 x-iPad amfid[200] <Error>: /private/var/containers/Bundle/Application/9A92B401-8E65-4E19-89DB-6B124EB7690B/WebDriverAgentRunner-Runner.app/PlugIns/WebDriverAgentRunner.xctest/Frameworks/WebDriverAgentLib.framework/WebDriverAgentLib not valid: 0xe8008019: The application does not have a valid signature.
Dec  2 15:57:00 x-iPad WebDriverAgentRunner-Runner[276] <Warning>: The bundle “WebDriverAgentRunner” couldn’t be loaded because it is damaged or missing necessary resources. Try reinstalling the bundle.
Dec  2 15:57:00 x-iPad WebDriverAgentRunner-Runner[276] <Warning>: (dlopen_preflight(/var/containers/Bundle/Application/9A92B401-8E65-4E19-89DB-6B124EB7690B/WebDriverAgentRunner-Runner.app/PlugIns/WebDriverAgentRunner.xctest/WebDriverAgentRunner): Library not loaded: @rpath/WebDriverAgentLib.framework/WebDriverAgentLib
	  Referenced from: /var/containers/Bundle/Application/9A92B401-8E65-4E19-89DB-6B124EB7690B/WebDriverAgentRunner-Runner.app/PlugIns/WebDriverAgentRunner.xctest/WebDriverAgentRunner
	  Reason: no suitable image found.  Did find:
		/private/var/containers/Bundle/Application/9A92B401-8E65-4E19-89DB-6B124EB7690B/WebDriverAgentRunner-Runner.app/PlugIns/WebDriverAgentRunner.xctest/Frameworks/WebDriverAgentLib.framework/WebDriverAgentLib: mmap() errno=1 validating first page of '/private/var/containers/Bundle/Application/9A92B401-8E65-4E19-89DB-6B124EB7690B/WebDriverAgentRunner-Runner.app/PlugIns/WebDriverAgentRunner.xctest/Frameworks/WebDriverAgentLib.framework/WebDriverAgentLib')
```

The code signature itself looks valid (though it's using the 2.4 format); not sure why it would cause an error. But I do know that setting the deployment target to 10.2 (or 10.3, for that matter, but not 11.0 or later) fixes this.