### PR TITLE
ci: bump macOS env

### DIFF
--- a/ci-jobs/build.yml
+++ b/ci-jobs/build.yml
@@ -12,8 +12,3 @@ jobs:
       vmImage: 'macOS-10.15'
       name: 'macOS_10_15'
       excludeXcode: '10.3.0,10.3,11.3,11.4,12'
-  - template: ./templates/build.yml
-    parameters:
-      # Exclude Xcode versions that were already covered in 10.15
-      excludeXcode: '11.1,11.2.1,11.2,11.3.1,11.3,11'
-      name: 'macOS_10_14'

--- a/ci-jobs/templates/build.yml
+++ b/ci-jobs/templates/build.yml
@@ -1,6 +1,6 @@
 parameters:
-  vmImage: 'macOS-10.14'
-  name: macOS_10_14
+  vmImage: 'macOS-10.15'
+  name: macOS_10_15
   excludeXcode: $(excludeXcode)
 jobs:
   - job: ${{ parameters.name }}


### PR DESCRIPTION
Probably this job is to build pre-built WDA packages for simulators
https://dev.azure.com/AppiumCI/Appium%20CI/_build?definitionId=36&_a=summary&view=runs

The last build that succeeded was probably https://github.com/appium/WebDriverAgent/releases/tag/v3.9.1


Will take a look again later