### PR TITLE
fix: set appearance in iOS 17+

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -340,11 +340,11 @@ static bool fb_isLocked;
     return YES;
   }
 
-#if __clang_major__ >= 14 && __clang_minor__ >= 0 && __clang_patchlevel__ >= 3
+#if __clang_major__ >= 15 || (__clang_major__ >= 14 && __clang_minor__ >= 0 && __clang_patchlevel__ >= 3)
   // Xcode 14.3.1 can build these values.
   // For iOS 17+
   if ([self respondsToSelector:NSSelectorFromString(@"appearance")]) {
-    self.appearance = appearance;
+    self.appearance = (XCUIDeviceAppearance) appearance;
     return YES;
   }
 #endif

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -340,7 +340,8 @@ static bool fb_isLocked;
     return YES;
   }
 
-#if __clang_major__ >= 15
+#if __clang_major__ >= 14 && __clang_minor__ >= 0 && __clang_patchlevel__ >= 3
+  // Xcode 14.3.1 can build these values.
   // For iOS 17+
   if ([self respondsToSelector:NSSelectorFromString(@"appearance")]) {
     switch (appearance) {

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -329,9 +329,6 @@ static bool fb_isLocked;
 
 - (BOOL)fb_setAppearance:(FBUIInterfaceAppearance)appearance error:(NSError **)error
 {
-  // Check the 'setAppearanceMode' first since 'appearance' below was introcued with Xcode 14.3
-  // but iOS 16.7 works with this 'setAppearanceMode' method.
-  // It is safe to check the old method first, then newer one.
   SEL selector = NSSelectorFromString(@"setAppearanceMode:");
   if (nil != selector && [self respondsToSelector:selector]) {
     NSMethodSignature *signature = [self methodSignatureForSelector:selector];
@@ -343,6 +340,7 @@ static bool fb_isLocked;
     return YES;
   }
 
+#if __clang_major__ >= 15
   // For iOS 17+
   if ([self respondsToSelector:NSSelectorFromString(@"appearance")]) {
     switch (appearance) {
@@ -360,6 +358,7 @@ static bool fb_isLocked;
         break;
     }
   }
+#endif
 
   return [[[FBErrorBuilder builder]
            withDescriptionFormat:@"Current Xcode SDK does not support appearance changing"]

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -344,20 +344,8 @@ static bool fb_isLocked;
   // Xcode 14.3.1 can build these values.
   // For iOS 17+
   if ([self respondsToSelector:NSSelectorFromString(@"appearance")]) {
-    switch (appearance) {
-      case FBUIInterfaceAppearanceUnspecified:
-        self.appearance = XCUIDeviceAppearanceUnspecified;
-        return YES;
-      case FBUIInterfaceAppearanceLight:
-        self.appearance = XCUIDeviceAppearanceLight;
-        return YES;
-      case FBUIInterfaceAppearanceDark:
-        self.appearance = XCUIDeviceAppearanceDark;
-        return YES;
-      default:
-        [FBLogger logFmt:@"No matched appearance pattern with %lu", appearance];
-        break;
-    }
+    self.appearance = appearance;
+    return YES;
   }
 #endif
 


### PR DESCRIPTION
It looks like iOS 17 needs to set appearance via below API.

```
/*!
 * Get or set the UI style of the device. Uses the `XCUIDeviceAppearance` enum to describe the UI style.
 */
@property (nonatomic) XCUIDeviceAppearance appearance API_AVAILABLE(macos(12.0), ios(15.0), tvos(15.0)) API_UNAVAILABLE(watchos);
```

In my testing, iOS 16.7 worked with `setAppearanceMode` so it would be safe to check `setAppearanceMode` first, then `appearance`