### PR TITLE
feat: Increase Xpath Lookup Performance

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBResolve.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBResolve.m
@@ -47,9 +47,7 @@ static char XCUIELEMENT_IS_RESOLVED_NATIVELY_KEY;
   if (nil == uid) {
     return self;
   }
-  NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id<FBXCElementSnapshot> snapshot, NSDictionary *bindings) {
-    return [[FBXCElementSnapshotWrapper wdUIDWithSnapshot:snapshot] isEqualToString:uid];
-  }];
+  NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K = %@",FBStringify(FBXCElementSnapshotWrapper, fb_uid), uid];
   return [query matchingPredicate:predicate].allElementsBoundByIndex.firstObject ?: self;
 }
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
@@ -40,11 +40,9 @@
 + (void)load
 {
   Class XCElementSnapshotCls = objc_lookUpClass("XCElementSnapshot");
-  if (XCElementSnapshotCls != nil)
-  {
-    Method uidMethod = class_getInstanceMethod(self.class, @selector(fb_uid));
-    class_addMethod(XCElementSnapshotCls, @selector(fb_uid), method_getImplementation(uidMethod), method_getTypeEncoding(uidMethod));
-  }
+  NSAssert(XCElementSnapshotCls != nil, @"Could not locate XCElementSnapshot class");
+  Method uidMethod = class_getInstanceMethod(self.class, @selector(fb_uid));
+  class_addMethod(XCElementSnapshotCls, @selector(fb_uid), method_getImplementation(uidMethod), method_getTypeEncoding(uidMethod));
 }
 #pragma diagnostic pop
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
@@ -7,12 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#import <objc/runtime.h>
+
 #import "XCUIElement+FBUID.h"
 
 #import "FBElementUtils.h"
 #import "XCUIApplication.h"
 #import "XCUIElement+FBUtilities.h"
-#import <objc/runtime.h>
 
 @implementation XCUIElement (FBUID)
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -162,10 +162,10 @@
   XCUIElementQuery *query = onlyChildren
     ? [self.fb_query childrenMatchingType:type]
     : [self.fb_query descendantsMatchingType:type];
-  NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id<FBXCElementSnapshot> snapshot, NSDictionary *bindings) {
-    return [matchedIds containsObject:[FBXCElementSnapshotWrapper wdUIDWithSnapshot:snapshot] ?: @""];
-  }];
+  
+  NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K IN %@",FBStringify(FBXCElementSnapshotWrapper, fb_uid), matchedIds];
   [matchedElements addObjectsFromArray:[query matchingPredicate:predicate].allElementsBoundByIndex];
+
   for (XCUIElement *el in matchedElements) {
     el.fb_isResolvedNatively = @NO;
   }


### PR DESCRIPTION
I’ve ran some general tests using a vanilla XCUITest project to investigate the impact of using block predicates, and it appears that the impact is severe, especially when `allElementsBoundByIndex` returns multiple results.

For example, consider searching for `XCUIElementTypeButton` elements using a string predicate:
`[NSPredicate predicateWithFormat:@"elementType == 9”]`
Versus a block predicate:
`[NSPredicate predicateWithBlock:^BOOL(id<XCUIElementAttributes>  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
        return evaluatedObject.elementType == XCUIElementTypeButton;
 }];`

When testing the above predicates 50 times using the Apple Clock app on an iPhone 8 real device running iOS 15.7.2 (6 applicable elements are located), using the string-based predicate the average execution time is 90ms, whereas executing a query based on a block predicate takes 140ms on average.

Similarly, using the same predicates on the Settings app of the same device 50 times (67 applicable elements are located), using the string predicate takes 265ms on average to execute the query, whereas the block predicate query takes 552ms on average to execute.

This PR adds the `fb_uid` method as a property of the `XCElementSnapshot` class, allowing it to be used with string predicates.

My tests showed a significant performance increase when using this method, for example - using the Xpath `//XCUIElementTypeButton` in the clock app takes 750ms to execute in the current state, whereas with the new implementation it is now executed nearly twice as fast at 400ms on average.

This also helps with the issue raised in https://github.com/appium/appium/issues/18085 where deep nested elements cause snapshot retrieval to fail when increasing the maxSnapshotDepth to a higher value to locate such elements. I’ve built a simple app with a deep-nested structure (54 UIViews inside each other) and increased the snapshot depth to 100:
* Without the modification, attempting to take a snapshot of the app to search for the 54th nested element failed (Enqueue Failure: Failed to resolve query: Error kAXErrorIllegalArgument getting snapshot for element) due to a CoreFoundation error in `testmanagerd` (too many nested dictionaries).
* With the modification I was able to locate the element successfully.

I believe this modification is an important one since, aside from the beneficial performance increase, will help users with deep-nested iOS apps structures to use Appium.