### PR TITLE
feat: Add an ability to provide a scope for the XML page source

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -347,6 +347,10 @@
 		71414EDA2670A1EE003A8C5D /* LRUCacheNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 71414ED32670A1ED003A8C5D /* LRUCacheNode.m */; };
 		71414EDB2670A1EE003A8C5D /* LRUCacheNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 71414ED32670A1ED003A8C5D /* LRUCacheNode.m */; };
 		714801D11FA9D9FA00DC5997 /* FBSDKVersionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 714801D01FA9D9FA00DC5997 /* FBSDKVersionTests.m */; };
+		714D88CC2733FB970074A925 /* FBXMLGenerationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 714D88CA2733FB970074A925 /* FBXMLGenerationOptions.h */; };
+		714D88CD2733FB970074A925 /* FBXMLGenerationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 714D88CA2733FB970074A925 /* FBXMLGenerationOptions.h */; };
+		714D88CE2733FB970074A925 /* FBXMLGenerationOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 714D88CB2733FB970074A925 /* FBXMLGenerationOptions.m */; };
+		714D88CF2733FB970074A925 /* FBXMLGenerationOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 714D88CB2733FB970074A925 /* FBXMLGenerationOptions.m */; };
 		714EAA0D2673FDFE005C5B47 /* FBCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 714EAA0B2673FDFE005C5B47 /* FBCapabilities.h */; };
 		714EAA0E2673FDFE005C5B47 /* FBCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 714EAA0B2673FDFE005C5B47 /* FBCapabilities.h */; };
 		714EAA0F2673FDFE005C5B47 /* FBCapabilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 714EAA0C2673FDFE005C5B47 /* FBCapabilities.m */; };
@@ -974,6 +978,8 @@
 		71414ED32670A1ED003A8C5D /* LRUCacheNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LRUCacheNode.m; sourceTree = "<group>"; };
 		714801D01FA9D9FA00DC5997 /* FBSDKVersionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKVersionTests.m; sourceTree = "<group>"; };
 		714CA3C61DC23186000F12C9 /* FBXPathIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPathIntegrationTests.m; sourceTree = "<group>"; };
+		714D88CA2733FB970074A925 /* FBXMLGenerationOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBXMLGenerationOptions.h; sourceTree = "<group>"; };
+		714D88CB2733FB970074A925 /* FBXMLGenerationOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBXMLGenerationOptions.m; sourceTree = "<group>"; };
 		714EAA0B2673FDFE005C5B47 /* FBCapabilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBCapabilities.h; sourceTree = "<group>"; };
 		714EAA0C2673FDFE005C5B47 /* FBCapabilities.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBCapabilities.m; sourceTree = "<group>"; };
 		7150348521A6DAD600A0F4BA /* FBImageUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBImageUtils.h; sourceTree = "<group>"; };
@@ -1942,6 +1948,8 @@
 				EE7E271B1D06C69F001BEC7B /* FBXCTestCaseImplementationFailureHoldingProxy.m */,
 				EE35AD791E3B80C000A02D78 /* FBXCTestDaemonsProxy.h */,
 				EE35AD7A1E3B80C000A02D78 /* FBXCTestDaemonsProxy.m */,
+				714D88CA2733FB970074A925 /* FBXMLGenerationOptions.h */,
+				714D88CB2733FB970074A925 /* FBXMLGenerationOptions.m */,
 				712A0C861DA3E55D007D02E5 /* FBXPath-Private.h */,
 				711084421DA3AA7500F913D6 /* FBXPath.h */,
 				711084431DA3AA7500F913D6 /* FBXPath.m */,
@@ -2277,6 +2285,7 @@
 				641EE63E2240C5CA00173FCB /* _XCTestImplementation.h in Headers */,
 				641EE63F2240C5CA00173FCB /* FBTouchActionCommands.h in Headers */,
 				641EE6402240C5CA00173FCB /* FBTouchIDCommands.h in Headers */,
+				714D88CD2733FB970074A925 /* FBXMLGenerationOptions.h in Headers */,
 				641EE6412240C5CA00173FCB /* XCUIApplication.h in Headers */,
 				641EE6422240C5CA00173FCB /* FBCustomCommands.h in Headers */,
 				641EE6432240C5CA00173FCB /* _XCTestCaseInterruptionException.h in Headers */,
@@ -2665,6 +2674,7 @@
 				EE35AD261E3B77D600A02D78 /* XCApplicationMonitor_iOS.h in Headers */,
 				EE3A18661CDE734B00DE4205 /* FBKeyboard.h in Headers */,
 				AD6C269C1CF2494200F8B5FF /* XCUIApplication+FBHelpers.h in Headers */,
+				714D88CC2733FB970074A925 /* FBXMLGenerationOptions.h in Headers */,
 				EE35AD101E3B77D600A02D78 /* _XCTestObservationCenterImplementation.h in Headers */,
 				AD6C26981CF2481700F8B5FF /* XCUIDevice+FBHelpers.h in Headers */,
 				71A7EAF91E224648001DA4F2 /* FBClassChainQueryParser.h in Headers */,
@@ -3102,6 +3112,7 @@
 				641EE5DC2240C5CA00173FCB /* XCUIApplication+FBAlert.m in Sources */,
 				641EE5DD2240C5CA00173FCB /* FBAppiumActionsSynthesizer.m in Sources */,
 				641EE70F2240CE4800173FCB /* FBTVNavigationTracker.m in Sources */,
+				714D88CF2733FB970074A925 /* FBXMLGenerationOptions.m in Sources */,
 				641EE5DE2240C5CA00173FCB /* XCUIApplication+FBTouchAction.m in Sources */,
 				641EE5DF2240C5CA00173FCB /* FBWebServer.m in Sources */,
 				641EE5E02240C5CA00173FCB /* FBTCPSocket.m in Sources */,
@@ -3253,6 +3264,7 @@
 				EE7E271F1D06C69F001BEC7B /* FBXCTestCaseImplementationFailureHoldingProxy.m in Sources */,
 				7155D704211DCEF400166C20 /* FBMjpegServer.m in Sources */,
 				EEDFE1221D9C06F800E6FFE5 /* XCUIDevice+FBHealthCheck.m in Sources */,
+				714D88CE2733FB970074A925 /* FBXMLGenerationOptions.m in Sources */,
 				E444DCB424913C220060D7EB /* RoutingHTTPServer.m in Sources */,
 				7140974E1FAE20EE008FB2C5 /* FBBaseActionsSynthesizer.m in Sources */,
 				EEE3764A1D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.m in Sources */,

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
@@ -11,6 +11,7 @@
 
 @class XCElementSnapshot;
 @class XCAccessibilityElement;
+@class FBXMLGenerationOptions;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -45,18 +46,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDictionary *)fb_accessibilityTree;
 
 /**
- Return application elements tree in form of xml string
+ Return application elements tree in a form of xml string
+ with default options.
+
+ @return nil if there was a failure while retriveing the page source.
  */
 - (nullable NSString *)fb_xmlRepresentation;
 
 /**
- Return application elements tree in form of xml string exluding the given attribute names.
+ Return application elements tree in a form of xml string
 
- @param excludedAttributes the list of XML attribute names to be excluded from the resulting document.
- Invalid attribute names are silently skipped
- @returns The XML representation of the current element as a string
+ @param options Optional values that affect the resulting XML generation process.
+ @return nil if there was a failure while retriveing the page source.
  */
-- (NSString *)fb_xmlRepresentationWithoutAttributes:(NSArray<NSString *> *)excludedAttributes;
+- (nullable NSString *)fb_xmlRepresentationWithOptions:(nullable FBXMLGenerationOptions *)options;
 
 /**
  Return application elements tree in form of internal XCTest debugDescription string

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -20,6 +20,7 @@
 #import "FBXPath.h"
 #import "FBXCTestDaemonsProxy.h"
 #import "FBXCAXClientProxy.h"
+#import "FBXMLGenerationOptions.h"
 #import "XCAccessibilityElement.h"
 #import "XCElementSnapshot+FBHelpers.h"
 #import "XCUIDevice+FBHelpers.h"
@@ -180,15 +181,12 @@ static NSString* const FBUnknownBundleId = @"unknown";
 
 - (NSString *)fb_xmlRepresentation
 {
-  return [FBXPath xmlStringWithRootElement:self excludingAttributes:nil];
+  return [self fb_xmlRepresentationWithOptions:nil];
 }
 
-- (NSString *)fb_xmlRepresentationWithoutAttributes:(NSArray<NSString *> *)excludedAttributes
+- (NSString *)fb_xmlRepresentationWithOptions:(FBXMLGenerationOptions *)options
 {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnullable-to-nonnull-conversion"
-  return [FBXPath xmlStringWithRootElement:self excludingAttributes:excludedAttributes];
-#pragma clang diagnostic pop
+  return [FBXPath xmlStringWithRootElement:self options:options];
 }
 
 - (NSString *)fb_descriptionRepresentation

--- a/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -12,6 +12,7 @@
 #import "FBApplication.h"
 #import "FBRouteRequest.h"
 #import "FBSession.h"
+#import "FBXMLGenerationOptions.h"
 #import "XCUIApplication+FBHelpers.h"
 #import "XCUIElement+FBUtilities.h"
 #import "FBXPath.h"
@@ -43,14 +44,16 @@ static NSString *const SOURCE_FORMAT_DESCRIPTION = @"description";
   // This method might be called without session
   FBApplication *application = request.session.activeApplication ?: FBApplication.fb_activeApplication;
   NSString *sourceType = request.parameters[@"format"] ?: SOURCE_FORMAT_XML;
+  NSString *sourceScope = request.parameters[@"scope"];
   id result;
   if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_XML] == NSOrderedSame) {
     NSArray<NSString *> *excludedAttributes = nil == request.parameters[@"excluded_attributes"]
       ? nil
       : [request.parameters[@"excluded_attributes"] componentsSeparatedByString:@","];
-    result = nil == excludedAttributes
-      ? application.fb_xmlRepresentation
-      : [application fb_xmlRepresentationWithoutAttributes:(NSArray<NSString *> *)excludedAttributes];
+    result = [application fb_xmlRepresentationWithOptions:
+        [[[FBXMLGenerationOptions new]
+          withExcludedAttributes:excludedAttributes]
+         withScope:sourceScope]];
   } else if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_JSON] == NSOrderedSame) {
     result = application.fb_tree;
   } else if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_DESCRIPTION] == NSOrderedSame) {

--- a/WebDriverAgentLib/Utilities/FBXMLGenerationOptions.h
+++ b/WebDriverAgentLib/Utilities/FBXMLGenerationOptions.h
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FBXMLGenerationOptions : NSObject
+
+/**
+ XML buidling scope. Passing nil means the XML should be built in the default scope,
+ i.e no changes to the original tree structore. If the scope is provided then the resulting
+ XML tree will be put under the root, which name is equal to the given scope value.
+ */
+@property (nonatomic, nullable) NSString *scope;
+/**
+ The list of attribute names to exclude from the resulting document.
+ Passing nil means all the available attributes should be included
+ */
+@property (nonatomic, nullable) NSArray<NSString *> *excludedAttributes;
+
+/**
+ Allows to provide XML scope.
+
+ @param scope See the property description above
+ @return self instance for chaining
+ */
+- (FBXMLGenerationOptions *)withScope:(nullable NSString *)scope;
+
+/**
+ Allows to provide a list of excluded XML attributes.
+
+ @param excludedAttributes See the property description above
+ @return self instance for chaining
+ */
+- (FBXMLGenerationOptions *)withExcludedAttributes:(nullable NSArray<NSString *> *)excludedAttributes;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBXMLGenerationOptions.m
+++ b/WebDriverAgentLib/Utilities/FBXMLGenerationOptions.m
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBXMLGenerationOptions.h"
+
+@implementation FBXMLGenerationOptions
+
+- (FBXMLGenerationOptions *)withScope:(NSString *)scope
+{
+  self.scope = scope;
+  return self;
+}
+
+- (FBXMLGenerationOptions *)withExcludedAttributes:(NSArray<NSString *> *)excludedAttributes
+{
+  self.excludedAttributes = excludedAttributes;
+  return self;
+}
+
+@end

--- a/WebDriverAgentLib/Utilities/FBXPath.h
+++ b/WebDriverAgentLib/Utilities/FBXPath.h
@@ -27,6 +27,8 @@
 #pragma clang diagnostic pop
 #endif
 
+@class FBXMLGenerationOptions;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FBXPath : NSObject
@@ -47,12 +49,11 @@ NS_ASSUME_NONNULL_BEGIN
  representation, which is used for XPath search
  
  @param root the root element
- @param excludedAttributes the list of attribute names to exclude from the resulting document.
- Passing nil means all the available attributes should be included
+ @param options Optional values that affect the resulting XML creation process
  @return valid XML document as string or nil in case of failure
  */
 + (nullable NSString *)xmlStringWithRootElement:(id<FBElement>)root
-                            excludingAttributes:(nullable NSArray<NSString *> *)excludedAttributes;
+                                        options:(nullable FBXMLGenerationOptions *)options;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -12,6 +12,7 @@
 #import "FBConfiguration.h"
 #import "FBExceptions.h"
 #import "FBLogger.h"
+#import "FBXMLGenerationOptions.h"
 #import "NSString+FBXMLSafeString.h"
 #import "XCElementSnapshot+FBHelpers.h"
 #import "XCUIElement.h"
@@ -117,15 +118,44 @@ static NSString *const topNodeIndexPath = @"top";
 }
 
 + (nullable NSString *)xmlStringWithRootElement:(id<FBElement>)root
-                            excludingAttributes:(nullable NSArray<NSString *> *)excludedAttributes
+                                        options:(nullable FBXMLGenerationOptions *)options
 {
   xmlDocPtr doc;
   xmlTextWriterPtr writer = xmlNewTextWriterDoc(&doc, 0);
-  int rc = [self xmlRepresentationWithRootElement:root
+  int rc = xmlTextWriterStartDocument(writer, NULL, _UTF8Encoding, NULL);
+  if (rc < 0) {
+    [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterStartDocument. Error code: %d", rc];
+  } else {
+    if (nil != options.scope && [options.scope length] > 0) {
+      rc = xmlTextWriterStartElement(writer,
+                                     (xmlChar *)[[self safeXmlStringWithString:options.scope] UTF8String]);
+      if (rc < 0) {
+        [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterStartElement for the tag value '%@'. Error code: %d", options.scope, rc];
+      }
+    }
+
+    if (rc >= 0) {
+      rc = [self xmlRepresentationWithRootElement:root
                                            writer:writer
                                      elementStore:nil
                                             query:nil
-                              excludingAttributes:excludedAttributes];
+                              excludingAttributes:options.excludedAttributes];
+    }
+
+    if (rc >= 0 && nil != options.scope) {
+      rc = xmlTextWriterEndElement(writer);
+      if (rc < 0) {
+        [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterEndElement. Error code: %d", rc];
+      }
+    }
+
+    if (rc >= 0) {
+      rc = xmlTextWriterEndDocument(writer);
+      if (rc < 0) {
+        [FBLogger logFmt:@"Failed to invoke libxml2>xmlXPathNewContext. Error code: %d", rc];
+      }
+    }
+  }
   if (rc < 0) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);
@@ -141,7 +171,8 @@ static NSString *const topNodeIndexPath = @"top";
   return result;
 }
 
-+ (NSArray<XCElementSnapshot *> *)matchesWithRootElement:(id<FBElement>)root forQuery:(NSString *)xpathQuery
++ (NSArray<XCElementSnapshot *> *)matchesWithRootElement:(id<FBElement>)root
+                                                forQuery:(NSString *)xpathQuery
 {
   xmlDocPtr doc;
 
@@ -151,11 +182,22 @@ static NSString *const topNodeIndexPath = @"top";
     return [self throwException:FBXPathQueryEvaluationException forQuery:xpathQuery];
   }
   NSMutableDictionary *elementStore = [NSMutableDictionary dictionary];
-  int rc = [self xmlRepresentationWithRootElement:root
-                                           writer:writer
-                                     elementStore:elementStore
-                                            query:xpathQuery
-                              excludingAttributes:nil];
+  int rc = xmlTextWriterStartDocument(writer, NULL, _UTF8Encoding, NULL);
+  if (rc < 0) {
+    [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterStartDocument. Error code: %d", rc];
+  } else {
+    rc = [self xmlRepresentationWithRootElement:root
+                                         writer:writer
+                                   elementStore:elementStore
+                                          query:xpathQuery
+                            excludingAttributes:nil];
+    if (rc >= 0) {
+      rc = xmlTextWriterEndDocument(writer);
+      if (rc < 0) {
+        [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterEndDocument. Error code: %d", rc];
+      }
+    }
+  }
   if (rc < 0) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);
@@ -169,7 +211,8 @@ static NSString *const topNodeIndexPath = @"top";
     return [self throwException:FBInvalidXPathException forQuery:xpathQuery];
   }
 
-  NSArray *matchingSnapshots = [self collectMatchingSnapshots:queryResult->nodesetval elementStore:elementStore];
+  NSArray *matchingSnapshots = [self collectMatchingSnapshots:queryResult->nodesetval
+                                                 elementStore:elementStore];
   xmlXPathFreeObject(queryResult);
   xmlFreeTextWriter(writer);
   xmlFreeDoc(doc);
@@ -179,7 +222,8 @@ static NSString *const topNodeIndexPath = @"top";
   return matchingSnapshots;
 }
 
-+ (NSArray *)collectMatchingSnapshots:(xmlNodeSetPtr)nodeSet elementStore:(NSMutableDictionary *)elementStore
++ (NSArray *)collectMatchingSnapshots:(xmlNodeSetPtr)nodeSet
+                         elementStore:(NSMutableDictionary *)elementStore
 {
   if (xmlXPathNodeSetIsEmpty(nodeSet)) {
     return @[];
@@ -243,24 +287,13 @@ static NSString *const topNodeIndexPath = @"top";
   }
   [FBLogger logFmt:@"The following attributes were requested to be included into the XML: %@", includedAttributes];
 
-  int rc = xmlTextWriterStartDocument(writer, NULL, _UTF8Encoding, NULL);
-  if (rc < 0) {
-    [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterStartDocument. Error code: %d", rc];
-    return rc;
-  }
-
-  rc = [self writeXmlWithRootElement:root
-                           indexPath:(elementStore != nil ? topNodeIndexPath : nil)
-                        elementStore:elementStore
-                  includedAttributes:includedAttributes.copy
-                              writer:writer];
+  int rc = [self writeXmlWithRootElement:root
+                               indexPath:(elementStore != nil ? topNodeIndexPath : nil)
+                            elementStore:elementStore
+                      includedAttributes:includedAttributes.copy
+                                  writer:writer];
   if (rc < 0) {
     [FBLogger log:@"Failed to generate XML presentation of a screen element"];
-    return rc;
-  }
-  rc = xmlTextWriterEndDocument(writer);
-  if (rc < 0) {
-    [FBLogger logFmt:@"Failed to invoke libxml2>xmlXPathNewContext. Error code: %d", rc];
     return rc;
   }
   return 0;
@@ -290,7 +323,10 @@ static NSString *const topNodeIndexPath = @"top";
   return [str fb_xmlSafeStringWithReplacement:@""];
 }
 
-+ (int)recordElementAttributes:(xmlTextWriterPtr)writer forElement:(XCElementSnapshot *)element indexPath:(nullable NSString *)indexPath includedAttributes:(nullable NSSet<Class> *)includedAttributes
++ (int)recordElementAttributes:(xmlTextWriterPtr)writer
+                    forElement:(XCElementSnapshot *)element
+                     indexPath:(nullable NSString *)indexPath
+            includedAttributes:(nullable NSSet<Class> *)includedAttributes
 {
   for (Class attributeCls in FBElementAttribute.supportedAttributes) {
     // include all supported attributes by default unless enumerated explicitly

--- a/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
@@ -13,6 +13,7 @@
 #import "FBTestMacros.h"
 #import "FBXPath.h"
 #import "FBXCodeCompatibility.h"
+#import "FBXMLGenerationOptions.h"
 #import "XCUIElement.h"
 #import "XCUIElement+FBFind.h"
 #import "XCUIElement+FBUtilities.h"
@@ -52,16 +53,29 @@
 - (void)testSingleDescendantXMLRepresentation
 {
   XCElementSnapshot *snapshot = self.destinationSnapshot;
-  NSString *xmlStr = [FBXPath xmlStringWithRootElement:snapshot excludingAttributes:nil];
+  NSString *xmlStr = [FBXPath xmlStringWithRootElement:snapshot options:nil];
   XCTAssertNotNil(xmlStr);
   NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" index=\"%lu\"/>\n", snapshot.wdType, snapshot.wdType, snapshot.wdName, snapshot.wdLabel, snapshot.wdEnabled ? @"true" : @"false", snapshot.wdVisible ? @"true" : @"false", snapshot.wdAccessible ? @"true" : @"false", [snapshot.wdRect[@"x"] stringValue], [snapshot.wdRect[@"y"] stringValue], [snapshot.wdRect[@"width"] stringValue], [snapshot.wdRect[@"height"] stringValue], snapshot.wdIndex];
+  XCTAssertEqualObjects(xmlStr, expectedXml);
+}
+
+- (void)testSingleDescendantXMLRepresentationWithScope
+{
+  XCElementSnapshot *snapshot = self.destinationSnapshot;
+  NSString *scope = @"AppiumAUT";
+  FBXMLGenerationOptions *options = [[FBXMLGenerationOptions new] withScope:scope];
+  NSString *xmlStr = [FBXPath xmlStringWithRootElement:snapshot options:options];
+  XCTAssertNotNil(xmlStr);
+  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@>\n  <%@ type=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" index=\"%lu\"/>\n</%@>\n", scope, snapshot.wdType, snapshot.wdType, snapshot.wdName, snapshot.wdLabel, snapshot.wdEnabled ? @"true" : @"false", snapshot.wdVisible ? @"true" : @"false", snapshot.wdAccessible ? @"true" : @"false", [snapshot.wdRect[@"x"] stringValue], [snapshot.wdRect[@"y"] stringValue], [snapshot.wdRect[@"width"] stringValue], [snapshot.wdRect[@"height"] stringValue], snapshot.wdIndex, scope];
   XCTAssertEqualObjects(xmlStr, expectedXml);
 }
 
 - (void)testSingleDescendantXMLRepresentationWithoutAttributes
 {
   XCElementSnapshot *snapshot = self.destinationSnapshot;
-  NSString *xmlStr = [FBXPath xmlStringWithRootElement:snapshot excludingAttributes:@[@"visible", @"enabled", @"index", @"blabla"]];
+  FBXMLGenerationOptions *options = [[FBXMLGenerationOptions new]
+                                     withExcludedAttributes:@[@"visible", @"enabled", @"index", @"blabla"]];
+  NSString *xmlStr = [FBXPath xmlStringWithRootElement:snapshot options:options];
   XCTAssertNotNil(xmlStr);
   NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" name=\"%@\" label=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\"/>\n", snapshot.wdType, snapshot.wdType, snapshot.wdName, snapshot.wdLabel, snapshot.wdAccessible ? @"true" : @"false", [snapshot.wdRect[@"x"] stringValue], [snapshot.wdRect[@"y"] stringValue], [snapshot.wdRect[@"width"] stringValue], [snapshot.wdRect[@"height"] stringValue]];
   XCTAssertEqualObjects(xmlStr, expectedXml);

--- a/WebDriverAgentTests/UnitTests/FBXPathTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXPathTests.m
@@ -28,18 +28,24 @@
   NSMutableDictionary *elementStore = [NSMutableDictionary dictionary];
   int buffersize;
   xmlChar *xmlbuff;
-  int rc = [FBXPath xmlRepresentationWithRootElement:(XCElementSnapshot *)element
-                                              writer:writer
-                                        elementStore:elementStore
-                                               query:query
-                                 excludingAttributes:excludedAttributes];
-  if (0 == rc) {
+  int rc = xmlTextWriterStartDocument(writer, NULL, "UTF-8", NULL);
+  if (rc >= 0) {
+    rc = [FBXPath xmlRepresentationWithRootElement:(XCElementSnapshot *)element
+                                                writer:writer
+                                          elementStore:elementStore
+                                                 query:query
+                                   excludingAttributes:excludedAttributes];
+    if (rc >= 0) {
+      rc = xmlTextWriterEndDocument(writer);
+    }
+  }
+  if (rc >= 0) {
     xmlDocDumpFormatMemory(doc, &xmlbuff, &buffersize, 1);
   }
   xmlFreeTextWriter(writer);
   xmlFreeDoc(doc);
   
-  XCTAssertEqual(rc, 0);
+  XCTAssertTrue(rc >= 0);
   XCTAssertEqual(1, [elementStore count]);
 
   NSString *result = [NSString stringWithCString:(const char *)xmlbuff encoding:NSUTF8StringEncoding];
@@ -100,15 +106,21 @@
   NSMutableDictionary *elementStore = [NSMutableDictionary dictionary];
   XCUIElementDouble *root = [XCUIElementDouble new];
   NSString *query = [NSString stringWithFormat:@"//%@", root.wdType];
-  int rc = [FBXPath xmlRepresentationWithRootElement:(XCElementSnapshot *)root
-                                              writer:writer
-                                        elementStore:elementStore
-                                               query:query
-                                 excludingAttributes:nil];
+  int rc = xmlTextWriterStartDocument(writer, NULL, "UTF-8", NULL);
+  if (rc >= 0) {
+    rc = [FBXPath xmlRepresentationWithRootElement:(XCElementSnapshot *)root
+                                            writer:writer
+                                      elementStore:elementStore
+                                             query:query
+                               excludingAttributes:nil];
+    if (rc >= 0) {
+      rc = xmlTextWriterEndDocument(writer);
+    }
+  }
   if (rc < 0) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);
-    XCTAssertEqual(rc, 0);
+    XCTFail(@"Unable to create the source XML document");
   }
 
   xmlXPathObjectPtr queryResult = [FBXPath evaluate:query document:doc];


### PR DESCRIPTION
Currently we put the page source under `AppiumAUT` root in the driver code, which is suboptimal and adds additional unnecessary complications (from both performance and dependencies amount perspectives). This PR allows to provide the scope query parameter to the source request, so that WDA would put the source tree under the desired node itself without any further driver interactions.