### PR TITLE
chore: build only arm64 for generic build in a release

### DIFF
--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -28,7 +28,7 @@ jobs:
             -derivedDataPath $PKG_PATH_IOS \
             -scheme WebDriverAgentRunner \
             -destination generic/platform=iOS \
-            CODE_SIGNING_ALLOWED=NO
+            CODE_SIGNING_ALLOWED=NO ARCHS=arm64
       - name: Creating a zip of WebDriverAgentRunner-Runner.app for iOS
         run: |
           pushd appium_wda_ios/Build/Products/Debug-iphoneos
@@ -42,7 +42,7 @@ jobs:
             -derivedDataPath $PKG_PATH_TVOS \
             -scheme WebDriverAgentRunner_tvOS \
             -destination generic/platform=tvOS \
-            CODE_SIGNING_ALLOWED=NO
+            CODE_SIGNING_ALLOWED=NO ARCHS=arm64
       - name: Creating a zip of WebDriverAgentRunner-Runner.app for tvOS
         run: |
           pushd appium_wda_tvos/Build/Products/Debug-appletvos


### PR DESCRIPTION
Current our supported iOS version is 12.0+. All devices which can have ios 12 is arm64, so theoretically our generic package build in a release also can only have arm64. It may reduce the package size.

https://www.innerfence.com/howto/apple-ios-devices-dates-versions-instruction-sets