### PR TITLE
Revert "fix: Assert app is installed before launching or activating it"

### DIFF
--- a/WebDriverAgentLib/FBApplication.h
+++ b/WebDriverAgentLib/FBApplication.h
@@ -44,16 +44,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)fb_switchToSystemApplicationWithError:(NSError **)error;
 
-/**
- Returns the bundle indentifier of the system app (ususally Springboard)
- */
-+ (NSString *)fb_systemApplicationBundleID;
-
-/**
- Checks if the app is installed on the device under test.
- */
-- (BOOL)fb_isInstalled;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/FBApplication.m
+++ b/WebDriverAgentLib/FBApplication.m
@@ -9,7 +9,6 @@
 
 #import "FBApplication.h"
 
-#import "FBExceptions.h"
 #import "FBXCAccessibilityElement.h"
 #import "FBLogger.h"
 #import "FBRunLoopSpinner.h"
@@ -17,7 +16,6 @@
 #import "FBActiveAppDetectionPoint.h"
 #import "FBXCodeCompatibility.h"
 #import "FBXCTestDaemonsProxy.h"
-#import "LSApplicationWorkspace.h"
 #import "XCUIApplication.h"
 #import "XCUIApplication+FBHelpers.h"
 #import "XCUIApplicationImpl.h"
@@ -135,16 +133,6 @@ static const NSTimeInterval APP_STATE_CHANGE_TIMEOUT = 5.0;
    [[FBXCAXClientProxy.sharedClient systemApplication] processIdentifier]];
 }
 
-+ (NSString *)fb_systemApplicationBundleID
-{
-  static dispatch_once_t onceToken;
-  static NSString *systemAppBundleID;
-  dispatch_once(&onceToken, ^{
-    systemAppBundleID = [[self.class fb_systemApplication] bundleID];
-  });
-  return systemAppBundleID;
-}
-
 + (instancetype)applicationWithPID:(pid_t)processID
 {
   if ([NSProcessInfo processInfo].processIdentifier == processID) {
@@ -153,31 +141,12 @@ static const NSTimeInterval APP_STATE_CHANGE_TIMEOUT = 5.0;
   return (FBApplication *)[FBXCAXClientProxy.sharedClient monitoredApplicationWithProcessIdentifier:processID];
 }
 
-/**
- https://github.com/appium/WebDriverAgent/issues/702
- */
-- (void)fb_assertInstalledByAction:(NSString *)action
-{
-  if (![self.bundleID isEqualToString:[self.class fb_systemApplicationBundleID]] && !self.fb_isInstalled) {
-    NSString *message = [NSString stringWithFormat:@"The application '%@' cannot be %@ because it is not installed on the device under test",
-                         self.bundleID, action];
-    [[NSException exceptionWithName:FBApplicationMissingException reason:message userInfo:nil] raise];
-  }
-}
-
 - (void)launch
 {
-  [self fb_assertInstalledByAction:@"launched"];
   [super launch];
   if (![self fb_waitForAppElement:APP_STATE_CHANGE_TIMEOUT]) {
     [FBLogger logFmt:@"The application '%@' is not running in foreground after %.2f seconds", self.bundleID, APP_STATE_CHANGE_TIMEOUT];
   }
-}
-
-- (void)activate
-{
-  [self fb_assertInstalledByAction:@"activated"];
-  [super activate];
 }
 
 - (void)terminate
@@ -210,11 +179,6 @@ static const NSTimeInterval APP_STATE_CHANGE_TIMEOUT = 5.0;
     return nil != activeApp && [activeApp.bundleID isEqualToString:systemApp.bundleID];
   }
           error:error];
-}
-
-- (BOOL)fb_isInstalled
-{
-  return [[LSApplicationWorkspace defaultWorkspace] applicationIsInstalled:self.bundleID];
 }
 
 @end

--- a/WebDriverAgentLib/Routing/FBExceptionHandler.m
+++ b/WebDriverAgentLib/Routing/FBExceptionHandler.m
@@ -24,8 +24,7 @@
     commandStatus = [FBCommandStatus noSuchDriverErrorWithMessage:exception.reason
                                                         traceback:traceback];
   } else if ([exception.name isEqualToString:FBInvalidArgumentException]
-             || [exception.name isEqualToString:FBElementAttributeUnknownException]
-             || [exception.name isEqualToString:FBApplicationMissingException]) {
+             || [exception.name isEqualToString:FBElementAttributeUnknownException]) {
     commandStatus = [FBCommandStatus invalidArgumentErrorWithMessage:exception.reason
                                                            traceback:traceback];
   } else if ([exception.name isEqualToString:FBApplicationCrashedException]

--- a/WebDriverAgentLib/Routing/FBExceptions.h
+++ b/WebDriverAgentLib/Routing/FBExceptions.h
@@ -49,7 +49,4 @@ extern NSString *const FBClassChainQueryParseException;
 /*! Exception used to notify about application crash */
 extern NSString *const FBApplicationCrashedException;
 
-/*! Exception used to notify about the application is not installed  */
-extern NSString *const FBApplicationMissingException;
-
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Routing/FBExceptions.m
+++ b/WebDriverAgentLib/Routing/FBExceptions.m
@@ -20,4 +20,3 @@ NSString *const FBInvalidXPathException = @"FBInvalidXPathException";
 NSString *const FBXPathQueryEvaluationException = @"FBXPathQueryEvaluationException";
 NSString *const FBClassChainQueryParseException = @"FBClassChainQueryParseException";
 NSString *const FBApplicationCrashedException = @"FBApplicationCrashedException";
-NSString *const FBApplicationMissingException = @"FBApplicationMissingException";

--- a/WebDriverAgentTests/IntegrationTests/FBSessionIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBSessionIntegrationTests.m
@@ -11,7 +11,6 @@
 
 #import "FBIntegrationTestCase.h"
 #import "FBApplication.h"
-#import "FBExceptions.h"
 #import "FBMacros.h"
 #import "FBSession.h"
 #import "FBXCodeCompatibility.h"
@@ -99,34 +98,6 @@ static NSString *const SETTINGS_BUNDLE_ID = @"com.apple.Preferences";
                                     arguments:nil
                                   environment:nil];
   FBAssertWaitTillBecomesTrue([self.session.activeApplication.bundleID isEqualToString:testedApp.bundleID]);
-}
-
-- (void)testAppWithInvalidBundleIDCannotBeStarted
-{
-  FBApplication *testedApp = [[FBApplication alloc] initWithBundleIdentifier:@"yolo"];
-  @try {
-    [testedApp launch];
-    XCTFail(@"An exception is expected to be thrown");
-  } @catch (NSException *exception) {
-    XCTAssertEqualObjects(FBApplicationMissingException, exception.name);
-  }
-}
-
-- (void)testAppWithInvalidBundleIDCannotBeActivated
-{
-  FBApplication *testedApp = [[FBApplication alloc] initWithBundleIdentifier:@"yolo"];
-  @try {
-    [testedApp activate];
-    XCTFail(@"An exception is expected to be thrown");
-  } @catch (NSException *exception) {
-    XCTAssertEqualObjects(FBApplicationMissingException, exception.name);
-  }
-}
-
-- (void)testAppWithInvalidBundleIDCannotBeTerminated
-{
-  FBApplication *testedApp = [[FBApplication alloc] initWithBundleIdentifier:@"yolo"];
-  [testedApp terminate];
 }
 
 - (void)testLaunchUnattachedApp


### PR DESCRIPTION
Reverts appium/WebDriverAgent#704

When I checked the below code on a real device, it always returned nil as below. Maybe we should find another way, or should make it work only for simulator right now.

```
(lldb) po [[LSApplicationWorkspace defaultWorkspace] applicationIsInstalled:self.bundleID]
 nil
```

System installed app such as `com.apple.Preferences` also failed to launch as below with this as:

```
 curl -X POST http://192.168.4.24:8100/session/D35C8AD1-2F19-4640-83A2-162F97C00A8E/wda/apps/launch -d '{ "bundleId": "com.apple.Preferences" }'
{
  "value" : {
    "error" : "invalid argument",
    "message" : "The application 'com.apple.Preferences' cannot be activated because it is not installed on the device under test",
    "traceback" : "(\n\t0   CoreFoundation                      0x00000001c1ba8cc0 4230C122-42E8-383B-BEEC-EE7B61F8BB61 + 40128\n\t1   libobjc.A.dylib                     0x00000001bacc83d0 objc_exception_throw + 60\n\t2   CoreFoundation                      0x00000001c1d15c6c 4230C122-42E8-383B-BEEC-EE7B61F8BB61 + 1535084\n\t3   WebDriverAgentLib                   0x000000010af4b464 -[FBApplication fb_assertInstalledByAction:] + 356\n\t4   WebDriverAgentLib                   0x000000010af4b584 -[FBApplication activate] + 40\n\t5   WebDriverAgentLib                   0x000000010af46f88 -[XCUIApplication(FBCompatibility) fb_activate] + 32\n\t6   WebDriverAgentLib                   0x000000010af0b728 -[FBSession launchApplicationWithBundleId:shouldWaitForQuiescence:arguments:environment:] + 448\n\t7   WebDriverAgentLib                   0x000000010af31ef8 +[FBSessionCommands handleSessionAppLaunch:] + 312\n\t8   WebDriverAgentLib                   0x000000010aed5d30 -[FBRoute_TargetAction mountRequest:intoResponse:] + 168\n\t9   WebDriverAgentLib                   0x000000010aec2928 __37-[FBWebServer registerRouteHandlers:]_block_invoke + 400\n\t10  WebDriverAgentLib                   0x000000010aef6f58 -[RoutingHTTPServer handleRoute:withRequest:response:] + 160\n\t11  WebDriverAgentLib                   0x000000010aef79e4 __72-[RoutingHTTPServer routeMethod:withPath:parameters:request:connection:]_block_invoke + 64\n\t12  libdispatch.dylib                   0x00000001c906aeac BB347F0E-F21C-3607-82E6-C8D750FDBF8C + 16044\n\t13  libdispatch.dylib                   0x00000001c907a500 BB347F0E-F21C-3607-82E6-C8D750FDBF8C + 79104\n\t14  libdispatch.dylib                   0x00000001c906aeac BB347F0E-F21C-3607-82E6-C8D750FDBF8C + 16044\n\t15  libdispatch.dylib                   0x00000001c90796a4 BB347F0E-F21C-3607-82E6-C8D750FDBF8C + 75428\n\t16  libdispatch.dylib                   0x00000001c90792f4 _dispatch_main_queue_callback_4CF + 44\n\t17  CoreFoundation                      0x00000001c1c37c28 4230C122-42E8-383B-BEEC-EE7B61F8BB61 + 625704\n\t18  CoreFoundation                      0x00000001c1c19560 4230C122-42E8-383B-BEEC-EE7B61F8BB61 + 501088\n\t19  CoreFoundation                      0x00000001c1c1e3ec CFRunLoopRunSpecific + 612\n\t20  Foundation                          0x00000001bbf1efd4 6E76DC96-11AF-3B2E-B71E-215F9CC6E822 + 270292\n\t21  WebDriverAgentLib                   0x000000010aec17dc -[FBWebServer startServing] + 328\n\t22  WebDriverAgentRunner                0x0000000104bcb980 -[UITestingUITests testRunner] + 80\n\t23  CoreFoundation                      0x00000001c1c11c04 4230C122-42E8-383B-BEEC-EE7B61F8BB61 + 470020\n\t24  CoreFoundation                      0x00000001c1bbfcb4 4230C122-42E8-383B-BEEC-EE7B61F8BB61 + 134324\n\t25  XCTestCore                          0x0000000104c5d8e8 +[XCTFailableInvocation invokeStandardConventionInvocation:completion:] + 68\n\t26  XCTestCore                          0x0000000104c5d89c __90+[XCTFailableInvocation invokeInvocation:withTestMethodConvention:lastObservedErrorIssue:]_block_invoke_3 + 28\n\t27  XCTestCore                          0x0000000104c5d228 __81+[XCTFailableInvocation invokeWithAsynchronousWait:lastObservedErrorIssue:block:]_block_invoke.5 + 112\n\t28  XCTestCore                          0x0000000104c1b938 +[XCTSwiftErrorObservation observeErrorsInBlock:] + 148\n\t29  XCTestCore                          0x0000000104c5d088 +[XCTFailableInvocation invokeWithAsynchronousWait:lastObservedErrorIssue:block:] + 460\n\t30  XCTestCore                          0x0000000104c5d5f4 +[XCTFailableInvocation invokeInvocation:withTestMethodConvention:lastObservedErrorIssue:] + 372\n\t31  XCTestCore                          0x0000000104c5d970 +[XCTFailableInvocation invokeInvocation:lastObservedErrorIssue:] + 72\n\t32  XCTestCore                          0x0000000104c4a8c0 __24-[XCTestCase invokeTest]_block_invoke_2 + 88\n\t33  XCTestCore                          0x0000000104c28c1c -[XCTMemoryChecker _assertInvalidObjectsDeallocatedAfterScope:] + 84\n\t34  XCTestCore                          0x0000000104c54220 -[XCTestCase assertInvalidObjectsDeallocatedAfterScope:] + 92\n\t35  XCTestCore                          0x0000000104c4a840 __24-[XCTestCase invokeTest]_block_invoke.98 + 172\n\t36  XCTestCore                          0x0000000104c14518 -[XCTestCase(XCTIssueHandling) _caughtUnhandledDeveloperExceptionPermittingControlFlowInterruptions:caughtInterruptionException:whileExecutingBlock:] + 164\n\t37  XCTestCore                          0x0000000104c4a3dc -[XCTestCase invokeTest] + 840\n\t38  XCTestCore                          0x0000000104c4b9dc __26-[XCTestCase performTest:]_block_invoke.155 + 36\n\t39  XCTestCore                          0x0000000104c14518 -[XCTestCase(XCTIssueHandling) _caughtUnhandledDeveloperExceptionPermittingControlFlowInterruptions:caughtInterruptionException:whileExecutingBlock:] + 164\n\t40  XCTestCore                          0x0000000104c4b530 __26-[XCTestCase performTest:]_block_invoke.141 + 464\n\t41  XCTestCore                          0x0000000104c32348 +[XCTContext _runInChildOfContext:forTestCase:markAsReportingBase:block:] + 180\n\t42  XCTestCore                          0x0000000104c3225c +[XCTContext runInContextForTestCase:markAsReportingBase:block:] + 144\n\t43  XCTestCore                          0x0000000104c4b1bc -[XCTestCase performTest:] + 308\n\t44  XCTestCore                          0x0000000104c033cc -[XCTest runTest] + 48\n\t45  XCTestCore                          0x0000000104c34fa4 -[XCTestSuite runTestBasedOnRepetitionPolicy:testRun:] + 68\n\t46  XCTestCore                          0x0000000104c34e84 __27-[XCTestSuite performTest:]_block_invoke + 164\n\t47  XCTestCore                          0x0000000104c34934 __59-[XCTestSuite _performProtectedSectionForTest:testSection:]_block_invoke + 48\n\t48  XCTestCore                          0x0000000104c32348 +[XCTContext _runInChildOfContext:forTestCase:markAsReportingBase:block:] + 180\n\t49  XCTestCore                          0x0000000104c3225c +[XCTContext runInContextForTestCase:markAsReportingBase:block:] + 144\n\t50  XCTestCore                          0x0000000104c348d0 -[XCTestSuite _performProtectedSectionForTest:testSection:] + 180\n\t51  XCTestCore                          0x0000000104c34b8c -[XCTestSuite performTest:] + 216\n\t52  XCTestCore                          0x0000000104c033cc -[XCTest runTest] + 48\n\t53  XCTestCore                          0x0000000104c34fa4 -[XCTestSuite runTestBasedOnRepetitionPolicy:testRun:] + 68\n\t54  XCTestCore                          0x0000000104c34e84 __27-[XCTestSuite performTest:]_block_invoke + 164\n\t55  XCTestCore                          0x0000000104c34934 __59-[XCTestSuite _performProtectedSectionForTest:testSection:]_block_invoke + 48\n\t56  XCTestCore                          0x0000000104c32348 +[XCTContext _runInChildOfContext:forTestCase:markAsReportingBase:block:] + 180\n\t57  XCTestCore                          0x0000000104c3225c +[XCTContext runInContextForTestCase:markAsReportingBase:block:] + 144\n\t58  XCTestCore                          0x0000000104c348d0 -[XCTestSuite _performProtectedSectionForTest:testSection:] + 180\n\t59  XCTestCore                          0x0000000104c34b8c -[XCTestSuite performTest:] + 216\n\t60  XCTestCore                          0x0000000104c033cc -[XCTest runTest] + 48\n\t61  XCTestCore                          0x0000000104c34fa4 -[XCTestSuite runTestBasedOnRepetitionPolicy:testRun:] + 68\n\t62  XCTestCore                          0x0000000104c34e84 __27-[XCTestSuite performTest:]_block_invoke + 164\n\t63  XCTestCore                          0x0000000104c34934 __59-[XCTestSuite _performProtectedSectionForTest:testSection:]_block_invoke + 48\n\t64  XCTestCore                          0x0000000104c32348 +[XCTContext _runInChildOfContext:forTestCase:markAsReportingBase:block:] + 180\n\t65  XCTestCore                          0x0000000104c3225c +[XCTContext runInContextForTestCase:markAsReportingBase:block:] + 144\n\t66  XCTestCore                          0x0000000104c348d0 -[XCTestSuite _performProtectedSectionForTest:testSection:] + 180\n\t67  XCTestCore                          0x0000000104c34b8c -[XCTestSuite performTest:] + 216\n\t68  XCTestCore                          0x0000000104c033cc -[XCTest runTest] + 48\n\t69  XCTestCore                          0x0000000104c04f14 __89-[XCTTestRunSession executeTestsWithIdentifiers:skippingTestsWithIdentifiers:completion:]_block_invoke + 104\n\t70  XCTestCore                          0x0000000104c32348 +[XCTContext _runInChildOfContext:forTestCase:markAsReportingBase:block:] + 180\n\t71  XCTestCore                          0x0000000104c3225c +[XCTContext runInContextForTestCase:markAsReportingBase:block:] + 144\n\t72  XCTestCore                          0x0000000104c04e08 -[XCTTestRunSession executeTestsWithIdentifiers:skippingTestsWithIdentifiers:completion:] + 296\n\t73  XCTestCore                          0x0000000104c6a4c0 __72-[XCTExecutionWorker enqueueTestIdentifiersToRun:testIdentifiersToSkip:]_block_invoke_2 + 136\n\t74  XCTestCore                          0x0000000104c6a610 -[XCTExecutionWorker runWithError:] + 108\n\t75  XCTestCore                          0x0000000104c2f54c __25-[XCTestDriver _runTests]_block_invoke.266 + 56\n\t76  XCTestCore                          0x0000000104c0d670 -[XCTestObservationCenter _observeTestExecutionForBlock:] + 288\n\t77  XCTestCore                          0x0000000104c2f1a8 -[XCTestDriver _runTests] + 1092\n\t78  XCTestCore                          0x0000000104c039bc _XCTestMain + 88\n\t79  WebDriverAgentRunner-Runner         0x0000000104695d1c -[_XCTRunnerAppDelegate application:didFinishLaunchingWithOptions:] + 0\n\t80  WebDriverAgentRunner-Runner         0x0000000104695d00 _XCTRunnerRunTests + 0\n\t81  CoreFoundation                      0x00000001c1be26e0 4230C122-42E8-383B-BEEC-EE7B61F8BB61 + 276192\n\t82  CoreFoundation                      0x00000001c1c49210 4230C122-42E8-383B-BEEC-EE7B61F8BB61 + 696848\n\t83  CoreFoundation                      0x00000001c1c190e8 4230C122-42E8-383B-BEEC-EE7B61F8BB61 + 499944\n\t84  CoreFoundation                      0x00000001c1c1e3ec CFRunLoopRunSpecific + 612\n\t85  GraphicsServices                    0x00000001fc7db35c GSEventRunModal + 164\n\t86  UIKitCore                           0x00000001c3fab6e8 B3834960-244B-34E4-9EA0-CA4BB44EF0F3 + 3790568\n\t87  UIKitCore                           0x00000001c3fab34c UIApplicationMain + 340\n\t88  WebDriverAgentRunner-Runner         0x0000000104695ed0 main + 160\n\t89  dyld                                0x00000001e110edec 8A423F3F-B318-315E-99C7-05EE532E9C0D + 89580\n)"
  },
  "sessionId" : "D35C8AD1-2F19-4640-83A2-162F97C00A8E"
}%
```

For real device, if we do similar thing, maybe we should the app installation in xcuitest driver layer...?