### PR TITLE
feat: add placeholderValue

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -115,6 +115,15 @@
   return FBTransferEmptyStringToNil(label);
 }
 
+- (NSString *)wdPlaceholderValue
+{
+  NSString *placehlderValue = self.placeholderValue;
+  if (nil != placehlderValue) {
+    return placehlderValue;
+  }
+  return FBTransferEmptyStringToNil(placehlderValue);
+}
+
 - (NSString *)wdType
 {
   return [FBElementTypeTransformer stringWithElementType:self.elementType];

--- a/WebDriverAgentLib/Routing/FBElement.h
+++ b/WebDriverAgentLib/Routing/FBElement.h
@@ -62,6 +62,9 @@ NS_ASSUME_NONNULL_BEGIN
 /*! Element's index relatively to its parent. Starts from zero */
 @property (nonatomic, readonly) NSUInteger wdIndex;
 
+/*! Element's placeholder value */
+@property (nonatomic, readonly, copy, nullable) NSString *wdPlaceholderValue;
+
 /**
  Returns value of given property specified in WebDriver Spec
  Check the FBElement protocol to get list of supported attributes.

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -729,7 +729,7 @@ static NSString *const FBAbstractMethodInvocationException = @"AbstractMethodInv
 
 + (NSString *)valueForElement:(id<FBElement>)element
 {
-  return FBBoolToString(element.wdPlaceholderValue);
+  return element.wdPlaceholderValue;
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -100,6 +100,10 @@
 
 @end
 
+@interface FBPlaceholderValueAttribute : FBElementAttribute
+
+@end
+
 #if TARGET_OS_TV
 
 @interface FBFocusedAttribute : FBElementAttribute
@@ -487,6 +491,7 @@ static NSString *const FBAbstractMethodInvocationException = @"AbstractMethodInv
            FBHeightAttribute.class,
            FBIndexAttribute.class,
            FBHittableAttribute.class,
+           FBPlaceholderValueAttribute.class,
           ];
 }
 
@@ -708,4 +713,19 @@ static NSString *const FBAbstractMethodInvocationException = @"AbstractMethodInv
   }
   return rc;
 }
+@end
+
+
+@implementation FBPlaceholderValueAttribute
+
++ (NSString *)name
+{
+  return @"placeholderValue";
+}
+
++ (NSString *)valueForElement:(id<FBElement>)element
+{
+  return FBBoolToString(element.wdPlaceholderValue);
+}
+
 @end

--- a/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
@@ -154,6 +154,7 @@
   XCTAssertEqualObjects(element.wdType, @"XCUIElementTypeSwitch");
   XCTAssertNil(element.wdName);
   XCTAssertNil(element.wdLabel);
+  XCTAssertNil(element.wdPlaceholderValue);
   XCTAssertEqualObjects(element.wdValue, @"1");
   XCTAssertFalse(element.wdSelected);
   XCTAssertTrue(element.wdHittable);

--- a/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
@@ -57,7 +57,7 @@
   NSString *xmlStr = [FBXPath xmlStringWithRootElement:wrappedSnapshot
                                                options:nil];
   XCTAssertNotNil(xmlStr);
-  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" index=\"%lu\"/>\n", wrappedSnapshot.wdType, wrappedSnapshot.wdType, wrappedSnapshot.wdName, wrappedSnapshot.wdLabel, FBBoolToString(wrappedSnapshot.wdEnabled), FBBoolToString(wrappedSnapshot.wdVisible), FBBoolToString(wrappedSnapshot.wdAccessible), [wrappedSnapshot.wdRect[@"x"] stringValue], [wrappedSnapshot.wdRect[@"y"] stringValue], [wrappedSnapshot.wdRect[@"width"] stringValue], [wrappedSnapshot.wdRect[@"height"] stringValue], wrappedSnapshot.wdIndex];
+  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" index=\"%lu\" placeholderValue=\"%@\"/>\n", wrappedSnapshot.wdType, wrappedSnapshot.wdType, wrappedSnapshot.wdName, wrappedSnapshot.wdLabel, FBBoolToString(wrappedSnapshot.wdEnabled), FBBoolToString(wrappedSnapshot.wdVisible), FBBoolToString(wrappedSnapshot.wdAccessible), [wrappedSnapshot.wdRect[@"x"] stringValue], [wrappedSnapshot.wdRect[@"y"] stringValue], [wrappedSnapshot.wdRect[@"width"] stringValue], [wrappedSnapshot.wdRect[@"height"] stringValue], wrappedSnapshot.wdIndex, wrappedSnapshot.wdPlaceholderValue];
   XCTAssertEqualObjects(xmlStr, expectedXml);
 }
 
@@ -70,7 +70,7 @@
   NSString *xmlStr = [FBXPath xmlStringWithRootElement:wrappedSnapshot
                                                options:options];
   XCTAssertNotNil(xmlStr);
-  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@>\n  <%@ type=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" index=\"%lu\"/>\n</%@>\n", scope, wrappedSnapshot.wdType, wrappedSnapshot.wdType, wrappedSnapshot.wdName, wrappedSnapshot.wdLabel, FBBoolToString(wrappedSnapshot.wdEnabled), FBBoolToString(wrappedSnapshot.wdVisible), FBBoolToString(wrappedSnapshot.wdAccessible), [wrappedSnapshot.wdRect[@"x"] stringValue], [wrappedSnapshot.wdRect[@"y"] stringValue], [wrappedSnapshot.wdRect[@"width"] stringValue], [wrappedSnapshot.wdRect[@"height"] stringValue], wrappedSnapshot.wdIndex, scope];
+  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@>\n  <%@ type=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" index=\"%lu\" placeholderValue=\"%@\"/>\n</%@>\n", scope, wrappedSnapshot.wdType, wrappedSnapshot.wdType, wrappedSnapshot.wdName, wrappedSnapshot.wdLabel, FBBoolToString(wrappedSnapshot.wdEnabled), FBBoolToString(wrappedSnapshot.wdVisible), FBBoolToString(wrappedSnapshot.wdAccessible), [wrappedSnapshot.wdRect[@"x"] stringValue], [wrappedSnapshot.wdRect[@"y"] stringValue], [wrappedSnapshot.wdRect[@"width"] stringValue], [wrappedSnapshot.wdRect[@"height"] stringValue], wrappedSnapshot.wdIndex, wrappedSnapshot.wdPlaceholderValue, scope];
   XCTAssertEqualObjects(xmlStr, expectedXml);
 }
 
@@ -83,7 +83,7 @@
   NSString *xmlStr = [FBXPath xmlStringWithRootElement:wrappedSnapshot
                                                options:options];
   XCTAssertNotNil(xmlStr);
-  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" name=\"%@\" label=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\"/>\n", wrappedSnapshot.wdType, wrappedSnapshot.wdType, wrappedSnapshot.wdName, wrappedSnapshot.wdLabel, FBBoolToString(wrappedSnapshot.wdAccessible), [wrappedSnapshot.wdRect[@"x"] stringValue], [wrappedSnapshot.wdRect[@"y"] stringValue], [wrappedSnapshot.wdRect[@"width"] stringValue], [wrappedSnapshot.wdRect[@"height"] stringValue]];
+  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" name=\"%@\" label=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" placeholderValue=\"%@\"/>\n", wrappedSnapshot.wdType, wrappedSnapshot.wdType, wrappedSnapshot.wdName, wrappedSnapshot.wdLabel, FBBoolToString(wrappedSnapshot.wdAccessible), [wrappedSnapshot.wdRect[@"x"] stringValue], [wrappedSnapshot.wdRect[@"y"] stringValue], [wrappedSnapshot.wdRect[@"width"] stringValue], [wrappedSnapshot.wdRect[@"height"] stringValue], wrappedSnapshot.wdPlaceholderValue];
   XCTAssertEqualObjects(xmlStr, expectedXml);
 }
 

--- a/WebDriverAgentTests/UnitTests/Doubles/XCElementSnapshotDouble.m
+++ b/WebDriverAgentTests/UnitTests/Doubles/XCElementSnapshotDouble.m
@@ -60,7 +60,7 @@
 
 - (NSString *)placeholderValue
 {
-  return @"";
+  return @"testPlaceholderValue";
 }
 
 - (BOOL)isSelected

--- a/WebDriverAgentTests/UnitTests/Doubles/XCUIElementDouble.h
+++ b/WebDriverAgentTests/UnitTests/Doubles/XCUIElementDouble.h
@@ -33,6 +33,7 @@
 @property (nonatomic, readwrite, getter=isWDAccessible) BOOL wdAccessible;
 @property (nonatomic, readwrite, getter = isWDFocused) BOOL wdFocused;
 @property (nonatomic, readwrite, getter = isWDHittable) BOOL wdHittable;
+@property (nonatomic, copy, readwrite, nullable) NSString *wdPlaceholderValue;
 @property (copy, nonnull) NSArray *children;
 @property (nonatomic, readwrite, assign) XCUIElementType elementType;
 @property (nonatomic, readwrite, getter=isWDAccessibilityContainer) BOOL wdAccessibilityContainer;

--- a/WebDriverAgentTests/UnitTests/Doubles/XCUIElementDouble.m
+++ b/WebDriverAgentTests/UnitTests/Doubles/XCUIElementDouble.m
@@ -23,6 +23,7 @@
     self.wdName = @"testName";
     self.wdLabel = @"testLabel";
     self.wdValue = @"magicValue";
+    self.wdPlaceholderValue = @"testPlaceholderValue";
     self.wdVisible = YES;
     self.wdAccessible = YES;
     self.wdEnabled = YES;

--- a/WebDriverAgentTests/UnitTests/FBXPathTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXPathTests.m
@@ -63,7 +63,7 @@
   NSString *resultXml = [self xmlStringWithElement:element
                                         xpathQuery:nil
                                excludingAttributes:nil];
-  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" value=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" index=\"%lu\" private_indexPath=\"top\"/>\n",
+  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" value=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" index=\"%lu\" placeholderValue=\"\" private_indexPath=\"top\"/>\n",
                            element.wdType, element.wdType, element.wdValue, element.wdName, element.wdLabel, FBBoolToString(element.wdEnabled), FBBoolToString(element.wdVisible), FBBoolToString(element.wdAccessible), element.wdRect[@"x"], element.wdRect[@"y"], element.wdRect[@"width"], element.wdRect[@"height"], element.wdIndex];
   XCTAssertTrue([resultXml isEqualToString: expectedXml]);
 }
@@ -75,7 +75,7 @@
   NSString *resultXml = [self xmlStringWithElement:element
                                         xpathQuery:nil
                                excludingAttributes:@[@"type", @"visible", @"value", @"index"]];
-  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ name=\"%@\" label=\"%@\" enabled=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" private_indexPath=\"top\"/>\n",
+  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ name=\"%@\" label=\"%@\" enabled=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" placeholderValue=\"\" private_indexPath=\"top\"/>\n",
                            element.wdType, element.wdName, element.wdLabel, FBBoolToString(element.wdEnabled), FBBoolToString(element.wdAccessible), element.wdRect[@"x"], element.wdRect[@"y"], element.wdRect[@"width"], element.wdRect[@"height"]];
   XCTAssertEqualObjects(resultXml, expectedXml);
 }

--- a/WebDriverAgentTests/UnitTests/FBXPathTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXPathTests.m
@@ -89,7 +89,7 @@
   NSString *resultXml = [self xmlStringWithElement:element
                                         xpathQuery:[NSString stringWithFormat:@"//%@[@*]", element.wdType]
                                excludingAttributes:@[@"visible"]];
-  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" value=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" index=\"%lu\" hittable=\"%@\" private_indexPath=\"top\"/>\n",
+  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" value=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" index=\"%lu\" hittable=\"%@\" placeholderValue=\"\" private_indexPath=\"top\"/>\n",
                            element.wdType, element.wdType, @"йоло&lt;&gt;&amp;&quot;", element.wdName, @"a&#10;b", FBBoolToString(element.wdEnabled), FBBoolToString(element.wdVisible), FBBoolToString(element.wdAccessible), element.wdRect[@"x"], element.wdRect[@"y"], element.wdRect[@"width"], element.wdRect[@"height"], element.wdIndex, FBBoolToString(element.wdHittable)];
   XCTAssertEqualObjects(expectedXml, resultXml);
 }

--- a/WebDriverAgentTests/UnitTests/FBXPathTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXPathTests.m
@@ -63,8 +63,8 @@
   NSString *resultXml = [self xmlStringWithElement:element
                                         xpathQuery:nil
                                excludingAttributes:nil];
-  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" value=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" index=\"%lu\" placeholderValue=\"\" private_indexPath=\"top\"/>\n",
-                           element.wdType, element.wdType, element.wdValue, element.wdName, element.wdLabel, FBBoolToString(element.wdEnabled), FBBoolToString(element.wdVisible), FBBoolToString(element.wdAccessible), element.wdRect[@"x"], element.wdRect[@"y"], element.wdRect[@"width"], element.wdRect[@"height"], element.wdIndex];
+  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" value=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" index=\"%lu\" placeholderValue=\"%@\" private_indexPath=\"top\"/>\n",
+                           element.wdType, element.wdType, element.wdValue, element.wdName, element.wdLabel, FBBoolToString(element.wdEnabled), FBBoolToString(element.wdVisible), FBBoolToString(element.wdAccessible), element.wdRect[@"x"], element.wdRect[@"y"], element.wdRect[@"width"], element.wdRect[@"height"], element.wdIndex, element.wdPlaceholderValue];
   XCTAssertTrue([resultXml isEqualToString: expectedXml]);
 }
 
@@ -75,8 +75,8 @@
   NSString *resultXml = [self xmlStringWithElement:element
                                         xpathQuery:nil
                                excludingAttributes:@[@"type", @"visible", @"value", @"index"]];
-  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ name=\"%@\" label=\"%@\" enabled=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" placeholderValue=\"\" private_indexPath=\"top\"/>\n",
-                           element.wdType, element.wdName, element.wdLabel, FBBoolToString(element.wdEnabled), FBBoolToString(element.wdAccessible), element.wdRect[@"x"], element.wdRect[@"y"], element.wdRect[@"width"], element.wdRect[@"height"]];
+  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ name=\"%@\" label=\"%@\" enabled=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" placeholderValue=\"%@\" private_indexPath=\"top\"/>\n",
+                           element.wdType, element.wdName, element.wdLabel, FBBoolToString(element.wdEnabled), FBBoolToString(element.wdAccessible), element.wdRect[@"x"], element.wdRect[@"y"], element.wdRect[@"width"], element.wdRect[@"height"], element.wdPlaceholderValue];
   XCTAssertEqualObjects(resultXml, expectedXml);
 }
 
@@ -89,8 +89,8 @@
   NSString *resultXml = [self xmlStringWithElement:element
                                         xpathQuery:[NSString stringWithFormat:@"//%@[@*]", element.wdType]
                                excludingAttributes:@[@"visible"]];
-  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" value=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" index=\"%lu\" hittable=\"%@\" placeholderValue=\"\" private_indexPath=\"top\"/>\n",
-                           element.wdType, element.wdType, @"йоло&lt;&gt;&amp;&quot;", element.wdName, @"a&#10;b", FBBoolToString(element.wdEnabled), FBBoolToString(element.wdVisible), FBBoolToString(element.wdAccessible), element.wdRect[@"x"], element.wdRect[@"y"], element.wdRect[@"width"], element.wdRect[@"height"], element.wdIndex, FBBoolToString(element.wdHittable)];
+  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" value=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" accessible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\" index=\"%lu\" hittable=\"%@\" placeholderValue=\"%@\" private_indexPath=\"top\"/>\n",
+                           element.wdType, element.wdType, @"йоло&lt;&gt;&amp;&quot;", element.wdName, @"a&#10;b", FBBoolToString(element.wdEnabled), FBBoolToString(element.wdVisible), FBBoolToString(element.wdAccessible), element.wdRect[@"x"], element.wdRect[@"y"], element.wdRect[@"width"], element.wdRect[@"height"], element.wdIndex, FBBoolToString(element.wdHittable), element.wdPlaceholderValue];
   XCTAssertEqualObjects(expectedXml, resultXml);
 }
 


### PR DESCRIPTION
To support https://github.com/appium/WebDriverAgent/issues/986

Add https://developer.apple.com/documentation/xctest/xcuielementattributes/placeholdervalue

Example usage with our UICatalog app in the text field view:

- find element
```
> e = driver.find_element :predicate, 'placeholderValue == "Placeholder text"'
=> #<Appium::Core::Element:0x1ca9e97bebb7606 id="BA000000-0000-0000-CEF9-000000000000">
e.placeholderValue
=> "Placeholder text"
```

- part of page source
```
                       <XCUIElementTypeOther type="XCUIElementTypeOther" enabled="true" visible="true" accessible="false" x="8" y="656" width="367" height="1" index="3" placeholderValue=""/>
                        <XCUIElementTypeTextField type="XCUIElementTypeTextField" value="￼￼" label="" enabled="true" visible="true" accessible="true" x="16" y="621" width="361" height="28" index="4" placeholderValue="Enter search text">
                          <XCUIElementTypeImage type="XCUIElementTypeImage" name="magnifyingglass" label="Search" enabled="true" visible="true" accessible="false" x="22" y="625" width="21" height="19" index="0" placeholderValue=""/>
```

<img width="430" alt="Screenshot 2025-03-08 at 1 01 17 AM" src="https://github.com/user-attachments/assets/9e40ed3a-6d41-4910-97e9-74dd5c79a677" />
