### PR TITLE
chore: disable debugger for wda

### DIFF
--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
@@ -24,8 +24,8 @@
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "YES"
       systemAttachmentLifetime = "keepNever">
       <Testables>

--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner_tvOS.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner_tvOS.xcscheme
@@ -24,8 +24,8 @@
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "YES"
       systemAttachmentLifetime = "keepNever">
       <MacroExpansion>


### PR DESCRIPTION
Disable "Debug Executable"
![Screenshot 2023-09-18 at 12 42 54 AM](https://github.com/appium/WebDriverAgent/assets/5511591/0509abb7-0dd9-4173-b002-f4fdf327165e)

This would slightly improve the launching performance via xcodebuild by skipping the debug server connection. 4k tv will have more improvement I guess since it is network-connected, and available via xcodebuild for now. As down-side, we should enable this checkbox to enable breakpoints for our development (if needed). Except for it, this uncheck won't break existing behavior as WDA functionality.

What do you think to disable it by default...?

As a downside, we need to enable it when we manually debug WDA