### PR TITLE
fix: Make sure we don't store element snapshot in the cache

### DIFF
--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -269,6 +269,7 @@
     NSString *focusedUUID = [elementCache storeElement:(useNativeCachingStrategy
                                                         ? focusedElement
                                                         : [focusedElement fb_stableInstanceWithUid:focusedElement.fb_uid])];
+    focusedElement.lastSnapshot = nil;
     if (focusedUUID && [focusedUUID isEqualToString:(id)request.parameters[@"uuid"]]) {
       isFocused = YES;
     }

--- a/WebDriverAgentLib/Routing/FBResponsePayload.m
+++ b/WebDriverAgentLib/Routing/FBResponsePayload.m
@@ -55,7 +55,9 @@ XCUIElement *maybeStable(XCUIElement *element)
 id<FBResponsePayload> FBResponseWithCachedElement(XCUIElement *element, FBElementCache *elementCache, BOOL compact)
 {
   [elementCache storeElement:maybeStable(element)];
-  return FBResponseWithStatus([FBCommandStatus okWithValue:FBDictionaryResponseWithElement(element, compact)]);
+  NSDictionary *response = FBDictionaryResponseWithElement(element, compact);
+  element.lastSnapshot = nil;
+  return FBResponseWithStatus([FBCommandStatus okWithValue:response]);
 }
 
 id<FBResponsePayload> FBResponseWithCachedElements(NSArray<XCUIElement *> *elements, FBElementCache *elementCache, BOOL compact)
@@ -64,6 +66,7 @@ id<FBResponsePayload> FBResponseWithCachedElements(NSArray<XCUIElement *> *eleme
   for (XCUIElement *element in elements) {
     [elementCache storeElement:maybeStable(element)];
     [elementsResponse addObject:FBDictionaryResponseWithElement(element, compact)];
+    element.lastSnapshot = nil;
   }
   return FBResponseWithStatus([FBCommandStatus okWithValue:elementsResponse]);
 }


### PR DESCRIPTION
This should reduce the memory footprint