### PR TITLE
feat: Add a capability to customize the default  state change timeout on app startup

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -156,11 +156,11 @@
         if (app.running) {
           [app terminate];
         }
-        id<FBResponsePayload> response = [self openDeepLink:initialUrl
-                                            withApplication:bundleID
-                                                    timeout:capabilities[FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC]];
-        if (nil != response) {
-          return response;
+        id<FBResponsePayload> errorResponse = [self openDeepLink:initialUrl
+                                                 withApplication:bundleID
+                                                         timeout:capabilities[FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC]];
+        if (nil != errorResponse) {
+          return errorResponse;
         }
       } else {
         NSTimeInterval defaultTimeout = _XCTApplicationStateTimeout();
@@ -184,11 +184,11 @@
       }
     } else if (appState == XCUIApplicationStateRunningBackground && !forceAppLaunch) {
       if (nil != initialUrl) {
-        id<FBResponsePayload> response = [self openDeepLink:initialUrl
-                                            withApplication:bundleID
-                                                    timeout:nil];
-        if (nil != response) {
-          return response;
+        id<FBResponsePayload> errorResponse = [self openDeepLink:initialUrl
+                                                 withApplication:bundleID
+                                                         timeout:nil];
+        if (nil != errorResponse) {
+          return errorResponse;
         }
       } else {
         [app activate];
@@ -197,11 +197,11 @@
   }
 
   if (nil != initialUrl && nil == bundleID) {
-    NSError *openError;
-    if (![XCUIDevice.sharedDevice fb_openUrl:initialUrl error:&openError]) {
-      NSString *errorMsg = [NSString stringWithFormat:@"Cannot open the URL %@. Original error: %@",
-                            initialUrl, openError.localizedDescription];
-      return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:errorMsg traceback:nil]);
+    id<FBResponsePayload> errorResponse = [self openDeepLink:initialUrl
+                                             withApplication:nil
+                                                     timeout:capabilities[FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC]];
+    if (nil != errorResponse) {
+      return errorResponse;
     }
   }
 
@@ -516,7 +516,7 @@
       return nil;
     }
     NSString *errorMsg = [NSString stringWithFormat:@"Cannot open the URL %@ with the %@ application. Original error: %@",
-                          initialUrl, bundleID, openError.localizedDescription];
+                          initialUrl, bundleID ?: @"default", openError.localizedDescription];
     return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:errorMsg traceback:nil]);
   } @finally {
     if (nil != timeout) {

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -156,19 +156,25 @@
         if (app.running) {
           [app terminate];
         }
-        NSError *openError;
-        if (![XCUIDevice.sharedDevice fb_openUrl:initialUrl
-                                 withApplication:bundleID
-                                           error:&openError]) {
-          NSString *errorMsg = [NSString stringWithFormat:@"Cannot open the URL %@ with the %@ application. Original error: %@",
-                                initialUrl, bundleID, openError.localizedDescription];
-          return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:errorMsg traceback:nil]);
+        id<FBResponsePayload> response = [self openDeepLink:initialUrl
+                                            withApplication:bundleID
+                                                    timeout:capabilities[FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC]];
+        if (nil != response) {
+          return response;
         }
       } else {
+        NSTimeInterval defaultTimeout = _XCTApplicationStateTimeout();
+        if (nil != capabilities[FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC]) {
+          _XCTSetApplicationStateTimeout([capabilities[FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC] doubleValue]);
+        }
         @try {
           [app launch];
         } @catch (NSException *e) {
           return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:e.reason traceback:nil]);
+        } @finally {
+          if (nil != capabilities[FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC]) {
+            _XCTSetApplicationStateTimeout(defaultTimeout);
+          }
         }
       }
       if (!app.running) {
@@ -178,13 +184,11 @@
       }
     } else if (appState == XCUIApplicationStateRunningBackground && !forceAppLaunch) {
       if (nil != initialUrl) {
-        NSError *openError;
-        if (![XCUIDevice.sharedDevice fb_openUrl:initialUrl
-                                 withApplication:bundleID
-                                           error:&openError]) {
-          NSString *errorMsg = [NSString stringWithFormat:@"Cannot open the URL %@ with the %@ application. Original error: %@",
-                                initialUrl, bundleID, openError.localizedDescription];
-          return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:errorMsg traceback:nil]);
+        id<FBResponsePayload> response = [self openDeepLink:initialUrl
+                                            withApplication:bundleID
+                                                    timeout:nil];
+        if (nil != response) {
+          return response;
         }
       } else {
         [app activate];
@@ -490,6 +494,35 @@
     @"device": [self.class deviceNameByUserInterfaceIdiom:[UIDevice currentDevice].userInterfaceIdiom],
     @"sdkVersion": [[UIDevice currentDevice] systemVersion]
   };
+}
+
++(nullable id<FBResponsePayload>)openDeepLink:(NSString *)initialUrl
+                              withApplication:(nullable NSString *)bundleID
+                                      timeout:(nullable NSNumber *)timeout
+{
+  NSError *openError;
+  NSTimeInterval defaultTimeout = _XCTApplicationStateTimeout();
+  if (nil != timeout) {
+    _XCTSetApplicationStateTimeout([timeout doubleValue]);
+  }
+  @try {
+    BOOL result = nil == bundleID
+      ? [XCUIDevice.sharedDevice fb_openUrl:initialUrl
+                                      error:&openError]
+      : [XCUIDevice.sharedDevice fb_openUrl:initialUrl
+                            withApplication:(id)bundleID
+                                      error:&openError];
+    if (result) {
+      return nil;
+    }
+    NSString *errorMsg = [NSString stringWithFormat:@"Cannot open the URL %@ with the %@ application. Original error: %@",
+                          initialUrl, bundleID, openError.localizedDescription];
+    return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:errorMsg traceback:nil]);
+  } @finally {
+    if (nil != timeout) {
+      _XCTSetApplicationStateTimeout(defaultTimeout);
+    }
+  }
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBCapabilities.h
+++ b/WebDriverAgentLib/Utilities/FBCapabilities.h
@@ -11,7 +11,7 @@
 
 /** Whether to use alternative elements visivility detection method */
 extern NSString* const FB_CAP_USE_TEST_MANAGER_FOR_VISIBLITY_DETECTION;
-/** Set the maximum amount of charatcers that could be typed within a minute (60 by default) */
+/** Set the maximum amount of characters that could be typed within a minute (60 by default) */
 extern NSString* const FB_CAP_MAX_TYPING_FREQUENCY;
 /** this setting was needed for some legacy stuff */
 extern NSString* const FB_CAP_USE_SINGLETON_TEST_MANAGER;
@@ -42,3 +42,5 @@ extern NSString* const FB_CAP_ENVIRNOMENT;
 extern NSString* const FB_CAP_USE_NATIVE_CACHING_STRATEGY;
 /** Whether to enforce software keyboard presence on simulator */
 extern NSString* const FB_CAP_FORCE_SIMULATOR_SOFTWARE_KEYBOARD_PRESENCE;
+/** Sets the application state change timeout for the initial app startup */
+extern NSString* const FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC;

--- a/WebDriverAgentLib/Utilities/FBCapabilities.m
+++ b/WebDriverAgentLib/Utilities/FBCapabilities.m
@@ -23,3 +23,4 @@ NSString* const FB_CAP_ARGUMENTS = @"arguments";
 NSString* const FB_CAP_ENVIRNOMENT = @"environment";
 NSString* const FB_CAP_USE_NATIVE_CACHING_STRATEGY = @"useNativeCachingStrategy";
 NSString* const FB_CAP_FORCE_SIMULATOR_SOFTWARE_KEYBOARD_PRESENCE = @"forceSimulatorSoftwareKeyboardPresence";
+NSString* const FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC = @"appLaunchStateTimeoutSec";


### PR DESCRIPTION
Sometimes I can observe apps that take really long to start or cannot start at all because of the fact they block the main thread, so it is not idling, thus preventing XCTest from interacting with it. The default XCTest timeout for app state change is 60 seconds, although we should be able to reduce it and fail the session startup earlier if we have such app.