### PR TITLE
fix: release element screenshot data

### DIFF
--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -562,17 +562,28 @@
 
 + (id<FBResponsePayload>)handleElementScreenshot:(FBRouteRequest *)request
 {
-  FBElementCache *elementCache = request.session.elementCache;
-  XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]
-                                       checkStaleness:YES];
-  NSData *screenshotData = [element.screenshot PNGRepresentation];
-  if (nil == screenshotData) {
-    NSString *errMsg = [NSString stringWithFormat:@"Cannot take a screenshot of %@", element.description];
-    return FBResponseWithStatus([FBCommandStatus unableToCaptureScreenErrorWithMessage:errMsg
-                                                                             traceback:nil]);
+  id<FBResponsePayload> response = nil;
+  @autoreleasepool {
+    FBElementCache *elementCache = request.session.elementCache;
+    XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]
+                                        checkStaleness:YES];
+    NSData *screenshotData = nil;
+    @autoreleasepool {
+      UIImage *screenshot = element.screenshot;
+      screenshotData = [screenshot PNGRepresentation];
+      screenshot = nil;
+
+      if (nil == screenshotData) {
+        NSString *errMsg = [NSString stringWithFormat:@"Cannot take a screenshot of %@", element.description];
+        return FBResponseWithStatus([FBCommandStatus unableToCaptureScreenErrorWithMessage:errMsg traceback:nil]);
+      }
+    }
+
+    NSString *screenshot = [screenshotData base64EncodedStringWithOptions:0];
+    screenshotData = nil;
+
+    return FBResponseWithObject(screenshot);
   }
-  NSString *screenshot = [screenshotData base64EncodedStringWithOptions:0];
-  return FBResponseWithObject(screenshot);
 }
 
 

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -562,20 +562,19 @@
 
 + (id<FBResponsePayload>)handleElementScreenshot:(FBRouteRequest *)request
 {
-  id<FBResponsePayload> response = nil;
   @autoreleasepool {
     FBElementCache *elementCache = request.session.elementCache;
     XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]
                                         checkStaleness:YES];
     NSData *screenshotData = nil;
     @autoreleasepool {
-      UIImage *screenshot = element.screenshot;
-      screenshotData = [screenshot PNGRepresentation];
-      screenshot = nil;
-
+      XCUIScreenshot *screenshotObj = element.screenshot;
+      screenshotData = [screenshotObj PNGRepresentation];
+      screenshotObj = nil;
       if (nil == screenshotData) {
         NSString *errMsg = [NSString stringWithFormat:@"Cannot take a screenshot of %@", element.description];
-        return FBResponseWithStatus([FBCommandStatus unableToCaptureScreenErrorWithMessage:errMsg traceback:nil]);
+        return FBResponseWithStatus([FBCommandStatus unableToCaptureScreenErrorWithMessage:errMsg
+                                                                                traceback:nil]);
       }
     }
 

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -568,9 +568,7 @@
                                         checkStaleness:YES];
     NSData *screenshotData = nil;
     @autoreleasepool {
-      XCUIScreenshot *screenshotObj = element.screenshot;
-      screenshotData = [screenshotObj PNGRepresentation];
-      screenshotObj = nil;
+      screenshotData = [element.screenshot PNGRepresentation];
       if (nil == screenshotData) {
         NSString *errMsg = [NSString stringWithFormat:@"Cannot take a screenshot of %@", element.description];
         return FBResponseWithStatus([FBCommandStatus unableToCaptureScreenErrorWithMessage:errMsg

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -577,10 +577,8 @@
                                                                                 traceback:nil]);
       }
     }
-
     NSString *screenshot = [screenshotData base64EncodedStringWithOptions:0];
     screenshotData = nil;
-
     return FBResponseWithObject(screenshot);
   }
 }


### PR DESCRIPTION
- This should reduce the memory footprint for screenshots, we are using autorelease pool and setting `sessionData` to `nil` 