### PR TITLE
ci: fix a ci script

### DIFF
--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -25,7 +25,7 @@ jobs:
       displayName: Install Ruby dependencies
     - script: mkdir -p Resources/WebDriverAgent.bundle
       displayName: Make Resources Folder
-    - script: node ./ci-jobs/scripts/build-webdriveragents.js
+    - script: node ./Scripts/build-webdriveragents.js
       displayName: Build WebDriverAgents
     - script: ls ./bundles
       displayName: List WDA Bundles


### PR DESCRIPTION
After https://github.com/appium/WebDriverAgent/pull/501

```
Error: Cannot find module './build-webdriveragent'
Require stack:
- /Users/runner/work/1/s/ci-jobs/scripts/build-webdriveragents.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)
    at Function.Module._load (internal/modules/cjs/loader.js:667:27)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/Users/runner/work/1/s/ci-jobs/scripts/build-webdriveragents.js:1:29)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/Users/runner/work/1/s/ci-jobs/scripts/build-webdriveragents.js' ]
}
```

https://dev.azure.com/AppiumCI/Appium%20CI/_build/results?buildId=15211&view=logs&j=41c89b73-5f8a-5ac1-e763-5d413837a9db&t=6747af84-484e-5213-42f3-edd16a8a2b96