### PR TITLE
fix: Wait for the browser to load before continuing the session

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -188,6 +188,10 @@
           if (nil != errorResponse) {
             NSLog(@"Was not able to open the default URL %@ in Safari", healthEndpoint);
           }
+          NSLog(@"Waiting for %@ to finish loading", healthEndpoint);
+          // To avoid the race condition while starting the remote debugger
+          [app fb_waitUntilStableWithTimeout:15.0];
+          NSLog(@"Load completed: %@", healthEndpoint);
         }
       }
       if (!app.running) {


### PR DESCRIPTION
Related to https://github.com/appium/appium-xcuitest-driver/pull/2447#issuecomment-2270588882