### PR TITLE
fix: Always assume en0 is the WiFi interface

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
@@ -70,7 +70,7 @@ typedef NS_ENUM(NSUInteger, FBUIInterfaceAppearance) {
 - (nullable NSData *)fb_screenshotWithError:(NSError*__autoreleasing*)error;
 
 /**
- Returns device current wifi ip4 address
+ Returns device's current wifi ip4 address
  */
 - (nullable NSString *)fb_wifiIPAddress;
 

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -134,7 +134,7 @@ static bool fb_isLocked;
       continue;
     }
     NSString *interfaceName = [NSString stringWithUTF8String:temp_addr->ifa_name];
-    if(![interfaceName containsString:@"en"]) {
+    if(![interfaceName isEqualToString:@"en0"]) {
       temp_addr = temp_addr->ifa_next;
       continue;
     }


### PR DESCRIPTION
We must only assume that the `en0` is the device's Wi-Fi interface instead of any interface whose name starts with `en`. See https://stackoverflow.com/questions/30748480/swift-get-devices-wifi-ip-address for more details