### PR TITLE
chore: Disable automatic screen recording by default

### DIFF
--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -49,9 +49,13 @@ extern NSString *const FBSnapshotMaxDepthKey;
 
 /*! Disables XCTest automated screenshots taking */
 + (void)disableScreenshots;
-
 /*! Enables XCTest automated screenshots taking */
 + (void)enableScreenshots;
+
+/*! Disables XCTest automated videos taking (iOS 17+) */
++ (void)disableScreenRecordings;
+/*! Enables XCTest automated videos taking  (iOS 17+) */
++ (void)enableScreenRecordings;
 
 /* The maximum typing frequency for all typing activities */
 + (void)setMaxTypingFrequency:(NSUInteger)value;

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -94,6 +94,16 @@ static UIInterfaceOrientation FBScreenshotOrientation;
   [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"DisableScreenshots"];
 }
 
++ (void)disableScreenRecordings
+{
+  [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"DisableDiagnosticScreenRecordings"];
+}
+
++ (void)enableScreenRecordings
+{
+  [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"DisableDiagnosticScreenRecordings"];
+}
+
 + (NSRange)bindingPortRange
 {
   // 'WebDriverAgent --port 8080' can be passed via the arguments to the process

--- a/WebDriverAgentRunner/UITestingUITests.m
+++ b/WebDriverAgentRunner/UITestingUITests.m
@@ -26,6 +26,11 @@
   [FBConfiguration disableRemoteQueryEvaluation];
   [FBConfiguration configureDefaultKeyboardPreferences];
   [FBConfiguration disableApplicationUIInterruptionsHandling];
+  if (NSProcessInfo.processInfo.environment[@"ENABLE_AUTOMATIC_SCREEN_RECORDINGS"]) {
+    [FBConfiguration enableScreenRecordings];
+  } else {
+    [FBConfiguration disableScreenRecordings];
+  }
   if (NSProcessInfo.processInfo.environment[@"ENABLE_AUTOMATIC_SCREENSHOTS"]) {
     [FBConfiguration enableScreenshots];
   } else {


### PR DESCRIPTION
Since Xcode 15/iOS 17 Apple has replaced diagnostic screenshots with video recording by default. Obviously this strategy does not really work our scenario, since WDA itself is literally single long test, which would result in a big video recording exceeding the free storage space. that is why it makes sense to disable this feature by default and (hopefully) being able to record videos on-demand while executing the test.