### PR TITLE
fix: run preinstalled wda without xcodebuild command

### DIFF
--- a/PrivateHeaders/XCTest/XCTRunnerDaemonSession.h
+++ b/PrivateHeaders/XCTest/XCTRunnerDaemonSession.h
@@ -34,6 +34,7 @@
 @property unsigned long long daemonProtocolVersion;
 @property(readonly) id <XCTestManager_ManagerInterface> daemonProxy;
 
++ (id)testmanagerdServiceName;
 + (instancetype)sharedSession;
 
 - (void)injectVoiceRecognitionAudioInputPaths:(id)arg1 completion:(CDUnknownBlockType)arg2;


### PR DESCRIPTION
https://appium.github.io/appium-xcuitest-driver/4.30/run-preinstalled-wda/

Hello, I found that the real device of iOS 17 will crash in non-Xcode Test mode. The reason is that the return value of testmanagerdServiceName in XCTRunnerDaemonSession is different in Test and non-Test scenarios. After modification and verification, it can support running the pre-installed WDA by hooking the testmanagerdServiceName method.