### PR TITLE
[wip] fix: remove self.label in wdName to reduce confusion

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -103,8 +103,7 @@
   if (nil != identifier && identifier.length != 0) {
     return identifier;
   }
-  NSString *label = self.label;
-  return FBTransferEmptyStringToNil(label);
+  return FBTransferEmptyStringToNil(identifier);
 }
 
 - (NSString *)wdLabel

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -109,8 +109,7 @@
 - (NSString *)wdLabel
 {
   NSString *label = self.label;
-  XCUIElementType elementType = self.elementType;
-  if (elementType == XCUIElementTypeTextField || elementType == XCUIElementTypeSecureTextField ) {
+  if (nil != label && label.length != 0) {
     return label;
   }
   return FBTransferEmptyStringToNil(label);


### PR DESCRIPTION
Tests are still broken, but I'd like to ask your opinions @mykola-mokhnach  @jlipps @dpgraham cc @Dan-Maor 


----


Currently, `wdName` returns `self.identifier` or `self.label`.

A friend of mine asked me about below case.

1.
```
<XCUIElementTuypeButton ... label="buttonLabel"> # no `name` attribute
```

2.
```
<XCUIElementTuypeButton ... name="buttonName" label="buttonLabel">
```

Then, `find_element :accessibility_id, 'buttonLabel'` returned the element in 1), but no element in 2). (Appium 1.20.0)
This behaviour confused him.

So, what do you think to remove `label` as `wdName`?
(And `label` always returns `self.label`)

Then, we can simply say:

- no `name` attribute but `label` exists -> `accessibility_id`, `id` and `name` lookup strategy failed to find an element
    - This case could happen frequently I guess since `identifier` only appears when users set `accessibility identifier` to an element but `label` works when they set a label like button name to an element.
- `name` attributes and `label` exists, but they differ -> `accessibility_id`, `id` and `name` lookup strategy find `name` element

But this will lead my the below comment: https://github.com/appium/WebDriverAgent/pull/449#issuecomment-755939135