### PR TITLE
fix: Respond to /health with a proper HTML

### DIFF
--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -217,7 +217,7 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
 - (void)registerServerKeyRouteHandlers
 {
   [self.server get:@"/health" withBlock:^(RouteRequest *request, RouteResponse *response) {
-    [response respondWithString:@"I-AM-ALIVE"];
+    [response respondWithString:@"<!DOCTYPE html><html><title>Health Check</title><body><p>I-AM-ALIVE</p></body></html>"];
   }];
 
   NSString *calibrationPage = @"<html>"


### PR DESCRIPTION
Currently this endpoint just returns a raw text. And since we use it as the default URL while starting Safari the remote debugger gets confused and is unable detect when the actual page load happens thus creating an extra wait of 6 seconds. Returning a valid HTML page instead resolves that issue