### PR TITLE
chore: expose build-webdriveragent script

### DIFF
--- a/Scripts/build-webdriveragent.js
+++ b/Scripts/build-webdriveragent.js
@@ -6,7 +6,7 @@ const { exec } = require('teen_process');
 const xcode = require('appium-xcode');
 
 const log = new logger.getLogger('WDABuild');
-const rootDir = path.resolve(__dirname, '..', '..');
+const rootDir = path.resolve(__dirname, '..');
 
 async function buildWebDriverAgent (xcodeVersion) {
   // Get Xcode version

--- a/docs/CREATING_BUNDLES.md
+++ b/docs/CREATING_BUNDLES.md
@@ -10,6 +10,6 @@ The bundle can be run manually as well, but the GitHub release will not be creat
 
 Building a WebDriverAgent bundle locally is useful if Azure pipelines doesn't build one of the Xcode bundles that we want.
 
-* Run `node ./ci-jobs/scripts/build-webdriveragent.js` 
+* Run `node ./Scripts/build-webdriveragent.js` 
 * This will build a single bundle to `prebuilt-agents`
 * The bundle will be built using the Xcode version installed locally

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:fix": "gulp eslint --fix",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "precommit-test": "gulp lint",
-    "bundle": "node ./ci-jobs/scripts/build-webdriveragent.js",
+    "bundle": "node ./Scripts/build-webdriveragent.js",
     "fetch-prebuilt-wda": "node ./Scripts/fetch-prebuilt-wda"
   },
   "bin": {
@@ -78,6 +78,7 @@
     "build/lib",
     "Scripts/build.sh",
     "Scripts/fetch-prebuilt-wda.js",
+    "Scripts/build-webdriveragent.js",
     "Cartfile",
     "Cartfile.resolved",
     "Configurations",
@@ -87,7 +88,6 @@
     "WebDriverAgentRunner",
     "WebDriverAgentTests",
     "XCTWebDriverAgentLib",
-    "WebDriverAgentRunner-Runner.app.zip",
-    "ci-jobs/scripts/build-webdriveragent.js"
+    "WebDriverAgentRunner-Runner.app.zip"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "WebDriverAgentRunner",
     "WebDriverAgentTests",
     "XCTWebDriverAgentLib",
-    "WebDriverAgentRunner-Runner.app.zip"
+    "WebDriverAgentRunner-Runner.app.zip",
+    "ci-jobs/scripts/build-webdriveragent.js"
   ]
 }


### PR DESCRIPTION
added "ci-jobs/scripts/build-webdriveragent.js" file to "files" field in package.json inorder to expose the build-webdriveragent script for the xcuitest driver to execute by calling "./node_modules/appium-webdriveragent/ci-jobs/scripts/build-webdriveragent.js"