### PR TITLE
chore: Avoid arc-performSelector-leaks warnings

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -177,7 +177,7 @@ static bool fb_isLocked;
             buildError:error];
   }
   SEL selector = NSSelectorFromString(@"activateWithVoiceRecognitionText:");
-  NSMethodSignature *signature = [self methodSignatureForSelector:selector];
+  NSMethodSignature *signature = [siriService methodSignatureForSelector:selector];
   NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
   [invocation setSelector:selector];
   [invocation setArgument:&text atIndex:2];

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -176,12 +176,13 @@ static bool fb_isLocked;
              withDescription:@"Siri service is not available on the device under test"]
             buildError:error];
   }
+  SEL selector = NSSelectorFromString(@"activateWithVoiceRecognitionText:");
+  NSMethodSignature *signature = [self methodSignatureForSelector:selector];
+  NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+  [invocation setSelector:selector];
+  [invocation setArgument:&text atIndex:2];
   @try {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-    [siriService performSelector:NSSelectorFromString(@"activateWithVoiceRecognitionText:")
-                      withObject:text];
-#pragma clang diagnostic pop
+    [invocation invokeWithTarget:siriService];
     return YES;
   } @catch (NSException *e) {
     return [[[FBErrorBuilder builder]

--- a/WebDriverAgentLib/Categories/XCUIElement+FBSwiping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBSwiping.m
@@ -34,10 +34,10 @@
     [invocation invokeWithTarget:self];
   } else {
     SEL selector = NSSelectorFromString([NSString stringWithFormat:@"swipe%@", direction.lowercaseString.capitalizedString]);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-    [self performSelector:selector];
-#pragma clang diagnostic pop
+    NSMethodSignature *signature = [self methodSignatureForSelector:selector];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    [invocation setSelector:selector];
+    [invocation invokeWithTarget:self];
   }
 }
 


### PR DESCRIPTION
Replace all calls of `performSelector` API with NSInvocation where the compiler complains about possible memory leaks. See https://stackoverflow.com/questions/7017281/performselector-may-cause-a-leak-because-its-selector-is-unknown for more details