### PR TITLE
fix: Tune scrollToVisibleElement

### DIFF
--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.h
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @return the snapshot visibleFrame
  */
-- (CGRect) fb_visibleFrameWithFallback;
+- (CGRect)fb_visibleFrameWithFallback;
 
 @end
 

--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.h
@@ -87,6 +87,13 @@ NS_ASSUME_NONNULL_BEGIN
 /**! Human-readable snapshot description */
 - (NSString *)fb_description;
 
+/**
+ Returns the snapshot visibleFrame with a fallback to direct attribute retrieval from FBXCAXClient in case of a snapshot fault (nil visibleFrame)
+ 
+ @return the snapshot visibleFrame
+ */
+- (CGRect) fb_visibleFrameWithFallback;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -69,6 +69,8 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
 
 inline static BOOL valuesAreEqual(id value1, id value2);
 
+inline static BOOL valuesAreEqualOrBlank(id value1, id value2);
+
 inline static BOOL isNilOrEmpty(id value);
 
 - (BOOL)fb_framelessFuzzyMatchesElement:(XCElementSnapshot *)snapshot
@@ -79,12 +81,14 @@ inline static BOOL isNilOrEmpty(id value);
     return [self.wdUID isEqualToString:(snapshot.wdUID ?: @"")];
   }
   
+  // Sometimes value and placeholderValue of a correct match from different snapshots are not the same (one is nil and one is a blank string)
+  // Therefore taking it into account when comparing
   return self.elementType == snapshot.elementType &&
     valuesAreEqual(self.identifier, snapshot.identifier) &&
     valuesAreEqual(self.title, snapshot.title) &&
     valuesAreEqual(self.label, snapshot.label) &&
-    valuesAreEqual(self.value, snapshot.value) &&
-    valuesAreEqual(self.placeholderValue, snapshot.placeholderValue);
+    valuesAreEqualOrBlank(self.value, snapshot.value) &&
+    valuesAreEqualOrBlank(self.placeholderValue, snapshot.placeholderValue);
 }
 
 - (NSArray<XCElementSnapshot *> *)fb_descendantsCellSnapshots
@@ -128,6 +132,28 @@ inline static BOOL isNilOrEmpty(id value);
     }
     return targetCellSnapshot;
 }
+
+- (CGRect) fb_visibleFrameWithFallback
+{
+  CGRect thisVisibleFrame = [self visibleFrame];
+  if (CGRectIsEmpty(thisVisibleFrame))
+  {
+    NSDictionary *visibleFrameDict = (NSDictionary*)[self fb_attributeValue:@"XC_kAXXCAttributeVisibleFrame"];
+    if (visibleFrameDict != nil)
+    {
+      id x = [visibleFrameDict valueForKey:@"X"];
+      id y = [visibleFrameDict valueForKey:@"Y"];
+      id height = [visibleFrameDict valueForKey:@"Height"];
+      id width = [visibleFrameDict valueForKey:@"Width"];
+      if (x != nil && y != nil && height != nil && width != nil)
+      {
+        thisVisibleFrame = CGRectMake([x doubleValue], [y doubleValue], [width doubleValue], [height doubleValue]);
+      }
+    }
+  }
+  return thisVisibleFrame;
+}
+
 @end
 
 inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, NSArray<NSNumber *> *types)
@@ -143,6 +169,11 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
 inline static BOOL valuesAreEqual(id value1, id value2)
 {
   return value1 == value2 || [value1 isEqual:value2];
+}
+
+inline static BOOL valuesAreEqualOrBlank(id value1, id value2)
+{
+  return valuesAreEqual(value1, value2) || (isNilOrEmpty(value1) && isNilOrEmpty(value2));
 }
 
 inline static BOOL isNilOrEmpty(id value)

--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -67,9 +67,9 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
   return result[attribute];
 }
 
-inline static BOOL valuesAreEqual(id value1, id value2);
+inline static BOOL areValuesEqual(id value1, id value2);
 
-inline static BOOL valuesAreEqualOrBlank(id value1, id value2);
+inline static BOOL areValuesEqualOrBlank(id value1, id value2);
 
 inline static BOOL isNilOrEmpty(id value);
 
@@ -84,11 +84,11 @@ inline static BOOL isNilOrEmpty(id value);
   // Sometimes value and placeholderValue of a correct match from different snapshots are not the same (one is nil and one is a blank string)
   // Therefore taking it into account when comparing
   return self.elementType == snapshot.elementType &&
-    valuesAreEqual(self.identifier, snapshot.identifier) &&
-    valuesAreEqual(self.title, snapshot.title) &&
-    valuesAreEqual(self.label, snapshot.label) &&
-    valuesAreEqualOrBlank(self.value, snapshot.value) &&
-    valuesAreEqualOrBlank(self.placeholderValue, snapshot.placeholderValue);
+    areValuesEqual(self.identifier, snapshot.identifier) &&
+    areValuesEqual(self.title, snapshot.title) &&
+    areValuesEqual(self.label, snapshot.label) &&
+    areValuesEqualOrBlank(self.value, snapshot.value) &&
+    areValuesEqualOrBlank(self.placeholderValue, snapshot.placeholderValue);
 }
 
 - (NSArray<XCElementSnapshot *> *)fb_descendantsCellSnapshots
@@ -133,22 +133,20 @@ inline static BOOL isNilOrEmpty(id value);
     return targetCellSnapshot;
 }
 
-- (CGRect) fb_visibleFrameWithFallback
+- (CGRect)fb_visibleFrameWithFallback
 {
   CGRect thisVisibleFrame = [self visibleFrame];
-  if (CGRectIsEmpty(thisVisibleFrame))
-  {
-    NSDictionary *visibleFrameDict = (NSDictionary*)[self fb_attributeValue:@"XC_kAXXCAttributeVisibleFrame"];
-    if (visibleFrameDict != nil)
-    {
-      id x = [visibleFrameDict valueForKey:@"X"];
-      id y = [visibleFrameDict valueForKey:@"Y"];
-      id height = [visibleFrameDict valueForKey:@"Height"];
-      id width = [visibleFrameDict valueForKey:@"Width"];
-      if (x != nil && y != nil && height != nil && width != nil)
-      {
-        thisVisibleFrame = CGRectMake([x doubleValue], [y doubleValue], [width doubleValue], [height doubleValue]);
-      }
+  if (!CGRectIsEmpty(thisVisibleFrame))
+    return thisVisibleFrame;
+  
+  NSDictionary *visibleFrameDict = (NSDictionary*)[self fb_attributeValue:@"XC_kAXXCAttributeVisibleFrame"];
+  if (visibleFrameDict != nil) {
+    id x = [visibleFrameDict objectForKey:@"X"];
+    id y = [visibleFrameDict objectForKey:@"Y"];
+    id height = [visibleFrameDict objectForKey:@"Height"];
+    id width = [visibleFrameDict objectForKey:@"Width"];
+    if (x != nil && y != nil && height != nil && width != nil) {
+      thisVisibleFrame = CGRectMake([x doubleValue], [y doubleValue], [width doubleValue], [height doubleValue]);
     }
   }
   return thisVisibleFrame;
@@ -166,14 +164,14 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
   return NO;
 }
 
-inline static BOOL valuesAreEqual(id value1, id value2)
+inline static BOOL areValuesEqual(id value1, id value2)
 {
   return value1 == value2 || [value1 isEqual:value2];
 }
 
-inline static BOOL valuesAreEqualOrBlank(id value1, id value2)
+inline static BOOL areValuesEqualOrBlank(id value1, id value2)
 {
-  return valuesAreEqual(value1, value2) || (isNilOrEmpty(value1) && isNilOrEmpty(value2));
+  return areValuesEqual(value1, value2) || (isNilOrEmpty(value1) && isNilOrEmpty(value2));
 }
 
 inline static BOOL isNilOrEmpty(id value)

--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -136,19 +136,23 @@ inline static BOOL isNilOrEmpty(id value);
 - (CGRect)fb_visibleFrameWithFallback
 {
   CGRect thisVisibleFrame = [self visibleFrame];
-  if (!CGRectIsEmpty(thisVisibleFrame))
+  if (!CGRectIsEmpty(thisVisibleFrame)) {
     return thisVisibleFrame;
+  }
   
   NSDictionary *visibleFrameDict = (NSDictionary*)[self fb_attributeValue:@"XC_kAXXCAttributeVisibleFrame"];
-  if (visibleFrameDict != nil) {
-    id x = [visibleFrameDict objectForKey:@"X"];
-    id y = [visibleFrameDict objectForKey:@"Y"];
-    id height = [visibleFrameDict objectForKey:@"Height"];
-    id width = [visibleFrameDict objectForKey:@"Width"];
-    if (x != nil && y != nil && height != nil && width != nil) {
-      thisVisibleFrame = CGRectMake([x doubleValue], [y doubleValue], [width doubleValue], [height doubleValue]);
-    }
+  if (visibleFrameDict == nil) {
+    return thisVisibleFrame;
   }
+  
+  id x = [visibleFrameDict objectForKey:@"X"];
+  id y = [visibleFrameDict objectForKey:@"Y"];
+  id height = [visibleFrameDict objectForKey:@"Height"];
+  id width = [visibleFrameDict objectForKey:@"Width"];
+  if (x != nil && y != nil && height != nil && width != nil) {
+    return CGRectMake([x doubleValue], [y doubleValue], [width doubleValue], [height doubleValue]);
+  }
+  
   return thisVisibleFrame;
 }
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
@@ -185,9 +185,11 @@ const CGFloat FBScrollTouchProportion = 0.75f;
   }
 
   // Cell is now visible, but it might be only partialy visible, scrolling till whole frame is visible
-  targetCellSnapshot = self.fb_takeSnapshot.fb_parentCellSnapshot;
-  CGVector scrollVector = CGVectorMake(targetCellSnapshot.visibleFrame.size.width - targetCellSnapshot.frame.size.width,
-                                       targetCellSnapshot.visibleFrame.size.height - targetCellSnapshot.frame.size.height
+  targetCellSnapshot = [([self fb_cachedSnapshot] ?: [self fb_takeSnapshot]) fb_parentCellSnapshot];
+  CGRect visibleFrame = targetCellSnapshot.fb_visibleFrameWithFallback;
+  
+  CGVector scrollVector = CGVectorMake(visibleFrame.size.width - targetCellSnapshot.frame.size.width,
+                                       visibleFrame.size.height - targetCellSnapshot.frame.size.height
                                        );
   if (![scrollView fb_scrollByVector:scrollVector inApplication:self.application error:error]) {
     return NO;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
@@ -184,7 +184,9 @@ const CGFloat FBScrollTouchProportion = 0.75f;
      buildError:error];
   }
 
-  // Cell is now visible, but it might be only partialy visible, scrolling till whole frame is visible
+  // Cell is now visible, but it might be only partialy visible, scrolling till whole frame is visible.
+  // Sometimes, attempting to grab the parent snapshot of the target cell after scrolling is complete causes a stale element reference exception.
+  // Trying fb_cachedSnapshot first
   targetCellSnapshot = [([self fb_cachedSnapshot] ?: [self fb_takeSnapshot]) fb_parentCellSnapshot];
   CGRect visibleFrame = targetCellSnapshot.fb_visibleFrameWithFallback;
   


### PR DESCRIPTION
We found some instances where scroll to visible did not function correctly and kept scrolling even though the element was found, which required some changes in the scroll to visible functions.

The required changes:
* In `fb_framelessFuzzyMatchesElement` the comparison sometimes yielded false negatives due to the values of the `value` and `placeholderValues` properties not being equal between snapshots - one is returned as a blank string, the other is nil - now taking this into account during the comparison.
* Sometimes, attempting to grab the parent snapshot of the target cell after scrolling is complete causes a stale element reference exception - handled by first using `fb_cachedSnapshot`.
* In the partially visible scroll section - sometimes visibleFrame is not returned correctly from the snapshot (returned as an empty `CGRect`), causing an incorrect final vector. Therefore added a fallback mechanism to retrieve the proper value directly from `FBXCAXClient`.

Also fixes https://github.com/appium/appium/issues/15114