### PR TITLE
fix: unrecognized selector sent to instance 0x2829adb20 error in clear

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -143,7 +143,12 @@
   do {
     if (retry >= MAX_CLEAR_RETRIES - 1) {
       // Last chance retry. Tripple-tap the field to select its content
-      [self tapWithNumberOfTaps:3 numberOfTouches:1];
+
+      if ([self respondsToSelector:@selector(tapWithNumberOfTaps:numberOfTouches:)]) {
+        // e.g. tvOS 17 raised unrecognized selector error for XCUIElementTypeSearchField
+        // while following typeText worked.
+        [self tapWithNumberOfTaps:3 numberOfTouches:1];
+      }
       return [FBKeyboard typeText:backspaceDeleteSequence error:error];
     }
 


### PR DESCRIPTION
When I explored https://github.com/appium/appium/issues/19389, I found out the below command
```
e = driver.find_element :class_name, 'XCUIElementTypeSearchField'
e.clear
```

returned

```
> e.clear
Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command. Original error: -[XCUIElement tapWithNumberOfTaps:numberOfTouches:]: unrecognized selector sent to instance 0x2829adb20
from UnknownError: An unknown server-side error occurred while processing the command. Original error: -[XCUIElement tapWithNumberOfTaps:numberOfTouches:]: unrecognized selector sent to instance 0x2829adb20
```

on a tvOS 17 device.


The clear search field worked, so we can simply skip the tapWithNumberOfTaps in case the platform does not have it 