### PR TITLE
fix: keep screenshot scale original as Appium/WDA

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -98,7 +98,8 @@ static bool fb_isLocked;
 
 - (NSData *)fb_screenshotWithError:(NSError*__autoreleasing*)error
 {
-  return [FBScreenshot takeInOriginalResolutionWithQuality:FBConfiguration.screenshotQuality error:error];
+  return [FBScreenshot takeInOriginalResolutionWithQuality:FBConfiguration.screenshotQuality
+                                                     error:error];
 }
 
 - (BOOL)fb_fingerTouchShouldMatch:(BOOL)shouldMatch

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -98,7 +98,7 @@ static bool fb_isLocked;
 
 - (NSData *)fb_screenshotWithError:(NSError*__autoreleasing*)error
 {
-  return [FBScreenshot takeWithQuality:FBConfiguration.screenshotQuality error:error];
+  return [FBScreenshot takeInOriginalResolutionWithQuality:FBConfiguration.screenshotQuality error:error];
 }
 
 - (BOOL)fb_fingerTouchShouldMatch:(BOOL)shouldMatch

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -243,7 +243,7 @@
   }
 #endif
 
-  // adjust element rect for the screen scale
+  // adjust element rect for the actual screen scale
   XCUIScreen *mainScreen = XCUIScreen.mainScreen;
   elementRect = CGRectMake(elementRect.origin.x * mainScreen.scale, elementRect.origin.y * mainScreen.scale,
                            elementRect.size.width * mainScreen.scale, elementRect.size.height * mainScreen.scale);

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -248,9 +248,9 @@
   elementRect = CGRectMake(elementRect.origin.x * mainScreen.scale, elementRect.origin.y * mainScreen.scale,
                            elementRect.size.width * mainScreen.scale, elementRect.size.height * mainScreen.scale);
 
-  return [FBScreenshot takeWithQuality:FBConfiguration.screenshotQuality
-                                  rect:elementRect
-                                 error:error];
+  return [FBScreenshot takeInOriginalResolutionWithQuality:FBConfiguration.screenshotQuality
+                                                      rect:elementRect
+                                                     error:error];
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -34,6 +34,7 @@
 #import "XCUIElementQuery.h"
 #import "XCUIElementQuery+FBHelpers.h"
 #import "XCUIElement+FBUID.h"
+#import "XCUIScreen.h"
 
 #define DEFAULT_AX_TIMEOUT 60.
 
@@ -241,6 +242,12 @@
     }
   }
 #endif
+
+  // adjust element rect for the screen scale
+  XCUIScreen *mainScreen = XCUIScreen.mainScreen;
+  elementRect = CGRectMake(elementRect.origin.x * mainScreen.scale, elementRect.origin.y * mainScreen.scale,
+                           elementRect.size.width * mainScreen.scale, elementRect.size.height * mainScreen.scale);
+
   return [FBScreenshot takeWithQuality:FBConfiguration.screenshotQuality
                                   rect:elementRect
                                  error:error];

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.h
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.h
@@ -42,7 +42,8 @@ extern const CGFloat FBMaxCompressionQuality;
 
  @param image The source image data
  @param uti Either kUTTypePNG or kUTTypeJPEG
- @param rect The cropping rectangle. Could be CGRectNull to avoid cropping
+ @param rect The cropping rectange for the screenshot. The value is expected be non-scaled one.
+             CGRectNull could be used to take a screenshot of the full screen.
  @param scalingFactor Scaling factor in range 0.01..1.0. A value of 1.0 won't perform scaling at all
  @param compressionQuality the compression quality in range 0.0..1.0 (0.0 for max. compression and 1.0 for lossless compression).
  Only works if UTI is set to kUTTypeJPEG

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.h
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.h
@@ -42,8 +42,9 @@ extern const CGFloat FBMaxCompressionQuality;
 
  @param image The source image data
  @param uti Either kUTTypePNG or kUTTypeJPEG
- @param rect The cropping rectange for the screenshot. The value is expected be non-scaled one.
-             CGRectNull could be used to take a screenshot of the full screen.
+ @param rect The cropping rectange for the screenshot. The value is expected to be non-scaled one
+            since it happens after scaling/orientation change.
+            CGRectNull could be used to take a screenshot of the full screen.
  @param scalingFactor Scaling factor in range 0.01..1.0. A value of 1.0 won't perform scaling at all
  @param compressionQuality the compression quality in range 0.0..1.0 (0.0 for max. compression and 1.0 for lossless compression).
  Only works if UTI is set to kUTTypeJPEG

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -123,6 +123,7 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
 {
   UIImage *uiImage = [UIImage imageWithData:image];
   UIImageOrientation orientation = uiImage.imageOrientation;
+  CGSize originalSize = uiImage.size;
 #if !TARGET_OS_TV
   if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationPortrait) {
     orientation = UIImageOrientationUp;
@@ -138,14 +139,16 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
                                 scale:uiImage.scale
                           orientation:orientation];
 
+  UIImage *resultImage;
+  CGSize scaledSize;
   if (fabs(1.0 - scalingFactor) > FLT_EPSILON) {
-    CGSize size = uiImage.size;
-    CGSize scaledSize = CGSizeMake(size.width * scalingFactor, size.height * scalingFactor);
-    UIGraphicsBeginImageContext(scaledSize);
-    [uiImage drawInRect:CGRectMake(0, 0, scaledSize.width, scaledSize.height)];
+    scaledSize = CGSizeMake(originalSize.width * scalingFactor, originalSize.height * scalingFactor);
+  } else {
+    scaledSize = originalSize;
   }
-
-  UIImage *resultImage = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsBeginImageContext(scaledSize);
+  [uiImage drawInRect:CGRectMake(0, 0, scaledSize.width, scaledSize.height)];
+  resultImage = UIGraphicsGetImageFromCurrentImageContext();
   UIGraphicsEndImageContext();
 
   if (!CGRectIsNull(rect)) {

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -122,11 +122,8 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
                                     error:(NSError **)error
 {
   UIImage *uiImage = [UIImage imageWithData:image];
-  UIImageOrientation orientation = uiImage.imageOrientation;
-
   CGSize originalSize = uiImage.size;
-  Boolean shouldScale = fabs(1.0 - scalingFactor) > FLT_EPSILON;
-
+  BOOL shouldScale = fabs(1.0 - scalingFactor) > FLT_EPSILON;
   CGSize scaledSize;
   if (shouldScale) {
     scaledSize = CGSizeMake(originalSize.width * scalingFactor, originalSize.height * scalingFactor);
@@ -134,6 +131,7 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
     scaledSize = originalSize;
   }
   UIGraphicsBeginImageContext(scaledSize);
+  UIImageOrientation orientation = uiImage.imageOrientation;
 #if !TARGET_OS_TV
   if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationPortrait) {
     orientation = UIImageOrientationUp;

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -140,9 +140,7 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
   uiImage = [UIImage imageWithCGImage:(CGImageRef)uiImage.CGImage
                                 scale:uiImage.scale
                           orientation:orientation];
-  if (fabs(1.0 - scalingFactor) > FLT_EPSILON) {
-    [uiImage drawInRect:CGRectMake(0, 0, scaledSize.width, scaledSize.height)];
-  }
+  [uiImage drawInRect:CGRectMake(0, 0, scaledSize.width, scaledSize.height)];
   UIImage *resultImage = UIGraphicsGetImageFromCurrentImageContext();
   UIGraphicsEndImageContext();
 

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -122,14 +122,8 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
                                     error:(NSError **)error
 {
   UIImage *uiImage = [UIImage imageWithData:image];
-  CGSize originalSize = uiImage.size;
-  BOOL shouldScale = fabs(1.0 - scalingFactor) > FLT_EPSILON;
-  CGSize scaledSize;
-  if (shouldScale) {
-    scaledSize = CGSizeMake(originalSize.width * scalingFactor, originalSize.height * scalingFactor);
-  } else {
-    scaledSize = originalSize;
-  }
+  CGSize size = uiImage.size;
+  CGSize scaledSize = CGSizeMake(size.width * scalingFactor, size.height * scalingFactor);
   UIGraphicsBeginImageContext(scaledSize);
   UIImageOrientation orientation = uiImage.imageOrientation;
 #if !TARGET_OS_TV
@@ -146,7 +140,7 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
   uiImage = [UIImage imageWithCGImage:(CGImageRef)uiImage.CGImage
                                 scale:uiImage.scale
                           orientation:orientation];
-  if (shouldScale) {
+  if (fabs(1.0 - scalingFactor) > FLT_EPSILON) {
     [uiImage drawInRect:CGRectMake(0, 0, scaledSize.width, scaledSize.height)];
   }
   UIImage *resultImage = UIGraphicsGetImageFromCurrentImageContext();

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -122,9 +122,6 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
                                     error:(NSError **)error
 {
   UIImage *uiImage = [UIImage imageWithData:image];
-  CGSize size = uiImage.size;
-  CGSize scaledSize = CGSizeMake(size.width * scalingFactor, size.height * scalingFactor);
-  UIGraphicsBeginImageContext(scaledSize);
   UIImageOrientation orientation = uiImage.imageOrientation;
 #if !TARGET_OS_TV
   if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationPortrait) {
@@ -140,7 +137,14 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
   uiImage = [UIImage imageWithCGImage:(CGImageRef)uiImage.CGImage
                                 scale:uiImage.scale
                           orientation:orientation];
-  [uiImage drawInRect:CGRectMake(0, 0, scaledSize.width, scaledSize.height)];
+
+  if (fabs(1.0 - scalingFactor) > FLT_EPSILON) {
+    CGSize size = uiImage.size;
+    CGSize scaledSize = CGSizeMake(size.width * scalingFactor, size.height * scalingFactor);
+    UIGraphicsBeginImageContext(scaledSize);
+    [uiImage drawInRect:CGRectMake(0, 0, scaledSize.width, scaledSize.height)];
+  }
+
   UIImage *resultImage = UIGraphicsGetImageFromCurrentImageContext();
   UIGraphicsEndImageContext();
 

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -123,7 +123,17 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
 {
   UIImage *uiImage = [UIImage imageWithData:image];
   UIImageOrientation orientation = uiImage.imageOrientation;
+
   CGSize originalSize = uiImage.size;
+  Boolean shouldScale = fabs(1.0 - scalingFactor) > FLT_EPSILON;
+
+  CGSize scaledSize;
+  if (shouldScale) {
+    scaledSize = CGSizeMake(originalSize.width * scalingFactor, originalSize.height * scalingFactor);
+  } else {
+    scaledSize = originalSize;
+  }
+  UIGraphicsBeginImageContext(scaledSize);
 #if !TARGET_OS_TV
   if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationPortrait) {
     orientation = UIImageOrientationUp;
@@ -138,17 +148,10 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
   uiImage = [UIImage imageWithCGImage:(CGImageRef)uiImage.CGImage
                                 scale:uiImage.scale
                           orientation:orientation];
-
-  UIImage *resultImage;
-  CGSize scaledSize;
-  if (fabs(1.0 - scalingFactor) > FLT_EPSILON) {
-    scaledSize = CGSizeMake(originalSize.width * scalingFactor, originalSize.height * scalingFactor);
-  } else {
-    scaledSize = originalSize;
+  if (shouldScale) {
+    [uiImage drawInRect:CGRectMake(0, 0, scaledSize.width, scaledSize.height)];
   }
-  UIGraphicsBeginImageContext(scaledSize);
-  [uiImage drawInRect:CGRectMake(0, 0, scaledSize.width, scaledSize.height)];
-  resultImage = UIGraphicsGetImageFromCurrentImageContext();
+  UIImage *resultImage = UIGraphicsGetImageFromCurrentImageContext();
   UIGraphicsEndImageContext();
 
   if (!CGRectIsNull(rect)) {

--- a/WebDriverAgentLib/Utilities/FBScreenshot.h
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  Retrieves non-scaled screenshot of the particular screen rectangle
 
  @param quality The number in range 0-2, where 2 (JPG) is the lowest and 0 (PNG) is the highest quality.
- @param rect The bounding rectange for the screenshot. The value should be non-scaled one.
+ @param rect The bounding rectange for the screenshot. The value is expected be non-scaled one.
              CGRectNull could be used to take a screenshot of the full screen.
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return Device screenshot as PNG- or JPG-encoded data or nil in case of failure

--- a/WebDriverAgentLib/Utilities/FBScreenshot.h
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.h
@@ -19,26 +19,27 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)isNewScreenshotAPISupported;
 
 /**
- Retrieves scaled screenshot of the whole screen
+ Retrieves non-scaled screenshot of the whole screen
 
  @param quality The number in range 0-2, where 2 (JPG) is the lowest and 0 (PNG) is the highest quality.
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return Device screenshot as PNG- or JPG-encoded data or nil in case of failure
  */
-+ (nullable NSData *)takeWithQuality:(NSUInteger)quality
-                               error:(NSError **)error;
++ (nullable NSData *)takeInOriginalResolutionWithQuality:(NSUInteger)quality
+                                                   error:(NSError **)error;
 
 /**
- Retrieves scaled screenshot of the particular screen rectangle
+ Retrieves non-scaled screenshot of the particular screen rectangle
 
  @param quality The number in range 0-2, where 2 (JPG) is the lowest and 0 (PNG) is the highest quality.
- @param rect The bounding rectange for the screenshot. CGRectNull could be used to take a screenshot of the full screen
+ @param rect The bounding rectange for the screenshot. The value should be non-scaled one.
+             CGRectNull could be used to take a screenshot of the full screen.
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return Device screenshot as PNG- or JPG-encoded data or nil in case of failure
  */
-+ (nullable NSData *)takeWithQuality:(NSUInteger)quality
-                                rect:(CGRect)rect
-                               error:(NSError **)error;
++ (nullable NSData *)takeInOriginalResolutionWithQuality:(NSUInteger)quality
+                                                    rect:(CGRect)rect
+                                                   error:(NSError **)error;
 
 /**
  Retrieves non-scaled screenshot of the whole screen

--- a/WebDriverAgentLib/Utilities/FBScreenshot.m
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.m
@@ -21,7 +21,7 @@
 #import "XCUIScreen.h"
 
 static const NSTimeInterval SCREENSHOT_TIMEOUT = 20.;
-static const CGFloat SCREENSHOT_SCALE = 1.0;  // Screenshot API should keep the scale
+static const CGFloat SCREENSHOT_SCALE = 1.0;  // Screenshot API should keep the original screen scale
 static const CGFloat HIGH_QUALITY = 0.8;
 static const CGFloat LOW_QUALITY = 0.25;
 

--- a/WebDriverAgentLib/Utilities/FBScreenshot.m
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.m
@@ -72,7 +72,7 @@ NSString *formatTimeInterval(NSTimeInterval interval) {
   if ([self.class isNewScreenshotAPISupported]) {
     XCUIScreen *mainScreen = XCUIScreen.mainScreen;
     return [self.class takeWithScreenID:mainScreen.displayID
-                                  scale:SCREENSHOT_SCALE
+                                  scale:mainScreen.scale  // TODO: Should fix element screenshot
                      compressionQuality:[self.class compressionQualityWithQuality:FBConfiguration.screenshotQuality]
                                    rect:rect
                               sourceUTI:[self.class imageUtiWithQuality:FBConfiguration.screenshotQuality]

--- a/WebDriverAgentLib/Utilities/FBScreenshot.m
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.m
@@ -21,6 +21,7 @@
 #import "XCUIScreen.h"
 
 static const NSTimeInterval SCREENSHOT_TIMEOUT = 20.;
+static const CGFloat SCREENSHOT_SCALE = 1.0;  // Screenshot API should keep the scale
 static const CGFloat HIGH_QUALITY = 0.8;
 static const CGFloat LOW_QUALITY = 0.25;
 
@@ -71,7 +72,7 @@ NSString *formatTimeInterval(NSTimeInterval interval) {
   if ([self.class isNewScreenshotAPISupported]) {
     XCUIScreen *mainScreen = XCUIScreen.mainScreen;
     return [self.class takeWithScreenID:mainScreen.displayID
-                                  scale:1.0 // Screenshot API should keep the scale
+                                  scale:SCREENSHOT_SCALE
                      compressionQuality:[self.class compressionQualityWithQuality:FBConfiguration.screenshotQuality]
                                    rect:rect
                               sourceUTI:[self.class imageUtiWithQuality:FBConfiguration.screenshotQuality]
@@ -90,7 +91,7 @@ NSString *formatTimeInterval(NSTimeInterval interval) {
   if ([self.class isNewScreenshotAPISupported]) {
     XCUIScreen *mainScreen = XCUIScreen.mainScreen;
     return [self.class takeWithScreenID:mainScreen.displayID
-                                  scale:1.0 // Screenshot API should keep the scale
+                                  scale:SCREENSHOT_SCALE
                      compressionQuality:[self.class compressionQualityWithQuality:FBConfiguration.screenshotQuality]
                                    rect:CGRectNull
                               sourceUTI:[self.class imageUtiWithQuality:FBConfiguration.screenshotQuality]

--- a/WebDriverAgentLib/Utilities/FBScreenshot.m
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.m
@@ -71,10 +71,18 @@ NSString *formatTimeInterval(NSTimeInterval interval) {
 {
   if ([self.class isNewScreenshotAPISupported]) {
     XCUIScreen *mainScreen = XCUIScreen.mainScreen;
+
+    // Note to fit to the old spec
+    CGRect newRect = rect;
+    newRect.origin.x = rect.origin.x * mainScreen.scale;
+    newRect.origin.y = rect.origin.y * mainScreen.scale;
+    newRect.size.height = rect.size.height * mainScreen.scale;
+    newRect.size.width = rect.size.width * mainScreen.scale;
+
     return [self.class takeWithScreenID:mainScreen.displayID
-                                  scale:mainScreen.scale  // TODO: Should fix element screenshot
+                                  scale:SCREENSHOT_SCALE
                      compressionQuality:[self.class compressionQualityWithQuality:FBConfiguration.screenshotQuality]
-                                   rect:rect
+                                   rect:newRect
                               sourceUTI:[self.class imageUtiWithQuality:FBConfiguration.screenshotQuality]
                                   error:error];
   }

--- a/WebDriverAgentLib/Utilities/FBScreenshot.m
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.m
@@ -71,18 +71,10 @@ NSString *formatTimeInterval(NSTimeInterval interval) {
 {
   if ([self.class isNewScreenshotAPISupported]) {
     XCUIScreen *mainScreen = XCUIScreen.mainScreen;
-
-    // Note to fit to the old spec
-    CGRect newRect = rect;
-    newRect.origin.x = rect.origin.x * mainScreen.scale;
-    newRect.origin.y = rect.origin.y * mainScreen.scale;
-    newRect.size.height = rect.size.height * mainScreen.scale;
-    newRect.size.width = rect.size.width * mainScreen.scale;
-
     return [self.class takeWithScreenID:mainScreen.displayID
                                   scale:SCREENSHOT_SCALE
                      compressionQuality:[self.class compressionQualityWithQuality:FBConfiguration.screenshotQuality]
-                                   rect:newRect
+                                   rect:rect
                               sourceUTI:[self.class imageUtiWithQuality:FBConfiguration.screenshotQuality]
                                   error:error];
   }

--- a/WebDriverAgentLib/Utilities/FBScreenshot.m
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.m
@@ -65,9 +65,9 @@ NSString *formatTimeInterval(NSTimeInterval interval) {
   }
 }
 
-+ (NSData *)takeWithQuality:(NSUInteger)quality
-                       rect:(CGRect)rect
-                      error:(NSError **)error
++ (NSData *)takeInOriginalResolutionWithQuality:(NSUInteger)quality
+                                           rect:(CGRect)rect
+                                          error:(NSError **)error
 {
   if ([self.class isNewScreenshotAPISupported]) {
     XCUIScreen *mainScreen = XCUIScreen.mainScreen;
@@ -85,8 +85,8 @@ NSString *formatTimeInterval(NSTimeInterval interval) {
   return nil;
 }
 
-+ (NSData *)takeWithQuality:(NSUInteger)quality
-                      error:(NSError **)error
++ (NSData *)takeInOriginalResolutionWithQuality:(NSUInteger)quality
+                                          error:(NSError **)error
 {
   if ([self.class isNewScreenshotAPISupported]) {
     XCUIScreen *mainScreen = XCUIScreen.mainScreen;

--- a/WebDriverAgentLib/Utilities/FBScreenshot.m
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.m
@@ -71,7 +71,7 @@ NSString *formatTimeInterval(NSTimeInterval interval) {
   if ([self.class isNewScreenshotAPISupported]) {
     XCUIScreen *mainScreen = XCUIScreen.mainScreen;
     return [self.class takeWithScreenID:mainScreen.displayID
-                                  scale:mainScreen.scale
+                                  scale:1.0 // Screenshot API should keep the scale
                      compressionQuality:[self.class compressionQualityWithQuality:FBConfiguration.screenshotQuality]
                                    rect:rect
                               sourceUTI:[self.class imageUtiWithQuality:FBConfiguration.screenshotQuality]
@@ -90,7 +90,7 @@ NSString *formatTimeInterval(NSTimeInterval interval) {
   if ([self.class isNewScreenshotAPISupported]) {
     XCUIScreen *mainScreen = XCUIScreen.mainScreen;
     return [self.class takeWithScreenID:mainScreen.displayID
-                                  scale:mainScreen.scale
+                                  scale:1.0 // Screenshot API should keep the scale
                      compressionQuality:[self.class compressionQualityWithQuality:FBConfiguration.screenshotQuality]
                                    rect:CGRectNull
                               sourceUTI:[self.class imageUtiWithQuality:FBConfiguration.screenshotQuality]

--- a/WebDriverAgentTests/IntegrationTests/FBElementScreenshotTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementScreenshotTests.m
@@ -52,8 +52,12 @@
 
   XCUIScreen *mainScreen = XCUIScreen.mainScreen;
   UIImage *buttonScreenshot = button.screenshot.image;
-  XCTAssertEqualWithAccuracy(buttonScreenshot.size.height * mainScreen.scale, image.size.height, FLT_EPSILON);
-  XCTAssertEqualWithAccuracy(buttonScreenshot.size.width * mainScreen.scale, image.size.width, FLT_EPSILON);
+  XCTAssertEqualWithAccuracy(buttonScreenshot.size.height * mainScreen.scale,
+                             image.size.height,
+                             FLT_EPSILON);
+  XCTAssertEqualWithAccuracy(buttonScreenshot.size.width * mainScreen.scale,
+                             image.size.width,
+                             FLT_EPSILON);
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/FBElementScreenshotTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementScreenshotTests.m
@@ -52,8 +52,8 @@
 
   XCUIScreen *mainScreen = XCUIScreen.mainScreen;
   UIImage *buttonScreenshot = button.screenshot.image;
-  XCTAssertEqualWithAccuracy(buttonScreenshot.size.height * mainScreen.scale, image.size.height, .0);
-  XCTAssertEqualWithAccuracy(buttonScreenshot.size.width * mainScreen.scale, image.size.width, .0);
+  XCTAssertEqualWithAccuracy(buttonScreenshot.size.height * mainScreen.scale, image.size.height, FLT_EPSILON);
+  XCTAssertEqualWithAccuracy(buttonScreenshot.size.width * mainScreen.scale, image.size.width, FLT_EPSILON);
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/FBElementScreenshotTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementScreenshotTests.m
@@ -52,8 +52,8 @@
 
   XCUIScreen *mainScreen = XCUIScreen.mainScreen;
   UIImage *buttonScreenshot = button.screenshot.image;
-  XCTAssertEqual(buttonScreenshot.size.height * mainScreen.scale, image.size.height);
-  XCTAssertEqual(buttonScreenshot.size.width * mainScreen.scale, image.size.width);
+  XCTAssertEqualWithAccuracy(buttonScreenshot.size.height * mainScreen.scale, image.size.height, .0);
+  XCTAssertEqualWithAccuracy(buttonScreenshot.size.width * mainScreen.scale, image.size.width, .0);
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/FBElementScreenshotTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementScreenshotTests.m
@@ -12,6 +12,7 @@
 #import "FBIntegrationTestCase.h"
 #import "XCUIDevice+FBRotation.h"
 #import "XCUIElement+FBUtilities.h"
+#import "XCUIScreen.h"
 
 @interface FBElementScreenshotTests : FBIntegrationTestCase
 @end
@@ -48,6 +49,11 @@
   UIImage *image = [UIImage imageWithData:screenshotData];
   XCTAssertNotNil(image);
   XCTAssertTrue(image.size.width > image.size.height);
+
+  XCUIScreen *mainScreen = XCUIScreen.mainScreen;
+  UIImage *buttonScreenshot = button.screenshot.image;
+  XCTAssertEqual(buttonScreenshot.size.height * mainScreen.scale, image.size.height);
+  XCTAssertEqual(buttonScreenshot.size.width * mainScreen.scale, image.size.width);
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
@@ -41,6 +41,8 @@
   XCTAssertTrue(FBIsPngImage(screenshotData));
 
   UIImage *screenshot = [UIImage imageWithData:screenshotData];
+  XCTAssertNotNil(screenshot);
+
   XCUIScreen *mainScreen = XCUIScreen.mainScreen;
   UIImage *screenshotExact = ((XCUIScreenshot *)mainScreen.screenshot).image;
   XCTAssertEqual(screenshotExact.size.height * mainScreen.scale, screenshot.size.height);
@@ -55,6 +57,7 @@
   XCTAssertNotNil(screenshotData);
   XCTAssertTrue(FBIsPngImage(screenshotData));
   XCTAssertNil(error);
+
   UIImage *screenshot = [UIImage imageWithData:screenshotData];
   XCTAssertNotNil(screenshot);
   XCTAssertTrue(screenshot.size.width > screenshot.size.height);

--- a/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
@@ -16,6 +16,7 @@
 #import "FBTestMacros.h"
 #import "XCUIDevice+FBHelpers.h"
 #import "XCUIDevice+FBRotation.h"
+#import "XCUIScreen.h"
 
 @interface XCUIDeviceHelperTests : FBIntegrationTestCase
 @end
@@ -35,9 +36,15 @@
 {
   NSError *error = nil;
   NSData *screenshotData = [[XCUIDevice sharedDevice] fb_screenshotWithError:&error];
-  XCTAssertNotNil([UIImage imageWithData:screenshotData]);
+  XCTAssertNotNil(screenshotData);
   XCTAssertNil(error);
   XCTAssertTrue(FBIsPngImage(screenshotData));
+
+  UIImage *screenshot = [UIImage imageWithData:screenshotData];
+  XCUIScreen *mainScreen = XCUIScreen.mainScreen;
+  UIImage *screenshotExact = ((XCUIScreenshot *)mainScreen.screenshot).image;
+  XCTAssertEqual(screenshotExact.size.height * mainScreen.scale, screenshot.size.height);
+  XCTAssertEqual(screenshotExact.size.width * mainScreen.scale, screenshot.size.width);
 }
 
 - (void)testLandscapeScreenshot
@@ -48,9 +55,14 @@
   XCTAssertNotNil(screenshotData);
   XCTAssertTrue(FBIsPngImage(screenshotData));
   XCTAssertNil(error);
-  UIImage *image = [UIImage imageWithData:screenshotData];
-  XCTAssertNotNil(image);
-  XCTAssertTrue(image.size.width > image.size.height);
+  UIImage *screenshot = [UIImage imageWithData:screenshotData];
+  XCTAssertNotNil(screenshot);
+  XCTAssertTrue(screenshot.size.width > screenshot.size.height);
+
+  XCUIScreen *mainScreen = XCUIScreen.mainScreen;
+  UIImage *screenshotExact = ((XCUIScreenshot *)mainScreen.screenshot).image;
+  XCTAssertEqual(screenshotExact.size.height * mainScreen.scale, screenshot.size.height);
+  XCTAssertEqual(screenshotExact.size.width * mainScreen.scale, screenshot.size.width);
 }
 
 - (void)testWifiAddress

--- a/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
@@ -45,8 +45,8 @@
 
   XCUIScreen *mainScreen = XCUIScreen.mainScreen;
   UIImage *screenshotExact = ((XCUIScreenshot *)mainScreen.screenshot).image;
-  XCTAssertEqual(screenshotExact.size.height * mainScreen.scale, screenshot.size.height);
-  XCTAssertEqual(screenshotExact.size.width * mainScreen.scale, screenshot.size.width);
+  XCTAssertEqualWithAccuracy(screenshotExact.size.height * mainScreen.scale, screenshot.size.height, .0);
+  XCTAssertEqualWithAccuracy(screenshotExact.size.width * mainScreen.scale, screenshot.size.width, .0);
 }
 
 - (void)testLandscapeScreenshot
@@ -64,8 +64,8 @@
 
   XCUIScreen *mainScreen = XCUIScreen.mainScreen;
   UIImage *screenshotExact = ((XCUIScreenshot *)mainScreen.screenshot).image;
-  XCTAssertEqual(screenshotExact.size.height * mainScreen.scale, screenshot.size.height);
-  XCTAssertEqual(screenshotExact.size.width * mainScreen.scale, screenshot.size.width);
+  XCTAssertEqualWithAccuracy(screenshotExact.size.height * mainScreen.scale, screenshot.size.height, .0);
+  XCTAssertEqualWithAccuracy(screenshotExact.size.width * mainScreen.scale, screenshot.size.width, .0);
 }
 
 - (void)testWifiAddress

--- a/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
@@ -34,6 +34,7 @@
 
 - (void)testScreenshot
 {
+  [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:UIDeviceOrientationPortrait];
   NSError *error = nil;
   NSData *screenshotData = [[XCUIDevice sharedDevice] fb_screenshotWithError:&error];
   XCTAssertNotNil(screenshotData);

--- a/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
@@ -45,8 +45,8 @@
 
   XCUIScreen *mainScreen = XCUIScreen.mainScreen;
   UIImage *screenshotExact = ((XCUIScreenshot *)mainScreen.screenshot).image;
-  XCTAssertEqualWithAccuracy(screenshotExact.size.height * mainScreen.scale, screenshot.size.height, .0);
-  XCTAssertEqualWithAccuracy(screenshotExact.size.width * mainScreen.scale, screenshot.size.width, .0);
+  XCTAssertEqualWithAccuracy(screenshotExact.size.height * mainScreen.scale, screenshot.size.height, FLT_EPSILON);
+  XCTAssertEqualWithAccuracy(screenshotExact.size.width * mainScreen.scale, screenshot.size.width, FLT_EPSILON);
 }
 
 - (void)testLandscapeScreenshot
@@ -64,8 +64,8 @@
 
   XCUIScreen *mainScreen = XCUIScreen.mainScreen;
   UIImage *screenshotExact = ((XCUIScreenshot *)mainScreen.screenshot).image;
-  XCTAssertEqualWithAccuracy(screenshotExact.size.height * mainScreen.scale, screenshot.size.height, .0);
-  XCTAssertEqualWithAccuracy(screenshotExact.size.width * mainScreen.scale, screenshot.size.width, .0);
+  XCTAssertEqualWithAccuracy(screenshotExact.size.height * mainScreen.scale, screenshot.size.height, FLT_EPSILON);
+  XCTAssertEqualWithAccuracy(screenshotExact.size.width * mainScreen.scale, screenshot.size.width, FLT_EPSILON);
 }
 
 - (void)testWifiAddress

--- a/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
@@ -45,8 +45,12 @@
 
   XCUIScreen *mainScreen = XCUIScreen.mainScreen;
   UIImage *screenshotExact = ((XCUIScreenshot *)mainScreen.screenshot).image;
-  XCTAssertEqualWithAccuracy(screenshotExact.size.height * mainScreen.scale, screenshot.size.height, FLT_EPSILON);
-  XCTAssertEqualWithAccuracy(screenshotExact.size.width * mainScreen.scale, screenshot.size.width, FLT_EPSILON);
+  XCTAssertEqualWithAccuracy(screenshotExact.size.height * mainScreen.scale,
+                             screenshot.size.height,
+                             FLT_EPSILON);
+  XCTAssertEqualWithAccuracy(screenshotExact.size.width * mainScreen.scale,
+                             screenshot.size.width,
+                             FLT_EPSILON);
 }
 
 - (void)testLandscapeScreenshot
@@ -64,8 +68,12 @@
 
   XCUIScreen *mainScreen = XCUIScreen.mainScreen;
   UIImage *screenshotExact = ((XCUIScreenshot *)mainScreen.screenshot).image;
-  XCTAssertEqualWithAccuracy(screenshotExact.size.height * mainScreen.scale, screenshot.size.height, FLT_EPSILON);
-  XCTAssertEqualWithAccuracy(screenshotExact.size.width * mainScreen.scale, screenshot.size.width, FLT_EPSILON);
+  XCTAssertEqualWithAccuracy(screenshotExact.size.height * mainScreen.scale,
+                             screenshot.size.height,
+                             FLT_EPSILON);
+  XCTAssertEqualWithAccuracy(screenshotExact.size.width * mainScreen.scale,
+                             screenshot.size.width,
+                             FLT_EPSILON);
 }
 
 - (void)testWifiAddress


### PR DESCRIPTION
https://github.com/appium/WebDriverAgent/issues/487

Screenshot API should keep the original scale since we do not provide capabilities to scale the width/height. The compression can be changed.
(Only MJPEG can change the scale for now)