### PR TITLE
fix: Fixed Xpath lookup for Xcode 14.3

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
@@ -59,7 +59,7 @@ static void swizzled_validatePredicateWithExpressionsAllowed(id self, SEL _cmd, 
       IMP swizzledImp = (IMP)swizzled_validatePredicateWithExpressionsAllowed;
       method_setImplementation(validatePredicateMethod, swizzledImp);
     } else {
-      [FBLogger log:@"Could not find method -[XCTElementQueryTransformerPredicateValidator validatePredicate:withExpressionsAllowed:]"];
+      [FBLogger log:@"Could not find method +[XCTElementQueryTransformerPredicateValidator validatePredicate:withExpressionsAllowed:]"];
     }
   }
   

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
@@ -51,15 +51,16 @@ static void swizzled_validatePredicateWithExpressionsAllowed(id self, SEL _cmd, 
   
   // Support for Xcode 14.3 requires disabling the new predicate validator, see https://github.com/appium/appium/issues/18444
   Class XCTElementQueryTransformerPredicateValidatorCls = objc_lookUpClass("XCTElementQueryTransformerPredicateValidator");
-  if (XCTElementQueryTransformerPredicateValidatorCls != nil) {
-    Method validatePredicateMethod = class_getClassMethod(XCTElementQueryTransformerPredicateValidatorCls, NSSelectorFromString(@"validatePredicate:withExpressionsAllowed:"));
-    if (validatePredicateMethod != nil) {
-      IMP swizzledImp = (IMP)swizzled_validatePredicateWithExpressionsAllowed;
-      method_setImplementation(validatePredicateMethod, swizzledImp);
-    } else {
-      [FBLogger log:@"Could not find method +[XCTElementQueryTransformerPredicateValidator validatePredicate:withExpressionsAllowed:]"];
-    }
+  if (XCTElementQueryTransformerPredicateValidatorCls == nil) {
+    return;
   }
+  Method validatePredicateMethod = class_getClassMethod(XCTElementQueryTransformerPredicateValidatorCls, NSSelectorFromString(@"validatePredicate:withExpressionsAllowed:"));
+  if (validatePredicateMethod == nil) {
+    [FBLogger log:@"Could not find method +[XCTElementQueryTransformerPredicateValidator validatePredicate:withExpressionsAllowed:]"];
+    return;
+  }
+  IMP swizzledImp = (IMP)swizzled_validatePredicateWithExpressionsAllowed;
+  method_setImplementation(validatePredicateMethod, swizzledImp);  
 }
 #pragma diagnostic pop
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
@@ -12,9 +12,9 @@
 #import "XCUIElement+FBUID.h"
 
 #import "FBElementUtils.h"
+#import "FBLogger.h"
 #import "XCUIApplication.h"
 #import "XCUIElement+FBUtilities.h"
-#import "FBLogger.h"
 
 @implementation XCUIElement (FBUID)
 
@@ -38,7 +38,6 @@
 
 static void swizzled_validatePredicateWithExpressionsAllowed(id self, SEL _cmd, id predicate, BOOL withExpressionsAllowed)
 {
-  return;
 }
 
 #pragma clang diagnostic push
@@ -52,17 +51,15 @@ static void swizzled_validatePredicateWithExpressionsAllowed(id self, SEL _cmd, 
   
   // Support for Xcode 14.3 requires disabling the new predicate validator, see https://github.com/appium/appium/issues/18444
   Class XCTElementQueryTransformerPredicateValidatorCls = objc_lookUpClass("XCTElementQueryTransformerPredicateValidator");
-  if (XCTElementQueryTransformerPredicateValidatorCls != nil)
-  {
+  if (XCTElementQueryTransformerPredicateValidatorCls != nil) {
     Method validatePredicateMethod = class_getClassMethod(XCTElementQueryTransformerPredicateValidatorCls, NSSelectorFromString(@"validatePredicate:withExpressionsAllowed:"));
-    if (nil != validatePredicateMethod) {
+    if (validatePredicateMethod != nil) {
       IMP swizzledImp = (IMP)swizzled_validatePredicateWithExpressionsAllowed;
       method_setImplementation(validatePredicateMethod, swizzledImp);
     } else {
       [FBLogger log:@"Could not find method +[XCTElementQueryTransformerPredicateValidator validatePredicate:withExpressionsAllowed:]"];
     }
   }
-  
 }
 #pragma diagnostic pop
 


### PR DESCRIPTION
https://github.com/appium/appium/issues/18444

With Xcode 14.3 Apple introduced a new predicate validation class called `XCTElementQueryTransformerPredicateValidator` which implements the `NSPredicateVisitor` protocol, used to validate that the predicate components comply with the expected properties in this context.

As part of the query execution the class function `+[XCTElementQueryTransformerPredicateValidator validatePredicate:withExpressionsAllowed:]` is called to validate the predicate, and since `fb_uid` is not an expected property of `XCElementSnapshot` the validation fails and an `NSException` is thrown.

I tried to find a way to add `fb_uid` as an acceptable property of the validator, however it appears that the list is defined statically and not as an accessible objective-c object, so it can’t be influenced, and in addition the validation call uses the number of expected objects statically.

<img width="1473" alt="Screenshot 2023-04-04 at 17 55 38" src="https://user-images.githubusercontent.com/24937888/229837602-ecc80164-b772-43b5-bbe8-1c27a62a24ff.png">

By swizzling the function and replacing it with a function which doesn’t do anything I managed to get Xpath lookup to work once more. 