### PR TITLE
feat: Add a possibility of starting a test with a deep link

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -171,7 +171,6 @@
                                                                   traceback:nil]);
       }
     } else if (appState == XCUIApplicationStateRunningBackground && !forceAppLaunch) {
-      [app activate];
       if (nil != initialUrl) {
         NSError *openError;
         didOpenInitialUrl = [XCUIDevice.sharedDevice fb_openUrl:initialUrl
@@ -182,6 +181,8 @@
                                 initialUrl, bundleID, openError.description];
           return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:errorMsg traceback:nil]);
         }
+      } else {
+        [app activate];
       }
     }
   }

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -138,7 +138,7 @@
   NSString *bundleID = capabilities[FB_CAP_BUNDLE_ID];
   NSString *initialUrl = capabilities[FB_CAP_INITIAL_URL];
   XCUIApplication *app = nil;
-  BOOL didOpenInitalUrl = NO;
+  BOOL didOpenInitialUrl = NO;
   if (bundleID != nil) {
     app = [[XCUIApplication alloc] initWithBundleIdentifier:bundleID];
     BOOL forceAppLaunch = YES;
@@ -154,15 +154,15 @@
       app.launchEnvironment = (NSDictionary <NSString *, NSString *> *)capabilities[FB_CAP_ENVIRNOMENT] ?: @{};
       if (nil != initialUrl) {
         NSError *openError;
-        didOpenInitalUrl = [XCUIDevice.sharedDevice fb_openUrl:initialUrl
+        didOpenInitialUrl = [XCUIDevice.sharedDevice fb_openUrl:initialUrl
                                                withApplication:bundleID
                                                          error:&openError];
-        if (!didOpenInitalUrl) {
+        if (!didOpenInitialUrl) {
           // TODO: Make it a failure after we stop supporting iOS 16
           [FBLogger logFmt:@"%@", openError.description];
         }
       }
-      if (!didOpenInitalUrl) {
+      if (!didOpenInitialUrl) {
         [app launch];
       }
       if (![app running]) {
@@ -174,10 +174,10 @@
       [app activate];
       if (nil != initialUrl) {
         NSError *openError;
-        didOpenInitalUrl = [XCUIDevice.sharedDevice fb_openUrl:initialUrl
+        didOpenInitialUrl = [XCUIDevice.sharedDevice fb_openUrl:initialUrl
                                                withApplication:bundleID
                                                          error:&openError];
-        if (!didOpenInitalUrl) {
+        if (!didOpenInitialUrl) {
           // TODO: Make it a failure after we stop supporting iOS 16
           [FBLogger logFmt:@"%@", openError.description];
         }

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -158,11 +158,11 @@
                                                withApplication:bundleID
                                                          error:&openError];
         if (!didOpenInitialUrl) {
-          // TODO: Make it a failure after we stop supporting iOS 16
-          [FBLogger logFmt:@"%@", openError.description];
+          NSString *errorMsg = [NSString stringWithFormat:@"Cannot open the URL %@ in %@ application. Original error: %@",
+                                initialUrl, bundleID, openError.description];
+          return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:errorMsg traceback:nil]);
         }
-      }
-      if (!didOpenInitialUrl) {
+      } else {
         [app launch];
       }
       if (![app running]) {
@@ -178,8 +178,9 @@
                                                withApplication:bundleID
                                                          error:&openError];
         if (!didOpenInitialUrl) {
-          // TODO: Make it a failure after we stop supporting iOS 16
-          [FBLogger logFmt:@"%@", openError.description];
+          NSString *errorMsg = [NSString stringWithFormat:@"Cannot open the URL %@ in %@ application. Original error: %@",
+                                initialUrl, bundleID, openError.description];
+          return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:errorMsg traceback:nil]);
         }
       }
     }
@@ -188,7 +189,9 @@
   if (nil != initialUrl && nil == bundleID) {
     NSError *openError;
     if (![XCUIDevice.sharedDevice fb_openUrl:initialUrl error:&openError]) {
-      return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:error.description traceback:nil]);
+      NSString *errorMsg = [NSString stringWithFormat:@"Cannot open the URL %@. Original error: %@",
+                            initialUrl, openError.description];
+      return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:errorMsg traceback:nil]);
     }
   }
 

--- a/WebDriverAgentLib/Utilities/FBCapabilities.h
+++ b/WebDriverAgentLib/Utilities/FBCapabilities.h
@@ -9,16 +9,35 @@
 
 #import <Foundation/Foundation.h>
 
+/** Whether to use alternative elements visivility detection method */
 extern NSString* const FB_CAP_USE_TEST_MANAGER_FOR_VISIBLITY_DETECTION;
+/** Set the maximum amount of charatcers that could be typed within a minute (60 by default) */
 extern NSString* const FB_CAP_MAX_TYPING_FREQUENCY;
+/** this setting was needed for some legacy stuff */
 extern NSString* const FB_CAP_USE_SINGLETON_TEST_MANAGER;
+/** Whether to disable screneshots that XCTest automaticallly creates after each step */
 extern NSString* const FB_CAP_DISABLE_AUTOMATIC_SCREENSHOTS;
+/** Whether to terminate the application under test after the session ends */
 extern NSString* const FB_CAP_SHOULD_TERMINATE_APP;
+/** The maximum amount of seconds to wait for the event loop to become idle */
 extern NSString* const FB_CAP_EVENT_LOOP_IDLE_DELAY_SEC;
+/** Bundle identifier of the application to run the test for */
 extern NSString* const FB_CAP_BUNDLE_ID;
+/** Usually a URL used as initial link to run Mobile Safari, but could be any other deep link
+    This might also work together with `FB_CAP_BUNLDE_ID`, which tells XCTest to open
+    the given deep link in the particular app.
+    Only works since iOS 16.4
+ */
+extern NSString* const FB_CAP_INITIAL_URL;
+/** Whether to enforrce (re)start of the application under test on session startup */
 extern NSString* const FB_CAP_FORCE_APP_LAUNCH;
+/** Whether to wait for quiescence before starting interaction with apps laucnhes in scope of the test session */
 extern NSString* const FB_CAP_SHOULD_WAIT_FOR_QUIESCENCE;
+/** Array of command line arguments to be passed to the application under test */
 extern NSString* const FB_CAP_ARGUMENTS;
+/** Dictionary of environment variables to be passed to the application under test */
 extern NSString* const FB_CAP_ENVIRNOMENT;
+/** Whether to use native XCTest caching strategy */
 extern NSString* const FB_CAP_USE_NATIVE_CACHING_STRATEGY;
+/** Whether to enforce software keyboard presence on simulator */
 extern NSString* const FB_CAP_FORCE_SIMULATOR_SOFTWARE_KEYBOARD_PRESENCE;

--- a/WebDriverAgentLib/Utilities/FBCapabilities.h
+++ b/WebDriverAgentLib/Utilities/FBCapabilities.h
@@ -23,10 +23,11 @@ extern NSString* const FB_CAP_SHOULD_TERMINATE_APP;
 extern NSString* const FB_CAP_EVENT_LOOP_IDLE_DELAY_SEC;
 /** Bundle identifier of the application to run the test for */
 extern NSString* const FB_CAP_BUNDLE_ID;
-/** Usually a URL used as initial link to run Mobile Safari, but could be any other deep link
-    This might also work together with `FB_CAP_BUNLDE_ID`, which tells XCTest to open
-    the given deep link in the particular app.
-    Only works since iOS 16.4
+/**
+ Usually an URL used as initial link to run Mobile Safari, but could be any other deep link.
+ This might also work together with `FB_CAP_BUNLDE_ID`, which tells XCTest to open
+ the given deep link in the particular app.
+ Only works since iOS 16.4
  */
 extern NSString* const FB_CAP_INITIAL_URL;
 /** Whether to enforrce (re)start of the application under test on session startup */

--- a/WebDriverAgentLib/Utilities/FBCapabilities.m
+++ b/WebDriverAgentLib/Utilities/FBCapabilities.m
@@ -16,6 +16,7 @@ NSString* const FB_CAP_DISABLE_AUTOMATIC_SCREENSHOTS = @"disableAutomaticScreens
 NSString* const FB_CAP_SHOULD_TERMINATE_APP = @"shouldTerminateApp";
 NSString* const FB_CAP_EVENT_LOOP_IDLE_DELAY_SEC = @"eventloopIdleDelaySec";
 NSString* const FB_CAP_BUNDLE_ID = @"bundleId";
+NSString* const FB_CAP_INITIAL_URL = @"initialUrl";
 NSString* const FB_CAP_FORCE_APP_LAUNCH = @"forceAppLaunch";
 NSString* const FB_CAP_SHOULD_WAIT_FOR_QUIESCENCE = @"shouldWaitForQuiescence";
 NSString* const FB_CAP_ARGUMENTS = @"arguments";

--- a/package.json
+++ b/package.json
@@ -8,9 +8,8 @@
     "dev": "npm run build -- --watch",
     "clean": "npm run build -- --clean",
     "lint": "eslint .",
+    "format": "prettier -w ./lib",
     "lint:fix": "npm run lint -- --fix",
-    "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
-    "precommit-lint": "lint-staged",
     "prepare": "npm run build",
     "test": "mocha --exit --timeout 1m \"./test/unit/**/*-specs.js\"",
     "e2e-test": "mocha --exit --timeout 10m \"./test/functional/**/*-specs.js\"",
@@ -23,20 +22,11 @@
     "node": ">=14",
     "npm": ">=8"
   },
-  "lint-staged": {
-    "*.js": [
-      "eslint --fix"
-    ]
-  },
   "prettier": {
     "bracketSpacing": false,
     "printWidth": 100,
     "singleQuote": true
   },
-  "pre-commit": [
-    "precommit-msg",
-    "precommit-lint"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/appium/WebDriverAgent.git"
@@ -83,9 +73,7 @@
     "eslint-plugin-import": "^2.28.0",
     "eslint-plugin-mocha": "^10.1.0",
     "eslint-plugin-promise": "^6.1.1",
-    "lint-staged": "^15.0.2",
     "mocha": "^10.0.0",
-    "pre-commit": "^1.2.2",
     "prettier": "^3.0.0",
     "semantic-release": "^23.0.0",
     "sinon": "^17.0.0",


### PR DESCRIPTION
The idea is that a client cold provide the `initialUrl` capability to WDA on session startup with or without `bundleId` one.
If the latter is provided then WDA tries to open the given deep link in the desired app, otherwise in the system-default one.
Might be used to start mobile safari with the desired URL already opened, which should save some seconds for the session startup.
Only works since iOS 16.4