### PR TITLE
refactor: Unify screenshots

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -456,6 +456,10 @@
 		71C8E55225399A6B008572C1 /* XCUIApplication+FBQuiescence.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C8E54F25399A6B008572C1 /* XCUIApplication+FBQuiescence.h */; };
 		71C8E55325399A6B008572C1 /* XCUIApplication+FBQuiescence.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C8E55025399A6B008572C1 /* XCUIApplication+FBQuiescence.m */; };
 		71C8E55425399A6B008572C1 /* XCUIApplication+FBQuiescence.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C8E55025399A6B008572C1 /* XCUIApplication+FBQuiescence.m */; };
+		71C9EAAC25E8415A00470CD8 /* FBScreenshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C9EAAA25E8415A00470CD8 /* FBScreenshot.h */; };
+		71C9EAAD25E8415A00470CD8 /* FBScreenshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C9EAAA25E8415A00470CD8 /* FBScreenshot.h */; };
+		71C9EAAE25E8415A00470CD8 /* FBScreenshot.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C9EAAB25E8415A00470CD8 /* FBScreenshot.m */; };
+		71C9EAAF25E8415A00470CD8 /* FBScreenshot.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C9EAAB25E8415A00470CD8 /* FBScreenshot.m */; };
 		71D04DC825356C43008A052C /* XCUIElement+FBCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 71D04DC625356C43008A052C /* XCUIElement+FBCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		71D04DC925356C43008A052C /* XCUIElement+FBCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 71D04DC625356C43008A052C /* XCUIElement+FBCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		71D04DCA25356C43008A052C /* XCUIElement+FBCaching.m in Sources */ = {isa = PBXBuildFile; fileRef = 71D04DC725356C43008A052C /* XCUIElement+FBCaching.m */; };
@@ -1022,6 +1026,8 @@
 		71BD20771F869E0F00B36EC2 /* FBAppiumTouchActionsIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBAppiumTouchActionsIntegrationTests.m; sourceTree = "<group>"; };
 		71C8E54F25399A6B008572C1 /* XCUIApplication+FBQuiescence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIApplication+FBQuiescence.h"; sourceTree = "<group>"; };
 		71C8E55025399A6B008572C1 /* XCUIApplication+FBQuiescence.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIApplication+FBQuiescence.m"; sourceTree = "<group>"; };
+		71C9EAAA25E8415A00470CD8 /* FBScreenshot.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBScreenshot.h; sourceTree = "<group>"; };
+		71C9EAAB25E8415A00470CD8 /* FBScreenshot.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBScreenshot.m; sourceTree = "<group>"; };
 		71D04DC625356C43008A052C /* XCUIElement+FBCaching.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIElement+FBCaching.h"; sourceTree = "<group>"; };
 		71D04DC725356C43008A052C /* XCUIElement+FBCaching.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIElement+FBCaching.m"; sourceTree = "<group>"; };
 		71D475C02538F5A8008D9401 /* XCUIApplicationProcess+FBQuiescence.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIApplicationProcess+FBQuiescence.h"; sourceTree = "<group>"; };
@@ -1888,6 +1894,8 @@
 				71F3E7D325417FF400E0C22B /* FBSettings.m */,
 				715AFABF1FFA29180053896D /* FBScreen.h */,
 				715AFAC01FFA29180053896D /* FBScreen.m */,
+				71C9EAAA25E8415A00470CD8 /* FBScreenshot.h */,
+				71C9EAAB25E8415A00470CD8 /* FBScreenshot.m */,
 				641EE70A2240CE2D00173FCB /* FBTVNavigationTracker.h */,
 				64B26509228CE4FF002A5025 /* FBTVNavigationTracker-Private.h */,
 				641EE70D2240CE4800173FCB /* FBTVNavigationTracker.m */,
@@ -2364,6 +2372,7 @@
 				641EE6AE2240C5CA00173FCB /* XCElementSnapshot+FBHitPoint.h in Headers */,
 				641EE6AF2240C5CA00173FCB /* XCTestContext.h in Headers */,
 				641EE6B02240C5CA00173FCB /* XCAccessibilityElement+FBComparison.h in Headers */,
+				71C9EAAD25E8415A00470CD8 /* FBScreenshot.h in Headers */,
 				641EE6B12240C5CA00173FCB /* XCTWaiterDelegate-Protocol.h in Headers */,
 				641EE6B22240C5CA00173FCB /* _XCTestExpectationImplementation.h in Headers */,
 				641EE6B32240C5CA00173FCB /* XCAXClient_iOS.h in Headers */,
@@ -2502,6 +2511,7 @@
 				718226F82587446200661B83 /* YYCache.h in Headers */,
 				EE35AD3F1E3B77D600A02D78 /* XCTDarwinNotificationExpectation.h in Headers */,
 				EE35AD5F1E3B77D600A02D78 /* XCTRunnerAutomationSession.h in Headers */,
+				71C9EAAC25E8415A00470CD8 /* FBScreenshot.h in Headers */,
 				EEC9EED620064FAA00BC0D5B /* XCUICoordinate+FBFix.h in Headers */,
 				EE35AD371E3B77D600A02D78 /* XCSourceCodeTreeNodeEnumerator.h in Headers */,
 				EE158AB01CBD456F00A3E3F0 /* XCUIElement+FBIsVisible.h in Headers */,
@@ -3056,6 +3066,7 @@
 				641EE5DF2240C5CA00173FCB /* FBWebServer.m in Sources */,
 				641EE5E02240C5CA00173FCB /* FBTCPSocket.m in Sources */,
 				641EE5E12240C5CA00173FCB /* FBErrorBuilder.m in Sources */,
+				71C9EAAF25E8415A00470CD8 /* FBScreenshot.m in Sources */,
 				641EE5E22240C5CA00173FCB /* XCUIElement+FBClassChain.m in Sources */,
 				641EE5E32240C5CA00173FCB /* NSExpression+FBFormat.m in Sources */,
 				641EE5E42240C5CA00173FCB /* XCUIApplication+FBHelpers.m in Sources */,
@@ -3232,6 +3243,7 @@
 				E444DC6D249131890060D7EB /* HTTPErrorResponse.m in Sources */,
 				71F5BE25252E576C00EE9EBA /* XCUIElement+FBSwiping.m in Sources */,
 				EE158AE51CBD456F00A3E3F0 /* FBSession.m in Sources */,
+				71C9EAAE25E8415A00470CD8 /* FBScreenshot.m in Sources */,
 				E444DCB224913C220060D7EB /* RoutingConnection.m in Sources */,
 				EE158AC11CBD456F00A3E3F0 /* FBFindElementCommands.m in Sources */,
 				EE7E271D1D06C69F001BEC7B /* FBDebugLogDelegateDecorator.m in Sources */,

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
@@ -54,15 +54,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Returns screenshot
-
- @param quality The number in range 0-2, where 2 (JPG) is the lowest and 0 (PNG) is the highest quality.
- @param error If there is an error, upon return contains an NSError object that describes the problem.
- @return Device screenshot as PNG- or JPG-encoded data or nil in case of failure
- */
-- (nullable NSData *)fb_rawScreenshotWithQuality:(NSUInteger)quality error:(NSError*__autoreleasing*)error;
-
-/**
- Returns screenshot
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return Device screenshot as PNG-encoded data or nil in case of failure
  */

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -18,17 +18,12 @@
 #import "FBImageUtils.h"
 #import "FBMacros.h"
 #import "FBMathUtils.h"
+#import "FBScreenshot.h"
 #import "FBXCodeCompatibility.h"
-#import "XCTestManager_ManagerInterface-Protocol.h"
-#import "FBXCTestDaemonsProxy.h"
-#import <MobileCoreServices/MobileCoreServices.h>
-
 #import "XCUIDevice.h"
-#import "XCUIScreen.h"
 
 static const NSTimeInterval FBHomeButtonCoolOffTime = 1.;
 static const NSTimeInterval FBScreenLockTimeout = 5.;
-static const NSTimeInterval SCREENSHOT_TIMEOUT = 2;
 
 @implementation XCUIDevice (FBHelpers)
 
@@ -103,30 +98,12 @@ static bool fb_isLocked;
 
 - (NSData *)fb_screenshotWithError:(NSError*__autoreleasing*)error
 {
-  NSData* screenshotData = [self fb_rawScreenshotWithQuality:FBConfiguration.screenshotQuality error:error];
+  NSData* screenshotData = [FBScreenshot screenshotWithQuality:FBConfiguration.screenshotQuality error:error];
 #if TARGET_OS_TV
   return FBAdjustScreenshotOrientationForApplication(screenshotData);
 #else
   return FBAdjustScreenshotOrientationForApplication(screenshotData, FBApplication.fb_activeApplication.interfaceOrientation);
 #endif
-}
-
-- (NSData *)fb_rawScreenshotWithQuality:(NSUInteger)quality error: (NSError*__autoreleasing*) error
-{
-  if ([XCUIDevice fb_isNewScreenshotAPISupported]) {
-    return [XCUIScreen.mainScreen screenshotDataForQuality:quality rect:CGRectNull error:error];
-  } else {
-    id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
-    __block NSData *screenshotData = nil;
-    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
-    [proxy _XCT_requestScreenshotWithReply:^(NSData *data, NSError *screenshotError) {
-      screenshotData = data;
-      *error = screenshotError;
-      dispatch_semaphore_signal(sem);
-    }];
-    dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(SCREENSHOT_TIMEOUT * NSEC_PER_SEC)));
-    return screenshotData;
-  }
 }
 
 - (BOOL)fb_fingerTouchShouldMatch:(BOOL)shouldMatch
@@ -138,16 +115,6 @@ static bool fb_isLocked;
     name = "com.apple.BiometricKit_Sim.fingerTouch.nomatch";
   }
   return notify_post(name) == NOTIFY_STATUS_OK;
-}
-
-+ (BOOL)fb_isNewScreenshotAPISupported
-{
-  static dispatch_once_t newScreenshotAPISupported;
-  static BOOL result;
-  dispatch_once(&newScreenshotAPISupported, ^{
-    result = [(NSObject *)[FBXCTestDaemonsProxy testRunnerProxy] respondsToSelector:@selector(_XCT_requestScreenshotOfScreenWithID:withRect:uti:compressionQuality:withReply:)];
-  });
-  return result;
 }
 
 - (NSString *)fb_wifiIPAddress

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -98,7 +98,7 @@ static bool fb_isLocked;
 
 - (NSData *)fb_screenshotWithError:(NSError*__autoreleasing*)error
 {
-  NSData* screenshotData = [FBScreenshot screenshotWithQuality:FBConfiguration.screenshotQuality error:error];
+  NSData* screenshotData = [FBScreenshot takeWithQuality:FBConfiguration.screenshotQuality error:error];
 #if TARGET_OS_TV
   return FBAdjustScreenshotOrientationForApplication(screenshotData);
 #else

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -19,22 +19,20 @@
 #import "FBMathUtils.h"
 #import "FBRunLoopSpinner.h"
 #import "FBSettings.h"
+#import "FBScreenshot.h"
 #import "FBXCAXClientProxy.h"
 #import "FBXCodeCompatibility.h"
-#import "FBXCTestDaemonsProxy.h"
 #import "XCUIApplication.h"
 #import "XCUIApplication+FBQuiescence.h"
 #import "XCUIApplicationImpl.h"
 #import "XCUIApplicationProcess.h"
 #import "XCTElementSetTransformer-Protocol.h"
-#import "XCTestManager_ManagerInterface-Protocol.h"
 #import "XCTestPrivateSymbols.h"
 #import "XCTRunnerDaemonSession.h"
 #import "XCUIElement+FBCaching.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
 #import "XCUIElementQuery.h"
 #import "XCUIElementQuery+FBHelpers.h"
-#import "XCUIScreen.h"
 #import "XCUIElement+FBUID.h"
 
 #define DEFAULT_AX_TIMEOUT 60.
@@ -243,9 +241,9 @@
     }
   }
 #endif
-  NSData *imageData = [XCUIScreen.mainScreen screenshotDataForQuality:FBConfiguration.screenshotQuality
-                                                                 rect:elementRect
-                                                                error:error];
+  NSData *imageData = [FBScreenshot screenshotWithQuality:FBConfiguration.screenshotQuality
+                                                     rect:elementRect
+                                                    error:error];
 #if !TARGET_OS_TV
   if (nil == imageData) {
     return nil;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -241,9 +241,9 @@
     }
   }
 #endif
-  NSData *imageData = [FBScreenshot screenshotWithQuality:FBConfiguration.screenshotQuality
-                                                     rect:elementRect
-                                                    error:error];
+  NSData *imageData = [FBScreenshot takeWithQuality:FBConfiguration.screenshotQuality
+                                               rect:elementRect
+                                              error:error];
 #if !TARGET_OS_TV
   if (nil == imageData) {
     return nil;

--- a/WebDriverAgentLib/Utilities/FBMjpegServer.m
+++ b/WebDriverAgentLib/Utilities/FBMjpegServer.m
@@ -11,16 +11,15 @@
 
 #import <mach/mach_time.h>
 #import <MobileCoreServices/MobileCoreServices.h>
+
 #import "GCDAsyncSocket.h"
 #import "FBApplication.h"
 #import "FBConfiguration.h"
 #import "FBLogger.h"
-#import "XCTestManager_ManagerInterface-Protocol.h"
-#import "FBXCTestDaemonsProxy.h"
-#import "XCUIScreen.h"
+#import "FBScreenshot.h"
 #import "FBImageIOScaler.h"
+#import "XCUIScreen.h"
 
-static const NSTimeInterval SCREENSHOT_TIMEOUT = 0.5;
 static const NSUInteger MAX_FPS = 60;
 
 static NSString *const SERVER_NAME = @"WDA MJPEG Server";
@@ -33,6 +32,7 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
 @property (nonatomic, readonly) NSMutableArray<GCDAsyncSocket *> *listeningClients;
 @property (nonatomic, readonly) mach_timebase_info_data_t timebaseInfo;
 @property (nonatomic, readonly) FBImageIOScaler *imageScaler;
+@property (nonatomic, readonly) unsigned int mainScreenID;
 
 @end
 
@@ -50,6 +50,7 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
       [self streamScreenshot];
     });
     _imageScaler = [[FBImageIOScaler alloc] init];
+    _mainScreenID = [XCUIScreen.mainScreen displayID];
   }
   return self;
 }
@@ -87,30 +88,16 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
     }
   }
 
-  __block NSData *screenshotData = nil;
-
   CGFloat scalingFactor = [FBConfiguration mjpegScalingFactor] / 100.0f;
   BOOL usesScaling = fabs(FBMaxScalingFactor - scalingFactor) > DBL_EPSILON;
-
   CGFloat compressionQuality = FBConfiguration.mjpegServerScreenshotQuality / 100.0f;
   // If scaling is applied we perform another JPEG compression after scaling
   // To get the desired compressionQuality we need to do a lossless compression here
   CGFloat screenshotCompressionQuality = usesScaling ? FBMaxCompressionQuality : compressionQuality;
-
-  id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
-  dispatch_semaphore_t sem = dispatch_semaphore_create(0);
-  [proxy _XCT_requestScreenshotOfScreenWithID:[[XCUIScreen mainScreen] displayID]
-                                       withRect:CGRectNull
-                                            uti:(__bridge id)kUTTypeJPEG
-                             compressionQuality:screenshotCompressionQuality
-                                      withReply:^(NSData *data, NSError *error) {
-    if (error != nil) {
-      [FBLogger logFmt:@"Error taking screenshot: %@", [error description]];
-    }
-    screenshotData = data;
-    dispatch_semaphore_signal(sem);
-  }];
-  dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(SCREENSHOT_TIMEOUT * NSEC_PER_SEC)));
+  NSData *screenshotData = [FBScreenshot screenshotWithScreenID:self.mainScreenID
+                                                        quality:screenshotCompressionQuality
+                                                           rect:CGRectNull
+                                                            uti:(__bridge id)kUTTypeJPEG];
   if (nil == screenshotData) {
     [self scheduleNextScreenshotWithInterval:timerInterval timeStarted:timeStarted];
     return;
@@ -144,12 +131,7 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
 
 + (BOOL)canStreamScreenshots
 {
-  static dispatch_once_t onceCanStream;
-  static BOOL result;
-  dispatch_once(&onceCanStream, ^{
-    result = [(NSObject *)[FBXCTestDaemonsProxy testRunnerProxy] respondsToSelector:@selector(_XCT_requestScreenshotOfScreenWithID:withRect:uti:compressionQuality:withReply:)];
-  });
-  return result;
+  return [FBScreenshot isNewScreenshotAPISupported];
 }
 
 - (void)didClientConnect:(GCDAsyncSocket *)newClient

--- a/WebDriverAgentLib/Utilities/FBMjpegServer.m
+++ b/WebDriverAgentLib/Utilities/FBMjpegServer.m
@@ -94,10 +94,10 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
   // If scaling is applied we perform another JPEG compression after scaling
   // To get the desired compressionQuality we need to do a lossless compression here
   CGFloat screenshotCompressionQuality = usesScaling ? FBMaxCompressionQuality : compressionQuality;
-  NSData *screenshotData = [FBScreenshot screenshotWithScreenID:self.mainScreenID
-                                                        quality:screenshotCompressionQuality
-                                                           rect:CGRectNull
-                                                            uti:(__bridge id)kUTTypeJPEG];
+  NSData *screenshotData = [FBScreenshot takeWithScreenID:self.mainScreenID
+                                                  quality:screenshotCompressionQuality
+                                                     rect:CGRectNull
+                                                      uti:(__bridge id)kUTTypeJPEG];
   if (nil == screenshotData) {
     [self scheduleNextScreenshotWithInterval:timerInterval timeStarted:timeStarted];
     return;

--- a/WebDriverAgentLib/Utilities/FBScreenshot.h
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.h
@@ -25,8 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return Device screenshot as PNG- or JPG-encoded data or nil in case of failure
  */
-+ (nullable NSData *)screenshotWithQuality:(NSUInteger)quality
-                                     error:(NSError **)error;
++ (nullable NSData *)takeWithQuality:(NSUInteger)quality
+                               error:(NSError **)error;
 
 /**
  Returns screenshot
@@ -36,9 +36,9 @@ NS_ASSUME_NONNULL_BEGIN
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return Device screenshot as PNG- or JPG-encoded data or nil in case of failure
  */
-+ (nullable NSData *)screenshotWithQuality:(NSUInteger)quality
-                                      rect:(CGRect)rect
-                                     error:(NSError **)error;
++ (nullable NSData *)takeWithQuality:(NSUInteger)quality
+                                rect:(CGRect)rect
+                               error:(NSError **)error;
 
 /**
  Returns screenshot
@@ -49,10 +49,10 @@ NS_ASSUME_NONNULL_BEGIN
  @param uti kUTType... constant, which defines the type of the returned screenshot image
  @return Device screenshot as PNG- or JPG-encoded data or nil in case of failure
  */
-+ (nullable NSData *)screenshotWithScreenID:(unsigned int)screenID
-                                    quality:(CGFloat)quality
-                                       rect:(CGRect)rect
-                                        uti:(NSString *)uti;
++ (nullable NSData *)takeWithScreenID:(unsigned int)screenID
+                              quality:(CGFloat)quality
+                                 rect:(CGRect)rect
+                                  uti:(NSString *)uti;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBScreenshot.h
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.h
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FBScreenshot : NSObject
+
+/**
+ Returns YES if the current OS SDK supports advanced screenshoting APIs (added since Xcode SDK 10)
+ */
++ (BOOL)isNewScreenshotAPISupported;
+
+/**
+ Returns screenshot
+
+ @param quality The number in range 0-2, where 2 (JPG) is the lowest and 0 (PNG) is the highest quality.
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return Device screenshot as PNG- or JPG-encoded data or nil in case of failure
+ */
++ (nullable NSData *)screenshotWithQuality:(NSUInteger)quality
+                                     error:(NSError **)error;
+
+/**
+ Returns screenshot
+
+ @param quality The number in range 0-2, where 2 (JPG) is the lowest and 0 (PNG) is the highest quality.
+ @param rect The bounding rectange for the screenshot. CGRectNull could be used to take a screenshot of the full screen
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return Device screenshot as PNG- or JPG-encoded data or nil in case of failure
+ */
++ (nullable NSData *)screenshotWithQuality:(NSUInteger)quality
+                                      rect:(CGRect)rect
+                                     error:(NSError **)error;
+
+/**
+ Returns screenshot
+
+ @param screenID The screen identifier to take the screenshot from
+ @param quality Normalized screenshot quality value in range 0..1, where 1 is the best quality
+ @param rect The bounding rectange for the screenshot. CGRectNull could be used to take a screenshot of the full screen
+ @param uti kUTType... constant, which defines the type of the returned screenshot image
+ @return Device screenshot as PNG- or JPG-encoded data or nil in case of failure
+ */
++ (nullable NSData *)screenshotWithScreenID:(unsigned int)screenID
+                                    quality:(CGFloat)quality
+                                       rect:(CGRect)rect
+                                        uti:(NSString *)uti;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBScreenshot.m
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.m
@@ -22,10 +22,8 @@ static const NSTimeInterval SCREENSHOT_TIMEOUT = .5;
 static NSLock *screenshotLock;
 
 NSString *formatTimeInterval(NSTimeInterval interval) {
-  NSDateComponentsFormatter *formatter = [[NSDateComponentsFormatter alloc] init];
-  formatter.allowedUnits = NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
-  formatter.zeroFormattingBehavior = NSDateComponentsFormatterZeroFormattingBehaviorPad;
-  return [formatter stringFromTimeInterval:interval];
+  NSUInteger milliseconds = (NSInteger)(interval * 1000);
+  return [NSString stringWithFormat:@"%ld ms", milliseconds];
 }
 
 @implementation FBScreenshot

--- a/WebDriverAgentLib/Utilities/FBScreenshot.m
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.m
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBScreenshot.h"
+
+#import "FBConfiguration.h"
+#import "FBErrorBuilder.h"
+#import "FBLogger.h"
+#import "FBXCodeCompatibility.h"
+#import "FBXCTestDaemonsProxy.h"
+#import "XCTestManager_ManagerInterface-Protocol.h"
+#import "XCUIScreen.h"
+
+static const NSTimeInterval SCREENSHOT_TIMEOUT = .5;
+
+static NSLock *screenshotLock;
+
+@implementation FBScreenshot
+
++ (void)load
+{
+  screenshotLock = [NSLock new];
+}
+
++ (BOOL)isNewScreenshotAPISupported
+{
+  static dispatch_once_t newScreenshotAPISupported;
+  static BOOL result;
+  dispatch_once(&newScreenshotAPISupported, ^{
+    result = [(NSObject *)[FBXCTestDaemonsProxy testRunnerProxy] respondsToSelector:@selector(_XCT_requestScreenshotOfScreenWithID:withRect:uti:compressionQuality:withReply:)];
+  });
+  return result;
+}
+
++ (NSData *)screenshotWithQuality:(NSUInteger)quality
+                             rect:(CGRect)rect
+                            error:(NSError **)error {
+  if ([self.class isNewScreenshotAPISupported]) {
+    [screenshotLock lock];
+    @try {
+      return [XCUIScreen.mainScreen screenshotDataForQuality:FBConfiguration.screenshotQuality
+                                                        rect:rect
+                                                       error:error];
+    } @finally {
+      [screenshotLock unlock];
+    }
+  }
+
+  [[[FBErrorBuilder builder]
+         withDescription:@"Screenshots of limited areas are only available for newer OS versions"]
+        buildError:error];
+  return nil;
+}
+
++ (NSData *)screenshotWithQuality:(NSUInteger)quality
+                            error:(NSError **)error
+{
+  if ([self.class isNewScreenshotAPISupported]) {
+    [screenshotLock lock];
+    @try {
+      return [XCUIScreen.mainScreen screenshotDataForQuality:quality
+                                                        rect:CGRectNull
+                                                       error:error];
+    } @finally {
+      [screenshotLock unlock];
+    }
+  }
+
+  id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
+  __block NSData *screenshotData = nil;
+  __block NSError *innerError = nil;
+  [screenshotLock lock];
+  dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+  [proxy _XCT_requestScreenshotWithReply:^(NSData *data, NSError *screenshotError) {
+    screenshotData = data;
+    innerError = screenshotError;
+    dispatch_semaphore_signal(sem);
+  }];
+  if (nil != innerError && error) {
+    *error = innerError;
+  }
+  dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(SCREENSHOT_TIMEOUT * NSEC_PER_SEC)));
+  [screenshotLock unlock];
+  return screenshotData;
+}
+
++ (NSData *)screenshotWithScreenID:(unsigned int)screenID
+                           quality:(CGFloat)quality
+                              rect:(CGRect)rect
+                               uti:(NSString *)uti
+{
+  id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
+  __block NSData *screenshotData = nil;
+  [screenshotLock lock];
+  dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+  [proxy _XCT_requestScreenshotOfScreenWithID:screenID
+                                     withRect:CGRectNull
+                                          uti:uti
+                           compressionQuality:quality
+                                    withReply:^(NSData *data, NSError *error) {
+    if (nil != error) {
+      [FBLogger logFmt:@"Got an error while taking a screenshot: %@", [error description]];
+    } else {
+      screenshotData = data;
+    }
+    dispatch_semaphore_signal(sem);
+  }];
+  dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(SCREENSHOT_TIMEOUT * NSEC_PER_SEC)));
+  [screenshotLock unlock];
+  return screenshotData;
+}
+
+@end

--- a/WebDriverAgentLib/Utilities/FBScreenshot.m
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.m
@@ -22,7 +22,7 @@ static const NSTimeInterval SCREENSHOT_TIMEOUT = .5;
 static NSLock *screenshotLock;
 
 NSString *formatTimeInterval(NSTimeInterval interval) {
-  NSUInteger milliseconds = (NSInteger)(interval * 1000);
+  NSUInteger milliseconds = (NSUInteger)(interval * 1000);
   return [NSString stringWithFormat:@"%ld ms", milliseconds];
 }
 

--- a/WebDriverAgentLib/Utilities/FBScreenshot.m
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.m
@@ -38,9 +38,10 @@ static NSLock *screenshotLock;
   return result;
 }
 
-+ (NSData *)screenshotWithQuality:(NSUInteger)quality
-                             rect:(CGRect)rect
-                            error:(NSError **)error {
++ (NSData *)takeWithQuality:(NSUInteger)quality
+                       rect:(CGRect)rect
+                      error:(NSError **)error
+{
   if ([self.class isNewScreenshotAPISupported]) {
     [screenshotLock lock];
     @try {
@@ -58,8 +59,8 @@ static NSLock *screenshotLock;
   return nil;
 }
 
-+ (NSData *)screenshotWithQuality:(NSUInteger)quality
-                            error:(NSError **)error
++ (NSData *)takeWithQuality:(NSUInteger)quality
+                      error:(NSError **)error
 {
   if ([self.class isNewScreenshotAPISupported]) {
     [screenshotLock lock];
@@ -90,10 +91,10 @@ static NSLock *screenshotLock;
   return screenshotData;
 }
 
-+ (NSData *)screenshotWithScreenID:(unsigned int)screenID
-                           quality:(CGFloat)quality
-                              rect:(CGRect)rect
-                               uti:(NSString *)uti
++ (NSData *)takeWithScreenID:(unsigned int)screenID
+                     quality:(CGFloat)quality
+                        rect:(CGRect)rect
+                         uti:(NSString *)uti
 {
   id<XCTestManager_ManagerInterface> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
   __block NSData *screenshotData = nil;


### PR DESCRIPTION
~~Adding global lock for screenshots should help to avoid unexpected testmanagerd crashes while one tries to take a screenshot while video recording is in progress. The PR ensures that only one request for a screenshot is sent simultaneously. Related to https://github.com/appium/appium/issues/15122~~

Removed locking as it does not help to address the original issue. Although, the refactoring itself still makes sense