### PR TITLE
fix: Add missing snapshotKeyHonorModalViews attribute to custom snapshot requests

### DIFF
--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
@@ -90,6 +90,8 @@ static id FBAXClient = nil;
                                     error:(NSError **)error
 {
   NSMutableDictionary *parameters = [[NSMutableDictionary alloc] init];
+  // Mimicking XCTest framework behavior (this attribute is added by default unless it is an excludingNonModalElements query)
+  // See https://github.com/appium/WebDriverAgent/pull/523
   if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"13.0")) {
     parameters[@"snapshotKeyHonorModalViews"] = @(NO);
   }

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
@@ -91,7 +91,7 @@ static id FBAXClient = nil;
 {
   NSMutableDictionary *parameters = [[NSMutableDictionary alloc] init];
   if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"13.0")) {
-    parameters[@"snapshotKeyHonorModalViews"] = @0;
+    parameters[@"snapshotKeyHonorModalViews"] = @(NO);
   }
   if (nil != maxDepth) {
     [parameters addEntriesFromDictionary:self.defaultParameters];

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
@@ -15,6 +15,7 @@
 #import "FBLogger.h"
 #import "XCAXClient_iOS.h"
 #import "XCUIDevice.h"
+#import "FBMacros.h"
 
 static id FBAXClient = nil;
 
@@ -88,9 +89,12 @@ static id FBAXClient = nil;
                                  maxDepth:(nullable NSNumber *)maxDepth
                                     error:(NSError **)error
 {
-  NSMutableDictionary *parameters = nil;
+  NSMutableDictionary *parameters = [[NSMutableDictionary alloc] init];
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"13.0")) {
+    parameters[@"snapshotKeyHonorModalViews"] = @0;
+  }
   if (nil != maxDepth) {
-    parameters = self.defaultParameters.mutableCopy;
+    [parameters addEntriesFromDictionary:self.defaultParameters];
     parameters[FBSnapshotMaxDepthKey] = maxDepth;
   }
   if ([FBAXClient respondsToSelector:@selector(requestSnapshotForElement:attributes:parameters:error:)]) {


### PR DESCRIPTION
We've been alerted of an instance where some objects were not identified when attempting to find elements or pull a page source from a certain page of an application.

When changing the implementation of `[XCUIElement fb_snapshotWithAttributes:attributeNames:maxDepth]` to use the generic snapshot instead of the custom one (with the additional attributes), the elements were resolved correctly.

Upon further investigation I discovered that from iOS 13 an additional key (`snapshotKeyHonorModalViews`) is required for the attributes dictionary when requesting a snapshot (can be seen in the reversed implementation of `[XCTElementQuery snapshotParameters]`).

This PR mimics the behavior of that function by adding the `snapshotKeyHonorModalViews` to the snapshot request dictionary.

Unfortunately I cannot create a test for this instance since this issue was received from a customer, and I am unable to replicate the page's behavior.