### PR TITLE
fix: bad access in authorizationStatus

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -307,7 +307,7 @@
   [locationManager startUpdatingLocation];
 
   CLAuthorizationStatus authStatus = [locationManager respondsToSelector:@selector(authorizationStatus)]
-    ? (CLAuthorizationStatus) [[locationManager performSelector:@selector(authorizationStatus)] integerValue]
+    ? (CLAuthorizationStatus) [locationManager performSelector:@selector(authorizationStatus)]
     : [CLLocationManager authorizationStatus];
 
   return FBResponseWithObject(@{

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -306,11 +306,9 @@
   [locationManager setPausesLocationUpdatesAutomatically:NO];
   [locationManager startUpdatingLocation];
 
-
   CLAuthorizationStatus authStatus;
   if ([locationManager respondsToSelector:@selector(authorizationStatus)]) {
-    // To fix warning
-    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature: [[locationManager class]
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[[locationManager class]
       instanceMethodSignatureForSelector:@selector(authorizationStatus)]];
     [invocation setSelector:@selector(authorizationStatus)];
     [invocation setTarget:locationManager];

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -315,9 +315,7 @@
     [invocation setSelector:@selector(authorizationStatus)];
     [invocation setTarget:locationManager];
     [invocation invoke];
-    CLAuthorizationStatus status;
-    [invocation getReturnValue:&status];
-    authStatus = status;
+    [invocation getReturnValue:&authStatus];
   } else {
     authStatus = [CLLocationManager authorizationStatus];
   }

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -306,9 +306,20 @@
   [locationManager setPausesLocationUpdatesAutomatically:NO];
   [locationManager startUpdatingLocation];
 
-  CLAuthorizationStatus authStatus = [locationManager respondsToSelector:@selector(authorizationStatus)]
-    ? (CLAuthorizationStatus) [locationManager performSelector:@selector(authorizationStatus)]
-    : [CLLocationManager authorizationStatus];
+
+  CLAuthorizationStatus authStatus;
+  if ([locationManager respondsToSelector:@selector(authorizationStatus)]) {
+    // To fix warning
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[[locationManager class] instanceMethodSignatureForSelector:@selector(authorizationStatus)]];
+    [invocation setSelector:@selector(authorizationStatus)];
+    [invocation setTarget:locationManager];
+    [invocation invoke];
+    NSInteger status = 0;
+    [invocation getReturnValue:&status];
+    authStatus = (CLAuthorizationStatus) status;
+  } else {
+    authStatus = [CLLocationManager authorizationStatus];
+  }
 
   return FBResponseWithObject(@{
     @"authorizationStatus": @(authStatus),

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -310,13 +310,14 @@
   CLAuthorizationStatus authStatus;
   if ([locationManager respondsToSelector:@selector(authorizationStatus)]) {
     // To fix warning
-    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[[locationManager class] instanceMethodSignatureForSelector:@selector(authorizationStatus)]];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature: [[locationManager class]
+      instanceMethodSignatureForSelector:@selector(authorizationStatus)]];
     [invocation setSelector:@selector(authorizationStatus)];
     [invocation setTarget:locationManager];
     [invocation invoke];
-    NSInteger status = 0;
+    CLAuthorizationStatus status;
     [invocation getReturnValue:&status];
-    authStatus = (CLAuthorizationStatus) status;
+    authStatus = status;
   } else {
     authStatus = [CLLocationManager authorizationStatus];
   }


### PR DESCRIPTION
The result of `[locationManager performSelector:@selector(authorizationStatus)]` is like `0x0000000000000003`. So, cast to `(CLAuthorizationStatus)` or `(int)` is safer without `integerValue`