### PR TITLE
fix: do nothing for an empty array in w3c actions

### DIFF
--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -740,14 +740,6 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   });
 
   NSArray<NSDictionary<NSString *, id> *> *actionItems = [actionDescription objectForKey:FB_KEY_ACTIONS];
-  if (nil == actionItems || 0 == actionItems.count) {
-   NSString *description = [NSString stringWithFormat:@"It is mandatory to have at least one item defined for each action. Action with id '%@' contains none", actionId];
-    if (error) {
-      *error = [[FBErrorBuilder.builder withDescription:description] build];
-    }
-    return nil;
-  }
-
   FBW3CKeyItemsChain *chain = [[FBW3CKeyItemsChain alloc] init];
   NSArray<NSDictionary<NSString *, id> *> *processedItems = [self preprocessedActionItemsWith:actionItems];
   for (NSDictionary<NSString *, id> *actionItem in processedItems) {
@@ -818,14 +810,6 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   }
 
   NSArray<NSDictionary<NSString *, id> *> *actionItems = [actionDescription objectForKey:FB_KEY_ACTIONS];
-  if (nil == actionItems || 0 == actionItems.count) {
-   NSString *description = [NSString stringWithFormat:@"It is mandatory to have at least one gesture item defined for each action. Action with id '%@' contains none", actionId];
-    if (error) {
-      *error = [[FBErrorBuilder.builder withDescription:description] build];
-    }
-    return nil;
-  }
-
   FBW3CGestureItemsChain *chain = [[FBW3CGestureItemsChain alloc] init];
   NSArray<NSDictionary<NSString *, id> *> *processedItems = [self preprocessedActionItemsWith:actionItems];
   for (NSDictionary<NSString *, id> *actionItem in processedItems) {
@@ -901,6 +885,21 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
       }
       return nil;
     }
+    
+    NSArray<NSDictionary<NSString *, id> *> *actionItems = [action objectForKey:FB_KEY_ACTIONS];
+    if (nil == actionItems) {
+     NSString *description = [NSString stringWithFormat:@"It is mandatory to have at least one item defined for each action. Action with id '%@' contains none", actionId];
+      if (error) {
+        *error = [[FBErrorBuilder.builder withDescription:description] build];
+      }
+      return nil;
+    }
+
+    if (0 == actionItems.count) {
+      [FBLogger logFmt:@"Action items in the action id '%@' had an empty array. Skipping the action.", actionId];
+      continue;
+    }
+
     [actionIds addObject:actionId];
     [actionsMapping setObject:action forKey:actionId];
   }

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -884,8 +884,7 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
         *error = [[FBErrorBuilder.builder withDescription:description] build];
       }
       return nil;
-    }
-    
+    }    
     NSArray<NSDictionary<NSString *, id> *> *actionItems = [action objectForKey:FB_KEY_ACTIONS];
     if (nil == actionItems) {
      NSString *description = [NSString stringWithFormat:@"It is mandatory to have at least one item defined for each action. Action with id '%@' contains none", actionId];
@@ -894,7 +893,6 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
       }
       return nil;
     }
-
     if (0 == actionItems.count) {
       [FBLogger logFmt:@"Action items in the action id '%@' had an empty array. Skipping the action.", actionId];
       continue;

--- a/WebDriverAgentTests/IntegrationTests/FBW3CTypeActionsTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CTypeActionsTests.m
@@ -154,4 +154,28 @@
   XCTAssertEqualObjects(textField.wdValue, @"🏀NBa");
 }
 
+- (void)testTextTypingWithEmptyActions
+{
+  if (![XCPointerEvent.class fb_areKeyEventsSupported]) {
+    return;
+  }
+
+  XCUIElement *textField = self.testedApplication.textFields[@"aIdentifier"];
+  [textField tap];
+  NSArray<NSDictionary<NSString *, id> *> *typeAction =
+    @[
+      @{
+      @"type": @"pointer",
+      @"id": @"touch",
+      @"actions": @[],
+      },
+    ];
+  NSError *error;
+  XCTAssertTrue([self.testedApplication fb_performW3CActions:typeAction
+                                                elementCache:nil
+                                                       error:&error]);
+  XCTAssertNil(error);
+  XCTAssertEqualObjects(textField.value, @"");
+}
+
 @end


### PR DESCRIPTION
Instead of https://github.com/appium/appium-xcuitest-driver/pull/2431

According to https://www.w3.org/TR/webdriver1/#input-source-state

> If actions is undefined or is not an Array, return error with error code invalid argument.

So, I think an empty array should not return an error...? instead, it could just skip the actions.


With this change, vanilla selenium's send_keys w3c actions via xcuitest driver logic will be:

```
[HTTP] --> POST /session/8dc9d907-6540-4ec2-8921-75f27e77bf7f/actions {"actions":[{"type":"pointer","id":"touch","actions":[{"type":"pause","duration":0},{"type":"pause","duration":0}],"parameters":{"pointerType":"touch"}},{"type":"key","id":"keyboard","actions":[{"type":"keyDown","value":"a"},{"type":"keyUp","value":"a"}]}]}
[debug] [XCUITestDriver@b5a8] Calling AppiumDriver.performActions() with args: [[{"type":"pointer","id":"touch","actions":[{"type":"pause","duration":0},{"type":"pause","duration":0}],"parameters":{"pointerType":"touch"}},{"type":"key","id":"keyboard","actions":[{"type":"keyDown","value":"a"},{"type":"keyUp","value":"a"}]}],"8dc9d907-6540-4ec2-8921-75f27e77bf7f"]
[debug] [XCUITestDriver@b5a8] Executing command 'performActions'
[debug] [XCUITestDriver@b5a8] Received the following W3C actions: [
  {
    "type": "pointer",
    "id": "touch",
    "actions": [
      {
        "type": "pause",
        "duration": 0
      },
      {
        "type": "pause",
        "duration": 0
      }
    ],
    "parameters": {
      "pointerType": "touch"
    }
  },
  {
    "type": "key",
    "id": "keyboard",
    "actions": [
      {
        "type": "keyDown",
        "value": "a"
      },
      {
        "type": "keyUp",
        "value": "a"
      }
    ]
  }
]
[debug] [XCUITestDriver@b5a8] Preprocessed actions: [
  {
    "type": "pointer",
    "id": "touch",
    "actions": [],
    "parameters": {
      "pointerType": "touch"
    }
  },
  {
    "type": "key",
    "id": "keyboard",
    "actions": [
      {
        "type": "keyDown",
        "value": "a"
      },
      {
        "type": "keyUp",
        "value": "a"
      }
    ]
  }
]
[debug] [XCUITestDriver@b5a8] Matched '/actions' to command name 'performActions'
[debug] [XCUITestDriver@b5a8] Proxying [POST /actions] to [POST http://127.0.0.1:8100/session/C763F861-FA8B-4245-A1C2-010A062D0995/actions] with body: {"actions":[{"type":"pointer","id":"touch","actions":[],"parameters":{"pointerType":"touch"}},{"type":"key","id":"keyboard","actions":[{"type":"keyDown","value":"a"},{"type":"keyUp","value":"a"}]}]}
[IOSSimulatorLog] [IOS_SYSLOG_ROW] 2024-07-17 21:15:55.032 Df WebDriverAgentRunner-Runner[72170:4b4fdc] (WebDriverAgentLib) Action items in the action id 'touch' had an empty array. Skipping the action.
[IOSSimulatorLog] [IOS_SYSLOG_ROW] 2024-07-17 21:15:55.033 Df testmanagerd[65740:4b55ef] [com.apple.dt.xctest:Default] Synthesizing event with implicit confirmation interval 5:
[IOSSimulatorLog] [IOS_SYSLOG_ROW] <XCSynthesizedEventRecord 'W3C Touch Action display 0'>
[IOSSimulatorLog] [IOS_SYSLOG_ROW] Path 1:
```

```ruby
# ruby
driver.action.send_keys('a').perform
```

For now, the command raises:

> Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command. Original error: Error Domain=com.facebook.WebDriverAgent Code=1 "It is mandatory to have at least one gesture item defined for each action. Action with id 'touch' contains none" UserInfo={NSLocalizedDescription=It is mandatory to have at least one gesture item defined for each action. Action with id 'touch' contains none}