### PR TITLE
chore: return operation error in `handleKeyboardInput`

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -558,7 +558,7 @@
   id keys = request.arguments[@"keys"];
 
   if (![destination respondsToSelector:@selector(typeKey:modifierFlags:)]) {
-    NSString *message = @"Not supported on this OS version";
+    NSString *message = @"typeKey API is only supported since Xcode15 and iPadOS 17";
     return FBResponseWithStatus([FBCommandStatus unsupportedOperationErrorWithMessage:message
                                                                             traceback:nil]);
   }

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -556,6 +556,13 @@
     ? [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]]
     : request.session.activeApplication;
   id keys = request.arguments[@"keys"];
+
+  if (![destination respondsToSelector:@selector(typeKey:modifierFlags:)]) {
+    NSString *message = @"Not supported on this OS version";
+    return FBResponseWithStatus([FBCommandStatus unsupportedOperationErrorWithMessage:message
+                                                                            traceback:nil]);
+  }
+
   if (![keys isKindOfClass:NSArray.class]) {
     NSString *message = @"The 'keys' argument must be an array";
     return FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:message

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -551,7 +551,7 @@
 + (id<FBResponsePayload>)handleKeyboardInput:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
-  BOOL hasElement = nil != request.parameters[@"uuid"];
+  BOOL hasElement = ![request.parameters[@"uuid"] isEqual:@"0"];
   XCUIElement *destination = hasElement
     ? [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]]
     : request.session.activeApplication;


### PR DESCRIPTION
Xcode 15 built WDA app without embedded XCTest frameworks raise unrecognized error for this new type of method call.

This PR just returns an explicit unsupported operation error for the case. This is for https://github.com/appium/WebDriverAgent/pull/797#discussion_r1373699613


e.;g. for iOS 16

```
[HTTP] --> POST /session/ba565cf2-f948-4012-b8bd-371d733b59cb/execute/sync
[HTTP] {"script":"mobile: keys","args":[{"keys":["o"]}]}
[debug] [XCUITestDriver@d5ea (ba565cf2)] Calling AppiumDriver.execute() with args: ["mobile: keys",[{"keys":["o"]}],"ba565cf2-f948-4012-b8bd-371d733b59cb"]
[debug] [XCUITestDriver@d5ea (ba565cf2)] Executing command 'execute'
[XCUITestDriver@d5ea (ba565cf2)] Proxying to WDA with an unknown route: POST /wda/element/0/keyboardInput
[debug] [XCUITestDriver@d5ea (ba565cf2)] Proxying [POST /wda/element/0/keyboardInput] to [POST http://127.0.0.1:8100/session/ED3F626B-675C-405E-B9AF-5F20A71FFFB2/wda/element/0/keyboardInput] with body: {"keys":["o"]}
[XCUITestDriver@d5ea (ba565cf2)] Got response with status 500: {"value":{"error":"unsupported operation","message":"Not supported on this OS version","traceback":""},"sessionId":"ED3F626B-675C-405E-B9AF-5F20A71FFFB2"}
[debug] [W3C] Matched W3C error code 'unsupported operation' to UnsupportedOperationError
[debug] [XCUITestDriver@d5ea (ba565cf2)] Encountered internal error running command: UnsupportedOperationError: Not supported on this OS version
[debug] [XCUITestDriver@d5ea (ba565cf2)]     at errorFromW3CJsonCode (/Users/kazu/GitHub/appium-xcuitest-driver/node_modules/@appium/base-driver/lib/protocol/errors.js:1059:25)
[debug] [XCUITestDriver@d5ea (ba565cf2)]     at ProxyRequestError.getActualError (/Users/kazu/GitHub/appium-xcuitest-driver/node_modules/@appium/base-driver/lib/protocol/errors.js:928:14)
[debug] [XCUITestDriver@d5ea (ba565cf2)]     at JWProxy.command (/Users/kazu/GitHub/appium-xcuitest-driver/node_modules/@appium/base-driver/lib/jsonwp-proxy/proxy.js:353:19)
[debug] [XCUITestDriver@d5ea (ba565cf2)]     at runMicrotasks (<anonymous>)
[debug] [XCUITestDriver@d5ea (ba565cf2)]     at processTicksAndRejections (node:internal/process/task_queues:96:5)
[debug] [XCUITestDriver@d5ea (ba565cf2)]     at XCUITestDriver.proxyCommand (/Users/kazu/GitHub/appium-xcuitest-driver/lib/commands/proxy-helper.js:109:35)
[debug] [XCUITestDriver@d5ea (ba565cf2)]     at XCUITestDriver.mobileKeys (/Users/kazu/GitHub/appium-xcuitest-driver/lib/commands/keyboard.js:54:12)
[debug] [XCUITestDriver@d5ea (ba565cf2)]     at XCUITestDriver.executeMethod (/Users/kazu/GitHub/appium-xcuitest-driver/node_modules/@appium/base-driver/lib/basedriver/commands/execute.ts:36:12)
[debug] [XCUITestDriver@d5ea (ba565cf2)]     at XCUITestDriver.execute (/Users/kazu/GitHub/appium-xcuitest-driver/lib/commands/execute.js:118:14)
[HTTP] <-- POST /session/ba565cf2-f948-4012-b8bd-371d733b59cb/execute/sync 500 105 ms - 1179
```


This is actually not necessary, since WDA just returns `unrecognized selector sent to instance 0x28367cd90` like this error message


current:
```
[XCUITestDriver@b970 (d349bf76)] Proxying to WDA with an unknown route: POST /wda/element/0/keyboardInput
[debug] [XCUITestDriver@b970 (d349bf76)] Proxying [POST /wda/element/0/keyboardInput] to [POST http://127.0.0.1:8100/session/A0EFA110-53DD-4414-8861-6541528E3AAE/wda/element/0/keyboardInput] with body: {"keys":["o"]}
[XCUITestDriver@b970 (d349bf76)] Got response with status 500: {"value":{"error":"unknown error","message":"-[XCUIApplication typeKey:modifierFlags:]: unrecognized selector sent to instance 0x28367cd90","traceback":"(\n\t0   CoreFoundation                      0x000000019c318c50 DF935525-036C-30AE-8D1D-4E5F3DD7876A + 40016\n\t1   libobjc.A.dylib                     0x00000001953b7e5c objc_exception_throw + 60\n\t2   CoreFoundation                      0x000000019c48daa8 DF935525-036C-30AE-8D1D-4E5F3DD7876A + 1567400\n\t3   CoreFoundation                      0x000000019c32f078 DF935525-036C-30AE-8D1D-4E5F3DD7876A + 131192\n\t4   CoreFoundation                      0x000000019c395890 _CF_forwarding_prep_0 + 96\n\t5   WebDriverAgentLib                   0x0000000106e11100 +[FBCustomCommands handleKeyboardInput:] + 1284\n\t6   WebDriverAgentLib                   0x0000000106ddd900 -[FBRoute_TargetAction mountRequest:intoResponse:] + 168\n\t7   WebDriverAgentLib                   0x0000000106dc8264 __37-[FBWebServer registerRouteHandlers:]_block_invoke + 408\n\t8   WebDri...
[debug] [W3C] Matched W3C error code 'unknown error' to UnknownError
[debug] [XCUITestDriver@b970 (d349bf76)] Encountered internal error running command: UnknownError: An unknown server-side error occurred while processing the command. Original error: -[XCUIApplication typeKey:modifierFlags:]: unrecognized selector sent to instance 0x28367cd90
[debug] [XCUITestDriver@b970 (d349bf76)]     at errorFromW3CJsonCode (/Users/kazu/GitHub/appium-xcuitest-driver/node_modules/@appium/base-driver/lib/protocol/errors.js:1059:25)
[debug] [XCUITestDriver@b970 (d349bf76)]     at ProxyRequestError.getActualError (/Users/kazu/GitHub/appium-xcuitest-driver/node_modules/@appium/base-driver/lib/protocol/errors.js:928:14)
[debug] [XCUITestDriver@b970 (d349bf76)]     at JWProxy.command (/Users/kazu/GitHub/appium-xcuitest-driver/node_modules/@appium/base-driver/lib/jsonwp-proxy/proxy.js:353:19)
[debug] [XCUITestDriver@b970 (d349bf76)]     at runMicrotasks (<anonymous>)
```