### PR TITLE
chore: Skip project cleanup if a fresh install is detected

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -210,7 +210,8 @@ class WebDriverAgent {
     }
 
     const timestampPath = path.resolve(homeFolder, WDA_UPGRADE_TIMESTAMP_PATH);
-    if (await fs.exists(timestampPath)) {
+    const didTimestampExist = await fs.exists(timestampPath);
+    if (didTimestampExist) {
       try {
         await fs.access(timestampPath, fs.W_OK);
       } catch (ign) {
@@ -240,6 +241,11 @@ class WebDriverAgent {
     } catch (e) {
       this.log.info(`Unable to create the recent WebDriverAgent upgrade timestamp at '${timestampPath}'. ` +
         `Original error: ${e.message}`);
+      return;
+    }
+
+    if (!didTimestampExist) {
+      this.log.info('There is no need to perform the project cleanup. A fresh install has been detected');
       return;
     }
 


### PR DESCRIPTION
This is needed to be able to precompile WDA sources after a fresh install