### PR TITLE
feat: add NSProcessInfoThermalState in device info

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -380,7 +380,8 @@
   // https://developer.apple.com/documentation/foundation/nslocale/1414388-autoupdatingcurrentlocale
   NSString *currentLocale = [[NSLocale autoupdatingCurrentLocale] localeIdentifier];
 
-  return FBResponseWithObject(@{
+  NSMutableDictionary *deviceInfo = [NSMutableDictionary dictionaryWithDictionary:
+  @{
     @"currentLocale": currentLocale,
     @"timeZone": self.timeZone,
     @"name": UIDevice.currentDevice.name,
@@ -394,7 +395,14 @@
 #else
     @"isSimulator": @(NO),
 #endif
-  });
+  }];
+
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    // https://developer.apple.com/documentation/foundation/nsprocessinfothermalstate
+    deviceInfo[@"thermalState"] = @(NSProcessInfo.processInfo.thermalState);
+  }
+
+  return FBResponseWithObject(deviceInfo);
 }
 
 /**


### PR DESCRIPTION
It shows the device's thermal status which is available since ios 11.
The value is 0 to 3. (normal case should be 0)

Tested on simulator 10, 11 and a real device 15.