### PR TITLE
fix: Only check existence if firstMatch is applied

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
@@ -45,7 +45,7 @@ NSString *const FB_SAFARI_APP_NAME = @"Safari";
                     descendantsMatchingType:XCUIElementTypeOther]
                    matchingPredicate:dstViewMatchPredicate]
                   containingPredicate:dstViewContainPredicate1]
-                 containingPredicate:dstViewContainPredicate2].fb_firstMatch;
+                 containingPredicate:dstViewContainPredicate2].allElementsBoundByIndex.firstObject;
   } else {
     NSPredicate *webViewPredicate = [NSPredicate predicateWithFormat:@"elementType == %lu", XCUIElementTypeWebView];
     // Find the first XCUIElementTypeOther which is the descendant of the scroll view
@@ -54,7 +54,7 @@ NSString *const FB_SAFARI_APP_NAME = @"Safari";
                     descendantsMatchingType:XCUIElementTypeOther]
                    matchingPredicate:dstViewMatchPredicate]
                   containingPredicate:dstViewContainPredicate1]
-                 containingPredicate:dstViewContainPredicate2].fb_firstMatch;
+                 containingPredicate:dstViewContainPredicate2].allElementsBoundByIndex.firstObject;
   }
   if (nil == candidate) {
     return nil;
@@ -80,7 +80,7 @@ NSString *const FB_SAFARI_APP_NAME = @"Safari";
   NSPredicate *alertCollectorPredicate = [NSPredicate predicateWithFormat:@"elementType IN {%lu,%lu,%lu}",
                                           XCUIElementTypeAlert, XCUIElementTypeSheet, XCUIElementTypeScrollView];
   XCUIElement *alert = [[self descendantsMatchingType:XCUIElementTypeAny]
-                        matchingPredicate:alertCollectorPredicate].fb_firstMatch;
+                        matchingPredicate:alertCollectorPredicate].allElementsBoundByIndex.firstObject;
   if (nil == alert) {
     return nil;
   }

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -192,7 +192,7 @@ static NSString* const FBUnknownBundleId = @"unknown";
 - (NSString *)fb_descriptionRepresentation
 {
   NSMutableArray<NSString *> *childrenDescriptions = [NSMutableArray array];
-  for (XCUIElement *child in [self.fb_query childrenMatchingType:XCUIElementTypeAny].allElementsBoundByAccessibilityElement) {
+  for (XCUIElement *child in [self.fb_query childrenMatchingType:XCUIElementTypeAny].allElementsBoundByIndex) {
     [childrenDescriptions addObject:child.debugDescription];
   }
   // debugDescription property of XCUIApplication instance shows descendants addresses in memory

--- a/WebDriverAgentLib/Categories/XCUIElement+FBResolve.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBResolve.m
@@ -50,7 +50,7 @@ static char XCUIELEMENT_IS_RESOLVED_NATIVELY_KEY;
   NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id<FBXCElementSnapshot> snapshot, NSDictionary *bindings) {
     return [[FBXCElementSnapshotWrapper wdUIDWithSnapshot:snapshot] isEqualToString:uid];
   }];
-  return [query matchingPredicate:predicate].fb_firstMatch ?: self;
+  return [query matchingPredicate:predicate].allElementsBoundByIndex.firstObject ?: self;
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -165,7 +165,7 @@
   }];
   query = [query matchingPredicate:predicate];
   if (1 == snapshots.count) {
-    XCUIElement *result = query.fb_firstMatch;
+    XCUIElement *result = query.allElementsBoundByIndex.firstObject;
     result.fb_isResolvedNatively = @NO;
     return result ? @[result] : @[];
   }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -132,11 +132,11 @@
   if (0 == snapshots.count) {
     return @[];
   }
-  NSMutableArray<NSString *> *sortedIds = [NSMutableArray new];
+  NSMutableArray<NSString *> *matchedIds = [NSMutableArray new];
   for (id<FBXCElementSnapshot> snapshot in snapshots) {
     NSString *uid = [FBXCElementSnapshotWrapper wdUIDWithSnapshot:snapshot];
     if (nil != uid) {
-      [sortedIds addObject:uid];
+      [matchedIds addObject:uid];
     }
   }
   NSMutableArray<XCUIElement *> *matchedElements = [NSMutableArray array];
@@ -146,11 +146,13 @@
       ? [FBXCElementSnapshotWrapper wdUIDWithSnapshot:self.lastSnapshot]
       : self.fb_uid;
   }
-  if ([sortedIds containsObject:uid]) {
+  if (nil != uid && [matchedIds containsObject:uid]) {
+    XCUIElement *stableSelf = self.fb_stableInstance;
+    stableSelf.fb_isResolvedNatively = @NO;
     if (1 == snapshots.count) {
-      return @[self];
+      return @[stableSelf];
     }
-    [matchedElements addObject:self];
+    [matchedElements addObject:stableSelf];
   }
   XCUIElementType type = XCUIElementTypeAny;
   NSArray<NSNumber *> *uniqueTypes = [snapshots valueForKeyPath:[NSString stringWithFormat:@"@distinctUnionOfObjects.%@", FBStringify(XCUIElement, elementType)]];
@@ -161,34 +163,13 @@
     ? [self.fb_query childrenMatchingType:type]
     : [self.fb_query descendantsMatchingType:type];
   NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id<FBXCElementSnapshot> snapshot, NSDictionary *bindings) {
-    return [sortedIds containsObject:[FBXCElementSnapshotWrapper wdUIDWithSnapshot:snapshot] ?: @""];
+    return [matchedIds containsObject:[FBXCElementSnapshotWrapper wdUIDWithSnapshot:snapshot] ?: @""];
   }];
-  query = [query matchingPredicate:predicate];
-  if (1 == snapshots.count) {
-    XCUIElement *result = query.allElementsBoundByIndex.firstObject;
-    result.fb_isResolvedNatively = @NO;
-    return result ? @[result] : @[];
-  }
-  // Rely here on the fact, that XPath always returns query results in the same
-  // order they appear in the document, which means we don't need to resort the resulting
-  // array. Although, if it turns out this is still not the case then we could always
-  // uncomment the sorting procedure below:
-  //  query = [query sorted:(id)^NSComparisonResult(XCElementSnapshot *a, XCElementSnapshot *b) {
-  //    NSUInteger first = [sortedIds indexOfObject:a.wdUID];
-  //    NSUInteger second = [sortedIds indexOfObject:b.wdUID];
-  //    if (first < second) {
-  //      return NSOrderedAscending;
-  //    }
-  //    if (first > second) {
-  //      return NSOrderedDescending;
-  //    }
-  //    return NSOrderedSame;
-  //  }];
-  NSArray<XCUIElement *> *result = query.fb_allMatches;
-  for (XCUIElement *el in result) {
+  [matchedElements addObjectsFromArray:[query matchingPredicate:predicate].allElementsBoundByIndex];
+  for (XCUIElement *el in matchedElements) {
     el.fb_isResolvedNatively = @NO;
   }
-  return result;
+  return matchedElements.copy;
 }
 
 - (void)fb_waitUntilStable

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -386,9 +386,11 @@
   // what ios-driver did and sadly, we must copy them.
   NSString *const name = request.arguments[@"name"];
   if (name) {
-    XCUIElement *childElement = [[[[element.fb_query descendantsMatchingType:XCUIElementTypeAny] matchingIdentifier:name] allElementsBoundByAccessibilityElement] lastObject];
+    XCUIElement *childElement = [[[[element.fb_query descendantsMatchingType:XCUIElementTypeAny]
+                                   matchingIdentifier:name] allElementsBoundByIndex] lastObject];
     if (!childElement) {
-      return FBResponseWithStatus([FBCommandStatus noSuchElementErrorWithMessage:[NSString stringWithFormat:@"'%@' identifier didn't match any elements", name] traceback:[NSString stringWithFormat:@"%@", NSThread.callStackSymbols]]);
+      return FBResponseWithStatus([FBCommandStatus noSuchElementErrorWithMessage:[NSString stringWithFormat:@"'%@' identifier didn't match any elements", name]
+                                                                       traceback:[NSString stringWithFormat:@"%@", NSThread.callStackSymbols]]);
     }
     return [self.class handleScrollElementToVisible:childElement withRequest:request];
   }
@@ -413,9 +415,11 @@
   if (predicateString) {
     NSPredicate *formattedPredicate = [NSPredicate fb_snapshotBlockPredicateWithPredicate:[NSPredicate
                                                                                            predicateWithFormat:predicateString]];
-    XCUIElement *childElement = [[[[element.fb_query descendantsMatchingType:XCUIElementTypeAny] matchingPredicate:formattedPredicate] allElementsBoundByAccessibilityElement] lastObject];
+    XCUIElement *childElement = [[[[element.fb_query descendantsMatchingType:XCUIElementTypeAny]
+                                   matchingPredicate:formattedPredicate] allElementsBoundByIndex] lastObject];
     if (!childElement) {
-      return FBResponseWithStatus([FBCommandStatus noSuchElementErrorWithMessage:[NSString stringWithFormat:@"'%@' predicate didn't match any elements", predicateString] traceback:[NSString stringWithFormat:@"%@", NSThread.callStackSymbols]]);
+      return FBResponseWithStatus([FBCommandStatus noSuchElementErrorWithMessage:[NSString stringWithFormat:@"'%@' predicate didn't match any elements", predicateString]
+                                                                       traceback:[NSString stringWithFormat:@"%@", NSThread.callStackSymbols]]);
     }
     return [self.class handleScrollElementToVisible:childElement withRequest:request];
   }
@@ -675,7 +679,7 @@ static const CGFloat DEFAULT_OFFSET = (CGFloat)0.2;
    */
   XCUIElement *element = application;
   if (isSDKVersionGreaterThanOrEqualTo(@"11.0")) {
-    XCUIElement *window = application.windows.fb_firstMatch;
+    XCUIElement *window = application.windows.allElementsBoundByIndex.firstObject;
     if (window) {
       element = window;
       id<FBXCElementSnapshot> snapshot = element.fb_cachedSnapshot ?: element.fb_takeSnapshot;

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -245,7 +245,7 @@
 
   NSPredicate *predicate = [NSPredicate predicateWithFormat:@"label == %@", label];
   XCUIElement *requestedButton = [[self.alertElement descendantsMatchingType:XCUIElementTypeButton]
-                                  matchingPredicate:predicate].fb_firstMatch;
+                                  matchingPredicate:predicate].allElementsBoundByIndex.firstObject;
   if (!requestedButton) {
     return [[[FBErrorBuilder builder]
              withDescriptionFormat:@"Failed to find button with label '%@' for alert: %@", label, self.alertElement]

--- a/WebDriverAgentLib/Utilities/FBScreen.m
+++ b/WebDriverAgentLib/Utilities/FBScreen.m
@@ -31,7 +31,7 @@
     expectVisibleBar = NO;
   }
 
-  XCUIElement *mainStatusBar = app.statusBars.fb_firstMatch;
+  XCUIElement *mainStatusBar = app.statusBars.allElementsBoundByIndex.firstObject;
   if (!mainStatusBar || (expectVisibleBar && !mainStatusBar.fb_isVisible)) {
     return CGSizeZero;
   }

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -65,10 +65,11 @@ NSString *const FBApplicationMethodNotSupportedException = @"FBApplicationMethod
 
 - (XCUIElement *)fb_firstMatch
 {
-  XCUIElement* match = FBConfiguration.useFirstMatch
-    ? self.firstMatch
-    : self.fb_allMatches.firstObject;
-  return [match exists] ? match : nil;
+  if (FBConfiguration.useFirstMatch) {
+    XCUIElement* match = self.firstMatch;
+    return [match exists] ? match : nil;
+  }
+  return self.fb_allMatches.firstObject;
 }
 
 - (NSArray<XCUIElement *> *)fb_allMatches

--- a/WebDriverAgentTests/IntegrationTests/FBAppiumTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBAppiumTouchActionsIntegrationTests.m
@@ -298,7 +298,7 @@
     [self launchApplication];
     [self goToAttributesPage];
   });
-  self.pickerWheel = self.testedApplication.pickerWheels.fb_firstMatch;
+  self.pickerWheel = self.testedApplication.pickerWheels.allElementsBoundByIndex.firstObject;
 }
 
 - (void)tearDown

--- a/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
@@ -61,7 +61,7 @@
 - (void)testIgnoredAccessibilityAttributes
 {
   // Images are neither accessibility elements nor contain them, so both checks should fail
-  XCUIElement *imageElement = self.testedApplication.images.fb_firstMatch;
+  XCUIElement *imageElement = self.testedApplication.images.allElementsBoundByIndex.firstObject;
   XCTAssertTrue(imageElement.exists);
   XCTAssertFalse(imageElement.fb_isAccessibilityElement);
   XCTAssertFalse(imageElement.isWDAccessibilityContainer);

--- a/WebDriverAgentTests/IntegrationTests/FBElementVisibilityTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementVisibilityTests.m
@@ -72,8 +72,8 @@
   [self launchApplication];
   [self goToScrollPageWithCells:YES];
   for (int i = 0 ; i < 10 ; i++) {
-    FBAssertWaitTillBecomesTrue(self.testedApplication.cells.allElementsBoundByAccessibilityElement[i].fb_isVisible);
-    FBAssertWaitTillBecomesTrue(self.testedApplication.staticTexts.allElementsBoundByAccessibilityElement[i].fb_isVisible);
+    FBAssertWaitTillBecomesTrue(self.testedApplication.cells.allElementsBoundByIndex[i].fb_isVisible);
+    FBAssertWaitTillBecomesTrue(self.testedApplication.staticTexts.allElementsBoundByIndex[i].fb_isVisible);
   }
 }
 

--- a/WebDriverAgentTests/IntegrationTests/FBElementVisibilityTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementVisibilityTests.m
@@ -36,7 +36,7 @@
   XCTAssertTrue(self.springboard.icons[@"Reminders"].fb_isVisible);
 
   // Check Icons on second screen screen
-  XCTAssertFalse(self.springboard.icons[@"IntegrationApp"].query.fb_firstMatch.fb_isVisible);
+  XCTAssertFalse(self.springboard.icons[@"IntegrationApp"].firstMatch.fb_isVisible);
 }
 
 - (void)testSpringBoardSubfolder
@@ -59,7 +59,7 @@
   XCTAssertFalse(self.springboard.icons[@"Reminders"].fb_isVisible);
   XCTAssertFalse([[[self.springboard descendantsMatchingType:XCUIElementTypeIcon]
                    matchingIdentifier:@"IntegrationApp"]
-                  fb_firstMatch].fb_isVisible);
+                  firstMatch].fb_isVisible);
 }
 
 - (void)testTableViewCells

--- a/WebDriverAgentTests/IntegrationTests/FBPasteboardTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBPasteboardTests.m
@@ -44,7 +44,7 @@
   if (![pastItemsQuery.firstMatch waitForExistenceWithTimeout:2.0]) {
     XCTFail(@"No matched element named 'Paste'");
   }
-  XCUIElement *pasteItem = pastItemsQuery.fb_firstMatch;
+  XCUIElement *pasteItem = pastItemsQuery.firstMatch;
   XCTAssertNotNil(pasteItem);
   [pasteItem tap];
   FBAssertWaitTillBecomesTrue([textField.value isEqualToString:text]);

--- a/WebDriverAgentTests/IntegrationTests/FBPickerWheelSelectTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBPickerWheelSelectTests.m
@@ -33,7 +33,7 @@ static const CGFloat DEFAULT_OFFSET = (CGFloat)0.2;
 
 - (void)testSelectNextPickerValue
 {
-  XCUIElement *element = self.testedApplication.pickerWheels.fb_firstMatch;
+  XCUIElement *element = self.testedApplication.pickerWheels.allElementsBoundByIndex.firstObject;
   XCTAssertTrue(element.exists);
   XCTAssertEqualObjects(element.wdType, @"XCUIElementTypePickerWheel");
   NSError *error;

--- a/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
@@ -415,7 +415,7 @@
     [self launchApplication];
     [self goToAttributesPage];
   });
-  self.pickerWheel = self.testedApplication.pickerWheels.fb_firstMatch;
+  self.pickerWheel = self.testedApplication.pickerWheels.allElementsBoundByIndex.firstObject;
 }
 
 - (void)tearDown

--- a/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
@@ -41,7 +41,7 @@
 
 - (id<FBXCElementSnapshot>)destinationSnapshot
 {
-  XCUIElement *matchingElement = self.testedView.buttons.fb_firstMatch;
+  XCUIElement *matchingElement = self.testedView.buttons.allElementsBoundByIndex.firstObject;
   FBAssertWaitTillBecomesTrue(nil != matchingElement.fb_takeSnapshot);
 
   id<FBXCElementSnapshot> snapshot = matchingElement.fb_takeSnapshot;

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
@@ -48,7 +48,8 @@
     @"Deadlock app",
     @"Touch",
   ]];
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingClassName:@"XCUIElementTypeButton" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingClassName:@"XCUIElementTypeButton"
+                                                                   shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(matchingSnapshots.count, expectedLabels.count);
   NSArray<NSString *> *labels = [matchingSnapshots valueForKeyPath:@"@distinctUnionOfObjects.label"];
   XCTAssertEqualObjects([NSSet setWithArray:labels], expectedLabels);
@@ -60,14 +61,16 @@
 
 - (void)testSingleDescendantWithClassName
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingClassName:@"XCUIElementTypeButton" shouldReturnAfterFirstMatch:YES];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingClassName:@"XCUIElementTypeButton"
+                                                                   shouldReturnAfterFirstMatch:YES];
   XCTAssertEqual(matchingSnapshots.count, 1);
   XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeButton);
 }
 
 - (void)testDescendantsWithIdentifier
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingIdentifier:@"Alerts" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingIdentifier:@"Alerts"
+                                                                    shouldReturnAfterFirstMatch:NO];
   int snapshotsCount = 1;
   if (@available(iOS 13.0, *)) {
     snapshotsCount = 2;
@@ -81,7 +84,8 @@
 
 - (void)testSingleDescendantWithIdentifier
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingIdentifier:@"Alerts" shouldReturnAfterFirstMatch:YES];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingIdentifier:@"Alerts"
+                                                                    shouldReturnAfterFirstMatch:YES];
   XCTAssertEqual(matchingSnapshots.count, 1);
   XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeButton);
   XCTAssertEqualObjects(matchingSnapshots.lastObject.label, @"Alerts");
@@ -89,7 +93,8 @@
 
 - (void)testStableInstance
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingIdentifier:@"Alerts" shouldReturnAfterFirstMatch:YES];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingIdentifier:@"Alerts"
+                                                                    shouldReturnAfterFirstMatch:YES];
   XCTAssertEqual(matchingSnapshots.count, 1);
   for (XCUIElement *el in @[matchingSnapshots.lastObject, matchingSnapshots.lastObject.fb_stableInstance]) {
     XCTAssertEqual(el.elementType, XCUIElementTypeButton);
@@ -105,7 +110,8 @@
 
 - (void)testDescendantsWithXPathQuery
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButton[@label='Alerts']" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButton[@label='Alerts']"
+                                                                    shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(matchingSnapshots.count, 1);
   XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeButton);
   XCTAssertEqualObjects(matchingSnapshots.lastObject.label, @"Alerts");
@@ -113,14 +119,16 @@
 
 - (void)testSelfWithXPathQuery
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeApplication" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeApplication"
+                                                                           shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(matchingSnapshots.count, 1);
   XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeApplication);
 }
 
 - (void)testSingleDescendantWithXPathQuery
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButton" shouldReturnAfterFirstMatch:YES];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButton"
+                                                                           shouldReturnAfterFirstMatch:YES];
   XCTAssertEqual(matchingSnapshots.count, 1);
   XCUIElement *matchingSnapshot = [matchingSnapshots firstObject];
   XCTAssertNotNil(matchingSnapshot);
@@ -130,26 +138,30 @@
 
 - (void)testSingleDescendantWithXPathQueryNoMatches
 {
-  XCUIElement *matchingSnapshot = [[self.testedView fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButtonnn" shouldReturnAfterFirstMatch:YES] firstObject];
+  XCUIElement *matchingSnapshot = [[self.testedView fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButtonnn"
+                                                         shouldReturnAfterFirstMatch:YES] firstObject];
   XCTAssertNil(matchingSnapshot);
 }
 
 - (void)testSingleLastDescendantWithXPathQuery
 {
-  XCUIElement *matchingSnapshot = [[self.testedView fb_descendantsMatchingXPathQuery:@"(//XCUIElementTypeButton)[last()]" shouldReturnAfterFirstMatch:YES] firstObject];
+  XCUIElement *matchingSnapshot = [[self.testedView fb_descendantsMatchingXPathQuery:@"(//XCUIElementTypeButton)[last()]"
+                                                         shouldReturnAfterFirstMatch:YES] firstObject];
   XCTAssertNotNil(matchingSnapshot);
   XCTAssertEqual(matchingSnapshot.elementType, XCUIElementTypeButton);
 }
 
 - (void)testDescendantsWithXPathQueryNoMatches
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButton[@label='Alerts1']" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButton[@label='Alerts1']"
+                                                                    shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(matchingSnapshots.count, 0);
 }
 
 - (void)testDescendantsWithComplexXPathQuery
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingXPathQuery:@"//*[@label='Scrolling']/preceding::*[boolean(string(@label))]" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingXPathQuery:@"//*[@label='Scrolling']/preceding::*[boolean(string(@label))]"
+                                                                    shouldReturnAfterFirstMatch:NO];
   int snapshotsCount = 3;
   if (@available(iOS 13.0, *)) {
     snapshotsCount = 6;
@@ -159,13 +171,15 @@
 
 - (void)testDescendantsWithWrongXPathQuery
 {
-  XCTAssertThrowsSpecificNamed([self.testedView fb_descendantsMatchingXPathQuery:@"//*[blabla(@label, Scrolling')]" shouldReturnAfterFirstMatch:NO],
+  XCTAssertThrowsSpecificNamed([self.testedView fb_descendantsMatchingXPathQuery:@"//*[blabla(@label, Scrolling')]"
+                                                     shouldReturnAfterFirstMatch:NO],
                                NSException, FBInvalidXPathException);
 }
 
 - (void)testFirstDescendantWithWrongXPathQuery
 {
-  XCTAssertThrowsSpecificNamed([self.testedView fb_descendantsMatchingXPathQuery:@"//*[blabla(@label, Scrolling')]" shouldReturnAfterFirstMatch:YES],
+  XCTAssertThrowsSpecificNamed([self.testedView fb_descendantsMatchingXPathQuery:@"//*[blabla(@label, Scrolling')]"
+                                                     shouldReturnAfterFirstMatch:YES],
                                NSException, FBInvalidXPathException);
 }
 
@@ -200,7 +214,8 @@
 - (void)testSelfWithPredicateString
 {
   NSPredicate *predicate = [NSPredicate predicateWithFormat:@"type == 'XCUIElementTypeApplication'"];
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingPredicate:predicate shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingPredicate:predicate
+                                                                          shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(matchingSnapshots.count, 1);
   XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeApplication);
 }
@@ -223,7 +238,9 @@
 
 - (void)testDescendantsWithPropertyStrict
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingProperty:@"label" value:@"Alert" partialSearch:NO];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingProperty:@"label"
+                                                                                        value:@"Alert"
+                                                                                partialSearch:NO];
   XCTAssertEqual(matchingSnapshots.count, 0);
   matchingSnapshots = [self.testedView fb_descendantsMatchingProperty:@"label" value:@"Alerts" partialSearch:NO];
   int snapshotsCount = 1;
@@ -237,7 +254,9 @@
 
 - (void)testGlobalWithPropertyStrict
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingProperty:@"label" value:@"Alert" partialSearch:NO];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingProperty:@"label"
+                                                                                               value:@"Alert"
+                                                                                       partialSearch:NO];
   XCTAssertEqual(matchingSnapshots.count, 0);
   matchingSnapshots = [self.testedApplication fb_descendantsMatchingProperty:@"label" value:@"Alerts" partialSearch:NO];
   int snapshotsCount = 1;
@@ -251,7 +270,9 @@
 
 - (void)testDescendantsWithPropertyPartial
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingProperty:@"label" value:@"Alerts" partialSearch:NO];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingProperty:@"label"
+                                                                                        value:@"Alerts"
+                                                                                partialSearch:NO];
   int snapshotsCount = 1;
   if (@available(iOS 13.0, *)) {
     snapshotsCount = 2;
@@ -265,7 +286,8 @@
 {
   NSArray<XCUIElement *> *matchingSnapshots;
   NSString *queryString =@"XCUIElementTypeWindow/XCUIElementTypeOther/**/XCUIElementTypeButton";
-  matchingSnapshots = [self.testedApplication fb_descendantsMatchingClassChain:queryString shouldReturnAfterFirstMatch:NO];
+  matchingSnapshots = [self.testedApplication fb_descendantsMatchingClassChain:queryString
+                                                   shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(matchingSnapshots.count, 5); // /XCUIElementTypeButton
   for (XCUIElement *matchingSnapshot in matchingSnapshots) {
     XCTAssertEqual(matchingSnapshot.elementType, XCUIElementTypeButton);
@@ -279,14 +301,17 @@
   if (@available(iOS 13.0, *)) {
     // iPhone
     queryString = @"XCUIElementTypeWindow/*/*/*/*[2]/*/*/XCUIElementTypeButton";
-    matchingSnapshots = [self.testedApplication fb_descendantsMatchingClassChain:queryString shouldReturnAfterFirstMatch:NO];
+    matchingSnapshots = [self.testedApplication fb_descendantsMatchingClassChain:queryString
+                                                     shouldReturnAfterFirstMatch:NO];
     if (matchingSnapshots.count == 0) {
       // iPad
       queryString = @"XCUIElementTypeWindow/*/*/*/*/*[2]/*/*/XCUIElementTypeButton";
-      matchingSnapshots = [self.testedApplication fb_descendantsMatchingClassChain:queryString shouldReturnAfterFirstMatch:NO];
+      matchingSnapshots = [self.testedApplication fb_descendantsMatchingClassChain:queryString
+                                                       shouldReturnAfterFirstMatch:NO];
     }
   } else {
-    matchingSnapshots = [self.testedApplication fb_descendantsMatchingClassChain:queryString shouldReturnAfterFirstMatch:NO];
+    matchingSnapshots = [self.testedApplication fb_descendantsMatchingClassChain:queryString
+                                                     shouldReturnAfterFirstMatch:NO];
   }
   XCTAssertEqual(matchingSnapshots.count, 5); // /XCUIElementTypeButton
   for (XCUIElement *matchingSnapshot in matchingSnapshots) {
@@ -298,7 +323,8 @@
 {
   NSArray<XCUIElement *> *matchingSnapshots;
   NSString *queryString = @"XCUIElementTypeWindow/**/XCUIElementTypeButton[`label BEGINSWITH 'A'`]";
-  matchingSnapshots = [self.testedApplication fb_descendantsMatchingClassChain:queryString shouldReturnAfterFirstMatch:NO];
+  matchingSnapshots = [self.testedApplication fb_descendantsMatchingClassChain:queryString
+                                                   shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(matchingSnapshots.count, 2);
   XCTAssertEqualObjects([matchingSnapshots firstObject].label, @"Alerts");
   XCTAssertEqualObjects([matchingSnapshots lastObject].label, @"Attributes");
@@ -307,8 +333,10 @@
 - (void)testDescendantsWithIndirectClassChainAndPredicates
 {
   NSString *queryString = @"XCUIElementTypeWindow/**/XCUIElementTypeButton[`label BEGINSWITH 'A'`]";
-  NSArray<XCUIElement *> *simpleQueryMatches = [self.testedApplication fb_descendantsMatchingClassChain:queryString shouldReturnAfterFirstMatch:NO];
-  NSArray<XCUIElement *> *deepQueryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"XCUIElementTypeWindow/**/XCUIElementTypeButton[`label BEGINSWITH 'A'`]" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *simpleQueryMatches = [self.testedApplication fb_descendantsMatchingClassChain:queryString
+                                                                            shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *deepQueryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"XCUIElementTypeWindow/**/XCUIElementTypeButton[`label BEGINSWITH 'A'`]"
+                                                                          shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(simpleQueryMatches.count, deepQueryMatches.count);
   XCTAssertEqualObjects([simpleQueryMatches firstObject].label, [deepQueryMatches firstObject].label);
   XCTAssertEqualObjects([simpleQueryMatches lastObject].label, [deepQueryMatches lastObject].label);
@@ -316,8 +344,10 @@
 
 - (void)testClassChainWithDescendantPredicate
 {
-  NSArray<XCUIElement *> *simpleQueryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"XCUIElementTypeWindow/*/*[1]" shouldReturnAfterFirstMatch:NO];
-  NSArray<XCUIElement *> *predicateQueryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"XCUIElementTypeWindow/*/*[$type == 'XCUIElementTypeButton' AND label BEGINSWITH 'A'$]" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *simpleQueryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"XCUIElementTypeWindow/*/*[1]"
+                                                                            shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *predicateQueryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"XCUIElementTypeWindow/*/*[$type == 'XCUIElementTypeButton' AND label BEGINSWITH 'A'$]"
+                                                                               shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(simpleQueryMatches.count, predicateQueryMatches.count);
   XCTAssertEqual([simpleQueryMatches firstObject].elementType, [predicateQueryMatches firstObject].elementType);
   XCTAssertEqual([simpleQueryMatches lastObject].elementType, [predicateQueryMatches lastObject].elementType);
@@ -325,7 +355,8 @@
 
 - (void)testSingleDescendantWithComplexIndirectClassChain
 {
-  NSArray<XCUIElement *> *queryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"**/*/XCUIElementTypeButton[2]" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *queryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"**/*/XCUIElementTypeButton[2]"
+                                                                      shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(queryMatches.count, 1);
   XCTAssertEqual(queryMatches.lastObject.elementType, XCUIElementTypeButton);
   XCTAssertEqualObjects(queryMatches.lastObject.label, @"Deadlock app");
@@ -333,7 +364,8 @@
 
 - (void)testSingleDescendantWithComplexIndirectClassChainAndZeroMatches
 {
-  NSArray<XCUIElement *> *queryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"**/*/XCUIElementTypeWindow" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *queryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"**/*/XCUIElementTypeWindow"
+                                                                      shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(queryMatches.count, 0);
 }
 
@@ -341,14 +373,16 @@
 {
   NSArray<XCUIElement *> *matchingSnapshots;
   NSString *queryString = @"XCUIElementTypeWindow[`name != 'bla'`]/**/XCUIElementTypeButton[`label BEGINSWITH \"A\"`][1]";
-  matchingSnapshots = [self.testedApplication fb_descendantsMatchingClassChain:queryString shouldReturnAfterFirstMatch:NO];
+  matchingSnapshots = [self.testedApplication fb_descendantsMatchingClassChain:queryString
+                                                   shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(matchingSnapshots.count, 1);
   XCTAssertEqualObjects([matchingSnapshots firstObject].label, @"Alerts");
 }
 
 - (void)testSingleDescendantWithClassChain
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingClassChain:@"XCUIElementTypeButton" shouldReturnAfterFirstMatch:YES];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingClassChain:@"XCUIElementTypeButton"
+                                                                    shouldReturnAfterFirstMatch:YES];
   
   XCTAssertEqual(matchingSnapshots.count, 1);
   XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeButton);
@@ -358,19 +392,22 @@
 - (void)testSingleDescendantWithClassChainAndNegativeIndex
 {
   NSArray<XCUIElement *> *matchingSnapshots;
-  matchingSnapshots = [self.testedView fb_descendantsMatchingClassChain:@"XCUIElementTypeButton[-1]" shouldReturnAfterFirstMatch:YES];
+  matchingSnapshots = [self.testedView fb_descendantsMatchingClassChain:@"XCUIElementTypeButton[-1]"
+                                            shouldReturnAfterFirstMatch:YES];
   
   XCTAssertEqual(matchingSnapshots.count, 1);
   XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeButton);
   XCTAssertTrue([matchingSnapshots.lastObject.label isEqualToString:@"Touch"]);
   
-  matchingSnapshots = [self.testedView fb_descendantsMatchingClassChain:@"XCUIElementTypeButton[-10]" shouldReturnAfterFirstMatch:YES];
+  matchingSnapshots = [self.testedView fb_descendantsMatchingClassChain:@"XCUIElementTypeButton[-10]"
+                                            shouldReturnAfterFirstMatch:YES];
   XCTAssertEqual(matchingSnapshots.count, 0);
 }
 
 - (void)testInvalidQueryWithClassChain
 {
-  XCTAssertThrowsSpecificNamed([self.testedView fb_descendantsMatchingClassChain:@"NoXCUIElementTypePrefix" shouldReturnAfterFirstMatch:YES],
+  XCTAssertThrowsSpecificNamed([self.testedView fb_descendantsMatchingClassChain:@"NoXCUIElementTypePrefix"
+                                                     shouldReturnAfterFirstMatch:YES],
                                NSException, FBClassChainQueryParseException);
 }
 
@@ -384,7 +421,8 @@
 
 - (void)testClassChainWithInvalidPredicate
 {
-  XCTAssertThrowsSpecificNamed([self.testedApplication fb_descendantsMatchingClassChain:@"XCUIElementTypeWindow[`bla != 'bla'`]" shouldReturnAfterFirstMatch:NO],
+  XCTAssertThrowsSpecificNamed([self.testedApplication fb_descendantsMatchingClassChain:@"XCUIElementTypeWindow[`bla != 'bla'`]"
+                                                            shouldReturnAfterFirstMatch:NO],
                                NSException, FBUnknownAttributeException);;
 }
 
@@ -411,8 +449,10 @@
     queryString = @"XCUIElementTypePicker";
   }
   FBAssertWaitTillBecomesTrue(self.testedApplication.buttons[@"Button"].fb_isVisible);
-  XCUIElement *datePicker = [self.testedApplication descendantsMatchingType:XCUIElementTypeDatePicker].fb_firstMatch;
-  NSArray<XCUIElement *> *matches = [datePicker fb_descendantsMatchingClassChain:queryString shouldReturnAfterFirstMatch:NO];
+  XCUIElement *datePicker = [self.testedApplication
+                             descendantsMatchingType:XCUIElementTypeDatePicker].allElementsBoundByIndex.firstObject;
+  NSArray<XCUIElement *> *matches = [datePicker fb_descendantsMatchingClassChain:queryString
+                                                     shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(matches.count, 1);
 
   XCUIElementType expectedType = XCUIElementTypeOther;
@@ -440,7 +480,8 @@
 
 - (void)testInvisibleDescendantWithXPathQuery
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeStaticText[@visible='false']" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeStaticText[@visible='false']"
+                                                                           shouldReturnAfterFirstMatch:NO];
   XCTAssertGreaterThan(matchingSnapshots.count, 1);
   XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeStaticText);
   XCTAssertFalse(matchingSnapshots.lastObject.fb_isVisible);

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementHelperIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementHelperIntegrationTests.m
@@ -32,9 +32,9 @@
 
 - (void)testDescendantsFiltering
 {
-  NSArray<XCUIElement *> *buttons = self.testedApplication.buttons.allElementsBoundByAccessibilityElement;
+  NSArray<XCUIElement *> *buttons = self.testedApplication.buttons.allElementsBoundByIndex;
   XCTAssertTrue(buttons.count > 0);
-  NSArray<XCUIElement *> *windows = self.testedApplication.windows.allElementsBoundByAccessibilityElement;
+  NSArray<XCUIElement *> *windows = self.testedApplication.windows.allElementsBoundByIndex;
   XCTAssertTrue(windows.count > 0);
   
   NSMutableArray<XCUIElement *> *allElements = [NSMutableArray array];


### PR DESCRIPTION
It turns out allMatchingSnapshotsWithError: API is not invoked for firstMatch while it is for both allElementsBoundByIndex and allElementsBoundByAccessibilityElement calls. So it makes sense to only have existence check for element instances returned by firstMatch to have a decent lookup performance.