### PR TITLE
fix: Pass-through modifier keys

### DIFF
--- a/WebDriverAgentLib/Utilities/FBW3CActionsHelpers.h
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsHelpers.h
@@ -31,18 +31,11 @@ NSString *_Nullable FBRequireValue(NSDictionary<NSString *, id> *actionItem, NSE
 NSNumber *_Nullable FBOptDuration(NSDictionary<NSString *, id> *actionItem, NSNumber *_Nullable defaultValue, NSError **error);
 
 /**
- * Checks whether the given key action value is a W3C meta modifier
- * @param value key action value
- * @returns YES if the value is a meta modifier
- */
-BOOL FBIsMetaModifier(NSString *value);
-
-/**
  * Maps W3C meta modifier to XCUITest compatible-one
  *
  * @param value key action value
- * @returns the mapped modifier value or 0 in case of failure
+ * @returns the mapped modifier value or null in case the char cannot be mapped
  */
-NSUInteger FBToMetaModifier(NSString *value);
+NSNumber *_Nullable FBToMetaModifier(NSString *value);
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBW3CActionsHelpers.h
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsHelpers.h
@@ -30,4 +30,14 @@ NSString *_Nullable FBRequireValue(NSDictionary<NSString *, id> *actionItem, NSE
  */
 NSNumber *_Nullable FBOptDuration(NSDictionary<NSString *, id> *actionItem, NSNumber *_Nullable defaultValue, NSError **error);
 
+/**
+ * Maps W3C meta modifier to XCUITest compatible-one
+ * See https://w3c.github.io/webdriver/#keyboard-actions
+ *
+ * @param value key action value
+ * @returns the mapped modifier value or the same input character
+ * if no mapped value could be found for it.
+ */
+NSString * FBMapIfSpecialCharacter(NSString *value);
+
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBW3CActionsHelpers.h
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsHelpers.h
@@ -30,12 +30,4 @@ NSString *_Nullable FBRequireValue(NSDictionary<NSString *, id> *actionItem, NSE
  */
 NSNumber *_Nullable FBOptDuration(NSDictionary<NSString *, id> *actionItem, NSNumber *_Nullable defaultValue, NSError **error);
 
-/**
- * Maps W3C meta modifier to XCUITest compatible-one
- *
- * @param value key action value
- * @returns the mapped modifier value or null in case the char cannot be mapped
- */
-NSNumber *_Nullable FBToMetaModifier(NSString *value);
-
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBW3CActionsHelpers.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsHelpers.m
@@ -55,6 +55,10 @@ NSNumber *_Nullable FBOptDuration(NSDictionary<NSString *, id> *actionItem, NSNu
 
 NSString *FBMapIfSpecialCharacter(NSString *value)
 {
+  if (0 == [value length]) {
+    return value;
+  }
+
   unichar charCode = [value characterAtIndex:0];
   switch (charCode) {
     case 0xE000:

--- a/WebDriverAgentLib/Utilities/FBW3CActionsHelpers.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsHelpers.m
@@ -53,32 +53,21 @@ NSNumber *_Nullable FBOptDuration(NSDictionary<NSString *, id> *actionItem, NSNu
   return durationObj;
 }
 
-BOOL FBIsMetaModifier(NSString *value)
+NSNumber *FBToMetaModifier(NSString *value)
 {
-  unichar charCode = [value characterAtIndex:0];
-  return charCode >= 0xE000 && charCode <= 0xF8FF;
-}
-
-NSUInteger FBToMetaModifier(NSString *value)
-{
-  if (!FBIsMetaModifier(value)) {
-    return 0;
-  }
-
   unichar charCode = [value characterAtIndex:0];
   switch (charCode) {
     case 0xE000:
-      return XCUIKeyModifierNone;
+      return @(XCUIKeyModifierNone);
     case 0xE03D:
-      return XCUIKeyModifierCommand;
+      return @(XCUIKeyModifierCommand);
     case 0xE009:
-      return XCUIKeyModifierControl;
+      return @(XCUIKeyModifierControl);
     case 0xE00A:
-      return XCUIKeyModifierOption;
+      return @(XCUIKeyModifierOption);
     case 0xE008:
-      return XCUIKeyModifierShift;
+      return @(XCUIKeyModifierShift);
     default:
-      [FBLogger logFmt:@"Skipping the unsupported meta modifier with code %@", @(charCode)];
-      return 0;
+      return nil;
   }
 }

--- a/WebDriverAgentLib/Utilities/FBW3CActionsHelpers.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsHelpers.m
@@ -52,22 +52,3 @@ NSNumber *_Nullable FBOptDuration(NSDictionary<NSString *, id> *actionItem, NSNu
   }
   return durationObj;
 }
-
-NSNumber *FBToMetaModifier(NSString *value)
-{
-  unichar charCode = [value characterAtIndex:0];
-  switch (charCode) {
-    case 0xE000:
-      return @(XCUIKeyModifierNone);
-    case 0xE03D:
-      return @(XCUIKeyModifierCommand);
-    case 0xE009:
-      return @(XCUIKeyModifierControl);
-    case 0xE00A:
-      return @(XCUIKeyModifierOption);
-    case 0xE008:
-      return @(XCUIKeyModifierShift);
-    default:
-      return nil;
-  }
-}

--- a/WebDriverAgentLib/Utilities/FBW3CActionsHelpers.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsHelpers.m
@@ -52,3 +52,65 @@ NSNumber *_Nullable FBOptDuration(NSDictionary<NSString *, id> *actionItem, NSNu
   }
   return durationObj;
 }
+
+NSString *FBMapIfSpecialCharacter(NSString *value)
+{
+  unichar charCode = [value characterAtIndex:0];
+  switch (charCode) {
+    case 0xE000:
+      return @"";
+    case 0xE003:
+      return [NSString stringWithFormat:@"%C", 0x0008];
+    case 0xE004:
+      return [NSString stringWithFormat:@"%C", 0x0009];
+    case 0xE006:
+      return [NSString stringWithFormat:@"%C", 0x000D];
+    case 0xE007:
+      return [NSString stringWithFormat:@"%C", 0x000A];
+    case 0xE00C:
+      return [NSString stringWithFormat:@"%C", 0x001B];
+    case 0xE00D:
+    case 0xE05D:
+      return @" ";
+    case 0xE017:
+      return [NSString stringWithFormat:@"%C", 0x007F];
+    case 0xE018:
+      return @";";
+    case 0xE019:
+      return @"=";
+    case 0xE01A:
+      return @"0";
+    case 0xE01B:
+      return @"1";
+    case 0xE01C:
+      return @"2";
+    case 0xE01D:
+      return @"3";
+    case 0xE01E:
+      return @"4";
+    case 0xE01F:
+      return @"5";
+    case 0xE020:
+      return @"6";
+    case 0xE021:
+      return @"7";
+    case 0xE022:
+      return @"8";
+    case 0xE023:
+      return @"9";
+    case 0xE024:
+      return @"*";
+    case 0xE025:
+      return @"+";
+    case 0xE026:
+      return @",";
+    case 0xE027:
+      return @"-";
+    case 0xE028:
+      return @".";
+    case 0xE029:
+      return @"/";
+    default:
+      return charCode >= 0xE000 && charCode <= 0xE05D ? @"" : value;
+  }
+}

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -410,17 +410,12 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
           currentItemIndex:(NSUInteger)currentItemIndex
 {
   NSInteger balance = 1;
-  NSNumber *metaModifier = FBToMetaModifier(self.value);
   for (NSInteger index = currentItemIndex - 1; index >= 0; index--) {
     FBW3CKeyItem *item = [allItems objectAtIndex:index];
     BOOL isKeyDown = [item isKindOfClass:FBKeyDownItem.class];
     BOOL isKeyUp = !isKeyDown && [item isKindOfClass:FBKeyUpItem.class];
     if (!isKeyUp && !isKeyDown) {
-      if (nil != metaModifier) {
-        continue;
-      } else {
-        break;
-      }
+      break;
     }
 
     NSString *value = [item performSelector:@selector(value)];
@@ -432,32 +427,6 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
     }
   }
   return 0 == balance;
-}
-
-- (NSUInteger)collectModifersWithItems:(NSArray *)allItems
-                      currentItemIndex:(NSUInteger)currentItemIndex
-{
-  NSUInteger modifiers = 0;
-  for (NSUInteger index = 0; index < currentItemIndex; index++) {
-    FBW3CKeyItem *item = [allItems objectAtIndex:index];
-    BOOL isKeyDown = [item isKindOfClass:FBKeyDownItem.class];
-    BOOL isKeyUp = !isKeyDown && [item isKindOfClass:FBKeyUpItem.class];
-    if (!isKeyUp && !isKeyDown) {
-      continue;
-    }
-
-    NSString *value = [item performSelector:@selector(value)];
-    NSUInteger modifier = [FBToMetaModifier(value) unsignedIntegerValue];
-    if (modifier > 0) {
-      if (isKeyDown) {
-        modifiers |= modifier;
-      } else if (item.offset < self.offset) {
-        // only cancel the modifier if it is not in the same group
-        modifiers &= ~modifier;
-      }
-    }
-  }
-  return modifiers;
 }
 
 - (NSString *)collectTextWithItems:(NSArray *)allItems
@@ -473,10 +442,6 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
     }
 
     NSString *value = [item performSelector:@selector(value)];
-    if (nil != FBToMetaModifier(value)) {
-      continue;
-    }
-
     if (isKeyUp) {
       [result addObject:value];
     }
@@ -497,10 +462,6 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
     return nil;
   }
 
-  if (nil != FBToMetaModifier(self.value)) {
-    return @[];
-  }
-
   BOOL isLastKeyUpInGroup = currentItemIndex == allItems.count - 1
     || [[allItems objectAtIndex:currentItemIndex + 1] isKindOfClass:FBKeyPauseItem.class];
   if (!isLastKeyUpInGroup) {
@@ -510,10 +471,6 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   NSString *text = [self collectTextWithItems:allItems currentItemIndex:currentItemIndex];
   NSTimeInterval offset = FBMillisToSeconds(self.offset);
   XCPointerEventPath *resultPath = [[XCPointerEventPath alloc] initForTextInput];
-  // TODO: Figure out how meta modifiers could be applied
-  // TODO: The current approach throws zero division error on execution
-  // NSUInteger modifiers = [self collectModifersWithItems:allItems currentItemIndex:currentItemIndex];
-  // [resultPath setModifiers:modifiers mergeWithCurrentModifierFlags:NO atOffset:0];
   [resultPath typeText:text
               atOffset:offset
            typingSpeed:FBConfiguration.maxTypingFrequency
@@ -555,17 +512,12 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
         currentItemIndex:(NSUInteger)currentItemIndex
 {
   NSInteger balance = 1;
-  NSNumber *metaModifier = FBToMetaModifier(self.value);
   for (NSUInteger index = currentItemIndex + 1; index < allItems.count; index++) {
     FBW3CKeyItem *item = [allItems objectAtIndex:index];
     BOOL isKeyDown = [item isKindOfClass:FBKeyDownItem.class];
     BOOL isKeyUp = !isKeyDown && [item isKindOfClass:FBKeyUpItem.class];
     if (!isKeyUp && !isKeyDown) {
-      if (nil != metaModifier) {
-        continue;
-      } else {
-        break;
-      }
+      break;
     }
 
     NSString *value = [item performSelector:@selector(value)];

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -410,13 +410,13 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
           currentItemIndex:(NSUInteger)currentItemIndex
 {
   NSInteger balance = 1;
-  BOOL isSelfMetaModifier = FBIsMetaModifier(self.value);
+  NSNumber *metaModifier = FBToMetaModifier(self.value);
   for (NSInteger index = currentItemIndex - 1; index >= 0; index--) {
     FBW3CKeyItem *item = [allItems objectAtIndex:index];
     BOOL isKeyDown = [item isKindOfClass:FBKeyDownItem.class];
     BOOL isKeyUp = !isKeyDown && [item isKindOfClass:FBKeyUpItem.class];
     if (!isKeyUp && !isKeyDown) {
-      if (isSelfMetaModifier) {
+      if (nil != metaModifier) {
         continue;
       } else {
         break;
@@ -447,7 +447,7 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
     }
 
     NSString *value = [item performSelector:@selector(value)];
-    NSUInteger modifier = FBToMetaModifier(value);
+    NSUInteger modifier = [FBToMetaModifier(value) unsignedIntegerValue];
     if (modifier > 0) {
       if (isKeyDown) {
         modifiers |= modifier;
@@ -473,7 +473,7 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
     }
 
     NSString *value = [item performSelector:@selector(value)];
-    if (FBIsMetaModifier(value)) {
+    if (nil != FBToMetaModifier(value)) {
       continue;
     }
 
@@ -497,7 +497,7 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
     return nil;
   }
 
-  if (FBIsMetaModifier(self.value)) {
+  if (nil != FBToMetaModifier(self.value)) {
     return @[];
   }
 
@@ -555,13 +555,13 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
         currentItemIndex:(NSUInteger)currentItemIndex
 {
   NSInteger balance = 1;
-  BOOL isSelfMetaModifier = FBIsMetaModifier(self.value);
+  NSNumber *metaModifier = FBToMetaModifier(self.value);
   for (NSUInteger index = currentItemIndex + 1; index < allItems.count; index++) {
     FBW3CKeyItem *item = [allItems objectAtIndex:index];
     BOOL isKeyDown = [item isKindOfClass:FBKeyDownItem.class];
     BOOL isKeyUp = !isKeyDown && [item isKindOfClass:FBKeyUpItem.class];
     if (!isKeyUp && !isKeyDown) {
-      if (isSelfMetaModifier) {
+      if (nil != metaModifier) {
         continue;
       } else {
         break;

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -443,7 +443,7 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
 
     NSString *value = [item performSelector:@selector(value)];
     if (isKeyUp) {
-      [result addObject:value];
+      [result addObject:FBMapIfSpecialCharacter(value)];
     }
   }
   return [result.reverseObjectEnumerator.allObjects componentsJoinedByString:@""];

--- a/WebDriverAgentTests/IntegrationTests/FBW3CTypeActionsTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CTypeActionsTests.m
@@ -140,18 +140,21 @@
           @{@"type": @"keyUp", @"value": @"N"},
           @{@"type": @"keyDown", @"value": @"B"},
           @{@"type": @"keyUp", @"value": @"B"},
-          @{@"type": @"keyDown", @"value": @"a"},
-          @{@"type": @"keyUp", @"value": @"a"},
+          @{@"type": @"keyDown", @"value": @"A"},
+          @{@"type": @"keyUp", @"value": @"A"},
+          @{@"type": @"keyDown", @"value": @"\uE003"},
+          @{@"type": @"keyUp", @"value": @"\uE003"},
           @{@"type": @"pause", @"duration": @500},
           ],
       },
-      ];
+    ];
   NSError *error;
   XCTAssertTrue([self.testedApplication fb_performW3CActions:typeAction
                                                 elementCache:nil
                                                        error:&error]);
   XCTAssertNil(error);
-  XCTAssertEqualObjects(textField.wdValue, @"🏀NBa");
+
+  XCTAssertEqualObjects(textField.wdValue, @"🏀NBA\uE003");
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/FBW3CTypeActionsTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CTypeActionsTests.m
@@ -142,8 +142,10 @@
           @{@"type": @"keyUp", @"value": @"B"},
           @{@"type": @"keyDown", @"value": @"A"},
           @{@"type": @"keyUp", @"value": @"A"},
-          @{@"type": @"keyDown", @"value": @"\uE003"},
-          @{@"type": @"keyUp", @"value": @"\uE003"},
+          @{@"type": @"keyDown", @"value": @"a"},
+          @{@"type": @"keyUp", @"value": @"a"},
+          @{@"type": @"keyDown", @"value": [NSString stringWithFormat:@"%C", 0xE003]},
+          @{@"type": @"keyUp", @"value": [NSString stringWithFormat:@"%C", 0xE003]},
           @{@"type": @"pause", @"duration": @500},
           ],
       },
@@ -153,8 +155,7 @@
                                                 elementCache:nil
                                                        error:&error]);
   XCTAssertNil(error);
-
-  XCTAssertEqualObjects(textField.wdValue, @"🏀NBA\uE003");
+  XCTAssertEqualObjects(textField.wdValue, @"🏀NBA");
 }
 
 @end


### PR DESCRIPTION
The W3C actions spec defines the [range](https://w3c.github.io/webdriver/#keyboard-actions) of modifier keys that must be specially parsed, although iOS does not seem to support entering keys with modifiers (or at least I cannot find a way to make it work). Thus it makes sense to just pass these unicode chars through.

Addresses https://github.com/appium/appium/issues/17734