### PR TITLE
feat: do not get active process information in a new session request

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -410,6 +410,13 @@
   ];
 }
 
+/**
+ Return current session information.
+ This response does not have any active application information
+ because getting such information for "com.apple.springboard" (Home application's  budnle id in iOS)
+ could be expensive.
+ Usually when no bundle id is specified, or no app started, the default view could be the spring board.
+*/
 + (NSDictionary *)sessionInformation
 {
   return
@@ -438,15 +445,10 @@
 
 + (NSDictionary *)currentCapabilities
 {
-  FBApplication *application = [FBSession activeSession].activeApplication;
-  // to log the info in the system
-  [FBLogger logFmt:@"Current active application bundle id is %@", application.bundleID];
   return
   @{
     @"device": [self.class deviceNameByUserInterfaceIdiom:[UIDevice currentDevice].userInterfaceIdiom],
-    @"sdkVersion": [[UIDevice currentDevice] systemVersion],
-    @"browserName": application.label ?: [NSNull null],
-    @"CFBundleIdentifier": application.bundleID ?: [NSNull null],
+    @"sdkVersion": [[UIDevice currentDevice] systemVersion]
   };
 }
 

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -412,10 +412,7 @@
 
 /**
  Return current session information.
- This response does not have any active application information
- because getting such information for "com.apple.springboard" (Home application's  budnle id in iOS)
- could be expensive.
- Usually when no bundle id is specified, or no app started, the default view could be the spring board.
+ This response does not have any active application information.
 */
 + (NSDictionary *)sessionInformation
 {


### PR DESCRIPTION
After some investigation, I found `FBApplication *application = [FBSession activeSession].activeApplication;` (called in the last of new session request https://github.com/appium/WebDriverAgent/blob/7a0fb0dcaadf43ed684eccb66e470ba9ad605ca3/WebDriverAgentLib/Commands/FBSessionCommands.m#L177 ) could take 1 minute over when the view was `com.apple.springboard` in iOS. (e.g. no app/bundle id) It resulted in over 1 minute new session request time duration. It is pretty high.


Usually XCUITest driver's new session request completes in a few seconds, but in this situation, it could be 1 minute or so. The root cause was probably https://github.com/appium/WebDriverAgent/pull/772 . Resolving the springboard's application info, or the application's accessibility stuff is basically expensive.

Afaik, the response of WDA here is not important since https://github.com/appium/appium-xcuitest-driver/blob/master/lib/driver.js#L1352C9-L1352C24 does not have any references for the response. So we simply can remove them.

Instead, the new session request process speed will be able to keep fast by this. Only when bundle id is specified, launching it could take time by this.



Btw, because of the `com.apple.springboard`, like `http://127.0.0.1:8100/wda/activeAppInfo` endpoint also has the same issue. I observed resolving active application (and it is the springboard) could also take much longer time like this. But we do not have such endpoint call except for user's explicit call