### PR TITLE
chore: use PRODUCT_BUNDLE_IDENTIFIER to info.plist

### DIFF
--- a/WebDriverAgentRunner/Info.plist
+++ b/WebDriverAgentRunner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.facebook.wda.runner</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
`PRODUCT_BUNDLE_IDENTIFIER` should be ok as `CFBundleIdentifier` in the Info.plist.

I found that when i changed below signature's bundle id (usually our guide also addresses), the info.plist changed to `PRODUCT_BUNDLE_IDENTIFIER` to refer to the change. General built info.plist does not have `com.facebook.wda.runner` as well.

Thus this should not impact anything, but to follow better info.plist format.

![Screenshot 2023-10-21 at 9 06 52 AM](https://github.com/appium/WebDriverAgent/assets/5511591/c0ab30bc-24be-4631-9e09-fcefc5446568)
