### PR TITLE
feat: Add an endpoint to list active app candidates

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -210,7 +210,7 @@
   return (nil == app) ? @{} : @{
     @"pid": @(app.processID),
     @"bundleId": app.bundleID,
-    @"name": app.identifier,
+    @"state": @(app.state),
     @"processArguments": @{
       @"args": app.launchArguments ?: @[],
       @"env": app.launchEnvironment ?: @{}


### PR DESCRIPTION
Such endpoint could be useful if there are multiple apps running at the same time and we need to figure out which of them to activate manually in order to perform various on-screen interactions.