### PR TITLE
chore: Tune alert detection if system app is active

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -533,7 +533,7 @@ NSDictionary<NSNumber *, NSString *> *auditTypeValuesToNames(void) {
   if (nil == otherApp) {
     return NO;
   }
-  return [self.bundleID isEqualToString:(NSString *)otherApp.bundleID];
+  return self == otherApp || [self.bundleID isEqualToString:(NSString *)otherApp.bundleID];
 }
 
 @end

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -261,7 +261,12 @@
 - (XCUIElement *)alertElement
 {
   if (nil == self.element) {
-    self.element = XCUIApplication.fb_systemApplication.fb_alertElement ?: self.application.fb_alertElement;
+    XCUIApplication *systemApp = XCUIApplication.fb_systemApplication;
+    if ([systemApp fb_isSameAppAs:self.application]) {
+      self.element = systemApp.fb_alertElement;
+    } else {
+      self.element = systemApp.fb_alertElement ?: self.application.fb_alertElement;
+    }
   }
   return self.element;
 }


### PR DESCRIPTION
The previous implementation might perform an unnecessary element lookup if self.application is the same as the system one