### PR TITLE
feat: launch WDA via devicectl object

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -310,8 +310,7 @@ class WebDriverAgent {
     const {env} = opts;
 
     this.device.devicectl.launchApp({
-      // @ts-ignore
-      bundleId: this.bundleIdForXctest,  env, terminateExisting: true,
+      bundleId: this.bundleIdForXctest, env, terminateExisting: true,
     });
 
     // Launching app via decictl does not wait for the app start.

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -307,36 +307,12 @@ class WebDriverAgent {
    * @return {Promise<void>}
    */
   async _launchViaDevicectl(opts = {}) {
-    // FIXME: use appium-xcuitest-driver's Devicectl. Maybe it needs to be included in the `this.device`?
-    //
-
     const {env} = opts;
 
-    let xcrunBinnaryPath;
-    try {
-      xcrunBinnaryPath = await fs.which('xcrun');
-    } catch (e) {
-      throw new Error(
-        `xcrun has not been found in PATH. ` +
-          `Please make sure XCode development tools are installed`,
-      );
-    }
-
-    const cmd = [
-      'devicectl',
-      'device',
-      'process',
-      'launch',
-      `--device`, this.device.udid,
-      '--terminate-existing'
-    ];
-    if (!_.isEmpty(env)) {
-      cmd.push('--environment-variables', JSON.stringify(_.mapValues(env, (v) => _.toString(v))));
-    };
-    cmd.push(this.bundleIdForXctest);
-
-    const {stdout} = await exec(xcrunBinnaryPath, cmd);
-    this.log.debug(`The output of devicectl command: ${stdout}`);
+    this.device.devicectl.launchApp({
+      // @ts-ignore
+      bundleId: this.bundleIdForXctest,  env, terminateExisting: true,
+    });
 
     // Launching app via decictl does not wait for the app start.
     // We should wait for the app start by ourselves.

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -325,7 +325,7 @@ class WebDriverAgent {
       throw new Error(
         `Failed to start the preinstalled WebDriverAgent in ${this.wdaLaunchTimeout} ms. ` +
         `The WebDriverAgent might not be properly built or the device might be locked. ` +
-        'appium:wdaLaunchTimeout capability modifies the timeout.'
+        `The 'appium:wdaLaunchTimeout' capability modifies the timeout.`
       );
     }
   }

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -309,7 +309,7 @@ class WebDriverAgent {
   async _launchViaDevicectl(opts = {}) {
     const {env} = opts;
 
-    this.device.devicectl.launchApp({
+    await this.device.devicectl.launchApp({
       bundleId: this.bundleIdForXctest, env, terminateExisting: true,
     });
 


### PR DESCRIPTION
BREAKING CHANGE: calls launch app process command with devicectl via this.device.devicectl.


This change will require https://github.com/appium/appium-xcuitest-driver/pull/2354.

After merging this, this lib will bump the major version. Then the xcuitest driver should bump the wda deps with the expected major version.