### PR TITLE
feat: refer to appearance in device info on iOS 15+ simulators/devices

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
@@ -135,6 +135,14 @@ typedef NS_ENUM(NSUInteger, FBUIInterfaceAppearance) {
  */
 - (BOOL)fb_setAppearance:(FBUIInterfaceAppearance)appearance error:(NSError **)error;
 
+/**
+ Get current appearance prefefence.
+
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return 0 (automatic), 1 (light) or 2 (dark)
+ */
+- (long long)fb_getAppearance:(NSError **)error;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
@@ -140,7 +140,7 @@ typedef NS_ENUM(NSUInteger, FBUIInterfaceAppearance) {
 
  @return 0 (automatic), 1 (light) or 2 (dark), or nil
  */
-- (NSNumber *)fb_getAppearance;
+- (nullable NSNumber *)fb_getAppearance;
 
 @end
 

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
@@ -138,10 +138,9 @@ typedef NS_ENUM(NSUInteger, FBUIInterfaceAppearance) {
 /**
  Get current appearance prefefence.
 
- @param error If there is an error, upon return contains an NSError object that describes the problem.
- @return 0 (automatic), 1 (light) or 2 (dark)
+ @return 0 (automatic), 1 (light) or 2 (dark), or nil
  */
-- (long long)fb_getAppearance:(NSError **)error;
+- (NSNumber *)fb_getAppearance;
 
 @end
 

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -326,14 +326,12 @@ static bool fb_isLocked;
           buildError:error];
 }
 
-- (long long)fb_getAppearance:(NSError **)error
+- (NSNumber *)fb_getAppearance
 {
   if ([self respondsToSelector:@selector(appearanceMode)]) {
-    return [self appearanceMode];
+    return [NSNumber numberWithLongLong:[self appearanceMode]];
   }
-  return [[[FBErrorBuilder builder]
-           withDescriptionFormat:@"Current Xcode SDK does not support getting appearance value"]
-          buildError:error];
+  return nil;
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -328,10 +328,9 @@ static bool fb_isLocked;
 
 - (NSNumber *)fb_getAppearance
 {
-  if ([self respondsToSelector:@selector(appearanceMode)]) {
-    return [NSNumber numberWithLongLong:[self appearanceMode]];
-  }
-  return nil;
+  return [self respondsToSelector:@selector(appearanceMode)]
+  ? [NSNumber numberWithLongLong:[self appearanceMode]]
+  : nil;
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -326,4 +326,14 @@ static bool fb_isLocked;
           buildError:error];
 }
 
+- (long long)fb_getAppearance:(NSError **)error
+{
+  if ([self respondsToSelector:@selector(appearanceMode)]) {
+    return [self appearanceMode];
+  }
+  return [[[FBErrorBuilder builder]
+           withDescriptionFormat:@"Current Xcode SDK does not support getting appearance value"]
+          buildError:error];
+}
+
 @end

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -426,16 +426,17 @@
  */
 + (NSString *)userInterfaceStyle
 {
-#if !TARGET_OS_SIMULATOR
-  // For a real device.
-  // Simmulators returned wrong appearance value before.
-  NSNumber *appearance = [XCUIDevice.sharedDevice fb_getAppearance];
-  if (appearance != nil) {
-    return [self getAppearanceName:appearance];
-  }
-#endif
 
-  // For simulator, and as a fallback for a real device.
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"15.0")) {
+    // Only iOS 15+ simulators/devices return correct data while
+    // the api itself works in iOS 13 and 14 that has style preference.
+    NSNumber *appearance = [XCUIDevice.sharedDevice fb_getAppearance];
+    if (appearance != nil) {
+      return [self getAppearanceName:appearance];
+
+    }
+  }
+
   static id userInterfaceStyle = nil;
   static dispatch_once_t styleOnceToken;
   dispatch_once(&styleOnceToken, ^{
@@ -454,7 +455,7 @@
   return [self getAppearanceName:userInterfaceStyle];
 }
 
-+ (NSString *)getAppearanceName:(id)appearance
++ (NSString *)getAppearanceName:(NSNumber *)appearance
 {
   switch ([appearance longLongValue]) {
     case FBUIInterfaceAppearanceUnspecified:

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -427,23 +427,15 @@
 + (NSString *)userInterfaceStyle
 {
 #if !TARGET_OS_SIMULATOR
-  // This way is reliable on a real device.
-  NSError *error;
-  long long appearance = [XCUIDevice.sharedDevice fb_getAppearance:&error];
-  if (error == nil) {
-    switch (appearance) {
-      case 0: // UIUserInterfaceStyleUnspecified
-        return @"automatic";
-      case 1: // UIUserInterfaceStyleLight
-        return @"light";
-      case 2: // UIUserInterfaceStyleDark
-        return @"dark";
-      default:
-        return @"unknown";
-    }
+  // For a real device.
+  // Simmulators returned wrong appearance value before.
+  NSNumber *appearance = [XCUIDevice.sharedDevice fb_getAppearance];
+  if (appearance != nil) {
+    return [self getAppearanceName:appearance];
   }
 #endif
 
+  // For simulator, and as a fallback for a real device.
   static id userInterfaceStyle = nil;
   static dispatch_once_t styleOnceToken;
   dispatch_once(&styleOnceToken, ^{
@@ -459,10 +451,17 @@
     return @"unsupported";
   }
 
-  switch ([userInterfaceStyle integerValue]) {
-    case 1: // UIUserInterfaceStyleLight
+  return [self getAppearanceName:userInterfaceStyle];
+}
+
++ (NSString *)getAppearanceName:(id)appearance
+{
+  switch ([appearance longLongValue]) {
+    case FBUIInterfaceAppearanceUnspecified:
+      return @"automatic";
+    case FBUIInterfaceAppearanceLight:
       return @"light";
-    case 2: // UIUserInterfaceStyleDark
+    case FBUIInterfaceAppearanceDark:
       return @"dark";
     default:
       return @"unknown";

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -433,7 +433,6 @@
     NSNumber *appearance = [XCUIDevice.sharedDevice fb_getAppearance];
     if (appearance != nil) {
       return [self getAppearanceName:appearance];
-
     }
   }
 

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -426,6 +426,24 @@
  */
 + (NSString *)userInterfaceStyle
 {
+#if !TARGET_OS_SIMULATOR
+  // This way is reliable on a real device.
+  NSError *error;
+  long long appearance = [XCUIDevice.sharedDevice fb_getAppearance:&error];
+  if (error == nil) {
+    switch (appearance) {
+      case 0: // UIUserInterfaceStyleUnspecified
+        return @"automatic";
+      case 1: // UIUserInterfaceStyleLight
+        return @"light";
+      case 2: // UIUserInterfaceStyleDark
+        return @"dark";
+      default:
+        return @"unknown";
+    }
+  }
+#endif
+
   static id userInterfaceStyle = nil;
   static dispatch_once_t styleOnceToken;
   dispatch_once(&styleOnceToken, ^{


### PR DESCRIPTION
On real devices, the result of `appearanceMode` was reliable to respond current `userInterfaceStyle` in device info.
The result seems wrong on simulators. 