### PR TITLE
fix: set USE_PORT in plist as string

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -193,7 +193,7 @@ function getAdditionalRunContent (platformName, wdaRemotePort) {
   return {
     [runner]: {
       EnvironmentVariables: {
-        // USER_PORT must be 'string'
+        // USE_PORT must be 'string'
         USE_PORT: `${wdaRemotePort}`
       }
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -193,7 +193,8 @@ function getAdditionalRunContent (platformName, wdaRemotePort) {
   return {
     [runner]: {
       EnvironmentVariables: {
-        USE_PORT: wdaRemotePort
+        // USER_PORT must be 'string'
+        USE_PORT: `${wdaRemotePort}`
       }
     }
   };

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -112,7 +112,7 @@ describe('utils', function () {
       const wdaPort = getAdditionalRunContent(PLATFORM_NAME_IOS, 8000);
       wdaPort.WebDriverAgentRunner
         .EnvironmentVariables.USE_PORT
-        .should.equal(8000);
+        .should.equal('8000');
     });
 
     it('should return tvos format', function () {


### PR DESCRIPTION
Closes https://github.com/appium/appium/issues/15996

The original plist had:

```
			<key>USE_PORT</key>
			<string>8100</string>
```

but the copied one was:

```
			<key>USE_PORT</key>
			<integer>8100</integer>
```

This resulted
```
2021-10-22 22:57:56.960 xcodebuild[728:5263222] -[__NSCFNumber stringByReplacingOccurrencesOfString:withString:]: unrecognized selector sent to instance 0x8e2540d6b22aaf5f
** INTERNAL ERROR: Uncaught exception **
Uncaught Exception: -[__NSCFNumber stringByReplacingOccurrencesOfString:withString:]: unrecognized selector sent to instance 0x8e2540d6b22aaf5f
Stack:
  0   __exceptionPreprocess (in CoreFoundation)
  1   objc_exception_throw (in libobjc.A.dylib)
  2   -[NSObject(NSObject) __retain_OA] (in CoreFoundation)
  3   ___forwarding___ (in CoreFoundation)
  4   _CF_forwarding_prep_0 (in CoreFoundation)
  5   __64+[XCTHTestRunSpecification removePathPlaceholders:inDictionary:]_block_invoke (in XCTHarness)
  6   __64+[XCTHTestRunSpecification removePathPlaceholders:inDictionary:]_block_invoke.404 (in XCTHarness)
  7   __NSDICTIONARY_IS_CALLING_OUT_TO_A_BLOCK__ (in CoreFoundation)
  8   -[__NSDictionaryM enumerateKeysAndObjectsWithOptions:usingBlock:] (in CoreFoundation)
  9   +[XCTHTestRunSpecification removePathPlaceholders:inDictionary:] (in XCTHarness)
 10   -[XCTHTestRunCoder_V1 testRunSpecificationsInDictionaryRepresentation:removingPathPlaceholders:error:] (in XCTHarness)
 11   -[XCTHTestRunCoder_V1 testRunFileWithDictionaryRepresentation:removingPathPlaceholders:error:] (in XCTHarness)
 12   +[XCTHTestRunFileSerialization testRunFileWithDictionaryRepresentation:removingPathPlaceholders:error:] (in XCTHarness)
 13   +[XCTHTestRunFileSerialization testRunFileWithContentsOfURL:pathPlaceholders:error:] (in XCTHarness)
 14   specialized static XCTHTestRunFileSerialization.testRunFile(withContentsOf:derivedDataPath:) (in IDEFoundation)
 15   @objc static XCTHTestRunFileSerialization.testRunFile(withContentsOf:derivedDataPath:) (in IDEFoundation)
 16   -[Xcode3CommandLineBuildTool _resolveInputOptionsWithTimingSection:] (in Xcode3Core)
 17   -[Xcode3CommandLineBuildTool run] (in Xcode3Core)
 18   main (in xcodebuild)
 19   start (in libdyld.dylib)
```

---

Side note:

The below old version worked both `string` and `integer`. So, since Xcode 13 or around there, plist format probably became more strict.
```
kazu$ xcodebuild -version
Xcode 10.3
Build version 10G8
```