### PR TITLE
fix: Prevent freeze on launch/activate of a missing app

### DIFF
--- a/PrivateHeaders/XCTest/XCTRunnerDaemonSession.h
+++ b/PrivateHeaders/XCTest/XCTRunnerDaemonSession.h
@@ -80,4 +80,11 @@
 @property(readonly) _Bool supportsLocationSimulation;
 #endif
 
+// Since Xcode 10.2
+- (void)launchApplicationWithPath:(NSString *)arg1
+                         bundleID:(NSString *)arg2
+                        arguments:(NSArray *)arg3
+                      environment:(NSDictionary *)arg4
+                       completion:(void (^)(_Bool, NSError *))arg5;
+
 @end

--- a/WebDriverAgentLib/Routing/FBExceptionHandler.m
+++ b/WebDriverAgentLib/Routing/FBExceptionHandler.m
@@ -24,7 +24,8 @@
     commandStatus = [FBCommandStatus noSuchDriverErrorWithMessage:exception.reason
                                                         traceback:traceback];
   } else if ([exception.name isEqualToString:FBInvalidArgumentException]
-             || [exception.name isEqualToString:FBElementAttributeUnknownException]) {
+             || [exception.name isEqualToString:FBElementAttributeUnknownException]
+             || [exception.name isEqualToString:FBApplicationMissingException]) {
     commandStatus = [FBCommandStatus invalidArgumentErrorWithMessage:exception.reason
                                                            traceback:traceback];
   } else if ([exception.name isEqualToString:FBApplicationCrashedException]

--- a/WebDriverAgentLib/Routing/FBExceptions.h
+++ b/WebDriverAgentLib/Routing/FBExceptions.h
@@ -49,4 +49,7 @@ extern NSString *const FBClassChainQueryParseException;
 /*! Exception used to notify about application crash */
 extern NSString *const FBApplicationCrashedException;
 
+/*! Exception used to notify about the application is not installed  */
+extern NSString *const FBApplicationMissingException;
+
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Routing/FBExceptions.m
+++ b/WebDriverAgentLib/Routing/FBExceptions.m
@@ -20,3 +20,4 @@ NSString *const FBInvalidXPathException = @"FBInvalidXPathException";
 NSString *const FBXPathQueryEvaluationException = @"FBXPathQueryEvaluationException";
 NSString *const FBClassChainQueryParseException = @"FBClassChainQueryParseException";
 NSString *const FBApplicationCrashedException = @"FBApplicationCrashedException";
+NSString *const FBApplicationMissingException = @"FBApplicationMissingException";

--- a/WebDriverAgentTests/IntegrationTests/FBSessionIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBSessionIntegrationTests.m
@@ -11,6 +11,7 @@
 
 #import "FBIntegrationTestCase.h"
 #import "FBApplication.h"
+#import "FBExceptions.h"
 #import "FBMacros.h"
 #import "FBSession.h"
 #import "FBXCodeCompatibility.h"
@@ -105,6 +106,28 @@ static NSString *const SETTINGS_BUNDLE_ID = @"com.apple.Preferences";
   [FBUnattachedAppLauncher launchAppWithBundleId:SETTINGS_BUNDLE_ID];
   [self.session kill];
   XCTAssertEqualObjects(SETTINGS_BUNDLE_ID, FBApplication.fb_activeApplication.bundleID);
+}
+
+- (void)testAppWithInvalidBundleIDCannotBeStarted
+{
+  FBApplication *testedApp = [[FBApplication alloc] initWithBundleIdentifier:@"yolo"];
+  @try {
+    [testedApp launch];
+    XCTFail(@"An exception is expected to be thrown");
+  } @catch (NSException *exception) {
+    XCTAssertEqualObjects(FBApplicationMissingException, exception.name);
+  }
+}
+
+- (void)testAppWithInvalidBundleIDCannotBeActivated
+{
+  FBApplication *testedApp = [[FBApplication alloc] initWithBundleIdentifier:@"yolo"];
+  @try {
+    [testedApp activate];
+    XCTFail(@"An exception is expected to be thrown");
+  } @catch (NSException *exception) {
+    XCTAssertEqualObjects(FBApplicationMissingException, exception.name);
+  }
 }
 
 @end


### PR DESCRIPTION
This is another approach to workaround https://github.com/appium/WebDriverAgent/issues/702 after the [previous one](https://github.com/appium/WebDriverAgent/pull/704) has miserably failed due to real device security restrictions.