### PR TITLE
feat: use khidusage_keyboardclear to `clear` for iOS/iPad as the 1st attempt, tune tvOS

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -135,13 +135,8 @@
     return YES;
   }
   
-  NSString *placeholderValue = snapshot.placeholderValue;
-  if (nil != placeholderValue && [currentValue isEqualToString:placeholderValue]) {
-    // Short circuit if only the placeholder value left
-    return YES;
-  }
-  
   static NSString *backspaceDeleteSequence;
+  NSString *placeholderValue = snapshot.placeholderValue;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     backspaceDeleteSequence = [[NSString alloc] initWithData:(NSData *)[@"\\u0008\\u007F" dataUsingEncoding:NSASCIIStringEncoding]

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -151,7 +151,7 @@
     }
 
     if (retry == 0) {
-      // 1st attempt is via the IOHIDEvent as a fastest operation
+      // 1st attempt is via the IOHIDEvent as the fastest operation
       // https://github.com/appium/appium/issues/19389
       [[XCUIDevice sharedDevice] fb_performIOHIDEventWithPage:0x07  // kHIDPage_KeyboardOrKeypad
                                                         usage:0x9c  // kHIDUsage_KeyboardClear

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -22,6 +22,7 @@
 
 #define MAX_CLEAR_RETRIES 3
 
+
 @interface NSString (FBRepeat)
 
 - (NSString *)fb_repeatTimes:(NSUInteger)times;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -20,12 +20,7 @@
 #import "XCUIElement+FBUtilities.h"
 #import "FBXCodeCompatibility.h"
 
-
-#if TARGET_OS_IOS
 #define MAX_CLEAR_RETRIES 3
-#else
-#define MAX_CLEAR_RETRIES 2
-#endif
 
 @interface NSString (FBRepeat)
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -136,7 +136,6 @@
   }
   
   static NSString *backspaceDeleteSequence;
-  NSString *placeholderValue = snapshot.placeholderValue;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     backspaceDeleteSequence = [[NSString alloc] initWithData:(NSData *)[@"\\u0008\\u007F" dataUsingEncoding:NSASCIIStringEncoding]
@@ -144,6 +143,7 @@
   });
   
   NSUInteger retry = 0;
+  NSString *placeholderValue = snapshot.placeholderValue;
   NSUInteger preClearTextLength = [currentValue fb_visualLength];
   do {
     NSString *backspacesToType = [backspaceDeleteSequence fb_repeatTimes:preClearTextLength];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -183,6 +183,8 @@
 #else
   // tvOS does not need a focus.
   // kHIDPage_KeyboardOrKeypad did not work for tvOS's search field. (tvOS 17 at least)
+  // Tested XCUIElementTypeSearchField and XCUIElementTypeTextView whch were
+  // common search field and email/passowrd input in tvOS apps.
   return [FBKeyboard typeText:backspacesToType error:error];
 #endif
 }


### PR DESCRIPTION
https://github.com/appium/appium/issues/19389

Based on https://github.com/appium/WebDriverAgent/pull/810

for iOS/iPad -> 1st attempt is via khidusage_keyboardclear, if this works, it is the fastest in my observation. The next is `typeText` then `tapWithNumberOfTaps`

tvOS -> `typeText:backspacesToType` then `typeText:backspaceDeleteSequence`

In tvOS's default search field had text, it was not placeholder. So it would be nice to minimize the retrial.