### PR TITLE
modified JSONPayload to replace non-utf8 character as �

### DIFF
--- a/WebDriverAgentLib/Routing/FBResponseJSONPayload.m
+++ b/WebDriverAgentLib/Routing/FBResponseJSONPayload.m
@@ -24,22 +24,19 @@
 /*
  * Convenience method to do the check and validation in one.
  */
-+ (NSString*) makeValidUTF8:(NSString*) stringToCheck
++ (NSString*)makeValidUTF8:(NSString*)stringToCheck
 {
   if (![FBResponseJSONPayload isValidUTF8 :stringToCheck])
   {
     return [FBResponseJSONPayload removeInvalidCharsFromString:stringToCheck];
   }
-  else
-  {
-    return stringToCheck;
-  }
+  return stringToCheck;
 }
 
 /*
  * Returns true if the string can be converted to UTF8
  */
-+ (int) isValidUTF8:(NSString*) stringToCheck
++ (int)isValidUTF8:(NSString*)stringToCheck
 {
   return ([stringToCheck UTF8String] != nil);
 }
@@ -48,7 +45,7 @@
  * Removes invalid UTF8 chars from the NSString
  * This method is slow, so only run it on strings that fail the isValidUTF8 check.
  */
-+ (NSString*) removeInvalidCharsFromString:(NSString*) stringToCheck
++ (NSString*)removeInvalidCharsFromString:(NSString*)stringToCheck
 {
   NSMutableString* fixedUp = [NSMutableString stringWithString:@""];
   for (NSUInteger i = 0; i < [stringToCheck length]; i++)
@@ -57,13 +54,10 @@
     {
       unichar character = [stringToCheck characterAtIndex:i];
       NSString* charString = [[NSString alloc] initWithCharacters:&character length:1];
-      if ([charString UTF8String] == nil)
-      {
+      if ([charString UTF8String] == nil) {
         [FBLogger logFmt:@"Invalid UTF-8 sequence encountered at position %lu. Code: %hu (%X). Replacing with \ufffd", (unsigned long) i, character, character];
         [fixedUp appendString:@"\ufffd"];
-      }
-      else
-      {
+      } else {
         [fixedUp appendString:charString];
       }
     }
@@ -81,10 +75,9 @@
   }
   NSMutableDictionary* newDictionary = [NSMutableDictionary dictionary];
   for (NSString* key in dictionary){
-    if ([[dictionary objectForKey:key] isKindOfClass:[NSString class]]){
+    if ([[dictionary objectForKey:key] isKindOfClass:[NSString class]]) {
       [newDictionary setObject:[FBResponseJSONPayload makeValidUTF8:[dictionary objectForKey:key]] forKey:key];
-    }
-    else {
+    } else {
       [newDictionary setObject:[dictionary objectForKey:key] forKey:key];
     }
   }

--- a/WebDriverAgentLib/Routing/FBResponseJSONPayload.m
+++ b/WebDriverAgentLib/Routing/FBResponseJSONPayload.m
@@ -50,15 +50,13 @@
   NSMutableString* fixedUp = [NSMutableString stringWithString:@""];
   for (NSUInteger i = 0; i < [stringToCheck length]; i++)
   {
-    {
-      unichar character = [stringToCheck characterAtIndex:i];
-      NSString* charString = [[NSString alloc] initWithCharacters:&character length:1];
-      if ([charString UTF8String] == nil) {
-        [FBLogger logFmt:@"Invalid UTF-8 sequence encountered at position %lu. Code: %hu (%X). Replacing with \ufffd", (unsigned long) i, character, character];
-        [fixedUp appendString:@"\ufffd"];
-      } else {
-        [fixedUp appendString:charString];
-      }
+    unichar character = [stringToCheck characterAtIndex:i];
+    NSString* charString = [[NSString alloc] initWithCharacters:&character length:1];
+    if ([charString UTF8String] == nil) {
+      [FBLogger logFmt:@"Invalid UTF-8 sequence encountered at position %lu. Code: %hu (%X). Replacing with \ufffd", (unsigned long) i, character, character];
+      [fixedUp appendString:@"\ufffd"];
+    } else {
+      [fixedUp appendString:charString];
     }
   }
   [FBLogger logFmt:@"Given JSONPayload was NOT valid utf-8. Orig length %lu, fixed length %lu", (unsigned long)[stringToCheck length], (unsigned long)[fixedUp length]];

--- a/WebDriverAgentLib/Routing/FBResponseJSONPayload.m
+++ b/WebDriverAgentLib/Routing/FBResponseJSONPayload.m
@@ -50,7 +50,6 @@
   NSMutableString* fixedUp = [NSMutableString stringWithString:@""];
   for (NSUInteger i = 0; i < [stringToCheck length]; i++)
   {
-    @autoreleasepool
     {
       unichar character = [stringToCheck characterAtIndex:i];
       NSString* charString = [[NSString alloc] initWithCharacters:&character length:1];


### PR DESCRIPTION
I've got an Error `failed to convert to UTF8` when I was getting a page source from my device.
It was an WebView, so I think it contained some non UTF8 characters in the page. In order to continue the test, I thought it's better to return some page information rather than raising UTF8 conversion error. Therefore I've created the pull request. Thank you.

```
2023-01-08 13:50:41:798 [HTTP] --> POST /wd/hub/session/cfd06d4f-e25b-4ae8-a4d0-aa5668f01d19/execute/sync
2023-01-08 13:50:41:798 [HTTP] {"script":"mobile: source","args":[{"format":"description"}]}
2023-01-08 13:50:41:813 [W3C (cfd06d4f)] Calling AppiumDriver.execute() with args: ["mobile: source",[{"format":"description"}],"cfd06d4f-e25b-4ae8-a4d0-aa5668f01d19"]
2023-01-08 13:50:41:814 [XCUITest] Executing command 'execute'
2023-01-08 13:50:41:818 [WD Proxy] Matched '/source?format=description' to command name 'getPageSource'
2023-01-08 13:50:41:818 [WD Proxy] Proxying [GET /source?format=description] to [GET http://127.0.0.1:8204/session/A49ED027-78B2-4B05-A38F-246F2DD61F60/source?format=description] with no body
2023-01-08 13:50:41:826 [Xcode] 2023-01-08 13:50:41.790863+0900 WebDriverAgentRunner-Runner[507:11854] Request URL /session/A49ED027-78B2-4B05-A38F-246F2DD61F60/source?format=description -- http://127.0.0.1:8204/ | Params {
2023-01-08 13:50:41:826 [Xcode]     format = description;
2023-01-08 13:50:41:826 [Xcode]     sessionID = "A49ED027-78B2-4B05-A38F-246F2DD61F60";
2023-01-08 13:50:41:826 [Xcode] } | Arguments {
2023-01-08 13:50:41:826 [Xcode] }
2023-01-08 13:50:41:826 [Xcode] 
2023-01-08 13:50:41:838 [Xcode] 2023-01-08 13:50:41.802205+0900 WebDriverAgentRunner-Runner[507:11854] Getting the most recent active application (out of 1 total items)
2023-01-08 13:50:41:838 [Xcode] 
2023-01-08 13:50:41:840 [Xcode]     t =    44.43s Get all elements bound by accessibility element for: Children matching type Any
2023-01-08 13:50:41:840 [Xcode] 
2023-01-08 13:50:41:854 [Xcode]     t =    44.43s     Requesting snapshot of accessibility hierarchy for app with pid 513
2023-01-08 13:50:41:854 [Xcode] 
2023-01-08 13:50:42:848 [Xcode]     t =    45.44s     Find: Children matching type Any
2023-01-08 13:50:42:848 [Xcode] 
2023-01-08 13:50:42:890 [Xcode]     t =    45.48s Requesting snapshot of accessibility hierarchy for app with pid 513
2023-01-08 13:50:42:890 [Xcode] 
2023-01-08 13:50:44:036 [Xcode] 2023-01-08 13:50:44.001704+0900 WebDriverAgentRunner-Runner[507:12011] Error Domain=com.facebook.WebDriverAgent Code=1 "Cannot take a screenshot within 20000 ms timeout" UserInfo={NSLocalizedDescription=Cannot take a screenshot within 20000 ms timeout}
2023-01-08 13:50:44:036 [Xcode] 
2023-01-08 13:50:45:105 [Xcode] 2023-01-08 13:50:45.070423+0900 WebDriverAgentRunner-Runner[507:12011] Error Domain=com.facebook.WebDriverAgent Code=1 "Cannot take a screenshot within 20000 ms timeout" UserInfo={NSLocalizedDescription=Cannot take a screenshot within 20000 ms timeout}
2023-01-08 13:50:45:105 [Xcode] 
2023-01-08 13:50:45:732 [Xcode]     t =    48.32s Find: Children matching type Any
2023-01-08 13:50:45:733 [Xcode] 
2023-01-08 13:50:45:733 [Xcode]     t =    48.32s Find: Identity Binding
2023-01-08 13:50:45:733 [Xcode] 
2023-01-08 13:50:45:837 [Xcode]     t =    48.43s Find the Application 'com.my.app'
2023-01-08 13:50:45:837 [Xcode]     t =    48.43s     Requesting snapshot of accessibility hierarchy for app with pid 513
2023-01-08 13:50:45:837 [Xcode] 
2023-01-08 13:50:46:622 [Xcode] 2023-01-08 13:50:46.585560+0900 WebDriverAgentRunner-Runner[507:11854] *** Assertion failure in -[FBResponseJSONPayload dispatchWithResponse:](), FBResponseJSONPayload.m:45
2023-01-08 13:50:46:622 [Xcode] 
2023-01-08 13:50:46:642 [Xcode] 2023-01-08 13:50:46.607696+0900 WebDriverAgentRunner-Runner[507:11854] Response URL /session/A49ED027-78B2-4B05-A38F-246F2DD61F60/source?format=description -- http://127.0.0.1:8204/ | Status 500
2023-01-08 13:50:46:642 [Xcode] 
2023-01-08 13:50:46:652 [WD Proxy] Got response with status 500: {"value":{"error":"unknown error","message":"Valid JSON must be responded, error of Error Domain=NSCocoaErrorDomain Code=3852 \"The string 0x282dd90b0 failed to convert to UTF8\" UserInfo={NSDebugDescription=The string 0x282dd90b0 failed to convert to UTF8}","traceback":"(\n\t0   CoreFoundation                      0x0000000182096d50 7A0C7B81-A5B6-36A6-B41C-C7C790076454 + 597328\n\t1   libobjc.A.dylib                     0x00000001993fb6a8 objc_exception_throw + 56\n\t2   Foundation                          0x0000000183867afc 534D37B5-2B79-3993-AB18-822606B22ABF + 1190652\n\t3   WebDriverAgentLib                   0x00000001063357ac -[FBResponseJSONPayload dispatchWithResponse:] + 312\n\t4   WebDriverAgentLib                   0x0000000106316354 -[FBRoute_TargetAction mountRequest:intoResponse:] + 232\n\t5   WebDriverAgentLib                   0x0000000106301864 __37-[FBWebServer registerRouteHandlers:]_block_invoke + 520\n\t6   WebDriverAgentLib                   0x000000010633858c -[RoutingHTTPServer han...
2023-01-08 13:50:46:653 [W3C] Matched W3C error code 'unknown error' to UnknownError
2023-01-08 13:50:46:655 [W3C (cfd06d4f)] Encountered internal error running command: UnknownError: An unknown server-side error occurred while processing the command. Original error: Valid JSON must be responded, error of Error Domain=NSCocoaErrorDomain Code=3852 "The string 0x282dd90b0 failed to convert to UTF8" UserInfo={NSDebugDescription=The string 0x282dd90b0 failed to convert to UTF8}
2023-01-08 13:50:46:656 [W3C (cfd06d4f)]     at errorFromW3CJsonCode (/opt/apps/appium/node_modules/appium-base-driver/lib/protocol/errors.js:780:25)
2023-01-08 13:50:46:656 [W3C (cfd06d4f)]     at ProxyRequestError.getActualError (/opt/apps/appium/node_modules/appium-base-driver/lib/protocol/errors.js:663:14)
2023-01-08 13:50:46:656 [W3C (cfd06d4f)]     at JWProxy.command (/opt/apps/appium/node_modules/appium-base-driver/lib/jsonwp-proxy/proxy.js:272:19)
2023-01-08 13:50:46:656 [W3C (cfd06d4f)]     at processTicksAndRejections (internal/process/task_queues.js:95:5)
2023-01-08 13:50:46:656 [W3C (cfd06d4f)]     at XCUITestDriver.proxyCommand (/opt/apps/appium/node_modules/appium-xcuitest-driver/lib/commands/proxy-helper.js:96:12)
2023-01-08 13:50:46:656 [W3C (cfd06d4f)]     at XCUITestDriver.mobileGetSource (/opt/apps/appium/node_modules/appium-xcuitest-driver/lib/commands/source.js:50:10)
2023-01-08 13:50:46:656 [W3C (cfd06d4f)]     at XCUITestDriver.executeMobile (/opt/apps/appium/node_modules/appium-xcuitest-driver/lib/commands/execute.js:131:10)
2023-01-08 13:50:46:656 [W3C (cfd06d4f)]     at XCUITestDriver.execute (/opt/apps/appium/node_modules/appium-ios-driver/lib/commands/execute.js:15:12)
2023-01-08 13:50:46:656 [W3C (cfd06d4f)]     at XCUITestDriver.execute (/opt/apps/appium/node_modules/appium-xcuitest-driver/lib/commands/execute.js:16:10)
2023-01-08 13:50:46:658 [HTTP] <-- POST /wd/hub/session/cfd06d4f-e25b-4ae8-a4d0-aa5668f01d19/execute/sync 500 4859 ms - 1858
```