### PR TITLE
fix: Properly set snapshot lookup scope if limitXpathContextScope is disabled

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -12,6 +12,7 @@
 
 #import "FBMacros.h"
 #import "FBElementTypeTransformer.h"
+#import "FBConfiguration.h"
 #import "NSPredicate+FBFormat.h"
 #import "FBXCElementSnapshotWrapper+Helpers.h"
 #import "FBXCodeCompatibility.h"
@@ -109,8 +110,9 @@
     id<FBXCElementSnapshot> snapshot = matchingSnapshots.firstObject;
     matchingSnapshots = @[snapshot];
   }
-  return [self fb_filterDescendantsWithSnapshots:matchingSnapshots
-                                    onlyChildren:NO];
+  XCUIElement *scopeRoot = FBConfiguration.limitXpathContextScope ? self : self.application;
+  return [scopeRoot fb_filterDescendantsWithSnapshots:matchingSnapshots
+                                         onlyChildren:NO];
 }
 
 

--- a/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
@@ -108,10 +108,22 @@
                           [FBXCElementSnapshotWrapper ensureWrapped:[parentSnapshots objectAtIndex:0]].wdLabel,
                           @"MainView"
                           );
+    NSArray *elements = [button.application fb_filterDescendantsWithSnapshots:parentSnapshots onlyChildren:NO];
+    XCTAssertEqual(elements.count, 1);
+    XCTAssertEqualObjects(
+                          [[elements objectAtIndex:0] wdLabel],
+                          @"MainView"
+                          );
     NSArray *currentSnapshots = [FBXPath matchesWithRootElement:button forQuery:@"."];
     XCTAssertEqual(currentSnapshots.count, 1);
     XCTAssertEqualObjects(
                           [FBXCElementSnapshotWrapper ensureWrapped:[currentSnapshots objectAtIndex:0]].wdType,
+                          @"XCUIElementTypeButton"
+                          );
+    NSArray *currentElements = [button.application fb_filterDescendantsWithSnapshots:currentSnapshots onlyChildren:NO];
+    XCTAssertEqual(currentElements.count, 1);
+    XCTAssertEqualObjects(
+                          [[currentElements objectAtIndex:0] wdType],
                           @"XCUIElementTypeButton"
                           );
   } @finally {


### PR DESCRIPTION
Addresses https://discuss.appium.io/t/elements-snapshot-depth/45587/15