### PR TITLE
feat: Add a real frame property of the element

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -47,7 +47,7 @@ static NSString* const FBExclusionAttributeVisible = @"visible";
 static NSString* const FBExclusionAttributeAccessible = @"accessible";
 static NSString* const FBExclusionAttributeFocused = @"focused";
 static NSString* const FBExclusionAttributePlaceholderValue = @"placeholderValue";
-
+static NSString* const FBExclusionAttributeNativeFrame = @"nativeFrame";
 
 _Nullable id extractIssueProperty(id issue, NSString *propertyName) {
   SEL selector = NSSelectorFromString(propertyName);
@@ -205,8 +205,11 @@ NSDictionary<NSString *, NSString *> *customExclusionAttributesMap(void) {
   
   NSDictionary<NSString *, NSString *(^)(void)> *attributeBlocks = [self fb_attributeBlockMapForWrappedSnapshot:wrappedSnapshot];
 
-  NSSet *nonPrefixedKeys = [NSSet setWithObjects:FBExclusionAttributeFrame,
-                            FBExclusionAttributePlaceholderValue, nil];
+  NSSet *nonPrefixedKeys = [NSSet setWithObjects:
+                            FBExclusionAttributeFrame,
+                            FBExclusionAttributePlaceholderValue,
+                            FBExclusionAttributeNativeFrame,
+                            nil];
 
   for (NSString *key in attributeBlocks) {
       if (excludedAttributes == nil || ![excludedAttributes containsObject:key]) {
@@ -247,6 +250,9 @@ NSDictionary<NSString *, NSString *> *customExclusionAttributesMap(void) {
   [@{
     FBExclusionAttributeFrame: ^{
     return NSStringFromCGRect(wrappedSnapshot.wdFrame);
+  },
+    FBExclusionAttributeNativeFrame: ^{
+    return NSStringFromCGRect(wrappedSnapshot.wdNativeFrame);
   },
     FBExclusionAttributeEnabled: ^{
     return [@([wrappedSnapshot isWDEnabled]) stringValue];

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -211,6 +211,8 @@ NSDictionary<NSString *, NSString *> *customExclusionAttributesMap(void) {
                             FBExclusionAttributeNativeFrame,
                             nil];
 
+  NSSet *nonPrefixedKeys = [NSSet setWithObjects:FBExclusionAttributeFrame, FBExclusionAttributeNativeFrame, nil];
+
   for (NSString *key in attributeBlocks) {
       if (excludedAttributes == nil || ![excludedAttributes containsObject:key]) {
           NSString *value = ((NSString * (^)(void))attributeBlocks[key])();

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -211,8 +211,6 @@ NSDictionary<NSString *, NSString *> *customExclusionAttributesMap(void) {
                             FBExclusionAttributeNativeFrame,
                             nil];
 
-  NSSet *nonPrefixedKeys = [NSSet setWithObjects:FBExclusionAttributeFrame, FBExclusionAttributeNativeFrame, nil];
-
   for (NSString *key in attributeBlocks) {
       if (excludedAttributes == nil || ![excludedAttributes containsObject:key]) {
           NSString *value = ((NSString * (^)(void))attributeBlocks[key])();

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -147,6 +147,14 @@
     : CGRectIntegral(frame);
 }
 
+- (CGRect)wdNativeFrame
+{
+  // To avoid confusion regarding the frame returned by `wdFrame`,
+  // the current property is provided to represent the element's
+  // actual rendered frame.
+  return self.frame;
+}
+
 - (BOOL)isWDVisible
 {
   return self.fb_isVisible;

--- a/WebDriverAgentLib/Routing/FBElement.h
+++ b/WebDriverAgentLib/Routing/FBElement.h
@@ -20,6 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 /*! Element's frame in normalized (rounded dimensions without Infinity values) CGRect format */
 @property (nonatomic, readonly, assign) CGRect wdFrame;
 
+/*! Represents the element's frame as a CGRect, preserving the actual values. */
+@property (nonatomic, readonly, assign) CGRect wdNativeFrame;
+
 /*! Element's wsFrame in NSDictionary format */
 @property (nonatomic, readonly, copy) NSDictionary *wdRect;
 


### PR DESCRIPTION
### Summary
This pull request introduces support for retrieving the actual rendered frame of a UI element, providing a more precise representation than the standard `wdFrame` value.

### Motivation
The original `wdFrame` property applies rounding logic, which in some cases may lead to inaccurate element sizes or positions.

---
**Example Case: iPhone 16 Pro Simulator**

Consider the following scenario:
We have a button, and after launching the app, we retrieve its `frame` using either a UI test or from within `viewDidAppear`.
The returned `frame` is:
```(190.66666666666666, 426.6666666666667, 20.666666666666686, 20.66666666666663)```

However, when requesting the same frame from WebDriverAgent (wdFrame), we receive:
 ```(190, 426, 22, 22)```

This difference - sometimes exceeding 1 pt and occasionally reaching 2 pt  - can lead to inconsistencies, especially when performing 'pixel-perfect' validations.

---

### Proposed Solution
We can round the frame values to two decimal places, resulting in a more accurate and human-readable format:
```(190.67, 426.67, 20.67, 20.67)```

---

Could we make some toggle in the configuration? To turn on this property? 

Thanks for the idea with `nonPrefixedKeys`.
Ref: https://github.com/appium/WebDriverAgent/pull/1016