### PR TITLE
fix: Add arm64 arch to XctestrunFile path search for simulator

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -235,13 +235,15 @@ async function getXctestrunFilePath (deviceInfo, sdkVersion, bootstrapPath) {
       log.info(`Using '${filePath}' as xctestrun file`);
       return filePath;
     }
-    const originalXctestrunFile = path.resolve(bootstrapPath, getXctestrunFileName(deviceInfo, version));
-    if (await fs.exists(originalXctestrunFile)) {
-      // If this is first time run for given device, then first generate xctestrun file for device.
-      // We need to have a xctestrun file **per device** because we cant not have same wda port for all devices.
-      await fs.copyFile(originalXctestrunFile, filePath);
-      log.info(`Using '${filePath}' as xctestrun file copied by '${originalXctestrunFile}'`);
-      return filePath;
+    for (const archtecture of ['x86_64', 'arm64']) {
+      const originalXctestrunFile = path.resolve(bootstrapPath, getXctestrunFileName(deviceInfo, version, archtecture));
+      if (await fs.exists(originalXctestrunFile)) {
+        // If this is first time run for given device, then first generate xctestrun file for device.
+        // We need to have a xctestrun file **per device** because we cant not have same wda port for all devices.
+        await fs.copyFile(originalXctestrunFile, filePath);
+        log.info(`Using '${filePath}' as xctestrun file copied by '${originalXctestrunFile}'`);
+        return filePath;
+      }
     }
   }
 
@@ -257,12 +259,13 @@ async function getXctestrunFilePath (deviceInfo, sdkVersion, bootstrapPath) {
  * Return the name of xctestrun file
  * @param {DeviceInfo} deviceInfo
  * @param {string} version - The Xcode SDK version of OS.
+ * @param {string} architecture - The architecture of device.
  * @return {string} returns xctestrunFilePath for given device
  */
-function getXctestrunFileName (deviceInfo, version) {
+function getXctestrunFileName (deviceInfo, version, architecture = 'x86_64') {
   return isTvOS(deviceInfo.platformName)
-    ? `WebDriverAgentRunner_tvOS_appletv${deviceInfo.isRealDevice ? `os${version}-arm64` : `simulator${version}-x86_64`}.xctestrun`
-    : `WebDriverAgentRunner_iphone${deviceInfo.isRealDevice ? `os${version}-arm64` : `simulator${version}-x86_64`}.xctestrun`;
+    ? `WebDriverAgentRunner_tvOS_appletv${deviceInfo.isRealDevice ? `os${version}-arm64` : `simulator${version}-${architecture}`}.xctestrun`
+    : `WebDriverAgentRunner_iphone${deviceInfo.isRealDevice ? `os${version}-arm64` : `simulator${version}-${architecture}`}.xctestrun`;
 }
 
 /**

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -51,12 +51,36 @@ describe('utils', function () {
         .should.eventually.equal(path.resolve(`${bootstrapPath}/${udid}_${sdkVersion}.xctestrun`));
     });
 
+    it('should return sdk based path without udid with arm 64 architecture, copy them', async function () {
+      mocks.fs.expects('exists')
+        .withExactArgs(path.resolve(`${bootstrapPath}/${udid}_${sdkVersion}.xctestrun`))
+        .returns(false);
+      mocks.fs.expects('exists')
+        .withExactArgs(path.resolve(`${bootstrapPath}/WebDriverAgentRunner_iphonesimulator${sdkVersion}-x86_64.xctestrun`))
+        .returns(false);
+      mocks.fs.expects('exists')
+        .withExactArgs(path.resolve(`${bootstrapPath}/WebDriverAgentRunner_iphonesimulator${sdkVersion}-arm64.xctestrun`))
+        .returns(true);
+      mocks.fs.expects('copyFile')
+        .withExactArgs(
+          path.resolve(`${bootstrapPath}/WebDriverAgentRunner_iphonesimulator${sdkVersion}-arm64.xctestrun`),
+          path.resolve(`${bootstrapPath}/${udid}_${sdkVersion}.xctestrun`)
+        )
+        .returns(true);
+      const deviceInfo = {isRealDevice: false, udid, platformVersion};
+      await getXctestrunFilePath(deviceInfo, sdkVersion, bootstrapPath)
+      .should.eventually.equal(path.resolve(`${bootstrapPath}/${udid}_${sdkVersion}.xctestrun`));
+    });
+
     it('should return platform based path', async function () {
       mocks.fs.expects('exists')
         .withExactArgs(path.resolve(`${bootstrapPath}/${udid}_${sdkVersion}.xctestrun`))
         .returns(false);
       mocks.fs.expects('exists')
         .withExactArgs(path.resolve(`${bootstrapPath}/WebDriverAgentRunner_iphonesimulator${sdkVersion}-x86_64.xctestrun`))
+        .returns(false);
+      mocks.fs.expects('exists')
+        .withExactArgs(path.resolve(`${bootstrapPath}/WebDriverAgentRunner_iphonesimulator${sdkVersion}-arm64.xctestrun`))
         .returns(false);
       mocks.fs.expects('exists')
         .withExactArgs(path.resolve(`${bootstrapPath}/${udid}_${platformVersion}.xctestrun`))
@@ -74,6 +98,9 @@ describe('utils', function () {
         .returns(false);
       mocks.fs.expects('exists')
         .withExactArgs(path.resolve(`${bootstrapPath}/WebDriverAgentRunner_iphonesimulator${sdkVersion}-x86_64.xctestrun`))
+        .returns(false);
+      mocks.fs.expects('exists')
+        .withExactArgs(path.resolve(`${bootstrapPath}/WebDriverAgentRunner_iphonesimulator${sdkVersion}-arm64.xctestrun`))
         .returns(false);
       mocks.fs.expects('exists')
         .withExactArgs(path.resolve(`${bootstrapPath}/${udid}_${platformVersion}.xctestrun`))
@@ -95,7 +122,7 @@ describe('utils', function () {
 
     it('should raise an exception because of no files', async function () {
       const expected = path.resolve(`${bootstrapPath}/WebDriverAgentRunner_iphonesimulator${sdkVersion}-x86_64.xctestrun`);
-      mocks.fs.expects('exists').exactly(4).returns(false);
+      mocks.fs.expects('exists').exactly(6).returns(false);
 
       const deviceInfo = {isRealDevice: false, udid, platformVersion};
       try {


### PR DESCRIPTION
#837

Fixed to check both x86_64 and arm 64 if the device is a simulator.
I added an argument to `getXctestrunFileName` function but is has a default value, so it doesn't change the original behavior without it.