### PR TITLE
feat: Add /calibrate endpoint

### DIFF
--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -220,7 +220,12 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
     [response respondWithString:@"I-AM-ALIVE"];
   }];
 
-  NSString *calibrationPage = @"<html><header><script>function printMousePos(e){document.getElementById(\"x\").innerHTML=e.clientX,document.getElementById(\"y\").innerHTML=e.clientY}document.addEventListener(\"click\",printMousePos)</script></header><div><p id=x><p id=y></div></html>";
+  NSString *calibrationPage = @"<html>"
+  "<title>{\"x\":null,\"y\":null}</title>"
+  "<header>"
+  "<script>document.addEventListener(\"click\",function(e){document.title=JSON.stringify({x:e.clientX,y:e.clientY})})</script>"
+  "</header>"
+  "</html>";
   [self.server get:@"/calibrate" withBlock:^(RouteRequest *request, RouteResponse *response) {
     [response respondWithString:calibrationPage];
   }];

--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -220,6 +220,11 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
     [response respondWithString:@"I-AM-ALIVE"];
   }];
 
+  NSString *calibrationPage = @"<html><header><script>function printMousePos(e){document.getElementById(\"x\").innerHTML=e.clientX,document.getElementById(\"y\").innerHTML=e.clientY}document.addEventListener(\"click\",printMousePos)</script></header><div><p id=x><p id=y></div></html>";
+  [self.server get:@"/calibrate" withBlock:^(RouteRequest *request, RouteResponse *response) {
+    [response respondWithString:calibrationPage];
+  }];
+
   [self.server get:@"/wda/shutdown" withBlock:^(RouteRequest *request, RouteResponse *response) {
     [response respondWithString:@"Shutting down"];
     [self.delegate webServerDidRequestShutdown:self];


### PR DESCRIPTION
The PR adds GET /calibrate endpoint to WDA.

The idea is to use this special web page behind the endpoint to properly calibrate coordinates offset for nativeWebTap feature without applying ugly hacks like we do now. 
Basically I am going to add `mobile: calibrateNativeToWebCoordinates` endpoint, which will only work in web/safari context and it will be loading this url to mobile Safari. Then we perform native click at the window center, which should also show actual web click coordinates. Then we can calculate the actual  native/web coordinates delta and keep it to properly transform further native gesture coordinates. Ofc, the recalibration would be needed if the device changes orientation and there will be corner cases, but that method would be much more reliable in comparison to the ugly platform-dependent algorithm we use now in the xcuitest driver.

Kudos to Benjamin Karran for sharing this great idea.
