### PR TITLE
perf: tune webDriverAgentUrl case by skiping xcodebuild stuff

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -48,6 +48,9 @@ class WebDriverAgent {
 
     this.prebuildWDA = args.prebuildWDA;
 
+    // this.args.webDriverAgentUrl guiarantees the capabilities acually
+    // gave 'appium:webDriverAgentUrl' but 'this.webDriverAgentUrl'
+    // could be usd for caching WDA with xcodebuild.
     this.webDriverAgentUrl = args.webDriverAgentUrl;
 
     this.started = false;
@@ -64,10 +67,7 @@ class WebDriverAgent {
     this.usePreinstalledWDA = args.usePreinstalledWDA;
     this.xctestApiClient = null;
 
-    // FIXME: maybe 'this.webDriverAgentUrl' also can ignore
-    // the xcodebuild instance itself.
-
-    this.xcodebuild = this.usePreinstalledWDA
+    this.xcodebuild = this.canSkipXcodebuild
     ? null
     : new XcodeBuild(this.xcodeVersion, this.device, {
         platformVersion: this.platformVersion,
@@ -94,6 +94,16 @@ class WebDriverAgent {
         resultBundlePath: args.resultBundlePath,
         resultBundleVersion: args.resultBundleVersion,
       }, this.log);
+  }
+
+  /**
+   * Return true if the session does not need xcodebuild.
+   * @returns {boolean} Whether the session needs/has xcodebuild.
+   */
+  get canSkipXcodebuild () {
+    // Use this.args.webDriverAgentUrl to guarantee
+    // the capabilities set gave the `appium:webDriverAgentUrl`.
+    return this.usePreinstalledWDA || this.args.webDriverAgentUrl;
   }
 
   /**
@@ -266,7 +276,7 @@ class WebDriverAgent {
       return;
     }
 
-    if (this.usePreinstalledWDA) {
+    if (this.canSkipXcodebuild) {
       return;
     }
     try {
@@ -451,10 +461,13 @@ class WebDriverAgent {
         this.xctestApiClient.stop();
         this.xctestApiClient = null;
       }
-    } else {
+    } else if (!this.args.webDriverAgentUrl) {
       this.log.info('Shutting down sub-processes');
       await this.xcodebuild.quit();
       await this.xcodebuild.reset();
+    } else {
+      this.log.debug('Do not stop xcodebuild nor XCTest session ' +
+        'since the WDA session is managed by outside this driver.');
     }
 
     if (this.jwproxy) {
@@ -496,7 +509,7 @@ class WebDriverAgent {
   }
 
   async retrieveDerivedDataPath () {
-    if (this.usePreinstalledWDA) {
+    if (this.canSkipXcodebuild) {
       return;
     }
     return await this.xcodebuild.retrieveDerivedDataPath();

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -50,7 +50,7 @@ class WebDriverAgent {
 
     // this.args.webDriverAgentUrl guiarantees the capabilities acually
     // gave 'appium:webDriverAgentUrl' but 'this.webDriverAgentUrl'
-    // could be usd for caching WDA with xcodebuild.
+    // could be used for caching WDA with xcodebuild.
     this.webDriverAgentUrl = args.webDriverAgentUrl;
 
     this.started = false;

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -111,7 +111,7 @@ class WebDriverAgent {
    * @returns {string} Bundle ID for Xctest.
    */
   get bundleIdForXctest () {
-    return `${this.updatedWDABundleId}.xctrunner` || WDA_RUNNER_BUNDLE_ID_FOR_XCTEST;
+    return this.updatedWDABundleId ? `${this.updatedWDABundleId}.xctrunner` : WDA_RUNNER_BUNDLE_ID_FOR_XCTEST;
   }
 
   setWDAPaths (bootstrapPath, agentPath) {


### PR DESCRIPTION
Tune `webDriverAgentUrl` capability's case as same as with `usePreinstalledWDA`. Not a huge deal, but very slightly avoid xcodebuild class stuff.

In case a session has `webDriverAgentUrl`, basically a user manages the WDA process outside Appium/XCUITest driver. Thus, `if` clause which is for `this.usePreinstalledWDA` can apply as same.

The only two different points are `launch` and `quit`. `launch` already has both case, so this PR changes L464 a bit.