### PR TITLE
feat: Always apply the native snapshotting strategy for XCUIApplication instances

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -49,7 +49,7 @@
   __block id<FBXCElementSnapshot> snapshot = nil;
   @autoreleasepool {
     NSError *error = nil;
-    snapshot = inDepth
+    snapshot = inDepth && ![self isKindOfClass:XCUIApplication.class]
       ? [self.fb_query fb_uniqueSnapshotWithError:&error]
       : (id<FBXCElementSnapshot>)[self snapshotWithError:&error];
     if (nil == snapshot) {

--- a/WebDriverAgentTests/IntegrationTests/XCUIApplicationHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIApplicationHelperTests.m
@@ -20,6 +20,23 @@
 #import "XCUIElement+FBIsVisible.h"
 #import "FBXCodeCompatibility.h"
 
+void calculateMaxTreeDepth(NSDictionary *tree, NSNumber *currentDepth, NSNumber** maxDepth) {
+  if (nil == maxDepth) {
+    return;
+  }
+
+  NSArray *children = tree[@"children"];
+  if (nil == children || 0 == children.count) {
+    return;
+  }
+  for (NSDictionary *child in children) {
+    if (currentDepth.integerValue > [*maxDepth integerValue]) {
+      *maxDepth = currentDepth;
+    }
+    calculateMaxTreeDepth(child, @(currentDepth.integerValue + 1), maxDepth);
+  }
+}
+
 @interface XCUIApplicationHelperTests : FBIntegrationTestCase
 @end
 
@@ -40,7 +57,11 @@
 
 - (void)testApplicationTree
 {
-  XCTAssertNotNil(self.testedApplication.fb_tree);
+  NSDictionary *tree = self.testedApplication.fb_tree;
+  XCTAssertNotNil(tree);
+  NSNumber *maxDepth;
+  calculateMaxTreeDepth(tree, @0, &maxDepth);
+  XCTAssertGreaterThan(maxDepth.integerValue, 3);
   XCTAssertNotNil(self.testedApplication.fb_accessibilityTree);
 }
 


### PR DESCRIPTION
This should improve the snapshotting performance based on https://github.com/appium/WebDriverAgent/pull/997

