### PR TITLE
chore: add log to leave it in the system log

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -421,6 +421,8 @@
 + (NSDictionary *)currentCapabilities
 {
   FBApplication *application = [FBSession activeSession].activeApplication;
+  // to log the info in the system
+  [FBLogger logFmt:@"Current active application bundle id is %@", application.bundleID];
   return
   @{
     @"device": ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) ? @"ipad" : @"iphone",


### PR DESCRIPTION
I observed that `handleCreateSession` took 1 minute, but usually, it was in a few seconds.

Not clear the cause but maybe that was by https://github.com/appium/WebDriverAgent/blob/3ec962842f121bb6dbfc28ab1b30f69d0adc0123/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m#L26-L33 (so os side's something I guess), but it was not clear.

(called by https://github.com/appium/WebDriverAgent/blob/3ec962842f121bb6dbfc28ab1b30f69d0adc0123/WebDriverAgentLib/FBApplication.m#L120 )

For future logging, i'd like to leave a message in `currentCapabilities`, used the last part of `handleCreateSession` after getting the activeApplication here (to see log message when that was resolved.)