### PR TITLE
chore: keep error handling for the future possible usage

### DIFF
--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -692,6 +692,14 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   });
 
   NSArray<NSDictionary<NSString *, id> *> *actionItems = [actionDescription objectForKey:FB_KEY_ACTIONS];
+  if (nil == actionItems || 0 == actionItems.count) {
+   NSString *description = [NSString stringWithFormat:@"It is mandatory to have at least one item defined for each action. Action with id '%@' contains none", actionId];
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:description] build];
+    }
+    return nil;
+  }
+
   FBW3CKeyItemsChain *chain = [[FBW3CKeyItemsChain alloc] init];
   NSArray<NSDictionary<NSString *, id> *> *processedItems = [self preprocessedActionItemsWith:actionItems];
   for (NSDictionary<NSString *, id> *actionItem in processedItems) {
@@ -762,6 +770,14 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   }
 
   NSArray<NSDictionary<NSString *, id> *> *actionItems = [actionDescription objectForKey:FB_KEY_ACTIONS];
+  if (nil == actionItems || 0 == actionItems.count) {
+    NSString *description = [NSString stringWithFormat:@"It is mandatory to have at least one gesture item defined for each action. Action with id '%@' contains none", actionId];
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:description] build];
+    }
+    return nil;
+  }
+
   FBW3CGestureItemsChain *chain = [[FBW3CGestureItemsChain alloc] init];
   NSArray<NSDictionary<NSString *, id> *> *processedItems = [self preprocessedActionItemsWith:actionItems];
   for (NSDictionary<NSString *, id> *actionItem in processedItems) {


### PR DESCRIPTION
As same as https://github.com/appium/appium-mac2-driver/pull/308

Bring back removed error handlings from https://github.com/appium/WebDriverAgent/pull/919 for the possible future direct usage.
I'll merge this after CI passes.