### PR TITLE
feat: add system screen size/width in the system info endpoint

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -139,7 +139,7 @@
   XCUIApplication *app = XCUIApplication.fb_systemApplication;
 
   XCUIElement *mainStatusBar = app.statusBars.allElementsBoundByIndex.firstObject;
-  CGSize statusBarSize =  (nil == mainStatusBar) ? CGSizeZero : mainStatusBar.frame.size;
+  CGSize statusBarSize = (nil == mainStatusBar) ? CGSizeZero : mainStatusBar.frame.size;
 
 #if TARGET_OS_TV
   CGSize screenSize = app.frame.size;

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -144,7 +144,7 @@
   CGSize screenSize = FBAdjustDimensionsForApplication(frame.size, app.interfaceOrientation);
 #endif
 
-  CGSize statusBarSize = [FBScreen statusBarSizeForApplication];
+  CGSize statusBarSize = [FBScreen statusBarSize];
   return FBResponseWithObject(
                               @{
     @"screenSize":@{@"width": @(screenSize.width),

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -137,6 +137,9 @@
 + (id<FBResponsePayload>)handleGetScreen:(FBRouteRequest *)request
 {
   XCUIApplication *app = XCUIApplication.fb_systemApplication;
+
+  CGSize statusBarSize = app.statusBars.allElementsBoundByIndex.firstObject.frame.size;
+
 #if TARGET_OS_TV
   CGSize screenSize = app.frame.size;
 #else
@@ -144,7 +147,6 @@
   CGSize screenSize = FBAdjustDimensionsForApplication(frame.size, app.interfaceOrientation);
 #endif
 
-  CGSize statusBarSize = [FBScreen statusBarSize];
   return FBResponseWithObject(
                               @{
     @"screenSize":@{@"width": @(screenSize.width),

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -15,6 +15,7 @@
 #import "FBConfiguration.h"
 #import "FBKeyboard.h"
 #import "FBNotificationsHelper.h"
+#import "FBMathUtils.h"
 #import "FBPasteboard.h"
 #import "FBResponsePayload.h"
 #import "FBRoute.h"
@@ -48,6 +49,7 @@
     [[FBRoute GET:@"/wda/locked"].withoutSession respondWithTarget:self action:@selector(handleIsLocked:)],
     [[FBRoute GET:@"/wda/locked"] respondWithTarget:self action:@selector(handleIsLocked:)],
     [[FBRoute GET:@"/wda/screen"] respondWithTarget:self action:@selector(handleGetScreen:)],
+    [[FBRoute GET:@"/wda/screen"].withoutSession respondWithTarget:self action:@selector(handleGetScreen:)],
     [[FBRoute GET:@"/wda/activeAppInfo"] respondWithTarget:self action:@selector(handleActiveAppInfo:)],
     [[FBRoute GET:@"/wda/activeAppInfo"].withoutSession respondWithTarget:self action:@selector(handleActiveAppInfo:)],
 #if !TARGET_OS_TV // tvOS does not provide relevant APIs
@@ -134,10 +136,20 @@
 
 + (id<FBResponsePayload>)handleGetScreen:(FBRouteRequest *)request
 {
-  FBSession *session = request.session;
-  CGSize statusBarSize = [FBScreen statusBarSizeForApplication:session.activeApplication];
+  XCUIApplication *app = XCUIApplication.fb_systemApplication;
+  CGSize statusBarSize = [FBScreen statusBarSizeForApplication];
+
+#if TARGET_OS_TV
+  CGSize screenSize = app.frame.size;
+#else
+  CGRect frame = app.wdFrame;
+  CGSize screenSize = FBAdjustDimensionsForApplication(frame.size, app.interfaceOrientation);
+#endif
   return FBResponseWithObject(
                               @{
+    @"screenSize":@{@"width": @(screenSize.width),
+                    @"height": @(screenSize.height)
+    },
     @"statusBarSize": @{@"width": @(statusBarSize.width),
                         @"height": @(statusBarSize.height),
     },

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -144,8 +144,7 @@
 #if TARGET_OS_TV
   CGSize screenSize = app.frame.size;
 #else
-  CGRect frame = app.wdFrame;
-  CGSize screenSize = FBAdjustDimensionsForApplication(frame.size, app.interfaceOrientation);
+  CGSize screenSize = FBAdjustDimensionsForApplication(app.wdFrame.size, app.interfaceOrientation);
 #endif
 
   return FBResponseWithObject(

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -137,14 +137,14 @@
 + (id<FBResponsePayload>)handleGetScreen:(FBRouteRequest *)request
 {
   XCUIApplication *app = XCUIApplication.fb_systemApplication;
-  CGSize statusBarSize = [FBScreen statusBarSizeForApplication];
-
 #if TARGET_OS_TV
   CGSize screenSize = app.frame.size;
 #else
   CGRect frame = app.wdFrame;
   CGSize screenSize = FBAdjustDimensionsForApplication(frame.size, app.interfaceOrientation);
 #endif
+
+  CGSize statusBarSize = [FBScreen statusBarSizeForApplication];
   return FBResponseWithObject(
                               @{
     @"screenSize":@{@"width": @(screenSize.width),

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -138,7 +138,8 @@
 {
   XCUIApplication *app = XCUIApplication.fb_systemApplication;
 
-  CGSize statusBarSize = app.statusBars.allElementsBoundByIndex.firstObject.frame.size;
+  XCUIElement *mainStatusBar = app.statusBars.allElementsBoundByIndex.firstObject;
+  CGSize statusBarSize =  (nil == mainStatusBar) ? CGSizeZero : mainStatusBar.frame.size;
 
 #if TARGET_OS_TV
   CGSize screenSize = app.frame.size;

--- a/WebDriverAgentLib/Utilities/FBScreen.h
+++ b/WebDriverAgentLib/Utilities/FBScreen.h
@@ -18,11 +18,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (double)scale;
 
-/**
- The absolute size of application's status bar or CGSizeZero if it's hidden or does not exist
- */
-+ (CGSize)statusBarSize;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBScreen.h
+++ b/WebDriverAgentLib/Utilities/FBScreen.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The absolute size of application's status bar or CGSizeZero if it's hidden or does not exist
  */
-+ (CGSize)statusBarSizeForApplication:(XCUIApplication *)application;
++ (CGSize)statusBarSizeForApplication;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBScreen.h
+++ b/WebDriverAgentLib/Utilities/FBScreen.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The absolute size of application's status bar or CGSizeZero if it's hidden or does not exist
  */
-+ (CGSize)statusBarSizeForApplication;
++ (CGSize)statusBarSize;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBScreen.m
+++ b/WebDriverAgentLib/Utilities/FBScreen.m
@@ -19,17 +19,13 @@
   return [XCUIScreen.mainScreen scale];
 }
 
-+ (CGSize)statusBarSizeForApplication
++ (CGSize)statusBarSize
 {
-  XCUIApplication *app = XCUIApplication.fb_systemApplication;
-  // Since iOS 13 the status bar is no longer part of the application, it’s part of the SpringBoard
-  XCUIElement *mainStatusBar = app.statusBars.allElementsBoundByIndex.firstObject;
+  XCUIElement *mainStatusBar = XCUIApplication.fb_systemApplication.statusBars.allElementsBoundByIndex.firstObject;
   if (nil == mainStatusBar) {
     return CGSizeZero;
   }
-  CGSize result = mainStatusBar.frame.size;
-  // Workaround for https://github.com/appium/appium/issues/15961
-  return CGSizeMake(MAX(result.width, result.height), MIN(result.width, result.height));
+  return mainStatusBar.frame.size;
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBScreen.m
+++ b/WebDriverAgentLib/Utilities/FBScreen.m
@@ -19,7 +19,7 @@
   return [XCUIScreen.mainScreen scale];
 }
 
-+ (CGSize)statusBarSizeForApplication:(XCUIApplication *)application
++ (CGSize)statusBarSizeForApplication
 {
   XCUIApplication *app = XCUIApplication.fb_systemApplication;
   // Since iOS 13 the status bar is no longer part of the application, it’s part of the SpringBoard

--- a/WebDriverAgentLib/Utilities/FBScreen.m
+++ b/WebDriverAgentLib/Utilities/FBScreen.m
@@ -19,13 +19,4 @@
   return [XCUIScreen.mainScreen scale];
 }
 
-+ (CGSize)statusBarSize
-{
-  XCUIElement *mainStatusBar = XCUIApplication.fb_systemApplication.statusBars.allElementsBoundByIndex.firstObject;
-  if (nil == mainStatusBar) {
-    return CGSizeZero;
-  }
-  return mainStatusBar.frame.size;
-}
-
 @end

--- a/WebDriverAgentTests/IntegrationTests/FBScreenTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBScreenTests.m
@@ -30,7 +30,7 @@
 
 - (void)testStatusBarSize
 {
-  CGSize statusBarSize = [FBScreen statusBarSizeForApplication];
+  CGSize statusBarSize = [FBScreen statusBarSize];
   BOOL statusBarSizeIsZero = CGSizeEqualToSize(CGSizeZero, statusBarSize);
   XCTAssertFalse(statusBarSizeIsZero);
 }

--- a/WebDriverAgentTests/IntegrationTests/FBScreenTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBScreenTests.m
@@ -28,12 +28,5 @@
   XCTAssertTrue([FBScreen scale] >= 2);
 }
 
-- (void)testStatusBarSize
-{
-  CGSize statusBarSize = [FBScreen statusBarSize];
-  BOOL statusBarSizeIsZero = CGSizeEqualToSize(CGSizeZero, statusBarSize);
-  XCTAssertFalse(statusBarSizeIsZero);
-}
-
 @end
 

--- a/WebDriverAgentTests/IntegrationTests/FBScreenTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBScreenTests.m
@@ -30,7 +30,7 @@
 
 - (void)testStatusBarSize
 {
-  CGSize statusBarSize = [FBScreen statusBarSizeForApplication:self.testedApplication];
+  CGSize statusBarSize = [FBScreen statusBarSizeForApplication];
   BOOL statusBarSizeIsZero = CGSizeEqualToSize(CGSizeZero, statusBarSize);
   XCTAssertFalse(statusBarSizeIsZero);
 }


### PR DESCRIPTION
Add screenSize by system app in the device screen info. The status bar also refers to the system app, so they should be good. `statusBarSizeForApplication` does not use `application`, so this pr removes the argument as well.

endpoint: http://localhost:8100/wda/screen


tv
```
{
    "value": {
        "statusBarSize": {
            "width": 0,
            "height": 0
        },
        "scale": 2,
        "screenSize": {
            "width": 1920,
            "height": 1080
        }
    },
    "sessionId": null
}
```

iphone
```
{
    "value": {
        "statusBarSize": {
            "width": 393,
            "height": 54
        },
        "scale": 3,
        "screenSize": {
            "width": 393,
            "height": 852
        }
    },
    "sessionId": null
}
```


Tested with

- tvOS 16, 17
   - 17 real device
- ios 15.8, 16.4, 17.3 real devices