### PR TITLE
feat: apply shouldWaitForQuiescence for activate as well

### DIFF
--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -178,13 +178,13 @@ static FBSession *_activeSession = nil;
                                      environment:(nullable NSDictionary <NSString *, NSString *> *)environment
 {
   FBApplication *app = [[FBApplication alloc] initWithBundleIdentifier:bundleIdentifier];
+  if (nil == shouldWaitForQuiescence) {
+    // Iherit the quiescence check setting from the main app under test by default
+    app.fb_shouldWaitForQuiescence = nil != self.testedApplicationBundleId && self.shouldAppsWaitForQuiescence;
+  } else {
+    app.fb_shouldWaitForQuiescence = [shouldWaitForQuiescence boolValue];
+  }
   if (app.fb_state < 2) {
-    if (nil == shouldWaitForQuiescence) {
-      // Iherit the quiescence check setting from the main app under test by default
-      app.fb_shouldWaitForQuiescence = nil != self.testedApplicationBundleId && self.shouldAppsWaitForQuiescence;
-    } else {
-      app.fb_shouldWaitForQuiescence = [shouldWaitForQuiescence boolValue];
-    }
     app.launchArguments = arguments ?: @[];
     app.launchEnvironment = environment ?: @{};
     [app launch];


### PR DESCRIPTION
According to https://github.com/appium/WebDriverAgent/issues/738, long no response behavior in `launch` could occur in `activate` as well.

Then, maybe no reason to apply this workaround only for `launch`...? (I don't remember everything but maybe we did not apply this workaround for `activate` since we hadn't observed long wait in activate...?)