### PR TITLE
ci: use Xcode 14.2 for release

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-12
 
     env:
-      XCODE_VERSION: 14.1
+      XCODE_VERSION: 14.2
       ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner.zip"
       PKG_PATH_IOS: "appium_wda_ios"
       ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner.zip"


### PR DESCRIPTION
Xcode 14.2 built worked in https://github.com/appium/WebDriverAgent/pull/689. Just use the newer one.