### PR TITLE
fix: add nullable signature

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBResolve.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBResolve.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return Either the same element instance if `fb_isResolvedNatively` was set to NO (usually the cache for elements
  matched by xpath locators) or the stable instance of the self element based on the query by element's UUID.
  */
-- (XCUIElement *)fb_stableInstanceWithUid:(NSString *)uid;
+- (XCUIElement *)fb_stableInstanceWithUid:(NSString *__nullable)uid;
 
 @end
 


### PR DESCRIPTION
To support https://github.com/appium/WebDriverAgent/pull/973#issuecomment-2636169303

My local was just a warning, not an error though. `fb_stableInstanceWithUid` itself has `nil` check for the `uid`.