### PR TITLE
chore: simplify Script/build-webdriveragent.js

### DIFF
--- a/Scripts/build-webdriveragent.js
+++ b/Scripts/build-webdriveragent.js
@@ -34,7 +34,7 @@ async function buildWebDriverAgent (xcodeVersion) {
     throw e;
   }
 
-  const zipName = `wdaXcode${xcodeVersion}.zip`;
+  const zipName = `WebDriverAgentRunner-Runner-Sim-${xcodeVersion}.zip`;
   log.info(`Creating ${zipName} which includes ${wdaAppBundle}`);
   const appBundleZipPath = path.join(rootDir, zipName);
   await fs.rimraf(appBundleZipPath);

--- a/Scripts/build-webdriveragent.js
+++ b/Scripts/build-webdriveragent.js
@@ -11,10 +11,12 @@ const WDA_BUNDLE = 'WebDriverAgentRunner-Runner.app';
 const WDA_BUNDLE_PATH = path.join(DERIVED_DATA_PATH, 'Build', 'Products', 'Debug-iphonesimulator');
 
 async function buildWebDriverAgent (xcodeVersion) {
-  LOG.info(`Deleting ${DERIVED_DATA_PATH} if exists`);
-  if (await fs.exists(DERIVED_DATA_PATH)) {
-    await fs.rimraf(DERIVED_DATA_PATH);
-  }
+  LOG.info(`Cleaning ${DERIVED_DATA_PATH} if exists`);
+  try {
+    await exec('xcodebuild', ['clean', '-derivedDataPath', DERIVED_DATA_PATH, '-scheme', 'WebDriverAgentRunner'], {
+      cwd: ROOT_DIR
+    });
+  } catch (ign) {}
 
   // Get Xcode version
   xcodeVersion = xcodeVersion || await xcode.getVersion();

--- a/Scripts/build-webdriveragent.js
+++ b/Scripts/build-webdriveragent.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const { asyncify } = require('asyncbox');
-const { logger, fs, zip } = require('@appium/support');
+const { logger, fs } = require('@appium/support');
 const { exec } = require('teen_process');
 const xcode = require('appium-xcode');
 
@@ -39,7 +39,16 @@ async function buildWebDriverAgent (xcodeVersion) {
   const appBundleZipPath = path.join(ROOT_DIR, zipName);
   await fs.rimraf(appBundleZipPath);
   LOG.info(`Created './${zipName}'`);
-  await zip.toArchive(appBundleZipPath, {pattern: '*.app/**', cwd: WDA_BUNDLE_PATH});
+  try {
+    await exec('xattr', ['-cr', WDA_BUNDLE], {cwd: WDA_BUNDLE_PATH});
+    await exec('zip', ['-r', appBundleZipPath, WDA_BUNDLE], {cwd: WDA_BUNDLE_PATH});
+  } catch (e) {
+    LOG.error(`===FAILED TO ZIP ARCHIVE`);
+    LOG.error(e.stdout);
+    LOG.error(e.stderr);
+    LOG.error(e.message);
+    throw e;
+  }
   LOG.info(`Zip bundled at "${appBundleZipPath}"`);
 }
 

--- a/Scripts/build-webdriveragent.js
+++ b/Scripts/build-webdriveragent.js
@@ -4,43 +4,43 @@ const { logger, fs, zip } = require('@appium/support');
 const { exec } = require('teen_process');
 const xcode = require('appium-xcode');
 
-const log = new logger.getLogger('WDABuild');
-const rootDir = path.resolve(__dirname, '..');
-const derivedDataPath = `${rootDir}/wdaBuild`;
-const wdaAppBundle = 'WebDriverAgentRunner-Runner.app';
-const appBundlePath = path.join(derivedDataPath, 'Build', 'Products', 'Debug-iphonesimulator');
+const LOG = new logger.getLogger('WDABuild');
+const ROOT_DIR = path.resolve(__dirname, '..');
+const DERIVED_DATA_PATH = `${ROOT_DIR}/wdaBuild`;
+const WDA_BUNDLE = 'WebDriverAgentRunner-Runner.app';
+const WDA_BUNDLE_PATH = path.join(DERIVED_DATA_PATH, 'Build', 'Products', 'Debug-iphonesimulator');
 
 async function buildWebDriverAgent (xcodeVersion) {
-  log.info(`Deleting ${derivedDataPath} if exists`);
-  if (await fs.exists(derivedDataPath)) {
-    await fs.rimraf(derivedDataPath);
+  LOG.info(`Deleting ${DERIVED_DATA_PATH} if exists`);
+  if (await fs.exists(DERIVED_DATA_PATH)) {
+    await fs.rimraf(DERIVED_DATA_PATH);
   }
 
   // Get Xcode version
   xcodeVersion = xcodeVersion || await xcode.getVersion();
-  log.info(`Building WebDriverAgent for iOS for Xcode version '${xcodeVersion}'`);
+  LOG.info(`Building WebDriverAgent for iOS for Xcode version '${xcodeVersion}'`);
 
   // Clean and build
   try {
     await exec('/bin/bash', ['./Scripts/build.sh'], {
-      env: {TARGET: 'runner', SDK: 'sim', DERIVED_DATA_PATH: derivedDataPath},
-      cwd: rootDir
+      env: {TARGET: 'runner', SDK: 'sim', DERIVED_DATA_PATH},
+      cwd: ROOT_DIR
     });
   } catch (e) {
-    log.error(`===FAILED TO BUILD FOR ${xcodeVersion}`);
-    log.error(e.stdout);
-    log.error(e.stderr);
-    log.error(e.message);
+    LOG.error(`===FAILED TO BUILD FOR ${xcodeVersion}`);
+    LOG.error(e.stdout);
+    LOG.error(e.stderr);
+    LOG.error(e.message);
     throw e;
   }
 
   const zipName = `WebDriverAgentRunner-Runner-Sim-${xcodeVersion}.zip`;
-  log.info(`Creating ${zipName} which includes ${wdaAppBundle}`);
-  const appBundleZipPath = path.join(rootDir, zipName);
+  LOG.info(`Creating ${zipName} which includes ${WDA_BUNDLE}`);
+  const appBundleZipPath = path.join(ROOT_DIR, zipName);
   await fs.rimraf(appBundleZipPath);
-  log.info(`Created './${zipName}'`);
-  await zip.toArchive(appBundleZipPath, {pattern: '*.app/**', cwd: appBundlePath});
-  log.info(`Zip bundled at "${appBundleZipPath}"`);
+  LOG.info(`Created './${zipName}'`);
+  await zip.toArchive(appBundleZipPath, {pattern: '*.app/**', cwd: WDA_BUNDLE_PATH});
+  LOG.info(`Zip bundled at "${appBundleZipPath}"`);
 }
 
 if (require.main === module) {

--- a/Scripts/build-webdriveragent.js
+++ b/Scripts/build-webdriveragent.js
@@ -1,34 +1,31 @@
 const path = require('path');
-const os = require('os');
 const { asyncify } = require('asyncbox');
-const { logger, fs, mkdirp, zip } = require('@appium/support');
+const { logger, fs, zip } = require('@appium/support');
 const { exec } = require('teen_process');
 const xcode = require('appium-xcode');
 
 const log = new logger.getLogger('WDABuild');
 const rootDir = path.resolve(__dirname, '..');
+const derivedDataPath = `${rootDir}/wdaBuild`;
+const wdaAppBundle = 'WebDriverAgentRunner-Runner.app';
+const appBundlePath = path.join(derivedDataPath, 'Build', 'Products', 'Debug-iphonesimulator');
 
 async function buildWebDriverAgent (xcodeVersion) {
-  // Get Xcode version
-  xcodeVersion = xcodeVersion || await xcode.getVersion();
-  log.info(`Building bundle for Xcode version '${xcodeVersion}'`);
-
-  // Clear WebDriverAgent from derived data
-  const derivedDataPath = path.resolve(os.homedir(), 'Library', 'Developer',
-    'Xcode', 'DerivedData');
-  log.info(`Clearing contents of '${derivedDataPath}/WebDriverAgent-*'`);
-  for (const wdaPath of
-    await fs.glob('WebDriverAgent-*', {cwd: derivedDataPath, absolute: true})
-  ) {
-    log.info(`Deleting existing WDA: '${wdaPath}'`);
-    await fs.rimraf(wdaPath);
+  log.info(`Deleting ${derivedDataPath} if exists`);
+  if (await fs.exists(derivedDataPath)) {
+    await fs.rimraf(derivedDataPath);
   }
 
+  // Get Xcode version
+  xcodeVersion = xcodeVersion || await xcode.getVersion();
+  log.info(`Building WebDriverAgent for iOS for Xcode version '${xcodeVersion}'`);
+
   // Clean and build
-  log.info('Running ./Scripts/build.sh');
-  let env = {TARGET: 'runner', SDK: 'sim'};
   try {
-    await exec('/bin/bash', ['./Scripts/build.sh'], {env, cwd: rootDir});
+    await exec('/bin/bash', ['./Scripts/build.sh'], {
+      env: {TARGET: 'runner', SDK: 'sim', DERIVED_DATA_PATH: derivedDataPath},
+      cwd: rootDir
+    });
   } catch (e) {
     log.error(`===FAILED TO BUILD FOR ${xcodeVersion}`);
     log.error(e.stdout);
@@ -37,52 +34,13 @@ async function buildWebDriverAgent (xcodeVersion) {
     throw e;
   }
 
-  // Create bundles folder
-  const pathToBundles = path.resolve(rootDir, 'bundles');
-  await mkdirp(pathToBundles);
-
-  // Start creating zip
-  const uncompressedDir = path.resolve(rootDir, 'uncompressed');
-  await fs.rimraf(uncompressedDir);
-  await mkdirp(uncompressedDir);
-  log.info('Creating zip');
-
-  // Move contents of the root to folder called "uncompressed"
-  await exec('rsync', [
-    '-av', '.', uncompressedDir,
-    '--exclude', 'node_modules',
-    '--exclude', 'build',
-    '--exclude', 'ci-jobs',
-    '--exclude', 'lib',
-    '--exclude', 'test',
-    '--exclude', 'bundles',
-    '--exclude', 'azure-templates',
-  ], {cwd: rootDir});
-
-  // Move DerivedData/WebDriverAgent-* from Library to "uncompressed" folder
-  const wdaPath = (await fs.glob(`${derivedDataPath}/WebDriverAgent-*`))[0];
-  await mkdirp(path.resolve(uncompressedDir, 'DerivedData'));
-  await fs.rename(wdaPath, path.resolve(uncompressedDir, 'DerivedData', 'WebDriverAgent'));
-
-  // Compress the "uncompressed" bundle as a Zip
-  const pathToZip = path.resolve(pathToBundles, `webdriveragent-xcode_${xcodeVersion}.zip`);
-  await zip.toArchive(
-    pathToZip, {cwd: path.join(rootDir, 'uncompressed')}
-  );
-  log.info(`Zip bundled at "${pathToZip}"`);
-
-  // Now just zip the .app and place it in the root directory
-  // This zip file will be published to NPM
-  const wdaAppBundle = 'WebDriverAgentRunner-Runner.app';
-  const appBundlePath = path.join(uncompressedDir, 'DerivedData', 'WebDriverAgent',
-    'Build', 'Products', 'Debug-iphonesimulator', wdaAppBundle);
-  const appBundleZipPath = path.join(rootDir, `${wdaAppBundle}.zip`);
+  const zipName = `wdaXcode${xcodeVersion}.zip`;
+  log.info(`Creating ${zipName} which includes ${wdaAppBundle}`);
+  const appBundleZipPath = path.join(rootDir, zipName);
   await fs.rimraf(appBundleZipPath);
-  log.info(`Created './${wdaAppBundle}.zip'`);
-  await zip.toArchive(appBundleZipPath, {cwd: appBundlePath});
+  log.info(`Created './${zipName}'`);
+  await zip.toArchive(appBundleZipPath, {pattern: '*.app/**', cwd: appBundlePath});
   log.info(`Zip bundled at "${appBundleZipPath}"`);
-  // Clean up the uncompressed directory
-  await fs.rimraf(uncompressedDir);
 }
 
 if (require.main === module) {

--- a/Scripts/build-webdriveragent.js
+++ b/Scripts/build-webdriveragent.js
@@ -18,7 +18,7 @@ async function buildWebDriverAgent (xcodeVersion) {
 
   // Get Xcode version
   xcodeVersion = xcodeVersion || await xcode.getVersion();
-  LOG.info(`Building WebDriverAgent for iOS for Xcode version '${xcodeVersion}'`);
+  LOG.info(`Building WebDriverAgent for iOS using Xcode version '${xcodeVersion}'`);
 
   // Clean and build
   try {
@@ -28,9 +28,7 @@ async function buildWebDriverAgent (xcodeVersion) {
     });
   } catch (e) {
     LOG.error(`===FAILED TO BUILD FOR ${xcodeVersion}`);
-    LOG.error(e.stdout);
     LOG.error(e.stderr);
-    LOG.error(e.message);
     throw e;
   }
 
@@ -41,12 +39,10 @@ async function buildWebDriverAgent (xcodeVersion) {
   LOG.info(`Created './${zipName}'`);
   try {
     await exec('xattr', ['-cr', WDA_BUNDLE], {cwd: WDA_BUNDLE_PATH});
-    await exec('zip', ['-r', appBundleZipPath, WDA_BUNDLE], {cwd: WDA_BUNDLE_PATH});
+    await exec('zip', ['-qr', appBundleZipPath, WDA_BUNDLE], {cwd: WDA_BUNDLE_PATH});
   } catch (e) {
     LOG.error(`===FAILED TO ZIP ARCHIVE`);
-    LOG.error(e.stdout);
     LOG.error(e.stderr);
-    LOG.error(e.message);
     throw e;
   }
   LOG.info(`Zip bundled at "${appBundleZipPath}"`);


### PR DESCRIPTION
part of https://github.com/appium/appium/issues/17963

`npm run bundle` command will generate `WebDriverAgentRunner-Runner-Sim-<build xcode version>.zip` which includes `WebDriverAgentRunner-Runner.app`. I wonder if the simulator build also can be in https://github.com/appium/WebDriverAgent/releases We need to check if we need Xcode variations, the build is only for Intel (in the simulator build) etc.

Anyway, this PR simplify current `Scripts/build-webdriveragent.js` to have only building WDA with current Xcode version to run it on CI