### PR TITLE
ci: tune build environment for release

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -10,10 +10,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macos-12
 
     env:
-      XCODE_VERSION: 13.2.1
+      XCODE_VERSION: 14.1
       ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner.zip"
       PKG_PATH_IOS: "appium_wda_ios"
       ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner.zip"

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -6,10 +6,10 @@ on:
 jobs:
   build:
     name: Build WDA for real iOS and tvOS devices
-    runs-on: macos-11
+    runs-on: macos-12
 
     env:
-      XCODE_VERSION: 13.2.1
+      XCODE_VERSION: 14.1
       ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner.zip"
       PKG_PATH_IOS: "appium_wda_ios"
       ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner.zip"


### PR DESCRIPTION
According to https://github.com/appium/WebDriverAgent/actions/runs/3803903960, built by this PR conbination is much smaller than current one. Current one has 20MB app size with one `WebDriverAgentRunner-Runner.app` but this PR's env is 11MB, which is the same as my local machine built.

The diff was mostly in `Frameworks` package in the `WebDriverAgentRunner-Runner.app` so I guess soemthing Xcode package env on macOS 11 was larger than the 12.