### PR TITLE
fix: Restore screenshot functionality for iOS 14.4 simulators

### DIFF
--- a/WebDriverAgentLib/Utilities/FBScreenshot.m
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.m
@@ -212,6 +212,7 @@ NSString *formatTimeInterval(NSTimeInterval interval) {
   dispatch_once(&shouldUseSRApi, ^{
     if ([proxy respondsToSelector:@selector(_XCT_requestScreenshot:withReply:)]) {
 #if TARGET_OS_SIMULATOR
+      // Required to support simulators running iOS 14.4 and below with Xcode 12.5 and above due to unsupported API on the simulator side.
       result = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"14.5");
 #else
       result = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"15.0");

--- a/WebDriverAgentLib/Utilities/FBScreenshot.m
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.m
@@ -212,7 +212,7 @@ NSString *formatTimeInterval(NSTimeInterval interval) {
   dispatch_once(&shouldUseSRApi, ^{
     if ([proxy respondsToSelector:@selector(_XCT_requestScreenshot:withReply:)]) {
 #if TARGET_OS_SIMULATOR
-      result = YES;
+      result = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"14.5");
 #else
       result = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"15.0");
 #endif


### PR DESCRIPTION
It appears that the new screenshot API introduced with Xcode 12.5 (`_XCT_requestScreenshot:withReply:`) does not work on simulators running iOS 14.4 and below ("connection to testmanagerd interrupted"), thus not allowing to capture screenshots on such simulators when using Xcode 12.5+.

This commit sets the minimum supported simulator version for the newer screenshot API to 14.5 for simulators instead of always allowing it when the selector is detected.

Should probably also address https://github.com/appium/WebDriverAgent/issues/569