### PR TITLE
chore: wait for wda start in sim as well for preinstalled wda start

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -334,8 +334,6 @@ class WebDriverAgent {
     }
 
     const waitForWdaStart = async () => {
-      // Launching app via decictl does not wait for the app start.
-      // We should wait for the app start by ourselves.
       try {
         await waitForCondition(async () => !_.isNull(await this.getStatus()), {
           waitMs: this.wdaLaunchTimeout,

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -1,4 +1,4 @@
-import { waitForCondition } from 'asyncbox';
+import { retryInterval } from 'asyncbox';
 import _ from 'lodash';
 import path from 'path';
 import url from 'url';
@@ -190,9 +190,12 @@ class WebDriverAgent {
    *   }
    * }
    *
+   * @param {number} [timeoutMs=0] If the given timeoutMs is zero or negative number,
+   * this function will return the response of `/status` immediately. If the given timeoutMs,
+   * this function will try to get the response of `/status` up to the timeoutMs.
    * @return {Promise<any?>} State Object
    */
-  async getStatus () {
+  async getStatus (timeoutMs = 0) {
     const noSessionProxy = new NoSessionProxy({
       server: this.url.hostname,
       port: this.url.port,
@@ -200,7 +203,15 @@ class WebDriverAgent {
       timeout: 3000,
     });
     try {
-      return await noSessionProxy.command('/status', 'GET');
+      if (timeoutMs <= 0) {
+        return await noSessionProxy.command('/status', 'GET');
+      }
+
+      return await retryInterval(
+        timeoutMs / 300,
+        300,
+        async () => await noSessionProxy.command('/status', 'GET')
+      );
     } catch (err) {
       this.log.debug(`WDA is not listening at '${this.url.href}'`);
       return null;
@@ -333,21 +344,6 @@ class WebDriverAgent {
       xctestEnv.MJPEG_SERVER_PORT = this.mjpegServerPort;
     }
 
-    const waitForWdaStart = async () => {
-      try {
-        await waitForCondition(async () => !_.isNull(await this.getStatus()), {
-          waitMs: this.wdaLaunchTimeout,
-          intervalMs: 300,
-        });
-      } catch (err) {
-        throw new Error(
-          `Failed to start the preinstalled WebDriverAgent in ${this.wdaLaunchTimeout} ms. ` +
-          `The WebDriverAgent might not be properly built or the device might be locked. ` +
-          `The 'appium:wdaLaunchTimeout' capability modifies the timeout.`
-        );
-      }
-    };
-
     this.log.info('Launching WebDriverAgent on the device without xcodebuild');
     if (this.isRealDevice) {
       // Current method to launch WDA process can be done via 'xcrun devicectl',
@@ -370,9 +366,15 @@ class WebDriverAgent {
       });
     }
 
-    await waitForWdaStart();
     this.setupProxies(sessionId);
-    const status = await this.getStatus();
+    const status = await this.getStatus(this.wdaLaunchTimeout);
+    if (!status) {
+      throw new Error(
+        `Failed to start the preinstalled WebDriverAgent in ${this.wdaLaunchTimeout} ms. ` +
+        `The WebDriverAgent might not be properly built or the device might be locked. ` +
+        `The 'appium:wdaLaunchTimeout' capability modifies the timeout.`
+      );
+    }
     this.started = true;
     return status;
   }

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -233,7 +233,7 @@ class WebDriverAgent {
       });
     } catch (err) {
       this.log.debug(`Failed to get the status endpoint in ${timeoutMs} ms. ` +
-        `The last error by ${this.url.href} was ${lastError}. Original error:: ${err.message}.`);
+        `The last error while accessing ${this.url.href}: ${lastError}. Original error:: ${err.message}.`);
       throw new Error(`WDA was not ready in ${timeoutMs} ms.`);
     }
     return status;

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -317,7 +317,14 @@ class WebDriverAgent {
     await this.device.devicectl.launchApp(
       this.bundleIdForXctest, { env, terminateExisting: true }
     );
+    await this.waitForWdaStartForPreinstallWda();
+  }
 
+  /**
+   * Wait for the WebDriverAgent process start by checking the `/status`
+   * endpoint response up to this.wdaLaunchTimeout ms.
+   */
+  async waitForWdaStartForPreinstallWda() {
     // Launching app via decictl does not wait for the app start.
     // We should wait for the app start by ourselves.
     try {
@@ -368,6 +375,7 @@ class WebDriverAgent {
         ],
         env: xctestEnv,
       });
+      await this.waitForWdaStartForPreinstallWda();
     }
 
     this.setupProxies(sessionId);

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -1,4 +1,4 @@
-import { retryInterval } from 'asyncbox';
+import { waitForCondition } from 'asyncbox';
 import _ from 'lodash';
 import path from 'path';
 import url from 'url';
@@ -191,9 +191,11 @@ class WebDriverAgent {
    * }
    *
    * @param {number} [timeoutMs=0] If the given timeoutMs is zero or negative number,
-   * this function will return the response of `/status` immediately. If the given timeoutMs,
-   * this function will try to get the response of `/status` up to the timeoutMs.
-   * @return {Promise<any?>} State Object
+   *                               this function will return the response of `/status` immediately. If the given timeoutMs,
+   *                               this function will try to get the response of `/status` up to the timeoutMs.
+   * @return {Promise<import('@appium/types').StringRecord|null>} State Object
+   * @throws {Error} If there was an error within timeoutMs timeout.
+   *                 No error is raised if zero or negative number for the timeoutMs.
    */
   async getStatus (timeoutMs = 0) {
     const noSessionProxy = new NoSessionProxy({
@@ -202,20 +204,43 @@ class WebDriverAgent {
       base: this.basePath,
       timeout: 3000,
     });
-    try {
-      if (timeoutMs <= 0) {
-        return await noSessionProxy.command('/status', 'GET');
-      }
 
-      return await retryInterval(
-        timeoutMs / 300,
-        300,
-        async () => await noSessionProxy.command('/status', 'GET')
-      );
-    } catch (err) {
-      this.log.debug(`WDA is not listening at '${this.url.href}'`);
-      return null;
+    const getStatus = async () => await /** @type import('@appium/types').StringRecord */ (noSessionProxy.command('/status', 'GET'));
+
+    if (_.isNull(timeoutMs) || timeoutMs <= 0) {
+      try {
+        return await getStatus();
+      } catch (err) {
+        this.log.debug(`WDA is not listening at '${this.url.href}'`);
+        return null;
+      }
     }
+
+    let status = null;
+    let lastError = null;
+    await waitForCondition(async () => {
+      try {
+        status = await getStatus();
+        return true;
+      } catch (err) {
+        lastError = err;
+        return false;
+      }
+    }, {
+      waitMs: this.wdaLaunchTimeout,
+      intervalMs: 300,
+    });
+
+    if (status) {
+      return status;
+    }
+
+    if (lastError) {
+      this.log.debug(`WDA is not listening at '${this.url.href}'`);
+      throw lastError;
+    }
+
+    return null;
   }
 
   /**
@@ -333,7 +358,9 @@ class WebDriverAgent {
   /**
    * Launch WDA with preinstalled package without xcodebuild.
    * @param {string} sessionId Launch WDA and establish the session with this sessionId
-   * @return {Promise<any?>} State Object
+   * @return {Promise<import('@appium/types').StringRecord|null>} State Object
+   * @throws {Error} If there was an error within timeoutMs timeout.
+   *                 No error is raised if zero or negative number for the timeoutMs.
    */
   async launchWithPreinstalledWDA(sessionId) {
     const xctestEnv = {
@@ -366,8 +393,11 @@ class WebDriverAgent {
     }
 
     this.setupProxies(sessionId);
-    const status = await this.getStatus(this.wdaLaunchTimeout);
-    if (!status) {
+    let status;
+    try {
+      status = await this.getStatus(this.wdaLaunchTimeout);
+    } catch (err) {
+      this.log.debug(`Failed to get the status. Error ${err.message}`);
       throw new Error(
         `Failed to start the preinstalled WebDriverAgent in ${this.wdaLaunchTimeout} ms. ` +
         `The WebDriverAgent might not be properly built or the device might be locked. ` +

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -339,7 +339,6 @@ class WebDriverAgent {
           waitMs: this.wdaLaunchTimeout,
           intervalMs: 300,
         });
-
       } catch (err) {
         throw new Error(
           `Failed to start the preinstalled WebDriverAgent in ${this.wdaLaunchTimeout} ms. ` +

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -207,7 +207,7 @@ class WebDriverAgent {
 
     const getStatus = async () => await /** @type import('@appium/types').StringRecord */ (noSessionProxy.command('/status', 'GET'));
 
-    if (_.isNull(timeoutMs) || timeoutMs <= 0) {
+    if (_.isNil(timeoutMs) || timeoutMs <= 0) {
       try {
         return await getStatus();
       } catch (err) {
@@ -218,25 +218,28 @@ class WebDriverAgent {
 
     let status = null;
     let lastError = null;
-    await waitForCondition(async () => {
-      try {
-        status = await getStatus();
-        return true;
-      } catch (err) {
-        lastError = err;
-        return false;
-      }
-    }, {
-      waitMs: this.wdaLaunchTimeout,
-      intervalMs: 300,
-    });
+    try {
+      await waitForCondition(async () => {
+        try {
+          status = await getStatus();
+          return true;
+        } catch (err) {
+          lastError = err;
+          return false;
+        }
+      }, {
+        waitMs: timeoutMs,
+        intervalMs: 300,
+      });
+    } catch (err) {
+      throw new Error(`WDA was not ready in ${timeoutMs} ms`);
+    }
 
     if (status) {
       return status;
     }
 
     if (lastError) {
-      this.log.debug(`WDA is not listening at '${this.url.href}'`);
       throw lastError;
     }
 
@@ -397,7 +400,6 @@ class WebDriverAgent {
     try {
       status = await this.getStatus(this.wdaLaunchTimeout);
     } catch (err) {
-      this.log.debug(`Failed to get the status. Error ${err.message}`);
       throw new Error(
         `Failed to start the preinstalled WebDriverAgent in ${this.wdaLaunchTimeout} ms. ` +
         `The WebDriverAgent might not be properly built or the device might be locked. ` +

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -343,7 +343,6 @@ class WebDriverAgent {
     if (this.mjpegServerPort) {
       xctestEnv.MJPEG_SERVER_PORT = this.mjpegServerPort;
     }
-
     this.log.info('Launching WebDriverAgent on the device without xcodebuild');
     if (this.isRealDevice) {
       // Current method to launch WDA process can be done via 'xcrun devicectl',

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -205,30 +205,35 @@ class WebDriverAgent {
       timeout: 3000,
     });
 
-    const getStatus = async () => await /** @type import('@appium/types').StringRecord */ (noSessionProxy.command('/status', 'GET'));
+    const sendGetStatus = async () => await /** @type import('@appium/types').StringRecord */ (noSessionProxy.command('/status', 'GET'));
 
     if (_.isNil(timeoutMs) || timeoutMs <= 0) {
       try {
-        return await getStatus();
+        return await sendGetStatus();
       } catch (err) {
         this.log.debug(`WDA is not listening at '${this.url.href}'`);
         return null;
       }
     }
 
+    let lastError = null;
     let status = null;
     try {
       await waitForCondition(async () => {
         try {
-          status = await getStatus();
+          status = await sendGetStatus();
           return true;
-        } catch (ign) {}
+        } catch (err) {
+          lastError = err;
+        }
         return false;
       }, {
         waitMs: timeoutMs,
         intervalMs: 300,
       });
-    } catch (ign) {
+    } catch (err) {
+      this.log.debug(`Failed to get the status endpoint in ${timeoutMs} ms. ` +
+        `The last error was ${lastError}. Error: ${err.message}.`);
       throw new Error(`WDA was not ready in ${timeoutMs} ms.`);
     }
     return status;

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -217,33 +217,21 @@ class WebDriverAgent {
     }
 
     let status = null;
-    let lastError = null;
     try {
       await waitForCondition(async () => {
         try {
           status = await getStatus();
           return true;
-        } catch (err) {
-          lastError = err;
-          return false;
-        }
+        } catch (ign) {}
+        return false;
       }, {
         waitMs: timeoutMs,
         intervalMs: 300,
       });
-    } catch (err) {
-      throw new Error(`WDA was not ready in ${timeoutMs} ms`);
+    } catch (ign) {
+      throw new Error(`WDA was not ready in ${timeoutMs} ms.`);
     }
-
-    if (status) {
-      return status;
-    }
-
-    if (lastError) {
-      throw lastError;
-    }
-
-    return null;
+    return status;
   }
 
   /**

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -211,7 +211,7 @@ class WebDriverAgent {
       try {
         return await sendGetStatus();
       } catch (err) {
-        this.log.debug(`WDA is not listening at '${this.url.href}'`);
+        this.log.debug(`WDA is not listening at '${this.url.href}'. Original error:: ${err.message}`);
         return null;
       }
     }
@@ -233,7 +233,7 @@ class WebDriverAgent {
       });
     } catch (err) {
       this.log.debug(`Failed to get the status endpoint in ${timeoutMs} ms. ` +
-        `The last error was ${lastError}. Error: ${err.message}.`);
+        `The last error by ${this.url.href} was ${lastError}. Original error:: ${err.message}.`);
       throw new Error(`WDA was not ready in ${timeoutMs} ms.`);
     }
     return status;

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -317,29 +317,6 @@ class WebDriverAgent {
     await this.device.devicectl.launchApp(
       this.bundleIdForXctest, { env, terminateExisting: true }
     );
-    await this.waitForWdaStartForPreinstallWda();
-  }
-
-  /**
-   * Wait for the WebDriverAgent process start by checking the `/status`
-   * endpoint response up to this.wdaLaunchTimeout ms.
-   */
-  async waitForWdaStartForPreinstallWda() {
-    // Launching app via decictl does not wait for the app start.
-    // We should wait for the app start by ourselves.
-    try {
-      await waitForCondition(async () => !_.isNull(await this.getStatus()), {
-        waitMs: this.wdaLaunchTimeout,
-        intervalMs: 300,
-      });
-
-    } catch (err) {
-      throw new Error(
-        `Failed to start the preinstalled WebDriverAgent in ${this.wdaLaunchTimeout} ms. ` +
-        `The WebDriverAgent might not be properly built or the device might be locked. ` +
-        `The 'appium:wdaLaunchTimeout' capability modifies the timeout.`
-      );
-    }
   }
 
   /**
@@ -355,6 +332,25 @@ class WebDriverAgent {
     if (this.mjpegServerPort) {
       xctestEnv.MJPEG_SERVER_PORT = this.mjpegServerPort;
     }
+
+    const waitForWdaStart = async () => {
+      // Launching app via decictl does not wait for the app start.
+      // We should wait for the app start by ourselves.
+      try {
+        await waitForCondition(async () => !_.isNull(await this.getStatus()), {
+          waitMs: this.wdaLaunchTimeout,
+          intervalMs: 300,
+        });
+
+      } catch (err) {
+        throw new Error(
+          `Failed to start the preinstalled WebDriverAgent in ${this.wdaLaunchTimeout} ms. ` +
+          `The WebDriverAgent might not be properly built or the device might be locked. ` +
+          `The 'appium:wdaLaunchTimeout' capability modifies the timeout.`
+        );
+      }
+    };
+
     this.log.info('Launching WebDriverAgent on the device without xcodebuild');
     if (this.isRealDevice) {
       // Current method to launch WDA process can be done via 'xcrun devicectl',
@@ -375,9 +371,9 @@ class WebDriverAgent {
         ],
         env: xctestEnv,
       });
-      await this.waitForWdaStartForPreinstallWda();
     }
 
+    await waitForWdaStart();
     this.setupProxies(sessionId);
     const status = await this.getStatus();
     this.started = true;


### PR DESCRIPTION
On my local. simulators also needed a bit time to start the wda process with `usePreinstalledWDA`

```
caps = {
  "automationName": "xcuitest",
  "platformName": "ios",
  "platformVersion": "17.2",
  "deviceName": "iPhone 15",
  "appium:usePreinstalledWDA": true,
  "appium:updatedWDABundleId": "com.kazucocoa.WebDriverAgentRunner"
}
```

I think it's reasonable to add wait for wda process start in both...