### PR TITLE
feat: Configure app termination via shouldTerminateApp capability

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -104,6 +104,9 @@
       [FBConfiguration enableScreenshots];
     }
   }
+  if (requirements[@"shouldTerminateApp"]) {
+    [FBConfiguration setShouldTerminateApp:[requirements[@"shouldTerminateApp"] boolValue]];
+  }
   NSNumber *delay = requirements[@"eventloopIdleDelaySec"];
   if ([delay doubleValue] > 0.0) {
     [XCUIApplicationProcessDelay setEventLoopHasIdledDelay:[delay doubleValue]];

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -131,7 +131,7 @@ static FBSession *_activeSession = nil;
     self.alertsMonitor = nil;
   }
 
-  if (self.testedApplicationBundleId) {
+  if (self.testedApplicationBundleId && [FBConfiguration shouldTerminateApp]) {
     [[self.applications objectForKey:self.testedApplicationBundleId] terminate];
   }
   _activeSession = nil;

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -30,6 +30,10 @@ extern NSString *const FBSnapshotMaxDepthKey;
 + (void)setShouldUseCompactResponses:(BOOL)value;
 + (BOOL)shouldUseCompactResponses;
 
+/*! If set to YES (which is the default), the app will be terminated at the end of the session, if a bundleId was specified */
++ (void)setShouldTerminateApp:(BOOL)value;
++ (BOOL)shouldTerminateApp;
+
 /*! If shouldUseCompactResponses == NO, is the comma-separated list of fields to return with each element. Defaults to "type,label". */
 + (void)setElementResponseAttributes:(NSString *)value;
 + (NSString *)elementResponseAttributes;

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -31,6 +31,7 @@ static NSString *const axSettingsClassName = @"AXSettings";
 static BOOL FBShouldUseTestManagerForVisibilityDetection = NO;
 static BOOL FBShouldUseSingletonTestManager = YES;
 static BOOL FBShouldUseCompactResponses = YES;
+static BOOL FBShouldTerminateApp = YES;
 static NSString *FBElementResponseAttributes = @"type,label";
 static NSUInteger FBMaxTypingFrequency = 60;
 static NSUInteger FBMjpegServerScreenshotQuality = 25;
@@ -156,6 +157,16 @@ static UIInterfaceOrientation FBScreenshotOrientation = UIInterfaceOrientationUn
 + (BOOL)shouldUseCompactResponses
 {
   return FBShouldUseCompactResponses;
+}
+
++ (void)setShouldTerminateApp:(BOOL)value
+{
+  FBShouldTerminateApp = value;
+}
+
++ (BOOL)shouldTerminateApp
+{
+  return FBShouldTerminateApp;
 }
 
 + (void)setElementResponseAttributes:(NSString *)value


### PR DESCRIPTION
By default is true (as per the existing behaviour), which means the app gets terminated when the session gets killed, if a bundleId was specified.