### PR TITLE
fix: fix run test

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "semantic-release": "^22.0.5",
     "sinon": "^17.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.1.6"
+    "typescript": "~5.2"
   },
   "dependencies": {
     "@appium/base-driver": "^9.0.0",


### PR DESCRIPTION
It looks like the typescript update fixes this.

```
% npm run test

> appium-webdriveragent@5.15.1 test
> mocha --exit --timeout 1m "./test/unit/**/*-specs.js"


✖ ERROR: error TS6053: File '@appium/tsconfig/tsconfig.json' not found.
```


Let me title with `fix` to re-run a publishment script as well