### PR TITLE
fix: when 0 is given

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -551,7 +551,7 @@
 + (id<FBResponsePayload>)handleKeyboardInput:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  BOOL hasElement = nil != request.parameters[@"uuid"];
+  BOOL hasElement = ![request.parameters[@"uuid"] isEqual:@"0"];
   XCUIElement *destination = hasElement
     ? [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]]
     : request.session.activeApplication;


### PR DESCRIPTION
The default value is `0` in https://github.com/appium/appium-xcuitest-driver/pull/2156, then below exception occurs. Should here be `0` comparison to go to `equest.parameters[@"uuid"]]`?
```
[debug] [XCUITestDriver@eff3 (6cbdd727)] Encountered internal error running command: StaleElementReferenceError: The element identified by "0" is either not present or it has expired from the internal cache. Try to find it again
```