### PR TITLE
chore: do not cleanup with this.usePrebuiltWDA

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -449,7 +449,7 @@ class WebDriverAgent {
 
     // useXctestrunFile and usePrebuiltWDA use existing dependencies
     // It depends on user side
-    if (this.idb || this.useXctestrunFile || (this.derivedDataPath && this.usePrebuiltWDA)) {
+    if (this.idb || this.useXctestrunFile || this.usePrebuiltWDA) {
       this.log.info('Skipped WDA project cleanup according to the provided capabilities');
     } else {
       const synchronizationKey = path.normalize(this.bootstrapPath);


### PR DESCRIPTION
As same as `useXctestrunFile`, we do not need to restrict the cleanup method with `usePrebuiltWDA` case as well since both believe the prebuilt env is re-usable basically, thus it makes sense to follow the same behavior in both `useXctestrunFile` and `usePrebuiltWDA`.

https://github.com/appium/appium-xcuitest-driver/pull/2374 will tune the behavior further.