### PR TITLE
feat: Add duration in fb_pressButton for tvOS

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
@@ -75,15 +75,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)fb_openUrl:(NSString *)url error:(NSError **)error;
 
 /**
- Presses the corresponding hardware button on the device
+ Presses the corresponding hardware button on the device with duration.
 
  @param buttonName One of the supported button names: volumeUp (real devices only), volumeDown (real device only), home
+ @param duration Duration in seconds
  @return YES if the button has been pressed
  */
-- (BOOL)fb_pressButton:(NSString *)buttonName error:(NSError **)error;
-
-
-- (BOOL)fb_pressButton:(NSString *)buttonName forDuration:(int)duration error:(NSError **)error;
+- (BOOL)fb_pressButton:(NSString *)buttonName forDuration:(NSTimeInterval)duration error:(NSError **)error;
 
 
 /**

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
@@ -82,6 +82,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)fb_pressButton:(NSString *)buttonName error:(NSError **)error;
 
+
+- (BOOL)fb_pressButton:(NSString *)buttonName forDuration:(int)duration error:(NSError **)error;
+
+
 /**
  Activates Siri service voice recognition with the given text to parse
 

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
  Presses the corresponding hardware button on the device with duration.
 
  @param buttonName One of the supported button names: volumeUp (real devices only), volumeDown (real device only), home
- @param duration Duration in seconds
+ @param duration Duration in seconds. This argument works only on tvOS. On iOS, this value will be ignored.
  @return YES if the button has been pressed
  */
 - (BOOL)fb_pressButton:(NSString *)buttonName forDuration:(NSTimeInterval)duration error:(NSError **)error;

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -254,18 +254,19 @@ static bool fb_isLocked;
             buildError:error];
   }
 
-  if (duration < 0) {
-    [[XCUIRemote sharedRemote] pressButton:remoteButton];
-  } else {
+  (duration < 0)
+    // https://developer.apple.com/documentation/xctest/xcuiremote/1627476-pressbutton
+    ? [[XCUIRemote sharedRemote] pressButton:remoteButton]
     // https://developer.apple.com/documentation/xctest/xcuiremote/1627475-pressbutton
-    [[XCUIRemote sharedRemote] pressButton:remoteButton forDuration:duration];
-  }
+    : [[XCUIRemote sharedRemote] pressButton:remoteButton forDuration:duration];
+
   return YES;
 #endif
 }
 
 #if !TARGET_OS_TV
-- (BOOL)fb_pressButton:(NSString *)buttonName error:(NSError **)error
+- (BOOL)fb_pressButton:(NSString *)buttonName
+                 error:(NSError **)error
 {
   NSMutableArray<NSString *> *supportedButtonNames = [NSMutableArray array];
   XCUIDeviceButton dstButton = 0;

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -249,7 +249,12 @@ static bool fb_isLocked;
              withDescriptionFormat:@"The button '%@' is unknown. Only the following button names are supported: %@", buttonName, supportedButtonNames]
             buildError:error];
   }
+
   [[XCUIRemote sharedRemote] pressButton:remoteButton];
+
+  // TODO: this is only for tvOS
+  // https://developer.apple.com/documentation/xctest/xcuiremote/1627475-pressbutton
+  [[XCUIRemote sharedRemote] pressButton:remoteButton forDuration:10];
   return YES;
 }
 #else

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -190,9 +190,13 @@ static bool fb_isLocked;
   }
 }
 
-#if TARGET_OS_TV
-- (BOOL)fb_pressButton:(NSString *)buttonName error:(NSError **)error
+- (BOOL)fb_pressButton:(NSString *)buttonName
+           forDuration:(NSTimeInterval)duration
+                 error:(NSError **)error
 {
+#if !TARGET_OS_TV
+  return [self fb_pressButton:buttonName error:error];
+#else
   NSMutableArray<NSString *> *supportedButtonNames = [NSMutableArray array];
   NSInteger remoteButton = -1; // no remote button
   if ([buttonName.lowercaseString isEqualToString:@"home"]) {
@@ -250,15 +254,17 @@ static bool fb_isLocked;
             buildError:error];
   }
 
-  [[XCUIRemote sharedRemote] pressButton:remoteButton];
-
-  // TODO: this is only for tvOS
-  // https://developer.apple.com/documentation/xctest/xcuiremote/1627475-pressbutton
-  [[XCUIRemote sharedRemote] pressButton:remoteButton forDuration:10];
+  if (duration < 0) {
+    [[XCUIRemote sharedRemote] pressButton:remoteButton];
+  } else {
+    // https://developer.apple.com/documentation/xctest/xcuiremote/1627475-pressbutton
+    [[XCUIRemote sharedRemote] pressButton:remoteButton forDuration:duration];
+  }
   return YES;
+#endif
 }
-#else
 
+#if !TARGET_OS_TV
 - (BOOL)fb_pressButton:(NSString *)buttonName error:(NSError **)error
 {
   NSMutableArray<NSString *> *supportedButtonNames = [NSMutableArray array];

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -243,8 +243,11 @@
 + (id<FBResponsePayload>)handlePressButtonCommand:(FBRouteRequest *)request
 {
   NSError *error;
-  // TODO: add duration attribute
-  if (![XCUIDevice.sharedDevice fb_pressButton:(id)request.arguments[@"name"] error:&error]) {
+  NSNumber *requestedDuration = request.arguments[@"duration"];
+  NSTimeInterval duration = (requestedDuration ? requestedDuration.doubleValue : -1);
+  if (![XCUIDevice.sharedDevice fb_pressButton:(id)request.arguments[@"name"]
+                                   forDuration:duration
+                                         error:&error]) {
     return FBResponseWithUnknownError(error);
   }
   return FBResponseWithOK();

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -243,6 +243,7 @@
 + (id<FBResponsePayload>)handlePressButtonCommand:(FBRouteRequest *)request
 {
   NSError *error;
+  // TODO: add duration attribute
   if (![XCUIDevice.sharedDevice fb_pressButton:(id)request.arguments[@"name"] error:&error]) {
     return FBResponseWithUnknownError(error);
   }

--- a/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
@@ -119,14 +119,14 @@
 - (void)testPressingUnsupportedButton
 {
   NSError *error;
-  XCTAssertFalse([XCUIDevice.sharedDevice fb_pressButton:@"volumeUpp" error:&error]);
+  XCTAssertFalse([XCUIDevice.sharedDevice fb_pressButton:@"volumeUpp" forDuration:0 error:&error]);
   XCTAssertNotNil(error);
 }
 
 - (void)testPressingSupportedButton
 {
   NSError *error;
-  XCTAssertTrue([XCUIDevice.sharedDevice fb_pressButton:@"home" error:&error]);
+  XCTAssertTrue([XCUIDevice.sharedDevice fb_pressButton:@"home" forDuration:0 error:&error]);
   XCTAssertNil(error);
 }
 


### PR DESCRIPTION
Then, WDA can call https://developer.apple.com/documentation/xctest/xcuiremote/1627475-pressbutton
The duration works only on tvOS.

I considered creating a new method, `(BOOL)fb_pressButton:(NSString *)buttonName forDuration:(NSTimeInterval)duration error:(NSError **)error`, instead of extending it like this PR. But I thought handling iOS/tvOS behind one method made more sense in this case.