### PR TITLE
feat: Make automatic screenshot taking configurable

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -97,6 +97,14 @@
   if (requirements[@"shouldUseSingletonTestManager"]) {
     [FBConfiguration setShouldUseSingletonTestManager:[requirements[@"shouldUseSingletonTestManager"] boolValue]];
   }
+  if (requirements[@"disableAutomaticScreenshots"]) {
+    BOOL disable = [requirements[@"disableAutomaticScreenshots"] boolValue];
+    if (disable) {
+      [FBConfiguration disableScreenshots];
+    } else {
+      [FBConfiguration enableScreenshots];
+    }
+  }
   NSNumber *delay = requirements[@"eventloopIdleDelaySec"];
   if ([delay doubleValue] > 0.0) {
     [XCUIApplicationProcessDelay setEventLoopHasIdledDelay:[delay doubleValue]];

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -98,8 +98,7 @@
     [FBConfiguration setShouldUseSingletonTestManager:[requirements[@"shouldUseSingletonTestManager"] boolValue]];
   }
   if (requirements[@"disableAutomaticScreenshots"]) {
-    BOOL disable = [requirements[@"disableAutomaticScreenshots"] boolValue];
-    if (disable) {
+    if ([requirements[@"disableAutomaticScreenshots"] boolValue]) {
       [FBConfiguration disableScreenshots];
     } else {
       [FBConfiguration enableScreenshots];

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -43,8 +43,14 @@ extern NSString *const FBSnapshotMaxDepthKey;
 /*! Disables attribute key path analysis, which will cause XCTest on Xcode 9.x to ignore some elements */
 + (void)disableAttributeKeyPathAnalysis;
 
-/*! Disables XCTest from automated screenshots taking */
+/*! Disables XCTest automated screenshots taking */
 + (void)disableScreenshots;
+
+/*! Enables XCTest automated screenshots taking */
++ (void)enableScreenshots;
+
+/*! Disables XCTest automated screenshots taking, unless DISABLE_SCREENSHOTS env variable is set to NO */
++ (void)disableScreenshotsUnlessEnvironment;
 
 /* The maximum typing frequency for all typing activities */
 + (void)setMaxTypingFrequency:(NSUInteger)value;

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -49,9 +49,6 @@ extern NSString *const FBSnapshotMaxDepthKey;
 /*! Enables XCTest automated screenshots taking */
 + (void)enableScreenshots;
 
-/*! Disables XCTest automated screenshots taking, unless DISABLE_SCREENSHOTS env variable is set to NO */
-+ (void)disableScreenshotsUnlessEnvironment;
-
 /* The maximum typing frequency for all typing activities */
 + (void)setMaxTypingFrequency:(NSUInteger)value;
 + (NSUInteger)maxTypingFrequency;

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -96,15 +96,10 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
 
 + (void)disableScreenshotsUnlessEnvironment
 {
-  BOOL disable = YES;
-  NSString * envSetting = NSProcessInfo.processInfo.environment[@"DISABLE_SCREENSHOTS"];
-  if (envSetting && [envSetting isEqualToString:@"NO"]) {
-    disable = NO;
-  }
-  if (disable) {
-    [self disableScreenshots];
-  } else {
+  if (NSProcessInfo.processInfo.environment[@"ENABLE_AUTOMATIC_SCREENSHOTS"]) {
     [self enableScreenshots];
+  } else {
+    [self disableScreenshots];
   }
 }
 

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -94,15 +94,6 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
   [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"DisableScreenshots"];
 }
 
-+ (void)disableScreenshotsUnlessEnvironment
-{
-  if (NSProcessInfo.processInfo.environment[@"ENABLE_AUTOMATIC_SCREENSHOTS"]) {
-    [self enableScreenshots];
-  } else {
-    [self disableScreenshots];
-  }
-}
-
 + (NSRange)bindingPortRange
 {
   // 'WebDriverAgent --port 8080' can be passed via the arguments to the process

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -89,6 +89,25 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
   [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"DisableScreenshots"];
 }
 
++ (void)enableScreenshots
+{
+  [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"DisableScreenshots"];
+}
+
++ (void)disableScreenshotsUnlessEnvironment
+{
+  BOOL disable = YES;
+  NSString * envSetting = NSProcessInfo.processInfo.environment[@"DISABLE_SCREENSHOTS"];
+  if (envSetting && [envSetting isEqualToString:@"NO"]) {
+    disable = NO;
+  }
+  if (disable) {
+    [self disableScreenshots];
+  } else {
+    [self enableScreenshots];
+  }
+}
+
 + (NSRange)bindingPortRange
 {
   // 'WebDriverAgent --port 8080' can be passed via the arguments to the process

--- a/WebDriverAgentRunner/UITestingUITests.m
+++ b/WebDriverAgentRunner/UITestingUITests.m
@@ -25,7 +25,11 @@
   [FBDebugLogDelegateDecorator decorateXCTestLogger];
   [FBConfiguration disableRemoteQueryEvaluation];
   [FBConfiguration configureDefaultKeyboardPreferences];
-  [FBConfiguration disableScreenshotsUnlessEnvironment];
+  if (NSProcessInfo.processInfo.environment[@"ENABLE_AUTOMATIC_SCREENSHOTS"]) {
+    [FBConfiguration enableScreenshots];
+  } else {
+    [FBConfiguration disableScreenshots];
+  }
   [super setUp];
 }
 

--- a/WebDriverAgentRunner/UITestingUITests.m
+++ b/WebDriverAgentRunner/UITestingUITests.m
@@ -25,7 +25,7 @@
   [FBDebugLogDelegateDecorator decorateXCTestLogger];
   [FBConfiguration disableRemoteQueryEvaluation];
   [FBConfiguration configureDefaultKeyboardPreferences];
-  [FBConfiguration disableScreenshots];
+  [FBConfiguration disableScreenshotsUnlessEnvironment];
   [super setUp];
 }
 


### PR DESCRIPTION
- disable by default
- initial disabling avoidable by setting env var DISABLE_SCREENSHOTS=NO
- overridable on session start via `disableAutomaticScreenshots` capability

The reason for this change is that sometimes it's useful to turn this feature back on for debugging purposes, especially when working on complex setups with remote devices.