### PR TITLE
fix: Pull defaultAdditionalRequestParameters dynamically

### DIFF
--- a/WebDriverAgentLib/Categories/XCAXClient_iOS+FBSnapshotReqParams.m
+++ b/WebDriverAgentLib/Categories/XCAXClient_iOS+FBSnapshotReqParams.m
@@ -45,26 +45,18 @@ static id swizzledDefaultParameters(id self, SEL _cmd)
 {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    NSMutableDictionary *params = [NSMutableDictionary dictionaryWithDictionary:original_defaultParameters(self, _cmd)];
-    [params addEntriesFromDictionary:defaultAdditionalRequestParameters];
-    defaultRequestParameters = params.copy;
+    defaultRequestParameters = original_defaultParameters(self, _cmd);
   });
-  if (nil == defaultRequestParameters) {
-    return original_defaultParameters(self, _cmd);
-  }
   NSMutableDictionary *result = [NSMutableDictionary dictionaryWithDictionary:defaultRequestParameters];
-  if (nil != customRequestParameters && customRequestParameters.count > 0) {
-    [result addEntriesFromDictionary:customRequestParameters];
-  }
+  [result addEntriesFromDictionary:defaultAdditionalRequestParameters ?: @{}];
+  [result addEntriesFromDictionary:customRequestParameters ?: @{}];
   return result.copy;
 }
 
 static id swizzledSnapshotParameters(id self, SEL _cmd)
 {
   NSDictionary *result = original_snapshotParameters(self, _cmd);
-  if (nil == defaultAdditionalRequestParameters) {
-    defaultAdditionalRequestParameters = result;
-  }
+  defaultAdditionalRequestParameters = result;
   return result;
 }
 


### PR DESCRIPTION
It might be that the result of `snapshotParameters` API call changes during the test lifecycle, so it makes sense to always fetch it dynamically rather than just to remember once.