### PR TITLE
chore: tune release

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -14,9 +14,7 @@ jobs:
 
     env:
       XCODE_VERSION: 14.3.1
-      ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner.zip"
       PKG_PATH_IOS: "appium_wda_ios"
-      ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner.zip"
       PKG_PATH_TVOS: "appium_wda_tvos"
 
     steps:
@@ -34,6 +32,24 @@ jobs:
       name: Run build
     - run: npm run test
       name: Run test
+
+    # building WDA packages to test package build
+    - name: Build iOS
+      run: |
+        xcodebuild clean build-for-testing \
+          -project WebDriverAgent.xcodeproj \
+          -derivedDataPath $PKG_PATH_IOS \
+          -scheme WebDriverAgentRunner \
+          -destination generic/platform=iOS \
+          CODE_SIGNING_ALLOWED=NO ARCHS=arm64
+    - name: Build tvOS
+      run: |
+        xcodebuild clean build-for-testing \
+          -project WebDriverAgent.xcodeproj \
+          -derivedDataPath $PKG_PATH_TVOS \
+          -scheme WebDriverAgentRunner_tvOS \
+          -destination generic/platform=tvOS \
+          CODE_SIGNING_ALLOWED=NO ARCHS=arm64
 
     # release tasks
     - run: npx semantic-release

--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -35,42 +35,9 @@ jobs:
     - run: npm run test
       name: Run test
 
-    # building WDA packages
-    - name: Build iOS
-      run: |
-        xcodebuild clean build-for-testing \
-          -project WebDriverAgent.xcodeproj \
-          -derivedDataPath $PKG_PATH_IOS \
-          -scheme WebDriverAgentRunner \
-          -destination generic/platform=iOS \
-          CODE_SIGNING_ALLOWED=NO ARCHS=arm64
-    - name: Creating a zip of WebDriverAgentRunner-Runner.app for iOS after removing test frameworks
-      run: |
-        pushd appium_wda_ios/Build/Products/Debug-iphoneos
-        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XC*.framework
-        zip -r $ZIP_PKG_NAME_IOS WebDriverAgentRunner-Runner.app
-        popd
-        mv $PKG_PATH_IOS/Build/Products/Debug-iphoneos/$ZIP_PKG_NAME_IOS ./
-    - name: Build tvOS
-      run: |
-        xcodebuild clean build-for-testing \
-          -project WebDriverAgent.xcodeproj \
-          -derivedDataPath $PKG_PATH_TVOS \
-          -scheme WebDriverAgentRunner_tvOS \
-          -destination generic/platform=tvOS \
-          CODE_SIGNING_ALLOWED=NO ARCHS=arm64
-    - name: Creating a zip of WebDriverAgentRunner-Runner.app for tvOS after removing test frameworks
-      run: |
-        pushd appium_wda_tvos/Build/Products/Debug-appletvos
-        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XC*.framework
-        zip -r $ZIP_PKG_NAME_TVOS WebDriverAgentRunner_tvOS-Runner.app
-        popd
-        mv $PKG_PATH_TVOS/Build/Products/Debug-appletvos/$ZIP_PKG_NAME_TVOS ./
-
     # release tasks
     - run: npx semantic-release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Release
-

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -54,7 +54,7 @@ jobs:
           WD: appium_wda_tvos/Build/Products/Debug-appletvos
           ZIP_PKG_NAME: "${{ env.ZIP_PKG_NAME_TVOS }}"
 
-    - name: upload windows artifact
+    - name: upload WebDriverAgentRunner-Runner.zip
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.token }}
@@ -64,7 +64,7 @@ jobs:
         asset_name: WebDriverAgentRunner-Runner.zip
         asset_content_type: application/zip
 
-    - name: upload windows artifact
+    - name: upload WebDriverAgentRunner_tvOS-Runner.zip
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.token }}
@@ -98,7 +98,7 @@ jobs:
           SCHEME: WebDriverAgentRunner${{ matrix.target }}
           ARCHS: ${{ matrix.arch }}
           ZIP_PKG_NAME: "WebDriverAgentRunner${{ matrix.target }}-Build-Sim-${{ matrix.arch }}.zip"
-      - name: upload windows artifact
+      - name: upload windows WebDriverAgentRunner${{ matrix.target }}-Build-Sim-${{ matrix.arch }}.zip
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.token }}

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -2,10 +2,8 @@ name: Building WebDriverAgent
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Release"]
-    types:
-      - completed
+  release:
+    types: [published]
 
 env:
   HOST: macos-13
@@ -56,14 +54,25 @@ jobs:
           WD: appium_wda_tvos/Build/Products/Debug-appletvos
           ZIP_PKG_NAME: "${{ env.ZIP_PKG_NAME_TVOS }}"
 
-      - name: Upload the built generic app package for iOS
-        uses: actions/upload-artifact@v3.1.0
-        with:
-          path: "${{ env.ZIP_PKG_NAME_IOS }}"
-      - name: Upload the built generic app package for tvOS
-        uses: actions/upload-artifact@v3.1.0
-        with:
-          path: "${{ env.ZIP_PKG_NAME_TVOS }}"
+    - name: upload windows artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.token }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: "${{ env.ZIP_PKG_NAME_IOS }}"
+        asset_name: WebDriverAgentRunner-Runner.zip
+        asset_content_type: application/zip
+
+    - name: upload windows artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.token }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ${{ env.ZIP_PKG_NAME_TVOS }}"
+        asset_name: WebDriverAgentRunner_tvOS-Runner.zip
+        asset_content_type: application/zip
 
   for_simulator_devices:
     needs: [host_machine]
@@ -89,7 +98,12 @@ jobs:
           SCHEME: WebDriverAgentRunner${{ matrix.target }}
           ARCHS: ${{ matrix.arch }}
           ZIP_PKG_NAME: "WebDriverAgentRunner${{ matrix.target }}-Build-Sim-${{ matrix.arch }}.zip"
-      - name: Upload the built generic app package for WebDriverAgentRunner${{ matrix.target }} with ${{ matrix.arch }}
-        uses: actions/upload-artifact@v3.1.0
+      - name: upload windows artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.token }}
         with:
-          path: "WebDriverAgentRunner${{ matrix.target }}-Build-Sim-${{ matrix.arch }}.zip"
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: "WebDriverAgentRunner${{ matrix.target }}-Build-Sim-${{ matrix.arch }}.zip"
+          asset_name: "WebDriverAgentRunner${{ matrix.target }}-Build-Sim-${{ matrix.arch }}.zip"
+          asset_content_type: application/zip

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -54,25 +54,25 @@ jobs:
           WD: appium_wda_tvos/Build/Products/Debug-appletvos
           ZIP_PKG_NAME: "${{ env.ZIP_PKG_NAME_TVOS }}"
 
-    - name: upload WebDriverAgentRunner-Runner.zip
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.token }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: "${{ env.ZIP_PKG_NAME_IOS }}"
-        asset_name: WebDriverAgentRunner-Runner.zip
-        asset_content_type: application/zip
+      - name: upload WebDriverAgentRunner-Runner.zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.token }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: "${{ env.ZIP_PKG_NAME_IOS }}"
+          asset_name: WebDriverAgentRunner-Runner.zip
+          asset_content_type: application/zip
 
-    - name: upload WebDriverAgentRunner_tvOS-Runner.zip
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.token }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ${{ env.ZIP_PKG_NAME_TVOS }}"
-        asset_name: WebDriverAgentRunner_tvOS-Runner.zip
-        asset_content_type: application/zip
+      - name: upload WebDriverAgentRunner_tvOS-Runner.zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.token }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ env.ZIP_PKG_NAME_TVOS }}"
+          asset_name: WebDriverAgentRunner_tvOS-Runner.zip
+          asset_content_type: application/zip
 
   for_simulator_devices:
     needs: [host_machine]

--- a/.releaserc
+++ b/.releaserc
@@ -32,10 +32,6 @@
       "assets": ["docs", "package.json", "CHANGELOG.md"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
-    ["@semantic-release/github", {
-      "assets": [
-        "WebDriverAgentRunner-Runner.zip",
-        "WebDriverAgentRunner_tvOS-Runner.zip"
-    ]}]
+    ["@semantic-release/github"]
   ]
 }


### PR DESCRIPTION
Tries to tune release packages.

This aims to push prebuilt packages by https://github.com/appium/WebDriverAgent/actions/runs/8085583187


https://stackoverflow.com/questions/65521101/upload-url-for-githubs-upload-release-asset-action-when-the-trigger-is-a-releas