### PR TITLE
fix: Unknown type for CGFloat

### DIFF
--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -8,6 +8,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
In older xcode versions with iOS 15, WDA build is failing with below error due to missing import. Added the import


```
In file included from appium/packages/appium/xcuitest/9.2.4/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgentLib/Routing/FBWebServer.m:24:
appium/packages/appium/xcuitest/9.2.4/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgentLib/Utilities/FBConfiguration.h:139:4: error: expected a type
 + (CGFloat)mjpegScalingFactor;
    ^
 appium/packages/appium/xcuitest/9.2.4/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgentLib/Utilities/FBConfiguration.h:139:1: warning: method has no return type specified; defaults to 'id' [-Wmissing-method-return-type]
 + (CGFloat)mjpegScalingFactor;
 ^
            (id)
 appium/packages/appium/xcuitest/9.2.4/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgentLib/Utilities/FBConfiguration.h:140:32: error: expected a type
 (void)setMjpegScalingFactor:(CGFloat)scalingFactor;
                                ^
 appium/packages/appium/xcuitest/9.2.4/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent/WebDriverAgentLib/Routing/FBWebServer.m:145:44: error: sending 'float' to parameter of incompatible type 'id'
     [FBConfiguration setMjpegScalingFactor:[scalingFactor floatValue]];
```