### PR TITLE
chore: Move visibility cache to the active session instance

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -57,8 +57,11 @@
   if (nil == cache) {
     return isVisible;
   }
-
   NSMutableDictionary<NSString *, NSNumber *> *destination = [cache objectForKey:@(self.generation)];
+  if (nil == destination) {
+    return isVisible;
+  }
+
   NSNumber *visibleObj = [NSNumber numberWithBool:isVisible];
   [destination setObject:visibleObj forKey:[NSString stringWithFormat:@"%p", (void *)self]];
   if (isVisible && nil != ancestors) {

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -19,6 +19,7 @@
 #import "XCElementSnapshot+FBHelpers.h"
 #import "XCElementSnapshot+FBHitPoint.h"
 #import "XCUIElement+FBUtilities.h"
+#import "XCUIElement+FBUID.h"
 #import "XCTestPrivateSymbols.h"
 
 @implementation XCUIElement (FBIsVisible)
@@ -32,6 +33,11 @@
 @end
 
 @implementation XCElementSnapshot (FBIsVisible)
+
+- (NSString *)fb_uniqId
+{
+  return self.fb_uid ?: [NSString stringWithFormat:@"%p", (void *)self];
+}
 
 - (nullable NSNumber *)fb_cachedVisibilityValue
 {
@@ -47,7 +53,7 @@
     [cache setObject:[NSMutableDictionary dictionary] forKey:@(self.generation)];
     return nil;
   }
-  return [result objectForKey:[NSString stringWithFormat:@"%p", (void *)self]];
+  return [result objectForKey:self.fb_uniqId];
 }
 
 - (BOOL)fb_cacheVisibilityWithValue:(BOOL)isVisible
@@ -63,11 +69,11 @@
   }
 
   NSNumber *visibleObj = [NSNumber numberWithBool:isVisible];
-  [destination setObject:visibleObj forKey:[NSString stringWithFormat:@"%p", (void *)self]];
+  [destination setObject:visibleObj forKey:self.fb_uniqId];
   if (isVisible && nil != ancestors) {
     // if an element is visible then all its ancestors must be visible as well
     for (XCElementSnapshot *ancestor in ancestors) {
-      NSString *ancestorId = [NSString stringWithFormat:@"%p", (void *)ancestor];
+      NSString *ancestorId = ancestor.fb_uniqId;
       if (nil == [destination objectForKey:ancestorId]) {
         [destination setObject:visibleObj forKey:ancestorId];
       }

--- a/WebDriverAgentLib/Routing/FBSession.h
+++ b/WebDriverAgentLib/Routing/FBSession.h
@@ -34,6 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 /*! The action to apply to unexpected alerts. Either "accept"/"dismiss" or nil/empty string (by default) to do nothing */
 @property (nonatomic, nullable) NSString *defaultAlertAction;
 
+@property (nonatomic, readonly) NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber *> *> *elementsVisibilityCache;
+
 + (nullable instancetype)activeSession;
 
 /**

--- a/WebDriverAgentLib/Routing/FBSession.h
+++ b/WebDriverAgentLib/Routing/FBSession.h
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*! The action to apply to unexpected alerts. Either "accept"/"dismiss" or nil/empty string (by default) to do nothing */
 @property (nonatomic, nullable) NSString *defaultAlertAction;
 
+/*! Keeps cached visibility values for the current snapshots tree */
 @property (nonatomic, readonly) NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber *> *> *elementsVisibilityCache;
 
 + (nullable instancetype)activeSession;

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -35,6 +35,7 @@ NSString *const FBDefaultApplicationAuto = @"auto";
 @property (nonatomic) BOOL isTestedApplicationExpectedToRun;
 @property (nonatomic) BOOL shouldAppsWaitForQuiescence;
 @property (nonatomic, nullable) FBAlertsMonitor *alertsMonitor;
+@property (nonatomic, readwrite) NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber *> *> *elementsVisibilityCache;
 @end
 
 @interface FBSession (FBAlertsMonitorDelegate)
@@ -100,6 +101,7 @@ static FBSession *_activeSession = nil;
   FBSession *session = [FBSession new];
   session.alertsMonitor = nil;
   session.defaultAlertAction = nil;
+  session.elementsVisibilityCache = [NSMutableDictionary dictionary];
   session.identifier = [[NSUUID UUID] UUIDString];
   session.defaultActiveApplication = FBDefaultApplicationAuto;
   session.testedApplicationBundleId = nil;


### PR DESCRIPTION
Static objects are evil from memory usage perspective, so it makes more sense to keep this cache inside of session object, which gets cleaned up automatically