### PR TITLE
fix: xcode warning about com.facebook.wda.lib

### DIFF
--- a/WebDriverAgentLib/Info.plist
+++ b/WebDriverAgentLib/Info.plist
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>CFBundleDevelopmentRegion</key>
-    <string>en</string>
-    <key>CFBundleExecutable</key>
-    <string>$(EXECUTABLE_NAME)</string>
-    <key>CFBundleIdentifier</key>
-    <string>com.facebook.wda.lib</string>
-    <key>CFBundleInfoDictionaryVersion</key>
-    <string>6.0</string>
-    <key>CFBundleName</key>
-    <string>$(PRODUCT_NAME)</string>
-    <key>CFBundlePackageType</key>
-    <string>FMWK</string>
-    <key>CFBundleShortVersionString</key>
-    <string>8.5.4</string>
-    <key>CFBundleSignature</key>
-    <string>????</string>
-    <key>CFBundleVersion</key>
-    <string>8.5.4</string>
-    <key>NSPrincipalClass</key>
-    <string/>
-  </dict>
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>8.5.4</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>8.5.4</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
 </plist>


### PR DESCRIPTION
Fixes below Xcode warning.
```
    builtin-infoPlistUtility /Users/kazu/GitHub/WebDriverAgent/WebDriverAgentLib/Info.plist -producttype com.apple.product-type.framework -expandbuildsettings -format binary -platform iphoneos -requiredArchitecture arm64 -o /Users/kazu/GitHub/WebDriverAgent/build/Release-iphoneos/WebDriverAgentLib.framework/Info.plist
/Users/kazu/GitHub/WebDriverAgent/WebDriverAgent.xcodeproj: warning: User-supplied CFBundleIdentifier value 'com.facebook.wda.lib' in the Info.plist must be the same as the PRODUCT_BUNDLE_IDENTIFIER build setting value 'com.facebook.WebDriverAgentLib'. (in target 'WebDriverAgentLib' from project 'WebDriverAgent')
```

My change is via Xcode, thus this diff except for `$(PRODUCT_BUNDLE_IDENTIFIER)` was by Xcode. I have checked this did not break building for a real device as well.