### PR TITLE
chore: use bundle id outside opts for this.device.devicectl.launchApp

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -309,9 +309,9 @@ class WebDriverAgent {
   async _launchViaDevicectl(opts = {}) {
     const {env} = opts;
 
-    await this.device.devicectl.launchApp({
-      bundleId: this.bundleIdForXctest, env, terminateExisting: true,
-    });
+    await this.device.devicectl.launchApp(
+      this.bundleIdForXctest, { env, terminateExisting: true }
+    );
 
     // Launching app via decictl does not wait for the app start.
     // We should wait for the app start by ourselves.


### PR DESCRIPTION
To reflect https://github.com/appium/appium-xcuitest-driver/pull/2354

Tested with a real device that affects this change.