### PR TITLE
Lower deployment target to iOS 11

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -3834,7 +3834,7 @@
 					"$(SDKROOT)/usr/include/libxml2",
 					"$(SRCROOT)/Modules",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -3895,7 +3895,7 @@
 					"$(SDKROOT)/usr/include/libxml2",
 					"$(SRCROOT)/Modules",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Launching WDA on an iOS 11 device crashes with a missing image error since `WebDriverAgentLib` will link against the `CoreServices.framework`, which is apparently only available on iOS 12+.

I'm not sure if was intentionally bumped but it happened here  https://github.com/appium/WebDriverAgent/pull/557 and I assume it was done by the migration tool automatically.
I didn't put it back to iOS 10 as I was only able to verify it on iOS 11, and for the same reason I kept it unchanged for tvOS.