### PR TITLE
ci: add building WDA packages tasks in the release task

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -10,12 +10,15 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    # To specify Xcode version
+    runs-on: macos-11
 
     env:
       XCODE_VERSION: 13.2.1
-      ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner_RealDevice.zip"
-      ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner_RealDevice.zip"
+      ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner.zip"
+      PKG_PATH_IOS: "appium_wda_ios"
+      ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner.zip"
+      PKG_PATH_TVOS: "appium_wda_tvos"
 
     steps:
     # setup
@@ -41,22 +44,32 @@ jobs:
     # building WDA packages
     - name: Build iOS
       run: |
-        xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_ios -scheme WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
+        xcodebuild clean build-for-testing \
+          -project WebDriverAgent.xcodeproj \
+          -derivedDataPath $PKG_PATH_IOS \
+          -scheme WebDriverAgentRunner \
+          -destination generic/platform=iOS \
+          CODE_SIGNING_ALLOWED=NO
     - name: Creating a zip of WebDriverAgentRunner-Runner.app for iOS
       run: |
         pushd appium_wda_ios/Build/Products/Debug-iphoneos
-        zip -r "${{ env.ZIP_PKG_NAME_IOS }}" WebDriverAgentRunner-Runner.app
+        zip -r $ZIP_PKG_NAME_IOS WebDriverAgentRunner-Runner.app
         popd
-        mv "appium_wda_ios/Build/Products/Debug-iphoneos/${{ env.ZIP_PKG_NAME_IOS }}" ./
+        mv $PKG_PATH_IOS/Build/Products/Debug-iphoneos/$ZIP_PKG_NAME_IOS ./
     - name: Build tvOS
       run: |
-        xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_tvos -scheme WebDriverAgentRunner_tvOS -destination generic/platform=tvOS CODE_SIGNING_ALLOWED=NO
+        xcodebuild clean build-for-testing \
+          -project WebDriverAgent.xcodeproj \
+          -derivedDataPath $PKG_PATH_TVOS \
+          -scheme WebDriverAgentRunner_tvOS \
+          -destination generic/platform=tvOS \
+          CODE_SIGNING_ALLOWED=NO
     - name: Creating a zip of WebDriverAgentRunner-Runner.app for tvOS
       run: |
         pushd appium_wda_tvos/Build/Products/Debug-appletvos
-        zip -r "${{ env.ZIP_PKG_NAME_TVOS }}" WebDriverAgentRunner_tvOS-Runner.app
+        zip -r $ZIP_PKG_NAME_TVOS WebDriverAgentRunner_tvOS-Runner.app
         popd
-        mv "appium_wda_tvos/Build/Products/Debug-appletvos/${{ env.ZIP_PKG_NAME_TVOS }}" ./
+        mv $PKG_PATH_TVOS/Build/Products/Debug-appletvos/$ZIP_PKG_NAME_TVOS ./
 
     # release tasks
     - run: npx semantic-release

--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -18,11 +18,17 @@ jobs:
       ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner_RealDevice.zip"
 
     steps:
+    # setup
     - uses: actions/checkout@v2
     - name: Use Node.js 18.x
       uses: actions/setup-node@v1
       with:
         node-version: 18.x
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: "${{ env.XCODE_VERSION }}"
+
+    # nodejs
     - run: |
         npm install -g appium@next
         npm install --no-package-lock
@@ -31,6 +37,8 @@ jobs:
       name: Run build
     - run: npm run test
       name: Run test
+
+    # building WDA packages
     - name: Build iOS
       run: |
         xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_ios -scheme WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
@@ -49,6 +57,8 @@ jobs:
         zip -r "${{ env.ZIP_PKG_NAME_TVOS }}" WebDriverAgentRunner_tvOS-Runner.app
         popd
         mv "appium_wda_tvos/Build/Products/Debug-appletvos/${{ env.ZIP_PKG_NAME_TVOS }}" ./
+
+    # release tasks
     - run: npx semantic-release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -11,6 +11,12 @@ on:
 jobs:
   build:
     runs-on: macos-latest
+
+    env:
+      XCODE_VERSION: 13.2.1
+      ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner_RealDevice.zip"
+      ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner_RealDevice.zip"
+
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js 18.x
@@ -25,8 +31,32 @@ jobs:
       name: Run build
     - run: npm run test
       name: Run test
+    - name: Build iOS
+      run: |
+        xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_ios -scheme WebDriverAgentRunner -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
+    - name: Creating a zip of WebDriverAgentRunner-Runner.app for iOS
+      run: |
+        pushd appium_wda_ios/Build/Products/Debug-iphoneos
+        zip -r "${{ env.ZIP_PKG_NAME_IOS }}" WebDriverAgentRunner-Runner.app
+        popd
+        mv "appium_wda_ios/Build/Products/Debug-iphoneos/${{ env.ZIP_PKG_NAME_IOS }}" ./
+    - name: Build tvOS
+      run: |
+        xcodebuild clean build-for-testing -project WebDriverAgent.xcodeproj -derivedDataPath appium_wda_tvos -scheme WebDriverAgentRunner_tvOS -destination generic/platform=tvOS CODE_SIGNING_ALLOWED=NO
+    - name: Creating a zip of WebDriverAgentRunner-Runner.app for tvOS
+      run: |
+        pushd appium_wda_tvos/Build/Products/Debug-appletvos
+        zip -r "${{ env.ZIP_PKG_NAME_TVOS }}" WebDriverAgentRunner_tvOS-Runner.app
+        popd
+        mv "appium_wda_tvos/Build/Products/Debug-appletvos/${{ env.ZIP_PKG_NAME_TVOS }}" ./
     - run: npx semantic-release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Release
+    - name: Upload Release assets
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          "${{ env.ZIP_PKG_NAME_IOS }}"
+          "${{ env.ZIP_PKG_NAME_TVOS }}"


### PR DESCRIPTION
https://github.com/appium/WebDriverAgent/pull/614/files worked, so I've copied xcode build tasks from the PR to check if this works as part of publish.js.yml.

Previously ios.appium.settings used https://github.com/actions/upload-release-asset but it is now archived. The README had a link to https://github.com/softprops/action-gh-release to this PR tries to use it.

I need to run a release task to check if the release assets plugin works as expected...
(Just append two zip files)