### PR TITLE
feat: Support prebuiltWDAPath for iOS 17

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -307,7 +307,7 @@ class WebDriverAgent {
    * @return {Promise<void>}
    */
 
-  async _launchWdaViaDeviceCtl(opts={}) {
+  async _launchWdaViaDeviceCtl(opts = {}) {
     // FIXME: use appium-xcuitest-driver's Devicectl. Maybe it needs to be included in the `this.device`?
     //
 
@@ -333,7 +333,7 @@ class WebDriverAgent {
     ];
 
     if (_.isEmpty(env)) {
-      cmd.push('--environment-variables', JSON.stringify(_.mapValues(env, (v) => _.toString(v))))
+      cmd.push('--environment-variables', JSON.stringify(_.mapValues(env, (v) => _.toString(v))));
     };
 
     cmd.push(this.bundleIdForXctest);

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -1,3 +1,4 @@
+import { retryInterval } from 'asyncbox';
 import _ from 'lodash';
 import path from 'path';
 import url from 'url';
@@ -287,6 +288,73 @@ class WebDriverAgent {
     }
   }
 
+
+  /**
+   * @typedef {Object} LaunchingEnvironmentOptions
+   * @property {number} USE_PORT
+   * @property {string} WDA_PRODUCT_BUNDLE_IDENTIFIER
+   */
+
+  /**
+   * Launch WDA with preinstalled package with 'xcrun devicectl device process launch'.
+   * The WDA package must be prepared properly like published via
+   * https://github.com/appium/WebDriverAgent/releases
+   * with proper sign for this case.
+   *
+   * When we implement launching XCTest service via appium-ios-device,
+   * this implementation can be replaced with it.
+   *
+   * @param {LaunchingEnvironmentOptions}  launchingEnv launching environment for WebDriverAgent.
+   * @return {Promise<void>}
+   */
+
+  async _launchWdaViaDeviceCtl(launchingEnv) {
+    // FIXME: use appium-xcuitest-driver's Devicectl. Maybe it needs to be included in the `this.device`?
+
+    const envVar = {
+      // the port number must be string for the devicectl command.
+      USE_PORT: `${launchingEnv.USE_PORT}`,
+      WDA_PRODUCT_BUNDLE_IDENTIFIER: launchingEnv.WDA_PRODUCT_BUNDLE_IDENTIFIER
+    };
+
+    let xcrunBinnaryPath;
+    try {
+      xcrunBinnaryPath = await fs.which('xcrun');
+    } catch (e) {
+      throw new Error(
+        `xcrun has not been found in PATH. ` +
+          `Please make sure XCode development tools are installed`,
+      );
+    }
+
+    const {stdout} = await exec(xcrunBinnaryPath, [
+      'devicectl',
+      'device',
+      'process',
+      'launch',
+      `--device`, this.device.udid,
+      '--environment-variables', JSON.stringify(envVar),
+      '--terminate-existing',
+      this.bundleIdForXctest
+    ]);
+    this.log.debug(`The output of devicectl command: ${stdout}`);
+
+    // Launching app via decictl does not wait for the app start.
+    // We should wait for the app start by ourselves.
+    try {
+      await retryInterval(30, 1000, async () => {
+        if (_.isNull(await this.getStatus())) {
+          throw new Error();
+        }
+      });
+    } catch (err) {
+      throw new Error(
+        `Failed to start the preinstalled WebDriverAgent in ${30 * 1000} ms.` +
+        `The WebDriverAgent might not be properly built or the device might be locked.`
+      );
+    }
+  }
+
   /**
    * Launch WDA with preinstalled package without xcodebuild.
    * @param {string} sessionId Launch WDA and establish the session with this sessionId
@@ -302,8 +370,12 @@ class WebDriverAgent {
     }
     this.log.info('Launching WebDriverAgent on the device without xcodebuild');
     if (this.isRealDevice) {
-      this.xctestApiClient = new Xctest(this.device.udid, this.bundleIdForXctest, null, {env: xctestEnv});
-      await this.xctestApiClient.start();
+      if (util.compareVersions(this.platformVersion, '>=', '17.0')) {
+        await this._launchWdaViaDeviceCtl(xctestEnv);
+      } else {
+        this.xctestApiClient = new Xctest(this.device.udid, this.bundleIdForXctest, null, {env: xctestEnv});
+        await this.xctestApiClient.start();
+      }
     } else {
       await this.device.simctl.exec('launch', {
         args: [

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -1,4 +1,4 @@
-import { retryInterval } from 'asyncbox';
+import { waitForCondition } from 'asyncbox';
 import _ from 'lodash';
 import path from 'path';
 import url from 'url';
@@ -292,7 +292,7 @@ class WebDriverAgent {
 
   /**
    * @typedef {Object} launchWdaViaDeviceCtlOptions
-   * @property {Object} env environment variables for the launching WDA process
+   * @property {Record<string, string|number>} env environment variables for the launching WDA process
    */
 
   /**
@@ -304,7 +304,7 @@ class WebDriverAgent {
    * When we implement launching XCTest service via appium-ios-device,
    * this implementation can be replaced with it.
    *
-   * @param {launchWdaViaDeviceCtlOptions} opts launching WDA with devicectl command options.
+   * @param {?launchWdaViaDeviceCtlOptions} opts launching WDA with devicectl command options.
    * @return {Promise<void>}
    */
 
@@ -312,7 +312,7 @@ class WebDriverAgent {
     // FIXME: use appium-xcuitest-driver's Devicectl. Maybe it needs to be included in the `this.device`?
     //
 
-    const {env} = opts;
+    const {env} = opts || {};
 
     let xcrunBinnaryPath;
     try {
@@ -336,17 +336,14 @@ class WebDriverAgent {
     ]);
     this.log.debug(`The output of devicectl command: ${stdout}`);
 
-    const intervalTimeMs = 1000;
-    const maxRetry = this.wdaLaunchTimeout / intervalTimeMs;
-
     // Launching app via decictl does not wait for the app start.
     // We should wait for the app start by ourselves.
     try {
-      await retryInterval(maxRetry, intervalTimeMs, async () => {
-        if (_.isNull(await this.getStatus())) {
-          throw new Error();
-        }
+      await waitForCondition(async () => !_.isNull(await this.getStatus()), {
+        waitMs: this.wdaLaunchTimeout,
+        intervalMs: 300,
       });
+
     } catch (err) {
       throw new Error(
         `Failed to start the preinstalled WebDriverAgent in ${this.wdaLaunchTimeout} ms. ` +

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -306,8 +306,7 @@ class WebDriverAgent {
    * @param {LaunchWdaViaDeviceCtlOptions} [opts={}] launching WDA with devicectl command options.
    * @return {Promise<void>}
    */
-
-  async _launchWdaViaDeviceCtl(opts = {}) {
+  async _launchViaDevicectl(opts = {}) {
     // FIXME: use appium-xcuitest-driver's Devicectl. Maybe it needs to be included in the `this.device`?
     //
 
@@ -331,11 +330,9 @@ class WebDriverAgent {
       `--device`, this.device.udid,
       '--terminate-existing'
     ];
-
-    if (_.isEmpty(env)) {
+    if (!_.isEmpty(env)) {
       cmd.push('--environment-variables', JSON.stringify(_.mapValues(env, (v) => _.toString(v))));
     };
-
     cmd.push(this.bundleIdForXctest);
 
     const {stdout} = await exec(xcrunBinnaryPath, cmd);
@@ -377,7 +374,7 @@ class WebDriverAgent {
       // but it has limitation about the WDA preinstalled package.
       // https://github.com/appium/appium/issues/19206#issuecomment-2014182674
       if (util.compareVersions(this.platformVersion, '>=', '17.0')) {
-        await this._launchWdaViaDeviceCtl({env: xctestEnv});
+        await this._launchViaDevicectl({env: xctestEnv});
       } else {
         this.xctestApiClient = new Xctest(this.device.udid, this.bundleIdForXctest, null, {env: xctestEnv});
         await this.xctestApiClient.start();

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -67,6 +67,7 @@ class WebDriverAgent {
 
     this.updatedWDABundleId = args.updatedWDABundleId;
 
+    this.wdaLaunchTimeout = args.wdaLaunchTimeout || WDA_LAUNCH_TIMEOUT;
     this.usePreinstalledWDA = args.usePreinstalledWDA;
     this.xctestApiClient = null;
 
@@ -88,7 +89,7 @@ class WebDriverAgent {
         useSimpleBuildTest: args.useSimpleBuildTest,
         usePrebuiltWDA: args.usePrebuiltWDA,
         updatedWDABundleId: this.updatedWDABundleId,
-        launchTimeout: args.wdaLaunchTimeout || WDA_LAUNCH_TIMEOUT,
+        launchTimeout: this.wdaLaunchTimeout,
         wdaRemotePort: this.wdaRemotePort,
         useXctestrunFile: this.useXctestrunFile,
         derivedDataPath: args.derivedDataPath,
@@ -290,9 +291,8 @@ class WebDriverAgent {
 
 
   /**
-   * @typedef {Object} LaunchingEnvironmentOptions
-   * @property {number} USE_PORT
-   * @property {string} WDA_PRODUCT_BUNDLE_IDENTIFIER
+   * @typedef {Object} launchWdaViaDeviceCtlOptions
+   * @property {Object} env environment variables for the launching WDA process
    */
 
   /**
@@ -304,18 +304,15 @@ class WebDriverAgent {
    * When we implement launching XCTest service via appium-ios-device,
    * this implementation can be replaced with it.
    *
-   * @param {LaunchingEnvironmentOptions}  launchingEnv launching environment for WebDriverAgent.
+   * @param {launchWdaViaDeviceCtlOptions} opts launching WDA with devicectl command options.
    * @return {Promise<void>}
    */
 
-  async _launchWdaViaDeviceCtl(launchingEnv) {
+  async _launchWdaViaDeviceCtl(opts) {
     // FIXME: use appium-xcuitest-driver's Devicectl. Maybe it needs to be included in the `this.device`?
+    //
 
-    const envVar = {
-      // the port number must be string for the devicectl command.
-      USE_PORT: `${launchingEnv.USE_PORT}`,
-      WDA_PRODUCT_BUNDLE_IDENTIFIER: launchingEnv.WDA_PRODUCT_BUNDLE_IDENTIFIER
-    };
+    const {env} = opts;
 
     let xcrunBinnaryPath;
     try {
@@ -333,24 +330,28 @@ class WebDriverAgent {
       'process',
       'launch',
       `--device`, this.device.udid,
-      '--environment-variables', JSON.stringify(envVar),
+      '--environment-variables', JSON.stringify(_.mapValues(env, (v) => _.toString(v))),
       '--terminate-existing',
       this.bundleIdForXctest
     ]);
     this.log.debug(`The output of devicectl command: ${stdout}`);
 
+    const intervalTimeMs = 1000;
+    const maxRetry = this.wdaLaunchTimeout / intervalTimeMs;
+
     // Launching app via decictl does not wait for the app start.
     // We should wait for the app start by ourselves.
     try {
-      await retryInterval(30, 1000, async () => {
+      await retryInterval(maxRetry, intervalTimeMs, async () => {
         if (_.isNull(await this.getStatus())) {
           throw new Error();
         }
       });
     } catch (err) {
       throw new Error(
-        `Failed to start the preinstalled WebDriverAgent in ${30 * 1000} ms.` +
-        `The WebDriverAgent might not be properly built or the device might be locked.`
+        `Failed to start the preinstalled WebDriverAgent in ${this.wdaLaunchTimeout} ms. ` +
+        `The WebDriverAgent might not be properly built or the device might be locked. ` +
+        'appium:wdaLaunchTimeout capability modifies the timeout.'
       );
     }
   }
@@ -370,8 +371,11 @@ class WebDriverAgent {
     }
     this.log.info('Launching WebDriverAgent on the device without xcodebuild');
     if (this.isRealDevice) {
+      // Current method to launch WDA process can be done via 'xcrun devicectl',
+      // but it has limitation about the WDA preinstalled package.
+      // https://github.com/appium/appium/issues/19206#issuecomment-2014182674
       if (util.compareVersions(this.platformVersion, '>=', '17.0')) {
-        await this._launchWdaViaDeviceCtl(xctestEnv);
+        await this._launchWdaViaDeviceCtl({env: xctestEnv});
       } else {
         this.xctestApiClient = new Xctest(this.device.udid, this.bundleIdForXctest, null, {env: xctestEnv});
         await this.xctestApiClient.start();

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -186,7 +186,6 @@ class WebDriverAgent {
    * }
    *
    * @return {Promise<any?>} State Object
-   * @throws {Error} If there was invalid response code or body
    */
   async getStatus () {
     const noSessionProxy = new NoSessionProxy({
@@ -291,8 +290,8 @@ class WebDriverAgent {
 
 
   /**
-   * @typedef {Object} launchWdaViaDeviceCtlOptions
-   * @property {Record<string, string|number>} env environment variables for the launching WDA process
+   * @typedef {Object} LaunchWdaViaDeviceCtlOptions
+   * @property {Record<string, string|number>} [env] environment variables for the launching WDA process
    */
 
   /**
@@ -304,15 +303,15 @@ class WebDriverAgent {
    * When we implement launching XCTest service via appium-ios-device,
    * this implementation can be replaced with it.
    *
-   * @param {?launchWdaViaDeviceCtlOptions} opts launching WDA with devicectl command options.
+   * @param {LaunchWdaViaDeviceCtlOptions} [opts={}] launching WDA with devicectl command options.
    * @return {Promise<void>}
    */
 
-  async _launchWdaViaDeviceCtl(opts) {
+  async _launchWdaViaDeviceCtl(opts={}) {
     // FIXME: use appium-xcuitest-driver's Devicectl. Maybe it needs to be included in the `this.device`?
     //
 
-    const {env} = opts || {};
+    const {env} = opts;
 
     let xcrunBinnaryPath;
     try {
@@ -324,16 +323,22 @@ class WebDriverAgent {
       );
     }
 
-    const {stdout} = await exec(xcrunBinnaryPath, [
+    const cmd = [
       'devicectl',
       'device',
       'process',
       'launch',
       `--device`, this.device.udid,
-      '--environment-variables', JSON.stringify(_.mapValues(env, (v) => _.toString(v))),
-      '--terminate-existing',
-      this.bundleIdForXctest
-    ]);
+      '--terminate-existing'
+    ];
+
+    if (_.isEmpty(env)) {
+      cmd.push('--environment-variables', JSON.stringify(_.mapValues(env, (v) => _.toString(v))))
+    };
+
+    cmd.push(this.bundleIdForXctest);
+
+    const {stdout} = await exec(xcrunBinnaryPath, cmd);
     this.log.debug(`The output of devicectl command: ${stdout}`);
 
     // Launching app via decictl does not wait for the app start.


### PR DESCRIPTION
closes https://github.com/appium/appium/issues/19206#issuecomment-2014182674 

This method requires WDA package that DOES NOT have `Frameworks/XC**` in the WDA package.
The configuration is the same as what users can get via https://github.com/appium/WebDriverAgent/releases

With the XC***, the WDA app launches successfully but the app ends immediately because testmanagerd process fails to start. Potentially we can avoid this limitation when our appium-ios-device gets the new protocol, or 3rd party tools. (I haven't tested)


Tested with:

- `appium:usePreinstalledWDA`
- `appium:updatedWDABundleId`
- `appium:prebuiltWDAPath`

I'll update https://appium.github.io/appium-xcuitest-driver/latest/guides/run-preinstalled-wda/ page as well later.