### PR TITLE
ci: build ios/tvos for generic devices with no code sign

### DIFF
--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -20,6 +20,27 @@ jobs:
       - name: Build iOS
         run: |
           xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_ios -scheme WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
+      - name: Creating a zip of WebDriverAgentRunner-Runner.app for iOS
+        run: |
+          pushd appium_wda_ios/Build/Products/Debug-iphoneos
+          zip -r "WebDriverAgentRunner-Runner-Xcode${{ env.XCODE_VERSION }}.zip" WebDriverAgentRunner-Runner.app
+          mv "WebDriverAgentRunner-Runner-${{ env.XCODE_VERSION }}.zip" ../../../..
+          popd
       - name: Build tvOS
         run: |
           xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_tvos -scheme WebDriverAgentRunner_tvOS -destination generic/platform=tvOS CODE_SIGNING_ALLOWED=NO
+      - name: Creating a zip of WebDriverAgentRunner-Runner.app for tvOS
+        run: |
+          pushd appium_wda_tvos/Build/Products/Debug-appletvos
+          zip -r "WebDriverAgentRunner_tvOS-Runner-Xcode${{ env.XCODE_VERSION }}.zip" WebDriverAgentRunner_tvOS-Runner.app
+          mv "WebDriverAgentRunner_tvOS-Runner-${{ env.XCODE_VERSION }}.zip" ../../../..
+          popd
+
+      - name: Upload the built generic app package for iOS
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          path: "WebDriverAgentRunner-Runner-${{ env.XCODE_VERSION }}.zip"
+      - name: Upload the built generic app package for tvOS
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          path: "WebDriverAgentRunner_tvOS-Runner-${{ env.XCODE_VERSION }}.zip"

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -11,8 +11,8 @@ jobs:
 
     env:
       XCODE_VERSION: 13.2.1
-      ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner-Xcode${{ env.XCODE_VERSION }}.zip"
-      ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner-Xcode${{ env.XCODE_VERSION }}.zip"
+      ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner.zip"
+      ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner.zip"
 
     steps:
       - name: Checkout

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -23,7 +23,7 @@ jobs:
           xcode-version: "${{ env.XCODE_VERSION }}"
       - name: Build iOS
         run: |
-          xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_ios -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
+          xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_ios -scheme WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
       - name: Build tvOS
         run: |
-          xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_tvos -scheme WebDriverAgentRunner_tvOS -target WebDriverAgentRunner_tvOS -destination generic/platform=tvOS CODE_SIGNING_ALLOWED=NO
+          xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_tvos -scheme WebDriverAgentRunner_tvOS -destination generic/platform=tvOS CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -2,17 +2,19 @@ name: Building WebDriverAgent
 
 on:
   workflow_dispatch:
-  pull_request:  # for testing
+  pull_request:  # for testing, will remove this after merging this PR once
 
 jobs:
   build:
-    name: Build and analyse default scheme using xcodebuild command
-    runs-on: macos-latest
+    name: Build WDA for real iOS and tvOS devices
+    runs-on: macos-11
 
     env:
       XCODE_VERSION: 13.2.1
       ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner.zip"
+      PKG_PATH_IOS: "appium_wda_ios"
       ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner.zip"
+      PKG_PATH_TVOS: "appium_wda_tvos"
 
     steps:
       - name: Checkout
@@ -22,22 +24,32 @@ jobs:
           xcode-version: "${{ env.XCODE_VERSION }}"
       - name: Build iOS
         run: |
-          xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_ios -scheme WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
+          xcodebuild clean build-for-testing \
+            -project WebDriverAgent.xcodeproj \
+            -derivedDataPath $PKG_PATH_IOS \
+            -scheme WebDriverAgentRunner \
+            -destination generic/platform=iOS \
+            CODE_SIGNING_ALLOWED=NO
       - name: Creating a zip of WebDriverAgentRunner-Runner.app for iOS
         run: |
           pushd appium_wda_ios/Build/Products/Debug-iphoneos
-          zip -r "${{ env.ZIP_PKG_NAME_IOS }}" WebDriverAgentRunner-Runner.app
+          zip -r $ZIP_PKG_NAME_IOS WebDriverAgentRunner-Runner.app
           popd
-          mv "appium_wda_ios/Build/Products/Debug-iphoneos/${{ env.ZIP_PKG_NAME_IOS }}" ./
+          mv $PKG_PATH_IOS/Build/Products/Debug-iphoneos/$ZIP_PKG_NAME_IOS ./
       - name: Build tvOS
         run: |
-          xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_tvos -scheme WebDriverAgentRunner_tvOS -destination generic/platform=tvOS CODE_SIGNING_ALLOWED=NO
+          xcodebuild clean build-for-testing \
+            -project WebDriverAgent.xcodeproj \
+            -derivedDataPath $PKG_PATH_TVOS \
+            -scheme WebDriverAgentRunner_tvOS \
+            -destination generic/platform=tvOS \
+            CODE_SIGNING_ALLOWED=NO
       - name: Creating a zip of WebDriverAgentRunner-Runner.app for tvOS
         run: |
           pushd appium_wda_tvos/Build/Products/Debug-appletvos
-          zip -r "${{ env.ZIP_PKG_NAME_TVOS }}" WebDriverAgentRunner_tvOS-Runner.app
+          zip -r $ZIP_PKG_NAME_TVOS WebDriverAgentRunner_tvOS-Runner.app
           popd
-          mv "appium_wda_tvos/Build/Products/Debug-appletvos/${{ env.ZIP_PKG_NAME_TVOS }}" ./
+          mv $PKG_PATH_TVOS/Build/Products/Debug-appletvos/$ZIP_PKG_NAME_TVOS ./
       - name: Upload the built generic app package for iOS
         uses: actions/upload-artifact@v3.1.0
         with:

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -1,7 +1,11 @@
 name: Building WebDriverAgent
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
 
 jobs:
   build:

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -11,6 +11,8 @@ jobs:
 
     env:
       XCODE_VERSION: 13.2.1
+      ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner-Xcode${{ env.XCODE_VERSION }}.zip"
+      ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner-Xcode${{ env.XCODE_VERSION }}.zip"
 
     steps:
       - name: Checkout
@@ -24,24 +26,23 @@ jobs:
       - name: Creating a zip of WebDriverAgentRunner-Runner.app for iOS
         run: |
           pushd appium_wda_ios/Build/Products/Debug-iphoneos
-          zip -r "WebDriverAgentRunner-Runner-Xcode${{ env.XCODE_VERSION }}.zip" WebDriverAgentRunner-Runner.app
-          mv "WebDriverAgentRunner-Runner-${{ env.XCODE_VERSION }}.zip" ../../../..
+          zip -r "${{ env.ZIP_PKG_NAME_IOS }}" WebDriverAgentRunner-Runner.app
           popd
+          mv "appium_wda_ios/Build/Products/Debug-iphoneos/${{ env.ZIP_PKG_NAME_IOS }}" ./
       - name: Build tvOS
         run: |
           xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_tvos -scheme WebDriverAgentRunner_tvOS -destination generic/platform=tvOS CODE_SIGNING_ALLOWED=NO
       - name: Creating a zip of WebDriverAgentRunner-Runner.app for tvOS
         run: |
           pushd appium_wda_tvos/Build/Products/Debug-appletvos
-          zip -r "WebDriverAgentRunner_tvOS-Runner-Xcode${{ env.XCODE_VERSION }}.zip" WebDriverAgentRunner_tvOS-Runner.app
-          mv "WebDriverAgentRunner_tvOS-Runner-${{ env.XCODE_VERSION }}.zip" ../../../..
+          zip -r "${{ env.ZIP_PKG_NAME_TVOS }}" WebDriverAgentRunner_tvOS-Runner.app
           popd
-
+          mv "appium_wda_tvos/Build/Products/Debug-appletvos/${{ env.ZIP_PKG_NAME_TVOS }}" ./
       - name: Upload the built generic app package for iOS
         uses: actions/upload-artifact@v3.1.0
         with:
-          path: "WebDriverAgentRunner-Runner-${{ env.XCODE_VERSION }}.zip"
+          path: "${{ env.ZIP_PKG_NAME_IOS }}"
       - name: Upload the built generic app package for tvOS
         uses: actions/upload-artifact@v3.1.0
         with:
-          path: "WebDriverAgentRunner_tvOS-Runner-${{ env.XCODE_VERSION }}.zip"
+          path: "${{ env.ZIP_PKG_NAME_TVOS }}"

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-latest
 
     env:
-      XCODE_VERSION: 13.4
+      XCODE_VERSION: 13.2.1
 
     steps:
       - name: Checkout

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -1,0 +1,25 @@
+name: Building WebDriverAgent
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    name: Build and analyse default scheme using xcodebuild command
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Print current xcodebuild env
+        run: |
+          xcode-select -p
+      - name: Build iOS
+        run: |
+          xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_ios -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
+      - name: Build tvOS
+        run: |
+          xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_tvos -scheme WebDriverAgentRunner_tvOS -target WebDriverAgentRunner_tvOS -destination generic/platform=tvOS CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -2,6 +2,7 @@ name: Building WebDriverAgent
 
 on:
   workflow_dispatch:
+  pull_request:  # for testing
 
 jobs:
   build:

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -1,22 +1,22 @@
 name: Building WebDriverAgent
 
 on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+  workflow_dispatch
 
 jobs:
   build:
     name: Build and analyse default scheme using xcodebuild command
     runs-on: macos-latest
 
+    env:
+      XCODE_VERSION: 13.4
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Print current xcodebuild env
-        run: |
-          xcode-select -p
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "${{ env.XCODE_VERSION }}"
       - name: Build iOS
         run: |
           xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_ios -scheme WebDriverAgentRunner -target WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -2,10 +2,6 @@ name: Building WebDriverAgent
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
 
 jobs:
   build:


### PR DESCRIPTION
I'd like to create iOS/tvOS no codesign packages for https://github.com/appium/appium-xcuitest-driver/pull/1444/files#diff-b204cc4e709cfe7d15d01a076131dcb538445d83b8bfab1b589b09d8f52c1648R191 

This PR just includes building them, but I'd like to eventually make this task for a release workflow after or middle of https://github.com/appium/WebDriverAgent/blob/master/.github/workflows/publish.js.yml