### PR TITLE
feat: look for critical notification in respectSystemAlerts

### DIFF
--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -178,10 +178,10 @@ static FBSession *_activeSession = nil;
   if (nil != self.testedApplication) {
     XCUIApplicationState testedAppState = self.testedApplication.state;
     if (testedAppState >= XCUIApplicationStateRunningForeground) {
-      NSPredicate *searchPredicate = [NSPredicate predicateWithFormat:@"%K == %@ OR identifier IN {%@, %@}",
+      NSPredicate *searchPredicate = [NSPredicate predicateWithFormat:@"%K == %@ OR %K IN {%@, %@}",
                                       @"elementType", @(XCUIElementTypeAlert), 
                                       // To look for `SBTransientOverlayWindow` elements. See https://github.com/appium/WebDriverAgent/pull/946
-                                      @"SBTransientOverlayWindow",
+                                      @"identifier", @"SBTransientOverlayWindow",
                                       // To look for 'criticalAlertSetting' elements https://developer.apple.com/documentation/usernotifications/unnotificationsettings/criticalalertsetting
                                       // See https://github.com/appium/appium/issues/20835
                                       @"Notification"];

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -184,7 +184,7 @@ static FBSession *_activeSession = nil;
                                       @"identifier", @"SBTransientOverlayWindow",
                                       // To look for 'criticalAlertSetting' elements https://developer.apple.com/documentation/usernotifications/unnotificationsettings/criticalalertsetting
                                       // See https://github.com/appium/appium/issues/20835
-                                      @"Notification"];
+                                      @"NotificationShortLookView"];
       if ([FBConfiguration shouldRespectSystemAlerts]
           && [[XCUIApplication.fb_systemApplication descendantsMatchingType:XCUIElementTypeAny]
               matchingPredicate:searchPredicate].count > 0) {

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -178,13 +178,13 @@ static FBSession *_activeSession = nil;
   if (nil != self.testedApplication) {
     XCUIApplicationState testedAppState = self.testedApplication.state;
     if (testedAppState >= XCUIApplicationStateRunningForeground) {
-      NSPredicate *searchPredicate = [NSPredicate predicateWithFormat:@"%K == %@ OR %K == %@ OR %K == %@",
+      NSPredicate *searchPredicate = [NSPredicate predicateWithFormat:@"%K == %@ OR identifier IN {%@, %@}",
                                       @"elementType", @(XCUIElementTypeAlert), 
-                                      // To ook for `SBTransientOverlayWindow` elements. See https://github.com/appium/WebDriverAgent/pull/946
-                                      @"identifier", @"SBTransientOverlayWindow",
+                                      // To look for `SBTransientOverlayWindow` elements. See https://github.com/appium/WebDriverAgent/pull/946
+                                      @"SBTransientOverlayWindow",
                                       // To look for 'criticalAlertSetting' elements https://developer.apple.com/documentation/usernotifications/unnotificationsettings/criticalalertsetting
                                       // See https://github.com/appium/appium/issues/20835
-                                      @"identifier", @"Notification"];
+                                      @"Notification"];
       if ([FBConfiguration shouldRespectSystemAlerts]
           && [[XCUIApplication.fb_systemApplication descendantsMatchingType:XCUIElementTypeAny]
               matchingPredicate:searchPredicate].count > 0) {

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -178,10 +178,13 @@ static FBSession *_activeSession = nil;
   if (nil != self.testedApplication) {
     XCUIApplicationState testedAppState = self.testedApplication.state;
     if (testedAppState >= XCUIApplicationStateRunningForeground) {
-      // We look for `SBTransientOverlayWindow` elements for half modals. See https://github.com/appium/WebDriverAgent/pull/946
-      NSPredicate *searchPredicate = [NSPredicate predicateWithFormat:@"%K == %@ OR %K == %@",
+      NSPredicate *searchPredicate = [NSPredicate predicateWithFormat:@"%K == %@ OR %K == %@ OR %K == %@",
                                       @"elementType", @(XCUIElementTypeAlert), 
-                                      @"identifier", @"SBTransientOverlayWindow"];
+                                      // To ook for `SBTransientOverlayWindow` elements. See https://github.com/appium/WebDriverAgent/pull/946
+                                      @"identifier", @"SBTransientOverlayWindow",
+                                      // To look for 'criticalAlertSetting' elements https://developer.apple.com/documentation/usernotifications/unnotificationsettings/criticalalertsetting
+                                      // See https://github.com/appium/appium/issues/20835
+                                      @"identifier", @"Notification"];
       if ([FBConfiguration shouldRespectSystemAlerts]
           && [[XCUIApplication.fb_systemApplication descendantsMatchingType:XCUIElementTypeAny]
               matchingPredicate:searchPredicate].count > 0) {


### PR DESCRIPTION
For https://github.com/appium/appium/issues/20835

Critical notification is by the springboard:

```
    <XCUIElementTypeWindow type="XCUIElementTypeWindow" enabled="true" visible="true" accessible="false" x="0" y="0" width="375" height="667" index="10">
      <XCUIElementTypeOther type="XCUIElementTypeOther" enabled="true" visible="true" accessible="false" x="0" y="0" width="375" height="667" index="0">
        <XCUIElementTypeOther type="XCUIElementTypeOther" enabled="true" visible="true" accessible="false" x="8" y="8" width="359" height="77" index="0">
          <XCUIElementTypeOther type="XCUIElementTypeOther" name="Notification" label="Notification" enabled="true" visible="true" accessible="false" x="8" y="8" width="359" height="77" index="0">
            <XCUIElementTypeOther type="XCUIElementTypeOther" enabled="true" visible="true" accessible="false" x="8" y="8" width="359" height="77" index="0">
              <XCUIElementTypeOther type="XCUIElementTypeOther" name="NotificationShortLookView" label="OWLET DREAM, 7 minutes ago, Owlet Dream, LOW PULSE RATE: Check on the Baby.,  CRITICAL" enabled="true" visible="true" accessible="true" x="8" y="8" width="359" height="77" index="0"/>
            </XCUIElementTypeOther>
          </XCUIElementTypeOther>
        </XCUIElementTypeOther>
      </XCUIElementTypeOther>
    </XCUIElementTypeWindow>
```

I'll try to test this out later.