### PR TITLE
feat: Drop older screenshoting APIs

### DIFF
--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -89,9 +89,9 @@ extern NSString *const FBSnapshotMaxDepthKey;
 + (void)setMjpegServerFramerate:(NSUInteger)framerate;
 
 /**
- The quality of phone display screenshots. The higher quality you set is the bigger screenshot size is.
- The highest quality value is 0 (lossless PNG). The lowest quality is 2 (highly compressed JPEG).
- The default quality value is 1 (high quality JPEG).
+ The quality of  display screenshots. The higher quality you set is the bigger screenshot size is.
+ The highest quality value is 0 (lossless PNG) or 3 (lossless HEIC). The lowest quality is 2 (highly compressed JPEG).
+ The default quality value is 3 (lossless HEIC).
  See https://developer.apple.com/documentation/xctest/xctimagequality?language=objc
  */
 + (NSUInteger)screenshotQuality;

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -443,7 +443,7 @@ static UIInterfaceOrientation FBScreenshotOrientation;
   FBShouldUseCompactResponses = YES;
   FBElementResponseAttributes = @"type,label";
   FBMaxTypingFrequency = 60;
-  FBScreenshotQuality = 1;
+  FBScreenshotQuality = 3;
   FBCustomSnapshotTimeout = 15.;
   FBShouldUseFirstMatch = NO;
   FBShouldBoundElementsByIndex = NO;

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.h
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.h
@@ -10,6 +10,8 @@
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>
 
+@class UTType;
+
 NS_ASSUME_NONNULL_BEGIN
 
 // Those values define the allowed ranges for the scaling factor and compression quality settings
@@ -25,14 +27,12 @@ extern const CGFloat FBMaxCompressionQuality;
  queue it will be replaced with the new one
 
  @param image The image to scale down
- @param uti Either kUTTypePNG or kUTTypeJPEG
  @param completionHandler called after successfully scaling down an image
  @param scalingFactor the scaling factor in range 0.01..1.0. A value of 1.0 won't perform scaling at all
  @param compressionQuality the compression quality in range 0.0..1.0 (0.0 for max. compression and 1.0 for lossless compression)
- Only applicable for kUTTypeJPEG
+ Only applicable for UTTypeJPEG
  */
 - (void)submitImage:(NSData *)image
-                uti:(NSString *)uti
       scalingFactor:(CGFloat)scalingFactor
  compressionQuality:(CGFloat)compressionQuality
   completionHandler:(void (^)(NSData *))completionHandler;
@@ -41,7 +41,7 @@ extern const CGFloat FBMaxCompressionQuality;
  Scales and crops the source image
 
  @param image The source image data
- @param uti Either kUTTypePNG or kUTTypeJPEG
+ @param uti Either UTTypePNG or UTTypeJPEG
  @param rect The cropping rectange for the screenshot. The value is expected to be non-scaled one
             since it happens after scaling/orientation change.
             CGRectNull could be used to take a screenshot of the full screen.
@@ -52,7 +52,7 @@ extern const CGFloat FBMaxCompressionQuality;
  @returns Processed image data compressed according to the given UTI or nil in case of a failure
  */
 - (nullable NSData *)scaledImageWithImage:(NSData *)image
-                                      uti:(NSString *)uti
+                                      uti:(UTType *)uti
                                      rect:(CGRect)rect
                             scalingFactor:(CGFloat)scalingFactor
                        compressionQuality:(CGFloat)compressionQuality

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -163,7 +163,7 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
 {
   NSMutableData *newImageData = [NSMutableData data];
   CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData(
-                                                                            (CFMutableDataRef)newImageData,
+                                                                            (__bridge CFMutableDataRef) newImageData,
                                                                             (__bridge CFStringRef) UTTypeJPEG.identifier,
                                                                             1,
                                                                             NULL);

--- a/WebDriverAgentLib/Utilities/FBImageIOScaler.m
+++ b/WebDriverAgentLib/Utilities/FBImageIOScaler.m
@@ -11,7 +11,7 @@
 
 #import <ImageIO/ImageIO.h>
 #import <UIKit/UIKit.h>
-#import <MobileCoreServices/MobileCoreServices.h>
+@import UniformTypeIdentifiers;
 
 #import "FBConfiguration.h"
 #import "FBErrorBuilder.h"
@@ -43,7 +43,6 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
 }
 
 - (void)submitImage:(NSData *)image
-                uti:(NSString *)uti
       scalingFactor:(CGFloat)scalingFactor
  compressionQuality:(CGFloat)compressionQuality
   completionHandler:(void (^)(NSData *))completionHandler
@@ -118,7 +117,7 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
 }
 
 - (nullable NSData *)scaledImageWithImage:(NSData *)image
-                                      uti:(NSString *)uti
+                                      uti:(UTType *)uti
                                      rect:(CGRect)rect
                             scalingFactor:(CGFloat)scalingFactor
                        compressionQuality:(CGFloat)compressionQuality
@@ -154,7 +153,7 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
     UIGraphicsEndImageContext();
   }
 
-  return [uti isEqualToString:(__bridge id)kUTTypePNG]
+  return [uti conformsToType:UTTypePNG]
     ? UIImagePNGRepresentation(resultImage)
     : UIImageJPEGRepresentation(resultImage, compressionQuality);
 }
@@ -163,7 +162,11 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
                     compressionQuality:(CGFloat)compressionQuality
 {
   NSMutableData *newImageData = [NSMutableData data];
-  CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((CFMutableDataRef)newImageData, kUTTypeJPEG, 1, NULL);
+  CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData(
+                                                                            (CFMutableDataRef)newImageData,
+                                                                            (__bridge CFStringRef) UTTypeJPEG.identifier,
+                                                                            1,
+                                                                            NULL);
   CFDictionaryRef compressionOptions = (__bridge CFDictionaryRef)@{
     (const NSString *)kCGImageDestinationLossyCompressionQuality: @(compressionQuality)
   };

--- a/WebDriverAgentLib/Utilities/FBMjpegServer.m
+++ b/WebDriverAgentLib/Utilities/FBMjpegServer.m
@@ -72,11 +72,6 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
 
 - (void)streamScreenshot
 {
-  if (![self.class canStreamScreenshots]) {
-    [FBLogger log:@"MJPEG server cannot start because the current iOS version is not supported"];
-    return;
-  }
-
   NSUInteger framerate = FBConfiguration.mjpegServerFramerate;
   uint64_t timerInterval = (uint64_t)(1.0 / ((0 == framerate || framerate > MAX_FPS) ? MAX_FPS : framerate) * NSEC_PER_SEC);
   uint64_t timeStarted = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW);
@@ -130,11 +125,6 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
       [client writeData:chunk withTimeout:-1 tag:0];
     }
   }
-}
-
-+ (BOOL)canStreamScreenshots
-{
-  return [FBScreenshot isNewScreenshotAPISupported];
 }
 
 - (void)didClientConnect:(GCDAsyncSocket *)newClient

--- a/WebDriverAgentLib/Utilities/FBMjpegServer.m
+++ b/WebDriverAgentLib/Utilities/FBMjpegServer.m
@@ -10,7 +10,7 @@
 #import "FBMjpegServer.h"
 
 #import <mach/mach_time.h>
-#import <MobileCoreServices/MobileCoreServices.h>
+@import UniformTypeIdentifiers;
 
 #import "GCDAsyncSocket.h"
 #import "FBApplication.h"
@@ -91,7 +91,7 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
   NSError *error;
   NSData *screenshotData = [FBScreenshot takeInOriginalResolutionWithScreenID:self.mainScreenID
                                                            compressionQuality:screenshotCompressionQuality
-                                                                          uti:(__bridge id)kUTTypeJPEG
+                                                                          uti:UTTypeJPEG
                                                                       timeout:FRAME_TIMEOUT
                                                                         error:&error];
   if (nil == screenshotData) {
@@ -102,7 +102,6 @@ static const char *QUEUE_NAME = "JPEG Screenshots Provider Queue";
 
   if (usesScaling) {
     [self.imageScaler submitImage:screenshotData
-                              uti:(__bridge id)kUTTypeJPEG
                     scalingFactor:scalingFactor
                compressionQuality:compressionQuality
                 completionHandler:^(NSData * _Nonnull scaled) {

--- a/WebDriverAgentLib/Utilities/FBScreenshot.h
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.h
@@ -16,9 +16,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Retrieves non-scaled screenshot of the whole screen
 
- @param quality The number in range 0-2, where 2 (JPG) is the lowest and 0 (PNG) is the highest quality.
+ @param quality The number in range 0-3, where 0 is PNG (lossless), 3 is HEIC (lossless), 1- low quality JPEG and 2 - high quality JPEG
  @param error If there is an error, upon return contains an NSError object that describes the problem.
- @return Device screenshot as PNG- or JPG-encoded data or nil in case of failure
+ @return Device screenshot as PNG-encoded data or nil in case of failure
  */
 + (nullable NSData *)takeInOriginalResolutionWithQuality:(NSUInteger)quality
                                                    error:(NSError **)error;
@@ -26,11 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Retrieves non-scaled screenshot of the particular screen rectangle
 
- @param quality The number in range 0-2, where 2 (JPG) is the lowest and 0 (PNG) is the highest quality.
+ @param quality The number in range 0-3, where 0 is PNG (lossless), 3 is HEIC (lossless), 1- low quality JPEG and 2 - high quality JPEG
  @param rect The bounding rectange for the screenshot. The value is expected be non-scaled one.
              CGRectNull could be used to take a screenshot of the full screen.
  @param error If there is an error, upon return contains an NSError object that describes the problem.
- @return Device screenshot as PNG- or JPG-encoded data or nil in case of failure
+ @return Device screenshot as PNG-encoded data or nil in case of failure
  */
 + (nullable NSData *)takeInOriginalResolutionWithQuality:(NSUInteger)quality
                                                     rect:(CGRect)rect
@@ -41,10 +41,10 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param screenID The screen identifier to take the screenshot from
  @param compressionQuality Normalized screenshot quality value in range 0..1, where 1 is the best quality
- @param uti kUTType... constant, which defines the type of the returned screenshot image
+ @param uti UTType... constant, which defines the type of the returned screenshot image
  @param timeout how much time to allow for the screenshot to be taken
  @param error If there is an error, upon return contains an NSError object that describes the problem.
- @return Device screenshot as PNG- or JPG-encoded data or nil in case of failure
+ @return Device screenshot as PNG-, HEIC- or JPG-encoded data or nil in case of failure
  */
 + (nullable NSData *)takeInOriginalResolutionWithScreenID:(long long)screenID
                                        compressionQuality:(CGFloat)compressionQuality

--- a/WebDriverAgentLib/Utilities/FBScreenshot.h
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.h
@@ -14,11 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FBScreenshot : NSObject
 
 /**
- Returns YES if the current OS SDK supports advanced screenshoting APIs (added since Xcode SDK 10)
- */
-+ (BOOL)isNewScreenshotAPISupported;
-
-/**
  Retrieves non-scaled screenshot of the whole screen
 
  @param quality The number in range 0-2, where 2 (JPG) is the lowest and 0 (PNG) is the highest quality.

--- a/WebDriverAgentLib/Utilities/FBScreenshot.h
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.h
@@ -8,6 +8,7 @@
  */
 
 #import <XCTest/XCTest.h>
+@class UTType;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -48,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable NSData *)takeInOriginalResolutionWithScreenID:(long long)screenID
                                        compressionQuality:(CGFloat)compressionQuality
-                                                      uti:(NSString *)uti
+                                                      uti:(UTType *)uti
                                                   timeout:(NSTimeInterval)timeout
                                                     error:(NSError **)error;
 

--- a/WebDriverAgentLib/Utilities/FBScreenshot.m
+++ b/WebDriverAgentLib/Utilities/FBScreenshot.m
@@ -10,7 +10,6 @@
 #import "FBScreenshot.h"
 
 @import UniformTypeIdentifiers;
-#import <MobileCoreServices/MobileCoreServices.h>
 
 #import "FBConfiguration.h"
 #import "FBErrorBuilder.h"

--- a/WebDriverAgentLib/Utilities/FBUnattachedAppLauncher.m
+++ b/WebDriverAgentLib/Utilities/FBUnattachedAppLauncher.m
@@ -8,6 +8,9 @@
  */
 
 #import "FBUnattachedAppLauncher.h"
+
+#import <MobileCoreServices/MobileCoreServices.h>
+
 #import "LSApplicationWorkspace.h"
 
 @implementation FBUnattachedAppLauncher

--- a/WebDriverAgentTests/IntegrationTests/FBImageIOScalerTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBImageIOScalerTests.m
@@ -8,7 +8,6 @@
  */
 
 #import <XCTest/XCTest.h>
-#import <MobileCoreServices/MobileCoreServices.h>
 
 #import "FBImageIOScaler.h"
 #import "FBIntegrationTestCase.h"
@@ -55,7 +54,6 @@
   id expScaled = [self expectationWithDescription:@"Receive scaled image"];
 
   [scaler submitImage:self.originalImage
-                  uti:(__bridge id)kUTTypeJPEG
         scalingFactor:scalingFactor
    compressionQuality:1.0
     completionHandler:^(NSData *scaled) {


### PR DESCRIPTION
I have also set the default screenshoting quality to 3, which abbreviates Apple HEIC image encoder.
This is a lossless format, which gives much better quality results being converted to PNG and it also ensures decent compression level, which helps to avoid unexpected memory issues on devices with larger screens