### PR TITLE
chore: remove WDA_BUNDLE_ID

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ import { asyncify } from 'asyncbox';
 const { checkForDependencies, bundleWDASim } = dependencies;
 const { NoSessionProxy } = proxies;
 const { WebDriverAgent } = driver;
-const { WDA_BUNDLE_ID, BOOTSTRAP_PATH, WDA_BASE_URL, WDA_RUNNER_BUNDLE_ID, PROJECT_FILE } = constants;
+const { BOOTSTRAP_PATH, WDA_BASE_URL, WDA_RUNNER_BUNDLE_ID, PROJECT_FILE } = constants;
 const { resetTestProcesses } = utils;
 
 
@@ -23,7 +23,7 @@ export {
   NoSessionProxy,
   checkForDependencies, bundleWDASim,
   resetTestProcesses,
-  BOOTSTRAP_PATH, WDA_BUNDLE_ID,
+  BOOTSTRAP_PATH,
   WDA_RUNNER_BUNDLE_ID, PROJECT_FILE,
   WDA_BASE_URL,
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -4,7 +4,6 @@ import path from 'path';
 const BOOTSTRAP_PATH = __dirname.endsWith('build')
   ? path.resolve(__dirname, '..', '..', '..')
   : path.resolve(__dirname, '..', '..');
-const WDA_BUNDLE_ID = 'com.apple.test.WebDriverAgentRunner-Runner';
 const WDA_PROJECT = path.join(BOOTSTRAP_PATH, 'WebDriverAgent.xcodeproj');
 const WDA_SCRIPTS_ROOT = path.join(BOOTSTRAP_PATH, 'Scripts');
 const WDA_RUNNER_BUNDLE_ID = 'com.facebook.WebDriverAgentRunner';
@@ -22,7 +21,7 @@ const SDK_DEVICE = 'iphoneos';
 const WDA_UPGRADE_TIMESTAMP_PATH = path.join('.appium', 'webdriveragent', 'upgrade.time');
 
 export {
-  BOOTSTRAP_PATH, WDA_BUNDLE_ID,
+  BOOTSTRAP_PATH,
   WDA_RUNNER_BUNDLE_ID, WDA_RUNNER_APP, PROJECT_FILE,
   WDA_PROJECT, WDA_SCHEME,
   PLATFORM_NAME_TVOS, PLATFORM_NAME_IOS,


### PR DESCRIPTION
We no longer need the bundle id since Xcode 11+ follows `.xctrunner` name like `com.facebook.WebDriverAgentRunner.xctrunner`.
No code refers to the constants as well. https://github.com/search?q=org%3Aappium+WDA_BUNDLE_ID&type=code

When xcdriver uninstalls `WebDriverAgentRunner-Runner`, it installs the app by searching the CFBundleIds (`WebDriverAgentRunner-Runner`).
https://github.com/appium/WebDriverAgent/blob/a1824895274c60798b506f31054e4ce1e0400c71/lib/webdriveragent.js#L179