### PR TITLE
Revert "chore: tune release"

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -14,7 +14,9 @@ jobs:
 
     env:
       XCODE_VERSION: 14.3.1
+      ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner.zip"
       PKG_PATH_IOS: "appium_wda_ios"
+      ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner.zip"
       PKG_PATH_TVOS: "appium_wda_tvos"
 
     steps:
@@ -33,7 +35,7 @@ jobs:
     - run: npm run test
       name: Run test
 
-    # building WDA packages to test package build
+    # building WDA packages
     - name: Build iOS
       run: |
         xcodebuild clean build-for-testing \
@@ -42,6 +44,13 @@ jobs:
           -scheme WebDriverAgentRunner \
           -destination generic/platform=iOS \
           CODE_SIGNING_ALLOWED=NO ARCHS=arm64
+    - name: Creating a zip of WebDriverAgentRunner-Runner.app for iOS after removing test frameworks
+      run: |
+        pushd appium_wda_ios/Build/Products/Debug-iphoneos
+        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XC*.framework
+        zip -r $ZIP_PKG_NAME_IOS WebDriverAgentRunner-Runner.app
+        popd
+        mv $PKG_PATH_IOS/Build/Products/Debug-iphoneos/$ZIP_PKG_NAME_IOS ./
     - name: Build tvOS
       run: |
         xcodebuild clean build-for-testing \
@@ -50,6 +59,13 @@ jobs:
           -scheme WebDriverAgentRunner_tvOS \
           -destination generic/platform=tvOS \
           CODE_SIGNING_ALLOWED=NO ARCHS=arm64
+    - name: Creating a zip of WebDriverAgentRunner-Runner.app for tvOS after removing test frameworks
+      run: |
+        pushd appium_wda_tvos/Build/Products/Debug-appletvos
+        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XC*.framework
+        zip -r $ZIP_PKG_NAME_TVOS WebDriverAgentRunner_tvOS-Runner.app
+        popd
+        mv $PKG_PATH_TVOS/Build/Products/Debug-appletvos/$ZIP_PKG_NAME_TVOS ./
 
     # release tasks
     - run: npx semantic-release
@@ -57,3 +73,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Release
+

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -2,8 +2,10 @@ name: Building WebDriverAgent
 
 on:
   workflow_dispatch:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
 
 env:
   HOST: macos-13
@@ -54,25 +56,14 @@ jobs:
           WD: appium_wda_tvos/Build/Products/Debug-appletvos
           ZIP_PKG_NAME: "${{ env.ZIP_PKG_NAME_TVOS }}"
 
-      - name: upload WebDriverAgentRunner-Runner.zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.token }}
+      - name: Upload the built generic app package for iOS
+        uses: actions/upload-artifact@v3.1.0
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: "${{ env.ZIP_PKG_NAME_IOS }}"
-          asset_name: WebDriverAgentRunner-Runner.zip
-          asset_content_type: application/zip
-
-      - name: upload WebDriverAgentRunner_tvOS-Runner.zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.token }}
+          path: "${{ env.ZIP_PKG_NAME_IOS }}"
+      - name: Upload the built generic app package for tvOS
+        uses: actions/upload-artifact@v3.1.0
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ env.ZIP_PKG_NAME_TVOS }}"
-          asset_name: WebDriverAgentRunner_tvOS-Runner.zip
-          asset_content_type: application/zip
+          path: "${{ env.ZIP_PKG_NAME_TVOS }}"
 
   for_simulator_devices:
     needs: [host_machine]
@@ -98,12 +89,7 @@ jobs:
           SCHEME: WebDriverAgentRunner${{ matrix.target }}
           ARCHS: ${{ matrix.arch }}
           ZIP_PKG_NAME: "WebDriverAgentRunner${{ matrix.target }}-Build-Sim-${{ matrix.arch }}.zip"
-      - name: upload windows WebDriverAgentRunner${{ matrix.target }}-Build-Sim-${{ matrix.arch }}.zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.token }}
+      - name: Upload the built generic app package for WebDriverAgentRunner${{ matrix.target }} with ${{ matrix.arch }}
+        uses: actions/upload-artifact@v3.1.0
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: "WebDriverAgentRunner${{ matrix.target }}-Build-Sim-${{ matrix.arch }}.zip"
-          asset_name: "WebDriverAgentRunner${{ matrix.target }}-Build-Sim-${{ matrix.arch }}.zip"
-          asset_content_type: application/zip
+          path: "WebDriverAgentRunner${{ matrix.target }}-Build-Sim-${{ matrix.arch }}.zip"

--- a/.releaserc
+++ b/.releaserc
@@ -32,6 +32,10 @@
       "assets": ["docs", "package.json", "CHANGELOG.md"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
-    ["@semantic-release/github"]
+    ["@semantic-release/github", {
+      "assets": [
+        "WebDriverAgentRunner-Runner.zip",
+        "WebDriverAgentRunner_tvOS-Runner.zip"
+    ]}]
   ]
 }


### PR DESCRIPTION
Reverts appium/WebDriverAgent#856

It looks like an action cannot trigger another actions. We may need to use another token for it. Maybe the best way is putting the simulator's wda build flow into the publish.js.yml as a following workflow step.

https://github.com/semantic-release/semantic-release/discussions/1906

Let me try later this way, although let's rever the pr