### PR TITLE
feat: add location data in the response by /wda/device/location

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -17,7 +17,7 @@ variables:
   MAX_TV_DEVICE_NAME: Apple TV 4K
   MAX_IPAD_DEVICE_NAME: iPad Pro (11-inch) (2nd generation)
   DEFAULT_NODE_VERSION: "10.x"
-  DEFAULT_RUBY_VERSION: ">= 2.6"
+  DEFAULT_RUBY_VERSION: "2.7"
 
 
 pool:

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -10,6 +10,7 @@
 #import "FBCustomCommands.h"
 
 #import <XCTest/XCUIDevice.h>
+#import <CoreLocation/CoreLocation.h>
 
 #import "FBApplication.h"
 #import "FBConfiguration.h"
@@ -305,6 +306,15 @@
   // https://developer.apple.com/documentation/foundation/nslocale/1414388-autoupdatingcurrentlocale
   NSString *currentLocale = [[NSLocale autoupdatingCurrentLocale] localeIdentifier];
 
+
+  // TODO: need some interactions to check location service.
+  CLLocationManager *locationManager = [[CLLocationManager alloc] init];
+  [locationManager setDistanceFilter:kCLHeadingFilterNone];
+  [locationManager setDesiredAccuracy:kCLLocationAccuracyBest];
+  [locationManager setPausesLocationUpdatesAutomatically:NO];
+  [locationManager startUpdatingLocation];
+  CLLocation *location = locationManager.location;
+
   return FBResponseWithObject(@{
     @"currentLocale": currentLocale,
     @"timeZone": self.timeZone,
@@ -314,6 +324,10 @@
     // https://developer.apple.com/documentation/uikit/uiuserinterfaceidiom?language=objc
     @"userInterfaceIdiom": @(UIDevice.currentDevice.userInterfaceIdiom),
     @"userInterfaceStyle": self.userInterfaceStyle,
+    @"location": @{
+        @"latitude": @(location.coordinate.latitude),
+        @"longitude": @(location.coordinate.longitude),
+    },
 #if TARGET_OS_SIMULATOR
     @"isSimulator": @(YES),
 #else

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -327,8 +327,8 @@
   [locationManager startUpdatingLocation];
 
   CLAuthorizationStatus authStatus = [locationManager respondsToSelector:@selector(authorizationStatus)]
-  ? (CLAuthorizationStatus) [locationManager performSelector:@selector(authorizationStatus)]
-  : [CLLocationManager authorizationStatus];
+    ? (CLAuthorizationStatus) [locationManager performSelector:@selector(authorizationStatus)]
+    : [CLLocationManager authorizationStatus];
 
   return FBResponseWithObject(@{
     @"authorizationStatus": @(authStatus),

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -323,17 +323,14 @@
   [locationManager setPausesLocationUpdatesAutomatically:NO];
   [locationManager startUpdatingLocation];
 
-  CLAuthorizationStatus authStatus;
-  if ([locationManager respondsToSelector:@selector(authorizationStatus)]) {
-    authStatus = locationManager.authorizationStatus;
-  } else {
-    authStatus = [CLLocationManager authorizationStatus];
-  }
-  CLLocation *location = locationManager.location;
+  CLAuthorizationStatus authStatus = [locationManager respondsToSelector:@selector(authorizationStatus)]
+  ? locationManager.authorizationStatus
+  : [CLLocationManager authorizationStatus];
+
   return FBResponseWithObject(@{
     @"authorizationStatus": @(authStatus),
-    @"latitude": @(location.coordinate.latitude),
-    @"longitude": @(location.coordinate.longitude),
+    @"latitude": @(locationManager.location.coordinate.latitude),
+    @"longitude": @(locationManager.location.coordinate.longitude),
   });
 #endif
 }

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -309,6 +309,9 @@
  https://developer.apple.com/documentation/corelocation/clauthorizationstatus
 
  Settings -> Privacy -> Location Service -> WebDriverAgent-Runner -> Always
+
+ The return value could be zero even the permission is Always
+ since the location service needs to update the location data.
  */
 + (id<FBResponsePayload>)handleGetLocation:(FBRouteRequest *)request
 {
@@ -324,7 +327,7 @@
   [locationManager startUpdatingLocation];
 
   CLAuthorizationStatus authStatus = [locationManager respondsToSelector:@selector(authorizationStatus)]
-  ? locationManager.authorizationStatus
+  ? (CLAuthorizationStatus) [locationManager performSelector:@selector(authorizationStatus)]
   : [CLLocationManager authorizationStatus];
 
   return FBResponseWithObject(@{

--- a/WebDriverAgentRunner/Info.plist
+++ b/WebDriverAgentRunner/Info.plist
@@ -20,5 +20,11 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string></string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string></string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string></string>
 </dict>
 </plist>


### PR DESCRIPTION
This is still a prototype to check the availability for `getGeoLocation` api.

Although we should allow privacy preference by manual (or by alert with additional implementation), this PR can return exact location data as the response of `/wda/device/info` on both simulator and real devices. (The path could be like `/wda/device/location` etc tho)
If the privacy preference is `Always`,WDA can return location data even it will be a background.

---


update:

Tested Real devices: iOS 12.4, 14.2 and 14.3
Simulators: tvOS, iOS 12.2, 13.0, 14.0

iOS devices always return zero location data except for `Always` privacy preference or turn location service off.
If users turn the privacy preference `Always` on via GUI interaction, the path returns exact location data.
Auth status `3` means the Always. So, we can show error messages as Appium log or error response in xcuitest-driver.