### PR TITLE
chore: use JPEG to produce smaller size element screenshots than PNG

### DIFF
--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -562,17 +562,31 @@
 
 + (id<FBResponsePayload>)handleElementScreenshot:(FBRouteRequest *)request
 {
-  FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]
-                                       checkStaleness:YES];
-  NSData *screenshotData = [element.screenshot PNGRepresentation];
-  if (nil == screenshotData) {
-    NSString *errMsg = [NSString stringWithFormat:@"Cannot take a screenshot of %@", element.description];
-    return FBResponseWithStatus([FBCommandStatus unableToCaptureScreenErrorWithMessage:errMsg
-                                                                             traceback:nil]);
+  @autoreleasepool {
+    FBElementCache *elementCache = request.session.elementCache;
+    XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]
+                                        checkStaleness:YES];
+    NSData *screenshotData = nil;
+    @autoreleasepool {
+      XCUIScreenshot *screenshotObj = element.screenshot;
+      if (nil == screenshotObj) {
+        NSString *errMsg = [NSString stringWithFormat:@"Cannot take a screenshot of %@", element.description];
+        return FBResponseWithStatus([FBCommandStatus unableToCaptureScreenErrorWithMessage:errMsg
+                                                                                traceback:nil]);
+      }
+      UIImage *screenshot = screenshotObj.image;
+      if (nil == screenshot) {
+        NSString *errMsg = [NSString stringWithFormat:@"Cannot take a screenshot of %@", element.description];
+        return FBResponseWithStatus([FBCommandStatus unableToCaptureScreenErrorWithMessage:errMsg
+                                                                                traceback:nil]);
+      }
+      screenshotData = UIImageJPEGRepresentation(screenshot, 0.9);
+      screenshot = nil;
+    }
+    NSString *base64String = [screenshotData base64EncodedStringWithOptions:0];
+    screenshotData = nil;
+    return FBResponseWithObject(base64String);
   }
-  NSString *screenshot = [screenshotData base64EncodedStringWithOptions:0];
-  return FBResponseWithObject(screenshot);
 }
 
 


### PR DESCRIPTION
- With this PR, we want to use JPEG compression (via UIImageJPEGRepresentation) with a quality of 0.9 to reduce data size compared to the existing PNG.
- Example: A 1080p screenshot ≈ 2MB (JPEG 0.9) vs. 6MB (PNG).
JPEG 0.9 is a strong candidate for the ideal JPEG quality value because we want to maintain quality and prevent pixel loss as much as possible while reducing the size.
- We are estimating around 50% smaller memory footprints with JPEG 0.9
- The goal is to reduce the WDA memory consumption during long-running sessions and prevent it from crashing.