### PR TITLE
ci: fix ci yml

### DIFF
--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -25,7 +25,7 @@ jobs:
       displayName: Install Ruby dependencies
     - script: mkdir -p Resources/WebDriverAgent.bundle
       displayName: Make Resources Folder
-    - script: node ./Scripts/build-webdriveragents.js
+    - script: node ./Scripts/build-webdriveragent.js
       displayName: Build WebDriverAgents
     - script: ls ./bundles
       displayName: List WDA Bundles


### PR DESCRIPTION
https://dev.azure.com/AppiumCI/Appium%20CI/_build/results?buildId=16797&view=logs&j=41c89b73-5f8a-5ac1-e763-5d413837a9db&t=6747af84-484e-5213-42f3-edd16a8a2b96 the failure is because wrong path in ci-jobs/templates/build.yml