### PR TITLE
fix: add autorelease pool to drain temporary objects

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -121,7 +121,9 @@
 {
   NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id<FBXCElementSnapshot> snapshot,
                                                                  NSDictionary<NSString *,id> * _Nullable bindings) {
-    return [[FBXCElementSnapshotWrapper wdNameWithSnapshot:snapshot] isEqualToString:accessibilityId];
+    @autoreleasepool {
+      return [[FBXCElementSnapshotWrapper wdNameWithSnapshot:snapshot] isEqualToString:accessibilityId];
+    }
   }];
   return [self fb_descendantsMatchingPredicate:predicate
                    shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -25,8 +25,10 @@ NSNumber* _Nullable fetchSnapshotVisibility(id<FBXCElementSnapshot> snapshot)
 
 - (BOOL)fb_isVisible
 {
-  id<FBXCElementSnapshot> snapshot = [self fb_takeSnapshot:NO];
-  return [FBXCElementSnapshotWrapper ensureWrapped:snapshot].fb_isVisible;
+   @autoreleasepool {
+     id<FBXCElementSnapshot> snapshot = [self fb_takeSnapshot:NO];
+     return [FBXCElementSnapshotWrapper ensureWrapped:snapshot].fb_isVisible;
+   }
 }
 
 @end
@@ -64,7 +66,9 @@ NSNumber* _Nullable fetchSnapshotVisibility(id<FBXCElementSnapshot> snapshot)
     NSMutableDictionary *updatedValue = [NSMutableDictionary dictionaryWithDictionary:self.additionalAttributes ?: @{}];
     [updatedValue setObject:attributeValue forKey:FB_XCAXAIsVisibleAttribute];
     self.snapshot.additionalAttributes = updatedValue.copy;
-    return [attributeValue boolValue];
+    @autoreleasepool {
+      return [attributeValue boolValue];
+    }
   }
 
   NSLog(@"Cannot determine visiblity of %@ natively: %@. Defaulting to: %@",

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -25,10 +25,10 @@ NSNumber* _Nullable fetchSnapshotVisibility(id<FBXCElementSnapshot> snapshot)
 
 - (BOOL)fb_isVisible
 {
-   @autoreleasepool {
-     id<FBXCElementSnapshot> snapshot = [self fb_takeSnapshot:NO];
-     return [FBXCElementSnapshotWrapper ensureWrapped:snapshot].fb_isVisible;
-   }
+  @autoreleasepool {
+    id<FBXCElementSnapshot> snapshot = [self fb_takeSnapshot:NO];
+    return [FBXCElementSnapshotWrapper ensureWrapped:snapshot].fb_isVisible;
+  }
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBResolve.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBResolve.m
@@ -38,11 +38,13 @@ static char XCUIELEMENT_IS_RESOLVED_NATIVELY_KEY;
     return self;
   }
   NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K = %@", FBStringify(FBXCElementSnapshotWrapper, fb_uid), uid];
-  XCUIElementQuery *query = [self.application.fb_query descendantsMatchingType:XCUIElementTypeAny];
-  XCUIElement *result = [query matchingPredicate:predicate].allElementsBoundByIndex.firstObject;
-  if (nil != result) {
-    result.fb_isResolvedNatively = @NO;
-    return result;
+  @autoreleasepool {
+    XCUIElementQuery *query = [self.application.fb_query descendantsMatchingType:XCUIElementTypeAny];
+    XCUIElement *result = [query matchingPredicate:predicate].allElementsBoundByIndex.firstObject;
+      if (nil != result) {
+        result.fb_isResolvedNatively = @NO;
+        return result;
+      }
   }
   return self;
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBResolve.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBResolve.m
@@ -41,10 +41,10 @@ static char XCUIELEMENT_IS_RESOLVED_NATIVELY_KEY;
   @autoreleasepool {
     XCUIElementQuery *query = [self.application.fb_query descendantsMatchingType:XCUIElementTypeAny];
     XCUIElement *result = [query matchingPredicate:predicate].allElementsBoundByIndex.firstObject;
-      if (nil != result) {
-        result.fb_isResolvedNatively = @NO;
-        return result;
-      }
+    if (nil != result) {
+      result.fb_isResolvedNatively = @NO;
+      return result;
+    }
   }
   return self;
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
@@ -178,23 +178,25 @@ const CGFloat FBScrollTouchProportion = 0.75f;
   FBXCElementSnapshotWrapper *scrollViewWrapped = [FBXCElementSnapshotWrapper ensureWrapped:scrollView];
   // Scrolling till cell is visible and get current value of frames
   while (![self fb_isEquivalentElementSnapshotVisible:prescrollSnapshot] && scrollCount < maxScrollCount) {
-    if (targetCellIndex < visibleCellIndex) {
-      scrollDirection == FBXCUIElementScrollDirectionVertical ?
-        [scrollViewWrapped fb_scrollUpByNormalizedDistance:normalizedScrollDistance
-                                             inApplication:self.application] :
-        [scrollViewWrapped fb_scrollLeftByNormalizedDistance:normalizedScrollDistance
-                                               inApplication:self.application];
-    }
-    else {
-      scrollDirection == FBXCUIElementScrollDirectionVertical ?
-        [scrollViewWrapped fb_scrollDownByNormalizedDistance:normalizedScrollDistance
+    @autoreleasepool {
+      if (targetCellIndex < visibleCellIndex) {
+        scrollDirection == FBXCUIElementScrollDirectionVertical ?
+          [scrollViewWrapped fb_scrollUpByNormalizedDistance:normalizedScrollDistance
                                                inApplication:self.application] :
-        [scrollViewWrapped fb_scrollRightByNormalizedDistance:normalizedScrollDistance
-                                                inApplication:self.application];
+          [scrollViewWrapped fb_scrollLeftByNormalizedDistance:normalizedScrollDistance
+                                                 inApplication:self.application];
+      }
+      else {
+        scrollDirection == FBXCUIElementScrollDirectionVertical ?
+          [scrollViewWrapped fb_scrollDownByNormalizedDistance:normalizedScrollDistance
+                                                 inApplication:self.application] :
+          [scrollViewWrapped fb_scrollRightByNormalizedDistance:normalizedScrollDistance
+                                                  inApplication:self.application];
+      }
+      scrollCount++;
+      // Wait for scroll animation
+      [self fb_waitUntilStableWithTimeout:FBConfiguration.animationCoolOffTimeout];
     }
-    scrollCount++;
-    // Wait for scroll animation
-    [self fb_waitUntilStableWithTimeout:FBConfiguration.animationCoolOffTimeout];
   }
 
   if (scrollCount >= maxScrollCount) {

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -46,22 +46,26 @@
 
 - (id<FBXCElementSnapshot>)fb_takeSnapshot:(BOOL)inDepth
 {
-  NSError *error = nil;
-  self.lastSnapshot = inDepth
+  __block id<FBXCElementSnapshot> snapshot = nil;
+  @autoreleasepool {
+    NSError *error = nil;
+    snapshot = inDepth
     ? [self.fb_query fb_uniqueSnapshotWithError:&error]
     : (id<FBXCElementSnapshot>)[self snapshotWithError:&error];
-  if (nil == self.lastSnapshot) {
-    NSString *hintText = @"Make sure the application UI has the expected state";
-    if (nil != error && [error.localizedDescription containsString:@"Identity Binding"]) {
-      hintText = [NSString stringWithFormat:@"%@. You could also try to switch the binding strategy using the 'boundElementsByIndex' setting for the element lookup", hintText];
+    if (nil == self.lastSnapshot) {
+      NSString *hintText = @"Make sure the application UI has the expected state";
+      if (nil != error && [error.localizedDescription containsString:@"Identity Binding"]) {
+        hintText = [NSString stringWithFormat:@"%@. You could also try to switch the binding strategy using the 'boundElementsByIndex' setting for the element lookup", hintText];
+      }
+      NSString *reason = [NSString stringWithFormat:@"The previously found element \"%@\" is not present in the current view anymore. %@",
+                          self.description, hintText];
+      if (nil != error) {
+        reason = [NSString stringWithFormat:@"%@. Original error: %@", reason, error.localizedDescription];
+      }
+      @throw [NSException exceptionWithName:FBStaleElementException reason:reason userInfo:@{}];
     }
-    NSString *reason = [NSString stringWithFormat:@"The previously found element \"%@\" is not present in the current view anymore. %@",
-                        self.description, hintText];
-    if (nil != error) {
-      reason = [NSString stringWithFormat:@"%@. Original error: %@", reason, error.localizedDescription];
-    }
-    @throw [NSException exceptionWithName:FBStaleElementException reason:reason userInfo:@{}];
   }
+  self.lastSnapshot = snapshot;
   return self.lastSnapshot;
 }
 
@@ -78,9 +82,11 @@
   }
   NSMutableArray<NSString *> *matchedIds = [NSMutableArray new];
   for (id<FBXCElementSnapshot> snapshot in snapshots) {
-    NSString *uid = [FBXCElementSnapshotWrapper wdUIDWithSnapshot:snapshot];
-    if (nil != uid) {
-      [matchedIds addObject:uid];
+    @autoreleasepool {
+      NSString *uid = [FBXCElementSnapshotWrapper wdUIDWithSnapshot:snapshot];
+      if (nil != uid) {
+        [matchedIds addObject:uid];
+      }
     }
   }
   NSMutableArray<XCUIElement *> *matchedElements = [NSMutableArray array];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -50,9 +50,9 @@
   @autoreleasepool {
     NSError *error = nil;
     snapshot = inDepth
-    ? [self.fb_query fb_uniqueSnapshotWithError:&error]
-    : (id<FBXCElementSnapshot>)[self snapshotWithError:&error];
-    if (nil == self.lastSnapshot) {
+      ? [self.fb_query fb_uniqueSnapshotWithError:&error]
+      : (id<FBXCElementSnapshot>)[self snapshotWithError:&error];
+    if (nil == snapshot) {
       NSString *hintText = @"Make sure the application UI has the expected state";
       if (nil != error && [error.localizedDescription containsString:@"Identity Binding"]) {
         hintText = [NSString stringWithFormat:@"%@. You could also try to switch the binding strategy using the 'boundElementsByIndex' setting for the element lookup", hintText];

--- a/WebDriverAgentLib/Routing/FBResponsePayload.m
+++ b/WebDriverAgentLib/Routing/FBResponsePayload.m
@@ -104,39 +104,38 @@ id<FBResponsePayload> FBResponseWithStatus(FBCommandStatus *status)
 inline NSDictionary *FBDictionaryResponseWithElement(XCUIElement *element, BOOL compact)
 {
   __block NSDictionary *finalResult = nil;
-    @autoreleasepool {
-      
-      id<FBXCElementSnapshot> snapshot = element.lastSnapshot ?: element.fb_cachedSnapshot ?: [element fb_takeSnapshot:YES];
-      NSDictionary *compactResult = FBToElementDict((NSString *)[FBXCElementSnapshotWrapper wdUIDWithSnapshot:snapshot]);
-      if (compact) {
-        return finalResult = compactResult;
-      }
+  @autoreleasepool {
+    id<FBXCElementSnapshot> snapshot = element.lastSnapshot ?: element.fb_cachedSnapshot ?: [element fb_takeSnapshot:YES];
+    NSDictionary *compactResult = FBToElementDict((NSString *)[FBXCElementSnapshotWrapper wdUIDWithSnapshot:snapshot]);
+    if (compact) {
+      return finalResult = compactResult;
+    }
 
-      NSMutableDictionary *result = compactResult.mutableCopy;
-      FBXCElementSnapshotWrapper *wrappedSnapshot = [FBXCElementSnapshotWrapper ensureWrapped:snapshot];
-      NSArray *fields = [FBConfiguration.elementResponseAttributes componentsSeparatedByString:@","];
-      for (NSString *field in fields) {
-        // 'name' here is the w3c-approved identifier for what we mean by 'type'
-        if ([field isEqualToString:@"name"] || [field isEqualToString:@"type"]) {
-          result[field] = wrappedSnapshot.wdType;
-        } else if ([field isEqualToString:@"text"]) {
-          result[field] = FBFirstNonEmptyValue(wrappedSnapshot.wdValue, wrappedSnapshot.wdLabel) ?: [NSNull null];
-        } else if ([field isEqualToString:@"rect"]) {
-          result[field] = wrappedSnapshot.wdRect;
-        } else if ([field isEqualToString:@"enabled"]) {
-          result[field] = @(wrappedSnapshot.wdEnabled);
-        } else if ([field isEqualToString:@"displayed"]) {
-          result[field] = @(wrappedSnapshot.wdVisible);
-        } else if ([field isEqualToString:@"selected"]) {
-          result[field] = @(wrappedSnapshot.wdSelected);
-        } else if ([field isEqualToString:@"label"]) {
-          result[field] = wrappedSnapshot.wdLabel ?: [NSNull null];
-        } else if ([field hasPrefix:arbitraryAttrPrefix]) {
-          NSString *attributeName = [field substringFromIndex:[arbitraryAttrPrefix length]];
-          result[field] = [wrappedSnapshot fb_valueForWDAttributeName:attributeName] ?: [NSNull null];
-        }
-        finalResult = result.copy;
-     }
+    NSMutableDictionary *result = compactResult.mutableCopy;
+    FBXCElementSnapshotWrapper *wrappedSnapshot = [FBXCElementSnapshotWrapper ensureWrapped:snapshot];
+    NSArray *fields = [FBConfiguration.elementResponseAttributes componentsSeparatedByString:@","];
+    for (NSString *field in fields) {
+      // 'name' here is the w3c-approved identifier for what we mean by 'type'
+      if ([field isEqualToString:@"name"] || [field isEqualToString:@"type"]) {
+        result[field] = wrappedSnapshot.wdType;
+      } else if ([field isEqualToString:@"text"]) {
+        result[field] = FBFirstNonEmptyValue(wrappedSnapshot.wdValue, wrappedSnapshot.wdLabel) ?: [NSNull null];
+      } else if ([field isEqualToString:@"rect"]) {
+        result[field] = wrappedSnapshot.wdRect;
+      } else if ([field isEqualToString:@"enabled"]) {
+        result[field] = @(wrappedSnapshot.wdEnabled);
+      } else if ([field isEqualToString:@"displayed"]) {
+        result[field] = @(wrappedSnapshot.wdVisible);
+      } else if ([field isEqualToString:@"selected"]) {
+        result[field] = @(wrappedSnapshot.wdSelected);
+      } else if ([field isEqualToString:@"label"]) {
+        result[field] = wrappedSnapshot.wdLabel ?: [NSNull null];
+      } else if ([field hasPrefix:arbitraryAttrPrefix]) {
+        NSString *attributeName = [field substringFromIndex:[arbitraryAttrPrefix length]];
+        result[field] = [wrappedSnapshot fb_valueForWDAttributeName:attributeName] ?: [NSNull null];
+      }
+      finalResult = result.copy;
+    }
   }
   return finalResult;
 }

--- a/WebDriverAgentLib/Routing/FBResponsePayload.m
+++ b/WebDriverAgentLib/Routing/FBResponsePayload.m
@@ -103,12 +103,13 @@ id<FBResponsePayload> FBResponseWithStatus(FBCommandStatus *status)
 
 inline NSDictionary *FBDictionaryResponseWithElement(XCUIElement *element, BOOL compact)
 {
-  __block NSDictionary *finalResult = nil;
+  __block NSDictionary *elementResponse = nil;
   @autoreleasepool {
     id<FBXCElementSnapshot> snapshot = element.lastSnapshot ?: element.fb_cachedSnapshot ?: [element fb_takeSnapshot:YES];
     NSDictionary *compactResult = FBToElementDict((NSString *)[FBXCElementSnapshotWrapper wdUIDWithSnapshot:snapshot]);
     if (compact) {
-      return finalResult = compactResult;
+      elementResponse = compactResult;
+      return elementResponse;
     }
 
     NSMutableDictionary *result = compactResult.mutableCopy;
@@ -134,8 +135,8 @@ inline NSDictionary *FBDictionaryResponseWithElement(XCUIElement *element, BOOL 
         NSString *attributeName = [field substringFromIndex:[arbitraryAttrPrefix length]];
         result[field] = [wrappedSnapshot fb_valueForWDAttributeName:attributeName] ?: [NSNull null];
       }
-      finalResult = result.copy;
     }
+    elementResponse = result.copy;
   }
-  return finalResult;
+  return elementResponse;
 }

--- a/WebDriverAgentLib/Routing/FBResponsePayload.m
+++ b/WebDriverAgentLib/Routing/FBResponsePayload.m
@@ -103,35 +103,40 @@ id<FBResponsePayload> FBResponseWithStatus(FBCommandStatus *status)
 
 inline NSDictionary *FBDictionaryResponseWithElement(XCUIElement *element, BOOL compact)
 {
-  id<FBXCElementSnapshot> snapshot = element.lastSnapshot ?: element.fb_cachedSnapshot ?: [element fb_takeSnapshot:YES];
-  NSDictionary *compactResult = FBToElementDict((NSString *)[FBXCElementSnapshotWrapper wdUIDWithSnapshot:snapshot]);
-  if (compact) {
-    return compactResult;
-  }
+  __block NSDictionary *finalResult = nil;
+    @autoreleasepool {
+      
+      id<FBXCElementSnapshot> snapshot = element.lastSnapshot ?: element.fb_cachedSnapshot ?: [element fb_takeSnapshot:YES];
+      NSDictionary *compactResult = FBToElementDict((NSString *)[FBXCElementSnapshotWrapper wdUIDWithSnapshot:snapshot]);
+      if (compact) {
+        return finalResult = compactResult;
+      }
 
-  NSMutableDictionary *result = compactResult.mutableCopy;
-  FBXCElementSnapshotWrapper *wrappedSnapshot = [FBXCElementSnapshotWrapper ensureWrapped:snapshot];
-  NSArray *fields = [FBConfiguration.elementResponseAttributes componentsSeparatedByString:@","];
-  for (NSString *field in fields) {
-    // 'name' here is the w3c-approved identifier for what we mean by 'type'
-    if ([field isEqualToString:@"name"] || [field isEqualToString:@"type"]) {
-      result[field] = wrappedSnapshot.wdType;
-    } else if ([field isEqualToString:@"text"]) {
-      result[field] = FBFirstNonEmptyValue(wrappedSnapshot.wdValue, wrappedSnapshot.wdLabel) ?: [NSNull null];
-    } else if ([field isEqualToString:@"rect"]) {
-      result[field] = wrappedSnapshot.wdRect;
-    } else if ([field isEqualToString:@"enabled"]) {
-      result[field] = @(wrappedSnapshot.wdEnabled);
-    } else if ([field isEqualToString:@"displayed"]) {
-      result[field] = @(wrappedSnapshot.wdVisible);
-    } else if ([field isEqualToString:@"selected"]) {
-      result[field] = @(wrappedSnapshot.wdSelected);
-    } else if ([field isEqualToString:@"label"]) {
-      result[field] = wrappedSnapshot.wdLabel ?: [NSNull null];
-    } else if ([field hasPrefix:arbitraryAttrPrefix]) {
-      NSString *attributeName = [field substringFromIndex:[arbitraryAttrPrefix length]];
-      result[field] = [wrappedSnapshot fb_valueForWDAttributeName:attributeName] ?: [NSNull null];
-    }
+      NSMutableDictionary *result = compactResult.mutableCopy;
+      FBXCElementSnapshotWrapper *wrappedSnapshot = [FBXCElementSnapshotWrapper ensureWrapped:snapshot];
+      NSArray *fields = [FBConfiguration.elementResponseAttributes componentsSeparatedByString:@","];
+      for (NSString *field in fields) {
+        // 'name' here is the w3c-approved identifier for what we mean by 'type'
+        if ([field isEqualToString:@"name"] || [field isEqualToString:@"type"]) {
+          result[field] = wrappedSnapshot.wdType;
+        } else if ([field isEqualToString:@"text"]) {
+          result[field] = FBFirstNonEmptyValue(wrappedSnapshot.wdValue, wrappedSnapshot.wdLabel) ?: [NSNull null];
+        } else if ([field isEqualToString:@"rect"]) {
+          result[field] = wrappedSnapshot.wdRect;
+        } else if ([field isEqualToString:@"enabled"]) {
+          result[field] = @(wrappedSnapshot.wdEnabled);
+        } else if ([field isEqualToString:@"displayed"]) {
+          result[field] = @(wrappedSnapshot.wdVisible);
+        } else if ([field isEqualToString:@"selected"]) {
+          result[field] = @(wrappedSnapshot.wdSelected);
+        } else if ([field isEqualToString:@"label"]) {
+          result[field] = wrappedSnapshot.wdLabel ?: [NSNull null];
+        } else if ([field hasPrefix:arbitraryAttrPrefix]) {
+          NSString *attributeName = [field substringFromIndex:[arbitraryAttrPrefix length]];
+          result[field] = [wrappedSnapshot fb_valueForWDAttributeName:attributeName] ?: [NSNull null];
+        }
+        finalResult = result.copy;
+     }
   }
-  return result.copy;
+  return finalResult;
 }

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -364,7 +364,7 @@ static NSString *const topNodeIndexPath = @"top";
 {
   NSAssert((indexPath == nil && elementStore == nil) || (indexPath != nil && elementStore != nil), @"Either both or none of indexPath and elementStore arguments should be equal to nil", nil);
 
-  id<FBXCElementSnapshot> currentSnapshot;
+  __block id<FBXCElementSnapshot> currentSnapshot;
   NSArray<id<FBXCElementSnapshot>> *children;
   if ([root isKindOfClass:XCUIElement.class]) {
     XCUIElement *element = (XCUIElement *)root;

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -373,7 +373,9 @@ static NSString *const topNodeIndexPath = @"top";
       // then the snapshot retrieval operation might freeze and time out
       [element.application fb_waitUntilStableWithTimeout:FBConfiguration.animationCoolOffTimeout];
     }
-    currentSnapshot = [element fb_takeSnapshot:YES];
+    @autoreleasepool {
+      currentSnapshot = [element fb_takeSnapshot:YES];
+    }
     children = currentSnapshot.children;
   } else {
     currentSnapshot = (id<FBXCElementSnapshot>)root;
@@ -400,18 +402,20 @@ static NSString *const topNodeIndexPath = @"top";
   }
 
   for (NSUInteger i = 0; i < [children count]; i++) {
-    id<FBXCElementSnapshot> childSnapshot = [children objectAtIndex:i];
-    NSString *newIndexPath = (indexPath != nil) ? [indexPath stringByAppendingFormat:@",%lu", (unsigned long)i] : nil;
-    if (elementStore != nil && newIndexPath != nil) {
-      [elementStore setObject:childSnapshot forKey:(id)newIndexPath];
-    }
-    rc = [self writeXmlWithRootElement:[FBXCElementSnapshotWrapper ensureWrapped:childSnapshot]
-                             indexPath:newIndexPath
-                          elementStore:elementStore
-                    includedAttributes:includedAttributes
-                                writer:writer];
-    if (rc < 0) {
-      return rc;
+    @autoreleasepool {
+      id<FBXCElementSnapshot> childSnapshot = [children objectAtIndex:i];
+      NSString *newIndexPath = (indexPath != nil) ? [indexPath stringByAppendingFormat:@",%lu", (unsigned long)i] : nil;
+      if (elementStore != nil && newIndexPath != nil) {
+        [elementStore setObject:childSnapshot forKey:(id)newIndexPath];
+      }
+      rc = [self writeXmlWithRootElement:[FBXCElementSnapshotWrapper ensureWrapped:childSnapshot]
+                               indexPath:newIndexPath
+                            elementStore:elementStore
+                      includedAttributes:includedAttributes
+                                  writer:writer];
+      if (rc < 0) {
+        return rc;
+      }
     }
   }
 

--- a/WebDriverAgentLib/Utilities/NSPredicate+FBFormat.m
+++ b/WebDriverAgentLib/Utilities/NSPredicate+FBFormat.m
@@ -59,8 +59,10 @@
   NSPredicate *wdPredicate = [self.class fb_formatSearchPredicate:input];
   return [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject,
                                                NSDictionary<NSString *,id> * _Nullable bindings) {
-    FBXCElementSnapshotWrapper *wrappedSnapshot = [FBXCElementSnapshotWrapper ensureWrapped:evaluatedObject];
-    return [wdPredicate evaluateWithObject:wrappedSnapshot];
+    @autoreleasepool {
+      FBXCElementSnapshotWrapper *wrappedSnapshot = [FBXCElementSnapshotWrapper ensureWrapped:evaluatedObject];
+      return [wdPredicate evaluateWithObject:wrappedSnapshot];
+    }
   }];
 }
 


### PR DESCRIPTION
### What?
1. Enclosed the loop's within an autorelease pool to drain temporary objects (like XCElementSnapshot instances) created during each iteration. This prevents these objects from accumulating in memory until the main autorelease pool drains, thus mitigating potential leaks.
2. Reduce memory usage of any temporary objects (e.g., the snapshot, wrapper, or internal objects from fb_takeSnapshot) if the method is called frequently (e.g., in loops or recursive traversals).