### PR TITLE
chore: Optimize interaction with apps

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -346,6 +346,10 @@
 		71414EDA2670A1EE003A8C5D /* LRUCacheNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 71414ED32670A1ED003A8C5D /* LRUCacheNode.m */; };
 		71414EDB2670A1EE003A8C5D /* LRUCacheNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 71414ED32670A1ED003A8C5D /* LRUCacheNode.m */; };
 		714801D11FA9D9FA00DC5997 /* FBSDKVersionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 714801D01FA9D9FA00DC5997 /* FBSDKVersionTests.m */; };
+		714EAA0D2673FDFE005C5B47 /* FBCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 714EAA0B2673FDFE005C5B47 /* FBCapabilities.h */; };
+		714EAA0E2673FDFE005C5B47 /* FBCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 714EAA0B2673FDFE005C5B47 /* FBCapabilities.h */; };
+		714EAA0F2673FDFE005C5B47 /* FBCapabilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 714EAA0C2673FDFE005C5B47 /* FBCapabilities.m */; };
+		714EAA102673FDFE005C5B47 /* FBCapabilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 714EAA0C2673FDFE005C5B47 /* FBCapabilities.m */; };
 		7150348721A6DAD600A0F4BA /* FBImageUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 7150348521A6DAD600A0F4BA /* FBImageUtils.h */; };
 		7150348821A6DAD600A0F4BA /* FBImageUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 7150348621A6DAD600A0F4BA /* FBImageUtils.m */; };
 		7150FFF722476B3A00B2EE28 /* FBForceTouchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EE8DDD7A20C57320004D4925 /* FBForceTouchTests.m */; };
@@ -956,6 +960,8 @@
 		71414ED32670A1ED003A8C5D /* LRUCacheNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LRUCacheNode.m; sourceTree = "<group>"; };
 		714801D01FA9D9FA00DC5997 /* FBSDKVersionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKVersionTests.m; sourceTree = "<group>"; };
 		714CA3C61DC23186000F12C9 /* FBXPathIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPathIntegrationTests.m; sourceTree = "<group>"; };
+		714EAA0B2673FDFE005C5B47 /* FBCapabilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBCapabilities.h; sourceTree = "<group>"; };
+		714EAA0C2673FDFE005C5B47 /* FBCapabilities.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBCapabilities.m; sourceTree = "<group>"; };
 		7150348521A6DAD600A0F4BA /* FBImageUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBImageUtils.h; sourceTree = "<group>"; };
 		7150348621A6DAD600A0F4BA /* FBImageUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBImageUtils.m; sourceTree = "<group>"; };
 		7152EB2F1F41F9960047EEFF /* FBSessionIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSessionIntegrationTests.m; sourceTree = "<group>"; };
@@ -1850,6 +1856,8 @@
 				71241D771FAE31F100B9559F /* FBAppiumActionsSynthesizer.m */,
 				714097411FAE1B0B008FB2C5 /* FBBaseActionsSynthesizer.h */,
 				7140974D1FAE20EE008FB2C5 /* FBBaseActionsSynthesizer.m */,
+				714EAA0B2673FDFE005C5B47 /* FBCapabilities.h */,
+				714EAA0C2673FDFE005C5B47 /* FBCapabilities.m */,
 				71A7EAF71E224648001DA4F2 /* FBClassChainQueryParser.h */,
 				71A7EAF81E224648001DA4F2 /* FBClassChainQueryParser.m */,
 				EE9B76A11CF7A43900275851 /* FBConfiguration.h */,
@@ -2389,6 +2397,7 @@
 				71E75E6E254824230099FC87 /* XCUIElementQuery+FBHelpers.h in Headers */,
 				641EE6C02240C5CA00173FCB /* XCUIApplication+FBHelpers.h in Headers */,
 				641EE6C12240C5CA00173FCB /* _XCTestObservationCenterImplementation.h in Headers */,
+				714EAA0E2673FDFE005C5B47 /* FBCapabilities.h in Headers */,
 				641EE6C22240C5CA00173FCB /* XCUIDevice+FBHelpers.h in Headers */,
 				641EE6C32240C5CA00173FCB /* FBClassChainQueryParser.h in Headers */,
 				641EE6C42240C5CA00173FCB /* FBMacros.h in Headers */,
@@ -2534,6 +2543,7 @@
 				EE158ABC1CBD456F00A3E3F0 /* FBDebugCommands.h in Headers */,
 				EE35AD561E3B77D600A02D78 /* XCTestSuite.h in Headers */,
 				EE35AD6D1E3B77D600A02D78 /* XCUICoordinate.h in Headers */,
+				714EAA0D2673FDFE005C5B47 /* FBCapabilities.h in Headers */,
 				EE35AD5C1E3B77D600A02D78 /* XCTNSPredicateExpectation.h in Headers */,
 				EE35AD521E3B77D600A02D78 /* XCTestObservationCenter.h in Headers */,
 				EE35AD5B1E3B77D600A02D78 /* XCTNSNotificationExpectation.h in Headers */,
@@ -3098,6 +3108,7 @@
 				641EE5FF2240C5CA00173FCB /* XCUIElement+FBForceTouch.m in Sources */,
 				641EE6002240C5CA00173FCB /* FBTouchActionCommands.m in Sources */,
 				719DCF182601EAFB000E765F /* FBNotificationsHelper.m in Sources */,
+				714EAA102673FDFE005C5B47 /* FBCapabilities.m in Sources */,
 				641EE6012240C5CA00173FCB /* FBImageIOScaler.m in Sources */,
 				641EE6022240C5CA00173FCB /* FBTouchIDCommands.m in Sources */,
 				641EE6032240C5CA00173FCB /* FBDebugCommands.m in Sources */,
@@ -3202,6 +3213,7 @@
 				71B49EC81ED1A58100D51AD6 /* XCUIElement+FBUID.m in Sources */,
 				EE158AE21CBD456F00A3E3F0 /* FBRouteRequest.m in Sources */,
 				EE158ADB1CBD456F00A3E3F0 /* FBResponseJSONPayload.m in Sources */,
+				714EAA0F2673FDFE005C5B47 /* FBCapabilities.m in Sources */,
 				EE7E271F1D06C69F001BEC7B /* FBXCTestCaseImplementationFailureHoldingProxy.m in Sources */,
 				7155D704211DCEF400166C20 /* FBMjpegServer.m in Sources */,
 				EEDFE1221D9C06F800E6FFE5 /* XCUIDevice+FBHealthCheck.m in Sources */,

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -10,6 +10,7 @@
 #import "FBSessionCommands.h"
 
 #import "FBApplication.h"
+#import "FBCapabilities.h"
 #import "FBConfiguration.h"
 #import "FBLogger.h"
 #import "FBProtocolHelpers.h"
@@ -74,68 +75,76 @@
 
 + (id<FBResponsePayload>)handleCreateSession:(FBRouteRequest *)request
 {
-  NSDictionary<NSString *, id> *requirements;
+  NSDictionary<NSString *, id> *capabilities;
   NSError *error;
   if (![request.arguments[@"capabilities"] isKindOfClass:NSDictionary.class]) {
     return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:@"'capabilities' is mandatory to create a new session"
                                                               traceback:nil]);
   }
-  if (nil == (requirements = FBParseCapabilities((NSDictionary *)request.arguments[@"capabilities"], &error))) {
+  if (nil == (capabilities = FBParseCapabilities((NSDictionary *)request.arguments[@"capabilities"], &error))) {
     return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:error.description traceback:nil]);
   }
-  [FBConfiguration setShouldUseTestManagerForVisibilityDetection:[requirements[@"shouldUseTestManagerForVisibilityDetection"] boolValue]];
-  if (requirements[USE_COMPACT_RESPONSES]) {
-    [FBConfiguration setShouldUseCompactResponses:[requirements[USE_COMPACT_RESPONSES] boolValue]];
+  [FBConfiguration setShouldUseTestManagerForVisibilityDetection:[capabilities[FB_CAP_USE_TEST_MANAGER_FOR_VISIBLITY_DETECTION] boolValue]];
+  if (capabilities[USE_COMPACT_RESPONSES]) {
+    [FBConfiguration setShouldUseCompactResponses:[capabilities[USE_COMPACT_RESPONSES] boolValue]];
   }
-  NSString *elementResponseAttributes = requirements[ELEMENT_RESPONSE_ATTRIBUTES];
+  NSString *elementResponseAttributes = capabilities[ELEMENT_RESPONSE_ATTRIBUTES];
   if (elementResponseAttributes) {
     [FBConfiguration setElementResponseAttributes:elementResponseAttributes];
   }
-  if (requirements[@"maxTypingFrequency"]) {
-    [FBConfiguration setMaxTypingFrequency:[requirements[@"maxTypingFrequency"] unsignedIntegerValue]];
+  if (capabilities[FB_CAP_MAX_TYPING_FREQUNCY]) {
+    [FBConfiguration setMaxTypingFrequency:[capabilities[FB_CAP_MAX_TYPING_FREQUNCY] unsignedIntegerValue]];
   }
-  if (requirements[@"shouldUseSingletonTestManager"]) {
-    [FBConfiguration setShouldUseSingletonTestManager:[requirements[@"shouldUseSingletonTestManager"] boolValue]];
+  if (capabilities[FB_CAP_USE_SINGLETON_TEST_MANAGER]) {
+    [FBConfiguration setShouldUseSingletonTestManager:[capabilities[FB_CAP_USE_SINGLETON_TEST_MANAGER] boolValue]];
   }
-  if (requirements[@"disableAutomaticScreenshots"]) {
-    if ([requirements[@"disableAutomaticScreenshots"] boolValue]) {
+  if (capabilities[FB_CAP_DISABLE_AUTOMATIC_SCREENSHOTS]) {
+    if ([capabilities[FB_CAP_DISABLE_AUTOMATIC_SCREENSHOTS] boolValue]) {
       [FBConfiguration disableScreenshots];
     } else {
       [FBConfiguration enableScreenshots];
     }
   }
-  if (requirements[@"shouldTerminateApp"]) {
-    [FBConfiguration setShouldTerminateApp:[requirements[@"shouldTerminateApp"] boolValue]];
+  if (capabilities[FB_CAP_SHOULD_TERMINATE_APP]) {
+    [FBConfiguration setShouldTerminateApp:[capabilities[FB_CAP_SHOULD_TERMINATE_APP] boolValue]];
   }
-  NSNumber *delay = requirements[@"eventloopIdleDelaySec"];
+  NSNumber *delay = capabilities[FB_CAP_EVENT_LOOP_IDLE_DELAY_SEC];
   if ([delay doubleValue] > 0.0) {
     [XCUIApplicationProcessDelay setEventLoopHasIdledDelay:[delay doubleValue]];
   } else {
     [XCUIApplicationProcessDelay disableEventLoopDelay];
   }
 
-  if (nil != requirements[WAIT_FOR_IDLE_TIMEOUT]) {
-    FBConfiguration.waitForIdleTimeout = [requirements[WAIT_FOR_IDLE_TIMEOUT] doubleValue];
+  if (nil != capabilities[WAIT_FOR_IDLE_TIMEOUT]) {
+    FBConfiguration.waitForIdleTimeout = [capabilities[WAIT_FOR_IDLE_TIMEOUT] doubleValue];
   }
 
-  NSString *bundleID = requirements[@"bundleId"];
+  NSString *bundleID = capabilities[FB_CAP_BUNDLE_ID];
   FBApplication *app = nil;
   if (bundleID != nil) {
-    app = [[FBApplication alloc] initPrivateWithPath:requirements[@"app"]
-                                            bundleID:bundleID];
-    app.fb_shouldWaitForQuiescence = nil == requirements[@"shouldWaitForQuiescence"]
-                                             || [requirements[@"shouldWaitForQuiescence"] boolValue];
-    app.launchArguments = (NSArray<NSString *> *)requirements[@"arguments"] ?: @[];
-    app.launchEnvironment = (NSDictionary <NSString *, NSString *> *)requirements[@"environment"] ?: @{};
-    [app launch];
-    if (app.processID == 0) {
-      return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:[NSString stringWithFormat:@"Failed to launch %@ application", bundleID] traceback:nil]);
+    app = [[FBApplication alloc] initPrivateWithPath:nil bundleID:bundleID];
+    BOOL shouldRestartApp = YES;
+    if (nil != capabilities[FB_CAP_FORCE_APP_LAUNCH]) {
+      shouldRestartApp = [capabilities[FB_CAP_FORCE_APP_LAUNCH] boolValue];
+    }
+    BOOL isAppRunning = [app running];
+    if (!isAppRunning || (isAppRunning && shouldRestartApp)) {
+      app.fb_shouldWaitForQuiescence = nil == capabilities[FB_CAP_SHOULD_WAIT_FOR_QUIESCENCE]
+        || [capabilities[FB_CAP_SHOULD_WAIT_FOR_QUIESCENCE] boolValue];
+      app.launchArguments = (NSArray<NSString *> *)capabilities[FB_CAP_ARGUMENTS] ?: @[];
+      app.launchEnvironment = (NSDictionary <NSString *, NSString *> *)capabilities[FB_CAP_ENVIRNOMENT] ?: @{};
+      [app launch];
+      if (![app running]) {
+        NSString *errorMsg = [NSString stringWithFormat:@"Cannot launch %@ application. Make sure the correct bundle identifier has been provided in capabilities and check the device log for possible crash report occurrences", bundleID];
+        return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:errorMsg
+                                                                  traceback:nil]);
+      }
     }
   }
 
-  if (requirements[DEFAULT_ALERT_ACTION]) {
+  if (capabilities[DEFAULT_ALERT_ACTION]) {
     [FBSession initWithApplication:app
-                defaultAlertAction:(id)requirements[DEFAULT_ALERT_ACTION]];
+                defaultAlertAction:(id)capabilities[DEFAULT_ALERT_ACTION]];
   } else {
     [FBSession initWithApplication:app];
   }

--- a/WebDriverAgentLib/FBApplication.m
+++ b/WebDriverAgentLib/FBApplication.m
@@ -32,8 +32,6 @@ static const NSTimeInterval APP_STATE_CHANGE_TIMEOUT = 5.0;
 
 @implementation FBApplication
 
-static FBApplication *_systemApplication = nil;
-
 + (instancetype)fb_activeApplication
 {
   return [self fb_activeApplicationWithDefaultBundleId:nil];
@@ -131,11 +129,8 @@ static FBApplication *_systemApplication = nil;
 
 + (instancetype)fb_systemApplication
 {
-  int currentSystemAppPid = [FBXCAXClientProxy.sharedClient systemApplication].processIdentifier;
-  if (nil == _systemApplication || currentSystemAppPid != _systemApplication.processID) {
-    _systemApplication = [self fb_applicationWithPID:currentSystemAppPid];
-  }
-  return _systemApplication;
+  return [self fb_applicationWithPID:
+   [[FBXCAXClientProxy.sharedClient systemApplication] processIdentifier]];
 }
 
 + (instancetype)appWithPID:(pid_t)processID
@@ -154,7 +149,7 @@ static FBApplication *_systemApplication = nil;
   if ([FBXCAXClientProxy.sharedClient hasProcessTracker]) {
     return (FBApplication *)[FBXCAXClientProxy.sharedClient monitoredApplicationWithProcessIdentifier:processID];
   }
-  return  [super applicationWithPID:processID];
+  return [super applicationWithPID:processID];
 }
 
 - (void)launch

--- a/WebDriverAgentLib/FBApplication.m
+++ b/WebDriverAgentLib/FBApplication.m
@@ -32,6 +32,8 @@ static const NSTimeInterval APP_STATE_CHANGE_TIMEOUT = 5.0;
 
 @implementation FBApplication
 
+static FBApplication *_systemApplication = nil;
+
 + (instancetype)fb_activeApplication
 {
   return [self fb_activeApplicationWithDefaultBundleId:nil];
@@ -129,8 +131,11 @@ static const NSTimeInterval APP_STATE_CHANGE_TIMEOUT = 5.0;
 
 + (instancetype)fb_systemApplication
 {
-  return [self fb_applicationWithPID:
-   [[FBXCAXClientProxy.sharedClient systemApplication] processIdentifier]];
+  int currentSystemAppPid = [FBXCAXClientProxy.sharedClient systemApplication].processIdentifier;
+  if (nil == _systemApplication || currentSystemAppPid != _systemApplication.processID) {
+    _systemApplication = [self fb_applicationWithPID:currentSystemAppPid];
+  }
+  return _systemApplication;
 }
 
 + (instancetype)appWithPID:(pid_t)processID

--- a/WebDriverAgentLib/Utilities/FBCapabilities.h
+++ b/WebDriverAgentLib/Utilities/FBCapabilities.h
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+extern NSString* const FB_CAP_USE_TEST_MANAGER_FOR_VISIBLITY_DETECTION;
+extern NSString* const FB_CAP_MAX_TYPING_FREQUNCY;
+extern NSString* const FB_CAP_USE_SINGLETON_TEST_MANAGER;
+extern NSString* const FB_CAP_DISABLE_AUTOMATIC_SCREENSHOTS;
+extern NSString* const FB_CAP_SHOULD_TERMINATE_APP;
+extern NSString* const FB_CAP_EVENT_LOOP_IDLE_DELAY_SEC;
+extern NSString* const FB_CAP_BUNDLE_ID;
+extern NSString* const FB_CAP_FORCE_APP_LAUNCH;
+extern NSString* const FB_CAP_SHOULD_WAIT_FOR_QUIESCENCE;
+extern NSString* const FB_CAP_ARGUMENTS;
+extern NSString* const FB_CAP_ENVIRNOMENT;

--- a/WebDriverAgentLib/Utilities/FBCapabilities.m
+++ b/WebDriverAgentLib/Utilities/FBCapabilities.m
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBCapabilities.h"
+
+NSString* const FB_CAP_USE_TEST_MANAGER_FOR_VISIBLITY_DETECTION = @"shouldUseTestManagerForVisibilityDetection";
+NSString* const FB_CAP_MAX_TYPING_FREQUNCY = @"maxTypingFrequency";
+NSString* const FB_CAP_USE_SINGLETON_TEST_MANAGER = @"shouldUseSingletonTestManager";
+NSString* const FB_CAP_DISABLE_AUTOMATIC_SCREENSHOTS = @"disableAutomaticScreenshots";
+NSString* const FB_CAP_SHOULD_TERMINATE_APP = @"shouldTerminateApp";
+NSString* const FB_CAP_EVENT_LOOP_IDLE_DELAY_SEC = @"eventloopIdleDelaySec";
+NSString* const FB_CAP_BUNDLE_ID = @"bundleId";
+NSString* const FB_CAP_FORCE_APP_LAUNCH = @"forceAppLaunch";
+NSString* const FB_CAP_SHOULD_WAIT_FOR_QUIESCENCE = @"shouldWaitForQuiescence";
+NSString* const FB_CAP_ARGUMENTS = @"arguments";
+NSString* const FB_CAP_ENVIRNOMENT = @"environment";

--- a/WebDriverAgentTests/IntegrationTests/FBSessionIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBSessionIntegrationTests.m
@@ -27,7 +27,6 @@
 
 
 static NSString *const SETTINGS_BUNDLE_ID = @"com.apple.Preferences";
-static NSString *const INTEGRATION_APP_BUNDLE_ID = @"com.facebook.wda.integrationApp";
 
 @implementation FBSessionIntegrationTests
 
@@ -35,7 +34,14 @@ static NSString *const INTEGRATION_APP_BUNDLE_ID = @"com.facebook.wda.integratio
 {
   [super setUp];
   [self launchApplication];
-  self.session = [FBSession initWithApplication:FBApplication.fb_activeApplication];
+  FBApplication *app = [[FBApplication alloc] initWithBundleIdentifier:self.testedApplication.bundleID];
+  self.session = [FBSession initWithApplication:app];
+}
+
+- (void)tearDown
+{
+  [self.session kill];
+  [super tearDown];
 }
 
 - (void)testSettingsAppCanBeOpenedInScopeOfTheCurrentSession
@@ -54,7 +60,7 @@ static NSString *const INTEGRATION_APP_BUNDLE_ID = @"com.facebook.wda.integratio
 
 - (void)testSettingsAppCanBeReopenedInScopeOfTheCurrentSession
 {
-  FBApplication *systemApp = FBApplication.fb_systemApplication;
+  FBApplication *systemApp = self.springboard;
   [self.session launchApplicationWithBundleId:SETTINGS_BUNDLE_ID
                       shouldWaitForQuiescence:nil
                                     arguments:nil
@@ -83,9 +89,9 @@ static NSString *const INTEGRATION_APP_BUNDLE_ID = @"com.facebook.wda.integratio
 
 - (void)testMainAppCanBeRestartedInScopeOfTheCurrentSession
 {
-  FBApplication *systemApp = FBApplication.fb_systemApplication;
-  FBApplication *testedApp = FBApplication.fb_activeApplication;
-  XCTAssertTrue([self.session terminateApplicationWithBundleId:testedApp.bundleID]);
+  FBApplication *systemApp = self.springboard;
+  FBApplication *testedApp = [[FBApplication alloc] initWithBundleIdentifier:self.testedApplication.bundleID];
+  [self.session terminateApplicationWithBundleId:testedApp.bundleID];
   FBAssertWaitTillBecomesTrue([self.session.activeApplication.bundleID isEqualToString:systemApp.bundleID]);
   [self.session launchApplicationWithBundleId:testedApp.bundleID
                       shouldWaitForQuiescence:nil

--- a/WebDriverAgentTests/IntegrationTests/FBSessionIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBSessionIntegrationTests.m
@@ -19,8 +19,6 @@
 
 @interface FBSession (Tests)
 
-@property (nonatomic) NSDictionary<NSString *, FBApplication *> *applications;
-
 @end
 
 @interface FBSessionIntegrationTests : FBIntegrationTestCase
@@ -29,6 +27,7 @@
 
 
 static NSString *const SETTINGS_BUNDLE_ID = @"com.apple.Preferences";
+static NSString *const INTEGRATION_APP_BUNDLE_ID = @"com.facebook.wda.integrationApp";
 
 @implementation FBSessionIntegrationTests
 
@@ -46,10 +45,10 @@ static NSString *const SETTINGS_BUNDLE_ID = @"com.apple.Preferences";
                       shouldWaitForQuiescence:nil
                                     arguments:nil
                                   environment:nil];
-  XCTAssertEqualObjects(SETTINGS_BUNDLE_ID, self.session.activeApplication.bundleID);
+  FBAssertWaitTillBecomesTrue([self.session.activeApplication.bundleID isEqualToString:SETTINGS_BUNDLE_ID]);
   XCTAssertEqual([self.session applicationStateWithBundleId:SETTINGS_BUNDLE_ID], 4);
   [self.session activateApplicationWithBundleId:testedApp.bundleID];
-  XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
+  FBAssertWaitTillBecomesTrue([self.session.activeApplication.bundleID isEqualToString: testedApp.bundleID]);
   XCTAssertEqual([self.session applicationStateWithBundleId:testedApp.bundleID], 4);
 }
 
@@ -60,14 +59,14 @@ static NSString *const SETTINGS_BUNDLE_ID = @"com.apple.Preferences";
                       shouldWaitForQuiescence:nil
                                     arguments:nil
                                   environment:nil];
-  FBAssertWaitTillBecomesTrue([SETTINGS_BUNDLE_ID isEqualToString:self.session.activeApplication.bundleID]);
+  FBAssertWaitTillBecomesTrue([self.session.activeApplication.bundleID isEqualToString:SETTINGS_BUNDLE_ID]);
   XCTAssertTrue([self.session terminateApplicationWithBundleId:SETTINGS_BUNDLE_ID]);
   FBAssertWaitTillBecomesTrue([systemApp.bundleID isEqualToString:self.session.activeApplication.bundleID]);
   [self.session launchApplicationWithBundleId:SETTINGS_BUNDLE_ID
                       shouldWaitForQuiescence:nil
                                     arguments:nil
                                   environment:nil];
-  XCTAssertEqualObjects(SETTINGS_BUNDLE_ID, self.session.activeApplication.bundleID);
+  FBAssertWaitTillBecomesTrue([self.session.activeApplication.bundleID isEqualToString:SETTINGS_BUNDLE_ID]);
 }
 
 - (void)testMainAppCanBeReactivatedInScopeOfTheCurrentSession
@@ -77,9 +76,9 @@ static NSString *const SETTINGS_BUNDLE_ID = @"com.apple.Preferences";
                       shouldWaitForQuiescence:nil
                                     arguments:nil
                                   environment:nil];
-  XCTAssertEqualObjects(SETTINGS_BUNDLE_ID, self.session.activeApplication.bundleID);
+  FBAssertWaitTillBecomesTrue([self.session.activeApplication.bundleID isEqualToString:SETTINGS_BUNDLE_ID]);
   [self.session activateApplicationWithBundleId:testedApp.bundleID];
-  XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
+  FBAssertWaitTillBecomesTrue([self.session.activeApplication.bundleID isEqualToString:testedApp.bundleID]);
 }
 
 - (void)testMainAppCanBeRestartedInScopeOfTheCurrentSession
@@ -87,18 +86,17 @@ static NSString *const SETTINGS_BUNDLE_ID = @"com.apple.Preferences";
   FBApplication *systemApp = FBApplication.fb_systemApplication;
   FBApplication *testedApp = FBApplication.fb_activeApplication;
   XCTAssertTrue([self.session terminateApplicationWithBundleId:testedApp.bundleID]);
-  XCTAssertEqualObjects(systemApp.bundleID, self.session.activeApplication.bundleID);
+  FBAssertWaitTillBecomesTrue([self.session.activeApplication.bundleID isEqualToString:systemApp.bundleID]);
   [self.session launchApplicationWithBundleId:testedApp.bundleID
                       shouldWaitForQuiescence:nil
                                     arguments:nil
                                   environment:nil];
-  XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
+  FBAssertWaitTillBecomesTrue([self.session.activeApplication.bundleID isEqualToString:testedApp.bundleID]);
 }
 
 - (void)testLaunchUnattachedApp
 {
   [FBUnattachedAppLauncher launchAppWithBundleId:SETTINGS_BUNDLE_ID];
-  XCTAssertNil(self.session.applications[SETTINGS_BUNDLE_ID]);
   [self.session kill];
   XCTAssertEqualObjects(SETTINGS_BUNDLE_ID, FBApplication.fb_activeApplication.bundleID);
 }

--- a/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.h
+++ b/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.h
@@ -12,4 +12,7 @@
 @interface FBApplicationDouble : NSObject
 @property (nonatomic, assign, readonly) BOOL didTerminate;
 @property (nonatomic, strong) NSString* bundleID;
+@property (nonatomic) BOOL fb_shouldWaitForQuiescence;
+
+- (BOOL)running;
 @end

--- a/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.m
+++ b/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.m
@@ -49,4 +49,19 @@
   return nil;
 }
 
+- (BOOL)fb_shouldWaitForQuiescence
+{
+  return NO;
+}
+
+-(void)setFb_shouldWaitForQuiescence:(BOOL)value
+{
+
+}
+
+- (BOOL)running
+{
+  return NO;
+}
+
 @end

--- a/WebDriverAgentTests/UnitTests/FBSessionTests.m
+++ b/WebDriverAgentTests/UnitTests/FBSessionTests.m
@@ -11,10 +11,12 @@
 
 #import "FBApplicationDouble.h"
 #import "FBSession.h"
+#import "FBConfiguration.h"
 
 @interface FBSessionTests : XCTestCase
 @property (nonatomic, strong) FBSession *session;
 @property (nonatomic, strong) FBApplication *testedApplication;
+@property (nonatomic) BOOL shouldTerminateAppValue;
 @end
 
 @implementation FBSessionTests
@@ -23,7 +25,16 @@
 {
   [super setUp];
   self.testedApplication = (id)FBApplicationDouble.new;
+  self.shouldTerminateAppValue = FBConfiguration.shouldTerminateApp;
+  [FBConfiguration setShouldTerminateApp:NO];
   self.session = [FBSession initWithApplication:self.testedApplication];
+}
+
+- (void)tearDown
+{
+  [self.session kill];
+  [FBConfiguration setShouldTerminateApp:self.shouldTerminateAppValue];
+  [super tearDown];
 }
 
 - (void)testSessionFetching
@@ -51,7 +62,6 @@
 - (void)testActiveSessionIsNilAfterKilling
 {
   [self.session kill];
-  XCTAssertTrue(((FBApplicationDouble *)self.testedApplication).didTerminate);
   XCTAssertNil([FBSession activeSession]);
 }
 


### PR DESCRIPTION
There is no need to cache all app instances, since this might seriously affect the amount of used memory. Now we only try keep the necessary stuff.

Thanks to @Dan-Maor for the hint