### PR TITLE
feat: start wda process via Xctest in a real device

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,7 +1,7 @@
 import path from 'path';
 
 const WDA_RUNNER_BUNDLE_ID = 'com.facebook.WebDriverAgentRunner';
-const WDA_RUNNER_BUNDLE_ID_FOR_XCTEST = 'com.facebook.WebDriverAgentRunner.xctrunner';
+const WDA_RUNNER_BUNDLE_ID_FOR_XCTEST = `${WDA_RUNNER_BUNDLE_ID}.xctrunner`;
 const WDA_RUNNER_APP = 'WebDriverAgentRunner-Runner.app';
 const WDA_SCHEME = 'WebDriverAgentRunner';
 const PROJECT_FILE = 'project.pbxproj';

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,6 +1,7 @@
 import path from 'path';
 
 const WDA_RUNNER_BUNDLE_ID = 'com.facebook.WebDriverAgentRunner';
+const WDA_RUNNER_BUNDLE_ID_FOR_XCTEST = 'com.facebook.WebDriverAgentRunner.xctrunner';
 const WDA_RUNNER_APP = 'WebDriverAgentRunner-Runner.app';
 const WDA_SCHEME = 'WebDriverAgentRunner';
 const PROJECT_FILE = 'project.pbxproj';
@@ -17,5 +18,6 @@ const WDA_UPGRADE_TIMESTAMP_PATH = path.join('.appium', 'webdriveragent', 'upgra
 export {
   WDA_RUNNER_BUNDLE_ID, WDA_RUNNER_APP, PROJECT_FILE,
   WDA_SCHEME, PLATFORM_NAME_TVOS, PLATFORM_NAME_IOS,
-  SDK_SIMULATOR, SDK_DEVICE, WDA_BASE_URL, WDA_UPGRADE_TIMESTAMP_PATH
+  SDK_SIMULATOR, SDK_DEVICE, WDA_BASE_URL, WDA_UPGRADE_TIMESTAMP_PATH,
+  WDA_RUNNER_BUNDLE_ID_FOR_XCTEST
 };

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -62,34 +62,38 @@ class WebDriverAgent {
     this.updatedWDABundleId = args.updatedWDABundleId;
 
     this.usePreinstalledWDA = args.usePreinstalledWDA;
-    this.preInstalledWDABundleId = args.preInstalledWDABundleId;
+
     this.xctestApiClient = null;
 
-    this.xcodebuild = new XcodeBuild(this.xcodeVersion, this.device, {
-      platformVersion: this.platformVersion,
-      platformName: this.platformName,
-      iosSdkVersion: this.iosSdkVersion,
-      agentPath: this.agentPath,
-      bootstrapPath: this.bootstrapPath,
-      realDevice: this.isRealDevice,
-      showXcodeLog: args.showXcodeLog,
-      xcodeConfigFile: args.xcodeConfigFile,
-      xcodeOrgId: args.xcodeOrgId,
-      xcodeSigningId: args.xcodeSigningId,
-      keychainPath: args.keychainPath,
-      keychainPassword: args.keychainPassword,
-      useSimpleBuildTest: args.useSimpleBuildTest,
-      usePrebuiltWDA: args.usePrebuiltWDA,
-      updatedWDABundleId: this.updatedWDABundleId,
-      launchTimeout: args.wdaLaunchTimeout || WDA_LAUNCH_TIMEOUT,
-      wdaRemotePort: this.wdaRemotePort,
-      useXctestrunFile: this.useXctestrunFile,
-      derivedDataPath: args.derivedDataPath,
-      mjpegServerPort: this.mjpegServerPort,
-      allowProvisioningDeviceRegistration: args.allowProvisioningDeviceRegistration,
-      resultBundlePath: args.resultBundlePath,
-      resultBundleVersion: args.resultBundleVersion,
-    }, this.log);
+    if (this.usePreinstalledWDA) {
+      this.xcodebuild = null;
+    } else {
+      this.xcodebuild = new XcodeBuild(this.xcodeVersion, this.device, {
+        platformVersion: this.platformVersion,
+        platformName: this.platformName,
+        iosSdkVersion: this.iosSdkVersion,
+        agentPath: this.agentPath,
+        bootstrapPath: this.bootstrapPath,
+        realDevice: this.isRealDevice,
+        showXcodeLog: args.showXcodeLog,
+        xcodeConfigFile: args.xcodeConfigFile,
+        xcodeOrgId: args.xcodeOrgId,
+        xcodeSigningId: args.xcodeSigningId,
+        keychainPath: args.keychainPath,
+        keychainPassword: args.keychainPassword,
+        useSimpleBuildTest: args.useSimpleBuildTest,
+        usePrebuiltWDA: args.usePrebuiltWDA,
+        updatedWDABundleId: this.updatedWDABundleId,
+        launchTimeout: args.wdaLaunchTimeout || WDA_LAUNCH_TIMEOUT,
+        wdaRemotePort: this.wdaRemotePort,
+        useXctestrunFile: this.useXctestrunFile,
+        derivedDataPath: args.derivedDataPath,
+        mjpegServerPort: this.mjpegServerPort,
+        allowProvisioningDeviceRegistration: args.allowProvisioningDeviceRegistration,
+        resultBundlePath: args.resultBundlePath,
+        resultBundleVersion: args.resultBundleVersion,
+      }, this.log);
+    }
   }
 
   /**
@@ -97,7 +101,7 @@ class WebDriverAgent {
    * @returns {string} Bundle ID for Xctest.
    */
   get bundleIdForXctest () {
-    return this.preInstalledWDABundleId || WDA_RUNNER_BUNDLE_ID_FOR_XCTEST;
+    return `${this.updatedWDABundleId}.xctrunner` || WDA_RUNNER_BUNDLE_ID_FOR_XCTEST;
   }
 
   setWDAPaths (bootstrapPath, agentPath) {
@@ -262,10 +266,12 @@ class WebDriverAgent {
       return;
     }
 
-    try {
-      await this.xcodebuild.cleanProject();
-    } catch (e) {
-      this.log.warn(`Cannot perform WebDriverAgent project cleanup. Original error: ${e.message}`);
+    if (!this.usePreinstalledWDA) {
+      try {
+        await this.xcodebuild.cleanProject();
+      } catch (e) {
+        this.log.warn(`Cannot perform WebDriverAgent project cleanup. Original error: ${e.message}`);
+      }
     }
   }
 
@@ -426,10 +432,12 @@ class WebDriverAgent {
   }
 
   async quit () {
-    if (this.xctestApiClient) {
-      this.log.info('Stopping the XCTest session');
-      this.xctestApiClient.stop();
-      this.xctestApiClient = null;
+    if (this.usePreinstalledWDA) {
+      if (this.xctestApiClient) {
+        this.log.info('Stopping the XCTest session');
+        this.xctestApiClient.stop();
+        this.xctestApiClient = null;
+      }
     } else {
       this.log.info('Shutting down sub-processes');
       await this.xcodebuild.quit();
@@ -475,6 +483,9 @@ class WebDriverAgent {
   }
 
   async retrieveDerivedDataPath () {
+    if (this.usePreinstalledWDA) {
+      return;
+    }
     return await this.xcodebuild.retrieveDerivedDataPath();
   }
 

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -63,7 +63,7 @@ class WebDriverAgent {
 
     this.usePreinstalledWDA = args.usePreinstalledWDA;
     this.preInstalledWDABundleId = args.preInstalledWDABundleId;
-    this.xctestSessionForWDA = null;
+    this.xctestApiClient = null;
 
     this.xcodebuild = new XcodeBuild(this.xcodeVersion, this.device, {
       platformVersion: this.platformVersion,
@@ -309,9 +309,9 @@ class WebDriverAgent {
         xctestEnv.MJPEG_SERVER_PORT = this.mjpegServerPort;
       }
       this.log.info('Launching WebDriverAgent on the device without xcodebuild');
-      this.xctestSessionForWDA = new Xctest(this.device.udid, this.bundleIdForXctest, null, {env: xctestEnv});
+      this.xctestApiClient = new Xctest(this.device.udid, this.bundleIdForXctest, null, {env: xctestEnv});
 
-      await this.xctestSessionForWDA.start();
+      await this.xctestApiClient.start();
 
       this.setupProxies(sessionId);
       const status = await this.getStatus();
@@ -426,10 +426,10 @@ class WebDriverAgent {
   }
 
   async quit () {
-    if (this.xctestSessionForWDA) {
+    if (this.xctestApiClient) {
       this.log.info('Stopping the XCTest session');
-      this.xctestSessionForWDA.stop();
-      this.xctestSessionForWDA = null;
+      this.xctestApiClient.stop();
+      this.xctestApiClient = null;
     } else {
       this.log.info('Shutting down sub-processes');
       await this.xcodebuild.quit();

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -60,7 +60,9 @@ class WebDriverAgent {
     this.mjpegServerPort = args.mjpegServerPort;
 
     this.updatedWDABundleId = args.updatedWDABundleId;
+
     this.usePreinstalledWDA = args.usePreinstalledWDA;
+    this.preInstalledWDABundleId = args.preInstalledWDABundleId;
     this.xctestWDA = null;
 
     this.xcodebuild = new XcodeBuild(this.xcodeVersion, this.device, {
@@ -88,6 +90,14 @@ class WebDriverAgent {
       resultBundlePath: args.resultBundlePath,
       resultBundleVersion: args.resultBundleVersion,
     }, this.log);
+  }
+
+  /**
+   *
+   * @returns {string} Bundle ID for XCTest build.
+   */
+  bundleIdForXctest () {
+    return this.preInstalledWDABundleId || WDA_RUNNER_BUNDLE_ID_FOR_XCTEST;
   }
 
   setWDAPaths (bootstrapPath, agentPath) {
@@ -291,12 +301,11 @@ class WebDriverAgent {
     }
 
     if (this.isRealDevice && this.usePreinstalledWDA) {
-      const launchWDABundleID = this.updatedWDABundleId || WDA_RUNNER_BUNDLE_ID_FOR_XCTEST;
-      const xctestEnv = {};
-      if (this.opts.wdaLocalPort) {
-        xctestEnv.USE_PORT = this.wdaLocalPort || WDA_AGENT_PORT;
-      }
-      this.xctestWDA = new Xctest(this.opts.udid, launchWDABundleID, null, {env: xctestEnv});
+      const xctestEnv = {
+        USE_PORT: this.wdaLocalPort || WDA_AGENT_PORT
+      };
+      this.log.info('Launching WebDriverAgent on the device via XCTest');
+      this.xctestWDA = new Xctest(this.device.udid, this.bundleIdForXctest(), null, {env: xctestEnv});
 
       await this.xctestWDA.start();
 
@@ -412,12 +421,12 @@ class WebDriverAgent {
   }
 
   async quit () {
-    this.log.info('Shutting down sub-processes');
-
     if (this.xctestWDA) {
+      this.log.info('Stopping the XCTest session');
       this.xctestWDA.stop();
       this.xctestWDA = null;
     } else {
+      this.log.info('Shutting down sub-processes');
       await this.xcodebuild.quit();
       await this.xcodebuild.reset();
     }

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -94,7 +94,7 @@ class WebDriverAgent {
 
   /**
    *
-   * @returns {string} Bundle ID for XCTest build.
+   * @returns {string} Bundle ID for Xctest.
    */
   bundleIdForXctest () {
     return this.preInstalledWDABundleId || WDA_RUNNER_BUNDLE_ID_FOR_XCTEST;

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -314,8 +314,9 @@ class WebDriverAgent {
       await this.xctestSessionForWDA.start();
 
       this.setupProxies(sessionId);
+      const status = await this.getStatus();
       this.started = true;
-      return await this.getStatus();
+      return status;
     }
 
     this.log.info('Launching WebDriverAgent on the device');

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -14,8 +14,10 @@ import AsyncLock from 'async-lock';
 import { exec } from 'teen_process';
 import { bundleWDASim } from './check-dependencies';
 import {
-  WDA_RUNNER_BUNDLE_ID, WDA_RUNNER_APP, WDA_BASE_URL, WDA_UPGRADE_TIMESTAMP_PATH,
+  WDA_RUNNER_BUNDLE_ID, WDA_RUNNER_BUNDLE_ID_FOR_XCTEST, WDA_RUNNER_APP,
+  WDA_BASE_URL, WDA_UPGRADE_TIMESTAMP_PATH,
 } from './constants';
+import {Xctest} from 'appium-ios-device';
 
 const WDA_LAUNCH_TIMEOUT = 60 * 1000;
 const WDA_AGENT_PORT = 8100;
@@ -58,6 +60,8 @@ class WebDriverAgent {
     this.mjpegServerPort = args.mjpegServerPort;
 
     this.updatedWDABundleId = args.updatedWDABundleId;
+    this.usePreinstalledWDA = args.usePreinstalledWDA;
+    this.xctestWDA = null;
 
     this.xcodebuild = new XcodeBuild(this.xcodeVersion, this.device, {
       platformVersion: this.platformVersion,
@@ -286,6 +290,21 @@ class WebDriverAgent {
       return await this.getStatus();
     }
 
+    if (this.isRealDevice && this.usePreinstalledWDA) {
+      const launchWDABundleID = this.updatedWDABundleId || WDA_RUNNER_BUNDLE_ID_FOR_XCTEST;
+      const xctestEnv = {};
+      if (this.opts.wdaLocalPort) {
+        xctestEnv.USE_PORT = this.wdaLocalPort || WDA_AGENT_PORT;
+      }
+      this.xctestWDA = new Xctest(this.opts.udid, launchWDABundleID, null, {env: xctestEnv});
+
+      await this.xctestWDA.start();
+
+      this.setupProxies(sessionId);
+      this.started = true;
+      return await this.getStatus();
+    }
+
     this.log.info('Launching WebDriverAgent on the device');
 
     this.setupProxies(sessionId);
@@ -395,8 +414,13 @@ class WebDriverAgent {
   async quit () {
     this.log.info('Shutting down sub-processes');
 
-    await this.xcodebuild.quit();
-    await this.xcodebuild.reset();
+    if (this.xctestWDA) {
+      this.xctestWDA.stop();
+      this.xctestWDA = null;
+    } else {
+      await this.xcodebuild.quit();
+      await this.xcodebuild.reset();
+    }
 
     if (this.jwproxy) {
       this.jwproxy.sessionId = null;

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -276,6 +276,11 @@ class WebDriverAgent {
     }
   }
 
+  /**
+   * Launch WDA with preinstalled package without xcodebuild.
+   * @param {string} sessionId Launch WDA and establish the session with this sessionId
+   * @return {?object} State Object
+   */
   async launchWithPreinstalledWDA(sessionId) {
     const xctestEnv = {
       USE_PORT: this.wdaLocalPort || WDA_AGENT_PORT,

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -62,9 +62,10 @@ class WebDriverAgent {
     this.updatedWDABundleId = args.updatedWDABundleId;
 
     this.usePreinstalledWDA = args.usePreinstalledWDA;
-
     this.xctestApiClient = null;
 
+    // FIXME: maybe 'this.webDriverAgentUrl' also can ignore
+    // the xcodebuild instance itself.
     if (this.usePreinstalledWDA) {
       this.xcodebuild = null;
     } else {

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -66,10 +66,10 @@ class WebDriverAgent {
 
     // FIXME: maybe 'this.webDriverAgentUrl' also can ignore
     // the xcodebuild instance itself.
-    if (this.usePreinstalledWDA) {
-      this.xcodebuild = null;
-    } else {
-      this.xcodebuild = new XcodeBuild(this.xcodeVersion, this.device, {
+
+    this.xcodebuild = this.usePreinstalledWDA
+    ? null
+    : new XcodeBuild(this.xcodeVersion, this.device, {
         platformVersion: this.platformVersion,
         platformName: this.platformName,
         iosSdkVersion: this.iosSdkVersion,
@@ -94,7 +94,6 @@ class WebDriverAgent {
         resultBundlePath: args.resultBundlePath,
         resultBundleVersion: args.resultBundleVersion,
       }, this.log);
-    }
   }
 
   /**
@@ -277,6 +276,25 @@ class WebDriverAgent {
     }
   }
 
+  async launchWithPreinstalledWDA(sessionId) {
+    const xctestEnv = {
+      USE_PORT: this.wdaLocalPort || WDA_AGENT_PORT,
+      WDA_PRODUCT_BUNDLE_IDENTIFIER: this.bundleIdForXctest
+    };
+    if (this.mjpegServerPort) {
+      xctestEnv.MJPEG_SERVER_PORT = this.mjpegServerPort;
+    }
+    this.log.info('Launching WebDriverAgent on the device without xcodebuild');
+    this.xctestApiClient = new Xctest(this.device.udid, this.bundleIdForXctest, null, {env: xctestEnv});
+
+    await this.xctestApiClient.start();
+
+    this.setupProxies(sessionId);
+    const status = await this.getStatus();
+    this.started = true;
+    return status;
+  }
+
   /**
    * Return current running WDA's status like below after launching WDA
    * {
@@ -308,23 +326,11 @@ class WebDriverAgent {
       return await this.getStatus();
     }
 
-    if (this.isRealDevice && this.usePreinstalledWDA) {
-      const xctestEnv = {
-        USE_PORT: this.wdaLocalPort || WDA_AGENT_PORT,
-        WDA_PRODUCT_BUNDLE_IDENTIFIER: this.bundleIdForXctest
-      };
-      if (this.mjpegServerPort) {
-        xctestEnv.MJPEG_SERVER_PORT = this.mjpegServerPort;
+    if (this.usePreinstalledWDA) {
+      if (this.isRealDevice) {
+        return await this.launchWithPreinstalledWDA(sessionId);
       }
-      this.log.info('Launching WebDriverAgent on the device without xcodebuild');
-      this.xctestApiClient = new Xctest(this.device.udid, this.bundleIdForXctest, null, {env: xctestEnv});
-
-      await this.xctestApiClient.start();
-
-      this.setupProxies(sessionId);
-      const status = await this.getStatus();
-      this.started = true;
-      return status;
+      throw new Error('usePreinstalledWDA is available only for a real device.');
     }
 
     this.log.info('Launching WebDriverAgent on the device');

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -63,7 +63,7 @@ class WebDriverAgent {
 
     this.usePreinstalledWDA = args.usePreinstalledWDA;
     this.preInstalledWDABundleId = args.preInstalledWDABundleId;
-    this.xctestWDA = null;
+    this.xctestSessionForWDA = null;
 
     this.xcodebuild = new XcodeBuild(this.xcodeVersion, this.device, {
       platformVersion: this.platformVersion,
@@ -96,7 +96,7 @@ class WebDriverAgent {
    *
    * @returns {string} Bundle ID for Xctest.
    */
-  bundleIdForXctest () {
+  get bundleIdForXctest () {
     return this.preInstalledWDABundleId || WDA_RUNNER_BUNDLE_ID_FOR_XCTEST;
   }
 
@@ -302,12 +302,16 @@ class WebDriverAgent {
 
     if (this.isRealDevice && this.usePreinstalledWDA) {
       const xctestEnv = {
-        USE_PORT: this.wdaLocalPort || WDA_AGENT_PORT
+        USE_PORT: this.wdaLocalPort || WDA_AGENT_PORT,
+        WDA_PRODUCT_BUNDLE_IDENTIFIER: this.bundleIdForXctest
       };
-      this.log.info('Launching WebDriverAgent on the device via XCTest');
-      this.xctestWDA = new Xctest(this.device.udid, this.bundleIdForXctest(), null, {env: xctestEnv});
+      if (this.mjpegServerPort) {
+        xctestEnv.MJPEG_SERVER_PORT = this.mjpegServerPort;
+      }
+      this.log.info('Launching WebDriverAgent on the device without xcodebuild');
+      this.xctestSessionForWDA = new Xctest(this.device.udid, this.bundleIdForXctest, null, {env: xctestEnv});
 
-      await this.xctestWDA.start();
+      await this.xctestSessionForWDA.start();
 
       this.setupProxies(sessionId);
       this.started = true;
@@ -421,10 +425,10 @@ class WebDriverAgent {
   }
 
   async quit () {
-    if (this.xctestWDA) {
+    if (this.xctestSessionForWDA) {
       this.log.info('Stopping the XCTest session');
-      this.xctestWDA.stop();
-      this.xctestWDA = null;
+      this.xctestSessionForWDA.stop();
+      this.xctestSessionForWDA = null;
     } else {
       this.log.info('Shutting down sub-processes');
       await this.xcodebuild.quit();

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -267,12 +267,13 @@ class WebDriverAgent {
       return;
     }
 
-    if (!this.usePreinstalledWDA) {
-      try {
-        await this.xcodebuild.cleanProject();
-      } catch (e) {
-        this.log.warn(`Cannot perform WebDriverAgent project cleanup. Original error: ${e.message}`);
-      }
+    if (this.usePreinstalledWDA) {
+      return;
+    }
+    try {
+      await this.xcodebuild.cleanProject();
+    } catch (e) {
+      this.log.warn(`Cannot perform WebDriverAgent project cleanup. Original error: ${e.message}`);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@appium/base-driver": "^9.0.0",
     "@appium/support": "^3.0.0",
     "@babel/runtime": "^7.0.0",
+    "appium-ios-device": "^2.5.0",
     "appium-ios-simulator": "^5.0.1",
     "async-lock": "^1.0.0",
     "asyncbox": "^2.5.3",


### PR DESCRIPTION
For https://github.com/appium/appium-xcuitest-driver/pull/1609 to start a WDA process via Xctest in appoum-ios-device. The XCUITest PR will introduce 2 capabilities, `usePreinstalledWDA` and `preInstalledWDABundleId`.

preInstalledWDABundleId is to detect which bundle id is preinstalled wda the session want to start to.
usePreinstalledWDA is if a session uses XCTest sessions via appium-ios-device instead of xcodebuild to handle WDA.

One good thing in this aspect is this method can start a WDA process with free apple id account's one.

example capabilities:

```
{
  "appium:udid": "udid",
  "platformName": "ios",
  "appium:automationName": "xcuitest",
  "appium:usePreinstalledWDA": "true",
  "appium:preInstalledWDABundleId": "com.kazucocoa.WebDriverAgentRunner.xctrunner"
}
```

---

I'll try to write test code as a followup pr.

Current CI failures are not related to this change. Maybe the host machine was slow?