### PR TITLE
ci: tune test cases associated with w3c actions

### DIFF
--- a/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
@@ -267,6 +267,21 @@
   }
 }
 
+- (void)testNothingDoesWithoutError
+{
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"type": @"pointer",
+      @"id": @"finger1",
+      @"parameters": @{@"pointerType": @"touch"},
+      @"actions": @[],
+      },
+    ];
+  NSError *error;
+  XCTAssertTrue([self.testedApplication fb_performW3CActions:gesture elementCache:nil error:&error]);
+  XCTAssertNil(error);
+}
+
 - (void)testTap
 {
   NSArray<NSDictionary<NSString *, id> *> *gesture =

--- a/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
@@ -70,15 +70,6 @@
         },
       ],
     
-    // Chain element with empty 'actions'
-    @[@{
-        @"type": @"pointer",
-        @"id": @"finger1",
-        @"parameters": @{@"pointerType": @"touch"},
-        @"actions": @[],
-        },
-      ],
-    
     // Chain element without type
     @[@{
         @"id": @"finger1",

--- a/WebDriverAgentTests/IntegrationTests/FBW3CTypeActionsTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CTypeActionsTests.m
@@ -156,8 +156,17 @@
                                                        error:&error]);
   XCTAssertNil(error);
   XCTAssertEqualObjects(textField.wdValue, @"🏀NBA");
+}
 
-  NSArray<NSDictionary<NSString *, id> *> *typeAction2 =
+- (void)testTextTypingWithEmptyActions
+{
+  if (![XCPointerEvent.class fb_areKeyEventsSupported]) {
+    return;
+  }
+
+  XCUIElement *textField = self.testedApplication.textFields[@"aIdentifier"];
+  [textField tap];
+  NSArray<NSDictionary<NSString *, id> *> *typeAction =
     @[
       @{
       @"type": @"pointer",
@@ -165,11 +174,12 @@
       @"actions": @[],
       },
     ];
-  XCTAssertTrue([self.testedApplication fb_performW3CActions:typeAction2
+  NSError *error;
+  XCTAssertTrue([self.testedApplication fb_performW3CActions:typeAction
                                                 elementCache:nil
                                                        error:&error]);
   XCTAssertNil(error);
-  XCTAssertEqualObjects(textField.value, @"🏀NBA");
+  XCTAssertEqualObjects(textField.value, @"");
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/FBW3CTypeActionsTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CTypeActionsTests.m
@@ -156,17 +156,8 @@
                                                        error:&error]);
   XCTAssertNil(error);
   XCTAssertEqualObjects(textField.wdValue, @"🏀NBA");
-}
 
-- (void)testTextTypingWithEmptyActions
-{
-  if (![XCPointerEvent.class fb_areKeyEventsSupported]) {
-    return;
-  }
-
-  XCUIElement *textField = self.testedApplication.textFields[@"aIdentifier"];
-  [textField tap];
-  NSArray<NSDictionary<NSString *, id> *> *typeAction =
+  NSArray<NSDictionary<NSString *, id> *> *typeAction2 =
     @[
       @{
       @"type": @"pointer",
@@ -174,12 +165,11 @@
       @"actions": @[],
       },
     ];
-  NSError *error;
-  XCTAssertTrue([self.testedApplication fb_performW3CActions:typeAction
+  XCTAssertTrue([self.testedApplication fb_performW3CActions:typeAction2
                                                 elementCache:nil
                                                        error:&error]);
   XCTAssertNil(error);
-  XCTAssertEqualObjects(textField.value, @"");
+  XCTAssertEqualObjects(textField.value, @"🏀NBA");
 }
 
 @end


### PR DESCRIPTION
I wondered if reducing tests case help to improve the stability... by reducing the device setup etc.