### PR TITLE
chore: update the release config

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -77,9 +77,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Release
-    - name: Upload Release assets
-      uses: softprops/action-gh-release@v1
-      with:
-        files: |
-          "${{ env.ZIP_PKG_NAME_IOS }}"
-          "${{ env.ZIP_PKG_NAME_TVOS }}"
+

--- a/.releaserc
+++ b/.releaserc
@@ -13,6 +13,10 @@
       "assets": ["docs", "package.json"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
-    "@semantic-release/github",
+    ["@semantic-release/github", {
+      "assets": [
+        "WebDriverAgentRunner-Runner.zip",
+        "WebDriverAgentRunner_tvOS-Runner.zip"
+    ]}],
   ]
 }


### PR DESCRIPTION
`softprops/action-gh-release@v1` failed...

```
Error: ⚠️ GitHub Releases requires a tag
```

https://github.com/appium/WebDriverAgent/actions/runs/3224372451/jobs/5275439162

But I found:
https://github.com/semantic-release/semantic-release/blob/1463eb42cb57665ca42323027405e2abbeb3031f/docs/usage/plugins.md#plugin-options-configuration

Lets try this one...