### PR TITLE
Added iOS14 location permission alert accept support

### DIFF
--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -183,9 +183,19 @@
   if (nil == acceptButton) {
     NSArray<XCUIElement *> *buttons = [self.alertElement.fb_query
                                        descendantsMatchingType:XCUIElementTypeButton].allElementsBoundByIndex;
-    acceptButton = (alertSnapshot.elementType == XCUIElementTypeAlert || [self.class isSafariWebAlertWithSnapshot:alertSnapshot])
-      ? buttons.lastObject
-      : buttons.firstObject;
+    NSArray<XCUIElement *> *mapElements = [self.alertElement.fb_query
+                                       descendantsMatchingType:XCUIElementTypeMap].allElementsBoundByIndex;
+    if (mapElements.count > 0 &&
+        alertSnapshot.elementType == XCUIElementTypeAlert &&
+        buttons.count == 4) {
+      // this is a location permission alert for iOS 14
+      // allow while using app button
+      acceptButton = buttons[1];
+    } else {
+      acceptButton = (alertSnapshot.elementType == XCUIElementTypeAlert || [self.class isSafariWebAlertWithSnapshot:alertSnapshot])
+        ? buttons.lastObject
+        : buttons.firstObject;
+    }
   }
   return nil == acceptButton
     ? [[[FBErrorBuilder builder]


### PR DESCRIPTION
Currently appium will not work for iOS14 location permission alert when passing autoAcceptAlerts=True.

<img width="196" alt="image" src="https://user-images.githubusercontent.com/20297196/111145549-55d3e880-85c3-11eb-885e-253423e89c7b.png">

My PR will let Appium click "Allow While Using App" button in location permission alert.
