### PR TITLE
test: Remove the failing check

### DIFF
--- a/WebDriverAgentTests/IntegrationTests/FBElementScreenshotTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementScreenshotTests.m
@@ -9,6 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import "FBMacros.h"
 #import "FBIntegrationTestCase.h"
 #import "XCUIDevice+FBRotation.h"
 #import "XCUIElement+FBUtilities.h"
@@ -41,27 +42,11 @@
   XCUIElement *button = self.testedApplication.buttons[FBShowAlertButtonName];
   NSError *error = nil;
   NSData *screenshotData = [button fb_screenshotWithError:&error];
-  if (nil == screenshotData && [error.description containsString:@"available since Xcode9"]) {
-    return;
-  }
   XCTAssertNotNil(screenshotData);
   XCTAssertNil(error);
   UIImage *image = [UIImage imageWithData:screenshotData];
   XCTAssertNotNil(image);
   XCTAssertTrue(image.size.width > image.size.height);
-
-  XCUIScreen *mainScreen = XCUIScreen.mainScreen;
-  // Note about iPadOS 15.0 environment.
-  // The 'button.screenshot.image' (by XCTest) had a white image while 'image' had
-  // expected FBShowAlertButtonName area image by WebDriverAgent.
-  // It seems the native XCTest element screenshot has an issue on iPadOS.
-  UIImage *buttonScreenshot = button.screenshot.image;
-  XCTAssertEqualWithAccuracy(buttonScreenshot.size.height * mainScreen.scale,
-                             image.size.height,
-                             FLT_EPSILON);
-  XCTAssertEqualWithAccuracy(buttonScreenshot.size.width * mainScreen.scale,
-                             image.size.width,
-                             FLT_EPSILON);
 }
 
 @end


### PR DESCRIPTION
I don't see much point in checking the native element screenshot functionality as it is anyway not used by WDA is known to have bugs in non-portrait orientations.  