### PR TITLE
fix: respect defaultActiveApplication in activeApplication selection

### DIFF
--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -167,20 +167,18 @@ static FBSession *_activeSession = nil;
 - (XCUIApplication *)activeApplication
 {
   BOOL isAuto = [self.defaultActiveApplication isEqualToString:FBDefaultApplicationAuto];
-  NSString *defaultBundleId = isAuto
-    ? nil
-    : self.defaultActiveApplication;
+  NSString *defaultBundleId = isAuto ? nil : self.defaultActiveApplication;
 
   if (nil != defaultBundleId && [self applicationStateWithBundleId:defaultBundleId] >= XCUIApplicationStateRunningForeground) {
     return [self makeApplicationWithBundleId:defaultBundleId];
   }
 
-  if (isAuto && nil != self.testedApplication) {
+  if (nil != self.testedApplication) {
     XCUIApplicationState testedAppState = self.testedApplication.state;
     if (testedAppState >= XCUIApplicationStateRunningForeground) {
       return (XCUIApplication *)self.testedApplication;
     }
-    if (self.isTestedApplicationExpectedToRun && testedAppState <= XCUIApplicationStateNotRunning) {
+    if (!isAuto && self.isTestedApplicationExpectedToRun && testedAppState <= XCUIApplicationStateNotRunning) {
       NSString *description = [NSString stringWithFormat:@"The application under test with bundle id '%@' is not running, possibly crashed", self.testedApplication.bundleID];
       @throw [NSException exceptionWithName:FBApplicationCrashedException reason:description userInfo:nil];
     }

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -166,7 +166,8 @@ static FBSession *_activeSession = nil;
 
 - (XCUIApplication *)activeApplication
 {
-  if (nil != self.testedApplication) {
+  BOOL isAuto = [self.defaultActiveApplication isEqualToString:FBDefaultApplicationAuto];
+  if (isAuto && nil != self.testedApplication) {
     XCUIApplicationState testedAppState = self.testedApplication.state;
     if (testedAppState >= XCUIApplicationStateRunningForeground) {
       return (XCUIApplication *)self.testedApplication;
@@ -177,7 +178,7 @@ static FBSession *_activeSession = nil;
     }
   }
 
-  NSString *defaultBundleId = [self.defaultActiveApplication isEqualToString:FBDefaultApplicationAuto]
+  NSString *defaultBundleId = isAuto
     ? nil
     : self.defaultActiveApplication;
   return [XCUIApplication fb_activeApplicationWithDefaultBundleId:defaultBundleId];

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -178,7 +178,7 @@ static FBSession *_activeSession = nil;
     if (testedAppState >= XCUIApplicationStateRunningForeground) {
       return (XCUIApplication *)self.testedApplication;
     }
-    if (WebDriverAgentLib/Routing/FBSession.mself.isTestedApplicationExpectedToRun && testedAppState <= XCUIApplicationStateNotRunning) {
+    if (self.isTestedApplicationExpectedToRun && testedAppState <= XCUIApplicationStateNotRunning) {
       NSString *description = [NSString stringWithFormat:@"The application under test with bundle id '%@' is not running, possibly crashed", self.testedApplication.bundleID];
       @throw [NSException exceptionWithName:FBApplicationCrashedException reason:description userInfo:nil];
     }

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -167,6 +167,14 @@ static FBSession *_activeSession = nil;
 - (XCUIApplication *)activeApplication
 {
   BOOL isAuto = [self.defaultActiveApplication isEqualToString:FBDefaultApplicationAuto];
+  NSString *defaultBundleId = isAuto
+    ? nil
+    : self.defaultActiveApplication;
+
+  if (nil != defaultBundleId && [self applicationStateWithBundleId:defaultBundleId] >= XCUIApplicationStateRunningForeground) {
+    return [self makeApplicationWithBundleId:defaultBundleId];
+  }
+
   if (isAuto && nil != self.testedApplication) {
     XCUIApplicationState testedAppState = self.testedApplication.state;
     if (testedAppState >= XCUIApplicationStateRunningForeground) {
@@ -176,14 +184,6 @@ static FBSession *_activeSession = nil;
       NSString *description = [NSString stringWithFormat:@"The application under test with bundle id '%@' is not running, possibly crashed", self.testedApplication.bundleID];
       @throw [NSException exceptionWithName:FBApplicationCrashedException reason:description userInfo:nil];
     }
-  }
-
-  NSString *defaultBundleId = isAuto
-    ? nil
-    : self.defaultActiveApplication;
-
-  if (nil != defaultBundleId && [self applicationStateWithBundleId:defaultBundleId] >= XCUIApplicationStateRunningForeground) {
-    return [self makeApplicationWithBundleId:defaultBundleId];
   }
 
   return [XCUIApplication fb_activeApplicationWithDefaultBundleId:defaultBundleId];

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -178,7 +178,7 @@ static FBSession *_activeSession = nil;
     if (testedAppState >= XCUIApplicationStateRunningForeground) {
       return (XCUIApplication *)self.testedApplication;
     }
-    if (!isAuto && self.isTestedApplicationExpectedToRun && testedAppState <= XCUIApplicationStateNotRunning) {
+    if (WebDriverAgentLib/Routing/FBSession.mself.isTestedApplicationExpectedToRun && testedAppState <= XCUIApplicationStateNotRunning) {
       NSString *description = [NSString stringWithFormat:@"The application under test with bundle id '%@' is not running, possibly crashed", self.testedApplication.bundleID];
       @throw [NSException exceptionWithName:FBApplicationCrashedException reason:description userInfo:nil];
     }

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -181,6 +181,11 @@ static FBSession *_activeSession = nil;
   NSString *defaultBundleId = isAuto
     ? nil
     : self.defaultActiveApplication;
+
+  if (nil != defaultBundleId && [self applicationStateWithBundleId:defaultBundleId] >= XCUIApplicationStateRunningForeground) {
+    return [self makeApplicationWithBundleId:defaultBundleId];
+  }
+
   return [XCUIApplication fb_activeApplicationWithDefaultBundleId:defaultBundleId];
 }
 


### PR DESCRIPTION
I wondered if we could follow `defaultActiveApplication` first if it was not auto, which means the session explicitly wants to interact with the defaultActiveApplication first.

Then, `driver.settings.update({defaultActiveApplication: 'com.apple.springboard'})` would help to interact with springboard elements in a session like keyboard as well. It is easy to move to the default behavior with `driver.settings.update({defaultActiveApplication: 'auto'})`



Maybe.. current implementation no longer work with defaultActiveApplication unless a session does not include bundleId/app