### PR TITLE
feat: remove test frameworks in Frameworks and add device local references as rpath for real devices

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-13
 
     env:
-      XCODE_VERSION: 14.3.1
+      XCODE_VERSION: 15.0
       ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner.zip"
       PKG_PATH_IOS: "appium_wda_ios"
       ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner.zip"

--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-13
 
     env:
-      XCODE_VERSION: "15.0"
+      XCODE_VERSION: 14.3.1
       ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner.zip"
       PKG_PATH_IOS: "appium_wda_ios"
       ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner.zip"

--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -44,9 +44,15 @@ jobs:
           -scheme WebDriverAgentRunner \
           -destination generic/platform=iOS \
           CODE_SIGNING_ALLOWED=NO ARCHS=arm64
-    - name: Creating a zip of WebDriverAgentRunner-Runner.app for iOS
+    - name: Creating a zip of WebDriverAgentRunner-Runner.app for iOS after removing test frameworks
       run: |
         pushd appium_wda_ios/Build/Products/Debug-iphoneos
+        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XCTAutomationSupport.framework
+        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XCTest.framework
+        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XCTestCore.framework
+        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XCTestSupport.framework
+        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XCUIAutomation.framework
+        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XCUnit.framework
         zip -r $ZIP_PKG_NAME_IOS WebDriverAgentRunner-Runner.app
         popd
         mv $PKG_PATH_IOS/Build/Products/Debug-iphoneos/$ZIP_PKG_NAME_IOS ./
@@ -61,6 +67,12 @@ jobs:
     - name: Creating a zip of WebDriverAgentRunner-Runner.app for tvOS
       run: |
         pushd appium_wda_tvos/Build/Products/Debug-appletvos
+        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XCTAutomationSupport.framework
+        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XCTest.framework
+        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XCTestCore.framework
+        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XCTestSupport.framework
+        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XCUIAutomation.framework
+        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XCUnit.framework
         zip -r $ZIP_PKG_NAME_TVOS WebDriverAgentRunner_tvOS-Runner.app
         popd
         mv $PKG_PATH_TVOS/Build/Products/Debug-appletvos/$ZIP_PKG_NAME_TVOS ./

--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-13
 
     env:
-      XCODE_VERSION: 15.0
+      XCODE_VERSION: "15.0"
       ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner.zip"
       PKG_PATH_IOS: "appium_wda_ios"
       ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner.zip"
@@ -47,12 +47,7 @@ jobs:
     - name: Creating a zip of WebDriverAgentRunner-Runner.app for iOS after removing test frameworks
       run: |
         pushd appium_wda_ios/Build/Products/Debug-iphoneos
-        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XCTAutomationSupport.framework
-        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XCTest.framework
-        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XCTestCore.framework
-        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XCTestSupport.framework
-        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XCUIAutomation.framework
-        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XCUnit.framework
+        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XCT*.framework
         zip -r $ZIP_PKG_NAME_IOS WebDriverAgentRunner-Runner.app
         popd
         mv $PKG_PATH_IOS/Build/Products/Debug-iphoneos/$ZIP_PKG_NAME_IOS ./
@@ -64,15 +59,10 @@ jobs:
           -scheme WebDriverAgentRunner_tvOS \
           -destination generic/platform=tvOS \
           CODE_SIGNING_ALLOWED=NO ARCHS=arm64
-    - name: Creating a zip of WebDriverAgentRunner-Runner.app for tvOS
+    - name: Creating a zip of WebDriverAgentRunner-Runner.app for tvOS after removing test frameworks
       run: |
         pushd appium_wda_tvos/Build/Products/Debug-appletvos
-        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XCTAutomationSupport.framework
-        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XCTest.framework
-        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XCTestCore.framework
-        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XCTestSupport.framework
-        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XCUIAutomation.framework
-        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XCUnit.framework
+        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XCT*.framework
         zip -r $ZIP_PKG_NAME_TVOS WebDriverAgentRunner_tvOS-Runner.app
         popd
         mv $PKG_PATH_TVOS/Build/Products/Debug-appletvos/$ZIP_PKG_NAME_TVOS ./

--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Creating a zip of WebDriverAgentRunner-Runner.app for iOS after removing test frameworks
       run: |
         pushd appium_wda_ios/Build/Products/Debug-iphoneos
-        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XCT*.framework
+        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XC*.framework
         zip -r $ZIP_PKG_NAME_IOS WebDriverAgentRunner-Runner.app
         popd
         mv $PKG_PATH_IOS/Build/Products/Debug-iphoneos/$ZIP_PKG_NAME_IOS ./
@@ -62,7 +62,7 @@ jobs:
     - name: Creating a zip of WebDriverAgentRunner-Runner.app for tvOS after removing test frameworks
       run: |
         pushd appium_wda_tvos/Build/Products/Debug-appletvos
-        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XCT*.framework
+        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XC*.framework
         zip -r $ZIP_PKG_NAME_TVOS WebDriverAgentRunner_tvOS-Runner.app
         popd
         mv $PKG_PATH_TVOS/Build/Products/Debug-appletvos/$ZIP_PKG_NAME_TVOS ./

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   HOST: macos-13
-  XCODE_VERSION: "15.0"
+  XCODE_VERSION: 14.3.1
   DESTINATION_SIM: platform=iOS Simulator,name=iPhone 14 Pro
   DESTINATION_SIM_tvOS: platform=tvOS Simulator,name=Apple TV
 

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   HOST: macos-13
-  XCODE_VERSION: 15.0.0
+  XCODE_VERSION: "15.0"
   DESTINATION_SIM: platform=iOS Simulator,name=iPhone 14 Pro
   DESTINATION_SIM_tvOS: platform=tvOS Simulator,name=Apple TV
 

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   HOST: macos-13
-  XCODE_VERSION: 14.3.1
+  XCODE_VERSION: 15.0
   DESTINATION_SIM: platform=iOS Simulator,name=iPhone 14 Pro
   DESTINATION_SIM_tvOS: platform=tvOS Simulator,name=Apple TV
 

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   HOST: macos-13
-  XCODE_VERSION: 15.0
+  XCODE_VERSION: 15.0.0
   DESTINATION_SIM: platform=iOS Simulator,name=iPhone 14 Pro
   DESTINATION_SIM_tvOS: platform=tvOS Simulator,name=Apple TV
 

--- a/Scripts/ci/build-real.sh
+++ b/Scripts/ci/build-real.sh
@@ -14,12 +14,9 @@ xcodebuild clean build-for-testing \
 pushd $WD
 
 # to remove test packages to refer to the device local instead of embedded ones
-rm -rf $SCHEME-Runner.app/Frameworks/XCTAutomationSupport.framework
-rm -rf $SCHEME-Runner.app/Frameworks/XCTest.framework
-rm -rf $SCHEME-Runner.app/Frameworks/XCTestCore.framework
-rm -rf $SCHEME-Runner.app/Frameworks/XCTestSupport.framework
-rm -rf $SCHEME-Runner.app/Frameworks/XCUIAutomation.framework
-rm -rf $SCHEME-Runner.app/Frameworks/XCUnit.framework
+# XCTAutomationSupport.framework, XCTest.framewor, XCTestCore.framework,
+# XCUIAutomation.framework, XCUnit.framework
+rm -rf $SCHEME-Runner.app/Frameworks/XC*.framework
 
 zip -r $ZIP_PKG_NAME $SCHEME-Runner.app
 popd

--- a/Scripts/ci/build-real.sh
+++ b/Scripts/ci/build-real.sh
@@ -12,6 +12,15 @@ xcodebuild clean build-for-testing \
 # Only .app is needed.
 
 pushd $WD
+
+# to remove test packages to refer to the device local instead of embedded ones
+rm -rf $SCHEME-Runner.app/Frameworks/XCTAutomationSupport.framework
+rm -rf $SCHEME-Runner.app/Frameworks/XCTest.framework
+rm -rf $SCHEME-Runner.app/Frameworks/XCTestCore.framework
+rm -rf $SCHEME-Runner.app/Frameworks/XCTestSupport.framework
+rm -rf $SCHEME-Runner.app/Frameworks/XCUIAutomation.framework
+rm -rf $SCHEME-Runner.app/Frameworks/XCUnit.framework
+
 zip -r $ZIP_PKG_NAME $SCHEME-Runner.app
 popd
 mv $WD/$ZIP_PKG_NAME ./

--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -2414,7 +2414,6 @@
 				641EE6C02240C5CA00173FCB /* XCUIApplication+FBHelpers.h in Headers */,
 				641EE6C12240C5CA00173FCB /* _XCTestObservationCenterImplementation.h in Headers */,
 				714EAA0E2673FDFE005C5B47 /* FBCapabilities.h in Headers */,
-				716F0DA22A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.h in Headers */,
 				641EE6C22240C5CA00173FCB /* XCUIDevice+FBHelpers.h in Headers */,
 				71D3B3D6267FC7260076473D /* XCUIElement+FBResolve.h in Headers */,
 				641EE6C32240C5CA00173FCB /* FBClassChainQueryParser.h in Headers */,
@@ -3117,7 +3116,6 @@
 				641EE5FF2240C5CA00173FCB /* XCUIElement+FBForceTouch.m in Sources */,
 				716C9E0327315EFF005AD475 /* XCUIApplication+FBUIInterruptions.m in Sources */,
 				641EE6002240C5CA00173FCB /* FBTouchActionCommands.m in Sources */,
-				716F0DA42A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.m in Sources */,
 				719DCF182601EAFB000E765F /* FBNotificationsHelper.m in Sources */,
 				714EAA102673FDFE005C5B47 /* FBCapabilities.m in Sources */,
 				641EE6012240C5CA00173FCB /* FBImageIOScaler.m in Sources */,
@@ -3172,7 +3170,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				64B26508228C5514002A5025 /* XCUIElementDouble.m in Sources */,
-				716F0DA72A17323300CDD977 /* NSDictionaryFBUtf8SafeTests.m in Sources */,
 				64B26504228C5299002A5025 /* FBTVNavigationTrackerTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3496,6 +3493,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = WebDriverAgentRunner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3551,6 +3549,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = WebDriverAgentRunner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3603,6 +3602,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(PLATFORM_DIR)/Developer/Library/PrivateFrameworks",
@@ -3664,6 +3664,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(PLATFORM_DIR)/Developer/Library/PrivateFrameworks",
@@ -3915,6 +3916,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(PLATFORM_DIR)/Developer/Library/PrivateFrameworks",
@@ -3974,6 +3976,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"$(PLATFORM_DIR)/Developer/Library/PrivateFrameworks",
@@ -4212,6 +4215,7 @@
 			buildSettings = {
 				CLANG_STATIC_ANALYZER_MODE = deep;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = WebDriverAgentRunner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4259,6 +4263,7 @@
 			baseConfigurationReference = EEE5CABF1C80361500CBBDD9 /* IOSSettings.xcconfig */;
 			buildSettings = {
 				CLANG_STATIC_ANALYZER_MODE = deep;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = WebDriverAgentRunner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -3500,6 +3500,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+					/System/Developer/Library/Frameworks,
+					/System/Developer/Library/PrivateFrameworks,
+					/Developer/Library/PrivateFrameworks,
+					/Developer/Library/Frameworks,
 				);
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -3556,6 +3560,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+					/System/Developer/Library/Frameworks,
+					/System/Developer/Library/PrivateFrameworks,
+					/Developer/Library/PrivateFrameworks,
+					/Developer/Library/Frameworks,
 				);
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -3614,6 +3622,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+					/System/Developer/Library/Frameworks,
+					/System/Developer/Library/PrivateFrameworks,
+					/Developer/Library/PrivateFrameworks,
+					/Developer/Library/Frameworks,
 				);
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.WebDriverAgentLib;
@@ -3676,6 +3688,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+					/System/Developer/Library/Frameworks,
+					/System/Developer/Library/PrivateFrameworks,
+					/Developer/Library/PrivateFrameworks,
+					/Developer/Library/Frameworks,
 				);
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "";
@@ -3928,6 +3944,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+					/Developer/Library/Frameworks,
+					/Developer/Library/PrivateFrameworks,
+					/System/Developer/Library/PrivateFrameworks,
+					/System/Developer/Library/Frameworks,
 				);
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.WebDriverAgentLib;
@@ -3988,6 +4008,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+					/Developer/Library/Frameworks,
+					/Developer/Library/PrivateFrameworks,
+					/System/Developer/Library/PrivateFrameworks,
+					/System/Developer/Library/Frameworks,
 				);
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "";
@@ -4222,6 +4246,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+					/Developer/Library/Frameworks,
+					/Developer/Library/PrivateFrameworks,
+					/System/Developer/Library/PrivateFrameworks,
+					/System/Developer/Library/Frameworks,
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -4270,6 +4298,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+					/Developer/Library/Frameworks,
+					/Developer/Library/PrivateFrameworks,
+					/System/Developer/Library/PrivateFrameworks,
+					/System/Developer/Library/Frameworks,
 				);
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (

--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -312,6 +312,8 @@
 		64B26508228C5514002A5025 /* XCUIElementDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = 64B26507228C5514002A5025 /* XCUIElementDouble.m */; };
 		64B2650A228CE4FF002A5025 /* FBTVNavigationTracker-Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 64B26509228CE4FF002A5025 /* FBTVNavigationTracker-Private.h */; };
 		64B2650B228CE4FF002A5025 /* FBTVNavigationTracker-Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 64B26509228CE4FF002A5025 /* FBTVNavigationTracker-Private.h */; };
+		64E3502E2AC0B6EB005F3ACB /* NSDictionary+FBUtf8SafeDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 716F0DA02A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.m */; };
+		64E3502F2AC0B6FE005F3ACB /* NSDictionary+FBUtf8SafeDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 716F0D9F2A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.h */; };
 		711084441DA3AA7500F913D6 /* FBXPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 711084421DA3AA7500F913D6 /* FBXPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		711084451DA3AA7500F913D6 /* FBXPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 711084431DA3AA7500F913D6 /* FBXPath.m */; };
 		7119097C2152580600BA3C7E /* XCUIScreen.h in Headers */ = {isa = PBXBuildFile; fileRef = 7119097B2152580600BA3C7E /* XCUIScreen.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -2382,6 +2384,7 @@
 				641EE6A62240C5CA00173FCB /* FBImageIOScaler.h in Headers */,
 				641EE6A72240C5CA00173FCB /* FBSession-Private.h in Headers */,
 				641EE6A82240C5CA00173FCB /* NSString+FBXMLSafeString.h in Headers */,
+				64E3502F2AC0B6FE005F3ACB /* NSDictionary+FBUtf8SafeDictionary.h in Headers */,
 				641EE6A92240C5CA00173FCB /* FBCommandStatus.h in Headers */,
 				71822702258744A400661B83 /* HTTPResponseProxy.h in Headers */,
 				71822741258744BB00661B83 /* HTTPLogging.h in Headers */,
@@ -3048,6 +3051,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				64E3502E2AC0B6EB005F3ACB /* NSDictionary+FBUtf8SafeDictionary.m in Sources */,
 				718226CF2587443700661B83 /* GCDAsyncSocket.m in Sources */,
 				E444DCBC24917A5E0060D7EB /* HTTPResponseProxy.m in Sources */,
 				71D3B3D8267FC7260076473D /* XCUIElement+FBResolve.m in Sources */,


### PR DESCRIPTION
it seems like packages built with Xcode 14.5 do not work on iOS 17 real devices as XCTest framework's internal changes. The app process crashed then. Xcode 15 build with embedded test frameworks, or below method with Xcode 14.5 works.

Then, once we remove test packages in `WebDriverAgentRunner-Runner.app/Frameworks` work. It seems like test packages refer to the system local's one then instead of the embedded ones. It makes sense to keep referencing the device local's XCTest framework for real devices. For tvOS, the removal was not necessary. It seems like we should add the device local references as `rpath`. iOS is not necessary in my testing, but lets add the same to reduce diffs.

Thus, this pr:
- remove `Frameworks` for real devices
- ~use Xcode 15.0 in building packages~ <= no matched Xcode found error came by GH. will do something as another pr if needed
- Add device local references


I have tested iOS 14, 15, 16 and 17 and tvOS 16 with https://github.com/appium/WebDriverAgent/actions/runs/6291729735 , or locally built with Xcode 14.3.1 packages (as the same, they do not have XCTest frameworks' references), thus it should be ok...

---

Additional node:

Initially I thought https://github.com/appium/WebDriverAgent/pull/775 was necessary, but seems not for iPhone. Probably this is because the below option in Xcode could be related. The value is resolved as YES so let me explicitly set it as YES as well.

![Screenshot 2023-09-24 at 10 31 01 AM](https://github.com/appium/WebDriverAgent/assets/5511591/24904a4a-fd46-455f-9b78-16e68acc5082)


[Update]
It seems like the system references are necessary for TVs. I guess iOS take care about some references automatically probably for historical reasons? so maybe not necessary to add system references explicitly.