### PR TITLE
chore: move node-simctl to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint-plugin-import": "^2.28.0",
     "eslint-plugin-mocha": "^10.1.0",
     "eslint-plugin-promise": "^6.1.1",
+    "node-simctl": "^7.0.1",
     "mocha": "^10.0.0",
     "prettier": "^3.0.0",
     "semantic-release": "^23.0.0",
@@ -91,7 +92,6 @@
     "axios": "^1.4.0",
     "bluebird": "^3.5.5",
     "lodash": "^4.17.11",
-    "node-simctl": "^7.0.1",
     "source-map-support": "^0.x",
     "teen_process": "^2.0.0"
   },


### PR DESCRIPTION
`simctl` usage in this repo is only via `this.device.simctl` in prod so the deps can move to dev deps I think

```
.github/workflows/functional-test.yml:        target_sim_id=$(xcrun simctl list devices available | grep "$DEVICE_NAME (" | cut -d "(" -f2 | cut -d ")" -f1)
.github/workflows/functional-test.yml:        xcrun simctl bootstatus $target_sim_id -b
lib/webdriveragent.js:      await this.device.simctl.exec('launch', {
lib/webdriveragent.js:          await this.device.simctl.terminateApp(this.bundleIdForXctest);
package.json:    "node-simctl": "^7.0.1",
test/functional/helpers/simulator.js:import Simctl from 'node-simctl';
test/functional/helpers/simulator.js:  const simctl = new Simctl();
test/functional/helpers/simulator.js:  const allDevices = _.flatMap(_.values(await simctl.getDevices()));
test/functional/helpers/simulator.js:    simctl.udid = udid;
test/functional/helpers/simulator.js:    await simctl.shutdownDevice();
test/functional/helpers/simulator.js:  const simctl = new Simctl({udid});
test/functional/helpers/simulator.js:    await retryInterval(10, 1000, simctl.deleteDevice.bind(simctl));
test/functional/webdriveragent-e2e-specs.js:import Simctl from 'node-simctl';
test/functional/webdriveragent-e2e-specs.js:    let simctl;
test/functional/webdriveragent-e2e-specs.js:      simctl = new Simctl();
test/functional/webdriveragent-e2e-specs.js:      simctl.udid = await simctl.createDevice(
test/functional/webdriveragent-e2e-specs.js:      device = await getSimulator(simctl.udid);
test/functional/webdriveragent-e2e-specs.js:      await simctl.deleteDevice();
```