### PR TITLE
fix: Update relative event coordinates calculation for iOS 15.2+

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -185,16 +185,19 @@
   }
   CGPoint midPoint = CGPointMake(visibleRect.origin.x + visibleRect.size.width / 2,
                                  visibleRect.origin.y + visibleRect.size.height / 2);
-#if !TARGET_OS_TV // TV has no orientation, so it does not need to coordinate
-  XCElementSnapshot *appElement = ancestors.count > 0 ? [ancestors lastObject] : self;
-  CGRect appFrame = appElement.frame;
-  CGRect windowFrame = nil == parentWindow ? selfFrame : parentWindow.frame;
-  if ((appFrame.size.height > appFrame.size.width && windowFrame.size.height < windowFrame.size.width) ||
-      (appFrame.size.height < appFrame.size.width && windowFrame.size.height > windowFrame.size.width)) {
-    // This is the indication of the fact that transformation is broken and coordinates should be
-    // recalculated manually.
-    // However, upside-down case cannot be covered this way, which is not important for Appium
-    midPoint = FBInvertPointForApplication(midPoint, appFrame.size, FBApplication.fb_activeApplication.interfaceOrientation);
+#if !TARGET_OS_TV // TV has no orientation, so it does not need to transform coordinates
+  UIInterfaceOrientation interfaceOrientation = FBApplication.fb_activeApplication.interfaceOrientation;
+  if (interfaceOrientation != UIInterfaceOrientationPortrait) {
+    XCElementSnapshot *appElement = ancestors.count > 0 ? [ancestors lastObject] : self;
+    CGRect appFrame = appElement.frame;
+    CGRect windowFrame = nil == parentWindow ? selfFrame : parentWindow.frame;
+    if ((appFrame.size.height > appFrame.size.width && windowFrame.size.height < windowFrame.size.width) ||
+        (appFrame.size.height < appFrame.size.width && windowFrame.size.height > windowFrame.size.width)) {
+      // This is the indication of the fact that transformation is broken and coordinates should be
+      // recalculated manually.
+      // However, upside-down case cannot be covered this way, which is not important for Appium
+      midPoint = FBInvertPointForApplication(midPoint, appFrame.size, interfaceOrientation);
+    }
   }
 #endif
   XCAccessibilityElement *hitElement = [FBActiveAppDetectionPoint axElementWithPoint:midPoint];

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.h
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.h
@@ -15,6 +15,15 @@
 NS_ASSUME_NONNULL_BEGIN
 
 #if !TARGET_OS_TV
+
+/**
+ Xcode SDKs 11 to 13.1 (including) have known bug that makes xctest to not properly handle event coordinates
+ for non-portrait orientations.
+ 
+ @returns YES if the current platform has the above issue.
+ */
+BOOL FBShouldWorkaroundCoordinatesTranslationBug(void);
+
 @interface FBBaseActionItem : NSObject
 
 /*! Raw JSON representation of the corresponding action item */


### PR DESCRIPTION
@KazuCocoa I saw that you mentioned some tests stopped working for iOS 15.2-beta
I've tried them locally and it looks Apple did some fixes to XCTest, so we need to addict coordinates calculation for WDA.
Please recheck these tests with this PR and let me know if more patches are needed