### PR TITLE
test: change safari test

### DIFF
--- a/WebDriverAgentTests/IntegrationTests/FBSafariAlertTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBSafariAlertTests.m
@@ -48,26 +48,28 @@ static NSString *const SAFARI_BUNDLE_ID = @"com.apple.mobilesafari";
 
 - (void)testCanHandleSafariInputPrompt
 {
-  XCUIElement *urlInput = [[self.safariApp descendantsMatchingType:XCUIElementTypeTextField] matchingIdentifier:@"URL"].firstMatch;
+  XCUIElement *urlInput = [[self.safariApp
+                            descendantsMatchingType:XCUIElementTypeTextField]
+                           matchingPredicate:[
+                             NSPredicate predicateWithFormat:@"label == 'Address' or label == 'URL'"]].firstMatch;
   if (!urlInput.exists) {
-    [[[self.safariApp descendantsMatchingType:XCUIElementTypeButton] matchingIdentifier:@"URL"].firstMatch tap];
+    [[[self.safariApp descendantsMatchingType:XCUIElementTypeButton] matchingPredicate:[
+      NSPredicate predicateWithFormat:@"label == 'Address' or label == 'URL'"]].firstMatch tap];
   }
-  XCTAssertTrue([urlInput fb_typeText:@"https://www.seleniumeasy.com/test/javascript-alert-box-demo.html"
+  XCTAssertTrue([urlInput fb_typeText:@"https://www.w3schools.com/js/tryit.asp?filename=tryjs_alert"
                           shouldClear:YES
                                 error:nil]);
   [[[self.safariApp descendantsMatchingType:XCUIElementTypeButton] matchingIdentifier:@"Go"].firstMatch tap];
   XCUIElement *clickMeButton = [[self.safariApp descendantsMatchingType:XCUIElementTypeButton]
-                                matchingPredicate:[NSPredicate predicateWithFormat:@"label == 'Click for Prompt Box'"]].firstMatch;
+                                matchingPredicate:[NSPredicate predicateWithFormat:@"label == 'Try it'"]].firstMatch;
   XCTAssertTrue([clickMeButton waitForExistenceWithTimeout:15.0]);
   [clickMeButton tap];
   FBAlert *alert = [FBAlert alertWithApplication:self.safariApp];
-  FBAssertWaitTillBecomesTrue([alert.text isEqualToString:@"Please enter your name"]);
+  FBAssertWaitTillBecomesTrue([alert.text isEqualToString:@"I am an alert box!"]);
   NSArray *buttonLabels = alert.buttonLabels;
-  XCTAssertEqualObjects(buttonLabels.firstObject, @"Cancel");
-  XCTAssertNotNil([self.safariApp fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButton[@label='Cancel' and @visible='true']"
+  XCTAssertEqualObjects(buttonLabels.firstObject, @"Close");
+  XCTAssertNotNil([self.safariApp fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButton[@label='Close']"
                                        shouldReturnAfterFirstMatch:YES].firstObject);
-  XCTAssertEqualObjects(buttonLabels.lastObject, @"OK");
-  XCTAssertTrue([alert typeText:@"yolo" error:nil]);
   XCTAssertTrue([alert acceptWithError:nil]);
 }
 

--- a/WebDriverAgentTests/IntegrationTests/FBSafariAlertTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBSafariAlertTests.m
@@ -51,7 +51,8 @@ static NSString *const SAFARI_BUNDLE_ID = @"com.apple.mobilesafari";
   XCUIElement *urlInput = [[self.safariApp
                             descendantsMatchingType:XCUIElementTypeTextField]
                            matchingPredicate:[
-                             NSPredicate predicateWithFormat:@"label == 'Address' or label == 'URL'"]].firstMatch;
+                             NSPredicate predicateWithFormat:@"label == 'Address' or label == 'URL'"
+                           ]].firstMatch;
   if (!urlInput.exists) {
     [[[self.safariApp descendantsMatchingType:XCUIElementTypeButton] matchingPredicate:[
       NSPredicate predicateWithFormat:@"label == 'Address' or label == 'URL'"]].firstMatch tap];


### PR DESCRIPTION
https://www.seleniumeasy.com/test/javascript-alert-box-demo.html no longer exists.
I've changed to open https://www.w3schools.com/js/tryit.asp?filename=tryjs_alert to interact with a simple alert.

`@"label == 'Address' or label == 'URL'"` is for both iOS 15 and lower ones