### PR TITLE
feat: remove no longer unavailable process argument/environment

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -160,46 +160,10 @@
   return FBResponseWithObject(@{
     @"pid": @(app.processID),
     @"bundleId": app.bundleID,
-    @"name": app.identifier,
-    @"processArguments": [self processArguments:app],
+    @"name": app.identifier
   });
 }
 
-/**
- * Returns current active app and its arguments of active session
- *
- * @return The dictionary of current active bundleId and its process/environment argumens
- *
- * @example
- *
- *     [self currentActiveApplication]
- *     //=> {
- *     //       "processArguments" : {
- *     //       "env" : {
- *     //           "HAPPY" : "testing"
- *     //       },
- *     //       "args" : [
- *     //           "happy",
- *     //           "tseting"
- *     //       ]
- *     //   }
- *
- *     [self currentActiveApplication]
- *     //=> {}
- */
-+ (NSDictionary *)processArguments:(XCUIApplication *)app
-{
-  // Can be nil if no active activation is defined by XCTest
-  if (app == nil) {
-    return @{};
-  }
-
-  return
-  @{
-    @"args": app.launchArguments,
-    @"env": app.launchEnvironment
-  };
-}
 
 #if !TARGET_OS_TV
 + (id<FBResponsePayload>)handleSetPasteboard:(FBRouteRequest *)request


### PR DESCRIPTION
I confirmed `app.launchArguments` and `app.launchEnvironment` no longer return proper info via `XCUIApplication *app = request.session.activeApplication ?: FBApplication.fb_activeApplication;`.

https://github.com/appium/appium/issues/16259#issuecomment-998356792

`app.launchArguments` and `app.launchEnvironment` via `app` after https://github.com/appium/WebDriverAgent/blob/a1824895274c60798b506f31054e4ce1e0400c71/WebDriverAgentLib/Commands/FBSessionCommands.m#L118-L119 returned correct info though.

We can store the `app` explicitly or possibly can store `app.launchArguments` and `app.launchEnvironment` in WDA as static variables etc, but I guess simply removing them from `mobile:activeAppInfo` might reduce confusion.

The `launchArguments` and `launchEnvironment` themselves worked. (I checked in a simple app)

(I guess this was because some security something to not show them to 3rd party env)