### PR TITLE
feat: Add accessibility traits of the element

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -539,6 +539,10 @@
 		ADBC39981D07842800327304 /* XCUIElementDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = ADBC39971D07842800327304 /* XCUIElementDouble.m */; };
 		ADDA07241D6BB2BF001700AC /* FBScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = ADDA07231D6BB2BF001700AC /* FBScrollViewController.m */; };
 		ADEF63AF1D09DEBE0070A7E3 /* FBRuntimeUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ADEF63AE1D09DEBE0070A7E3 /* FBRuntimeUtilsTests.m */; };
+		B316351C2DDF0CF5007D9317 /* FBAccessibilityTraits.m in Sources */ = {isa = PBXBuildFile; fileRef = B316351B2DDF0CF5007D9317 /* FBAccessibilityTraits.m */; };
+		B316351D2DDF0CF5007D9317 /* FBAccessibilityTraits.m in Sources */ = {isa = PBXBuildFile; fileRef = B316351B2DDF0CF5007D9317 /* FBAccessibilityTraits.m */; };
+		B316351F2DDF0D0B007D9317 /* FBAccessibilityTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = B316351E2DDF0D0B007D9317 /* FBAccessibilityTraits.h */; };
+		B31635202DDF0D0B007D9317 /* FBAccessibilityTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = B316351E2DDF0D0B007D9317 /* FBAccessibilityTraits.h */; };
 		C845206222D5E79400EA68CB /* FBUnattachedAppLauncher.h in Headers */ = {isa = PBXBuildFile; fileRef = C8FB547722D4C1FC00B69954 /* FBUnattachedAppLauncher.h */; };
 		C845206322D5E79700EA68CB /* FBUnattachedAppLauncher.m in Sources */ = {isa = PBXBuildFile; fileRef = C8FB547822D4C1FC00B69954 /* FBUnattachedAppLauncher.m */; };
 		C8FB547422D3949C00B69954 /* LSApplicationWorkspace.h in Headers */ = {isa = PBXBuildFile; fileRef = C8FB547322D3949C00B69954 /* LSApplicationWorkspace.h */; };
@@ -1115,6 +1119,8 @@
 		ADDA07221D6BB2BF001700AC /* FBScrollViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBScrollViewController.h; sourceTree = "<group>"; };
 		ADDA07231D6BB2BF001700AC /* FBScrollViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBScrollViewController.m; sourceTree = "<group>"; };
 		ADEF63AE1D09DEBE0070A7E3 /* FBRuntimeUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBRuntimeUtilsTests.m; sourceTree = "<group>"; };
+		B316351B2DDF0CF5007D9317 /* FBAccessibilityTraits.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBAccessibilityTraits.m; sourceTree = "<group>"; };
+		B316351E2DDF0D0B007D9317 /* FBAccessibilityTraits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBAccessibilityTraits.h; sourceTree = "<group>"; };
 		C8FB547322D3949C00B69954 /* LSApplicationWorkspace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LSApplicationWorkspace.h; sourceTree = "<group>"; };
 		C8FB547722D4C1FC00B69954 /* FBUnattachedAppLauncher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBUnattachedAppLauncher.h; sourceTree = "<group>"; };
 		C8FB547822D4C1FC00B69954 /* FBUnattachedAppLauncher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBUnattachedAppLauncher.m; sourceTree = "<group>"; };
@@ -1979,6 +1985,8 @@
 				EE6B64FC1D0F86EF00E85F5D /* XCTestPrivateSymbols.m */,
 				633E904A220DEE7F007CADF9 /* XCUIApplicationProcessDelay.h */,
 				6385F4A5220A40760095BBDB /* XCUIApplicationProcessDelay.m */,
+				B316351B2DDF0CF5007D9317 /* FBAccessibilityTraits.m */,
+				B316351E2DDF0D0B007D9317 /* FBAccessibilityTraits.h */,
 			);
 			name = Utilities;
 			path = WebDriverAgentLib/Utilities;
@@ -2420,6 +2428,7 @@
 				641EE6A62240C5CA00173FCB /* FBImageProcessor.h in Headers */,
 				641EE6A72240C5CA00173FCB /* FBSession-Private.h in Headers */,
 				641EE6A82240C5CA00173FCB /* NSString+FBXMLSafeString.h in Headers */,
+				B316351F2DDF0D0B007D9317 /* FBAccessibilityTraits.h in Headers */,
 				64E3502F2AC0B6FE005F3ACB /* NSDictionary+FBUtf8SafeDictionary.h in Headers */,
 				641EE6A92240C5CA00173FCB /* FBCommandStatus.h in Headers */,
 				71822702258744A400661B83 /* HTTPResponseProxy.h in Headers */,
@@ -2712,6 +2721,7 @@
 				EE35AD571E3B77D600A02D78 /* XCTestSuiteRun.h in Headers */,
 				EE35AD701E3B77D600A02D78 /* XCUIElementAsynchronousHandlerWrapper.h in Headers */,
 				EE35AD4C1E3B77D600A02D78 /* XCTestLog.h in Headers */,
+				B31635202DDF0D0B007D9317 /* FBAccessibilityTraits.h in Headers */,
 				71BB58E82B96328700CB9BFE /* FBScreenRecordingRequest.h in Headers */,
 				EE35AD231E3B77D600A02D78 /* UITapGestureRecognizer-RecordingAdditions.h in Headers */,
 				EE35AD2A1E3B77D600A02D78 /* XCDebugLogDelegate-Protocol.h in Headers */,
@@ -3173,6 +3183,7 @@
 				641EE6082240C5CA00173FCB /* FBRuntimeUtils.m in Sources */,
 				641EE6092240C5CA00173FCB /* XCUIElement+FBUtilities.m in Sources */,
 				641EE60A2240C5CA00173FCB /* FBLogger.m in Sources */,
+				B316351D2DDF0CF5007D9317 /* FBAccessibilityTraits.m in Sources */,
 				641EE60B2240C5CA00173FCB /* FBCustomCommands.m in Sources */,
 				71BB58E42B9631F100CB9BFE /* FBScreenRecordingPromise.m in Sources */,
 				641EE60C2240C5CA00173FCB /* XCUIDevice+FBHelpers.m in Sources */,
@@ -3257,6 +3268,7 @@
 				71AE3CFA2D38EE8E0039FC36 /* XCUIElement+FBVisibleFrame.m in Sources */,
 				EEBBD48C1D47746D00656A81 /* XCUIElement+FBFind.m in Sources */,
 				EE158ADD1CBD456F00A3E3F0 /* FBResponsePayload.m in Sources */,
+				B316351C2DDF0CF5007D9317 /* FBAccessibilityTraits.m in Sources */,
 				E444DCB524913C220060D7EB /* RouteRequest.m in Sources */,
 				C8FB547A22D4C1FC00B69954 /* FBUnattachedAppLauncher.m in Sources */,
 				EE158ADF1CBD456F00A3E3F0 /* FBRoute.m in Sources */,

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -270,7 +270,7 @@ NSDictionary<NSString *, NSString *> *customExclusionAttributesMap(void) {
   },
     FBExclusionAttributeTraits: ^{
     return wrappedSnapshot.wdTraits;
-    }
+  }
   } mutableCopy];
   
   XCUIElementType elementType = wrappedSnapshot.elementType;

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -267,7 +267,10 @@ NSDictionary<NSString *, NSString *> *customExclusionAttributesMap(void) {
   },
     FBExclusionAttributeFocused: ^{
     return [@([wrappedSnapshot isWDFocused]) stringValue];
-  }
+  },
+    FBExclusionAttributeTraits: ^{
+    return wrappedSnapshot.wdTraits;
+    }
   } mutableCopy];
   
   XCUIElementType elementType = wrappedSnapshot.elementType;
@@ -278,11 +281,6 @@ NSDictionary<NSString *, NSString *> *customExclusionAttributesMap(void) {
       return (NSString *)FBValueOrNull(wrappedSnapshot.wdPlaceholderValue);
     };
   }
-  
-  // Accessibility traits as readable strings
-  blocks[FBExclusionAttributeTraits] = ^{
-    return wrappedSnapshot.wdTraits;
-  };
   
   return [blocks copy];
 }

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -48,6 +48,7 @@ static NSString* const FBExclusionAttributeAccessible = @"accessible";
 static NSString* const FBExclusionAttributeFocused = @"focused";
 static NSString* const FBExclusionAttributePlaceholderValue = @"placeholderValue";
 static NSString* const FBExclusionAttributeNativeFrame = @"nativeFrame";
+static NSString* const FBExclusionAttributeTraits = @"traits";
 
 _Nullable id extractIssueProperty(id issue, NSString *propertyName) {
   SEL selector = NSSelectorFromString(propertyName);
@@ -209,6 +210,7 @@ NSDictionary<NSString *, NSString *> *customExclusionAttributesMap(void) {
                             FBExclusionAttributeFrame,
                             FBExclusionAttributePlaceholderValue,
                             FBExclusionAttributeNativeFrame,
+                            FBExclusionAttributeTraits,
                             nil];
 
   for (NSString *key in attributeBlocks) {
@@ -276,6 +278,11 @@ NSDictionary<NSString *, NSString *> *customExclusionAttributesMap(void) {
       return (NSString *)FBValueOrNull(wrappedSnapshot.wdPlaceholderValue);
     };
   }
+  
+  // Accessibility traits as readable strings
+  blocks[FBExclusionAttributeTraits] = ^{
+    return wrappedSnapshot.wdTraits;
+  };
   
   return [blocks copy];
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -161,6 +161,8 @@
  This method converts the element's accessibility traits bitmask into human-readable strings
  using fb_accessibilityTraitsToStringsArray. The traits represent various accessibility
  characteristics of the element such as Button, Link, Image, etc.
+ You can find the list of possible traits in the Apple documentation:
+ https://developer.apple.com/documentation/uikit/uiaccessibilitytraits?language=objc
  
  @return A comma-separated string of accessibility traits, or an empty string if no traits are set
  */

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -22,6 +22,7 @@
 #import "FBElementUtils.h"
 #import "XCTestPrivateSymbols.h"
 #import "XCUIHitPointResult.h"
+#import "FBAccessibilityTraits.h"
 
 #define BROKEN_RECT CGRectMake(-1, -1, 0, 0)
 
@@ -153,6 +154,20 @@
   // the current property is provided to represent the element's
   // actual rendered frame.
   return self.frame;
+}
+
+/**
+ Returns a comma-separated string of accessibility traits for the element.
+ This method converts the element's accessibility traits bitmask into human-readable strings
+ using fb_accessibilityTraitsToStringsArray. The traits represent various accessibility
+ characteristics of the element such as Button, Link, Image, etc.
+ 
+ @return A comma-separated string of accessibility traits, or an empty string if no traits are set
+ */
+- (NSString *)wdTraits
+{
+  NSArray<NSString *> *traits = fb_accessibilityTraitsToStringsArray(self.snapshot.traits);
+  return [traits componentsJoinedByString:@", "];
 }
 
 - (BOOL)isWDVisible

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -159,7 +159,7 @@
 /**
  Returns a comma-separated string of accessibility traits for the element.
  This method converts the element's accessibility traits bitmask into human-readable strings
- using fb_accessibilityTraitsToStringsArray. The traits represent various accessibility
+ using FBAccessibilityTraitsToStringsArray. The traits represent various accessibility
  characteristics of the element such as Button, Link, Image, etc.
  You can find the list of possible traits in the Apple documentation:
  https://developer.apple.com/documentation/uikit/uiaccessibilitytraits?language=objc
@@ -168,7 +168,7 @@
  */
 - (NSString *)wdTraits
 {
-  NSArray<NSString *> *traits = fb_accessibilityTraitsToStringsArray(self.snapshot.traits);
+  NSArray<NSString *> *traits = FBAccessibilityTraitsToStringsArray(self.snapshot.traits);
   return [traits componentsJoinedByString:@", "];
 }
 

--- a/WebDriverAgentLib/Routing/FBElement.h
+++ b/WebDriverAgentLib/Routing/FBElement.h
@@ -38,6 +38,9 @@ NS_ASSUME_NONNULL_BEGIN
 /*! Element's type */
 @property (nonatomic, readonly, copy) NSString *wdType;
 
+/*! Element's accessibility traits as a comma-separated string */
+@property (nonatomic, readonly, copy) NSString *wdTraits;
+
 /*! Element's value */
 @property (nonatomic, readonly, strong, nullable) NSString *wdValue;
 

--- a/WebDriverAgentLib/Utilities/FBAccessibilityTraits.h
+++ b/WebDriverAgentLib/Utilities/FBAccessibilityTraits.h
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#ifndef FBAccessibilityTraits_h
+#define FBAccessibilityTraits_h
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Converts accessibility traits bitmask to an array of string representations
+ @param traits The accessibility traits bitmask
+ @return Array of strings representing the accessibility traits
+ */
+NSArray<NSString *> *fb_accessibilityTraitsToStringsArray(unsigned long long traits);
+
+NS_ASSUME_NONNULL_END
+
+#endif /* FBAccessibilityTraits_h */

--- a/WebDriverAgentLib/Utilities/FBAccessibilityTraits.h
+++ b/WebDriverAgentLib/Utilities/FBAccessibilityTraits.h
@@ -10,7 +10,7 @@
 #ifndef FBAccessibilityTraits_h
 #define FBAccessibilityTraits_h
 
-#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WebDriverAgentLib/Utilities/FBAccessibilityTraits.h
+++ b/WebDriverAgentLib/Utilities/FBAccessibilityTraits.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param traits The accessibility traits bitmask
  @return Array of strings representing the accessibility traits
  */
-NSArray<NSString *> *fb_accessibilityTraitsToStringsArray(unsigned long long traits);
+NSArray<NSString *> *FBAccessibilityTraitsToStringsArray(unsigned long long traits);
 
 NS_ASSUME_NONNULL_END
 

--- a/WebDriverAgentLib/Utilities/FBAccessibilityTraits.h
+++ b/WebDriverAgentLib/Utilities/FBAccessibilityTraits.h
@@ -7,9 +7,6 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#ifndef FBAccessibilityTraits_h
-#define FBAccessibilityTraits_h
-
 #import <XCTest/XCTest.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -22,5 +19,3 @@ NS_ASSUME_NONNULL_BEGIN
 NSArray<NSString *> *FBAccessibilityTraitsToStringsArray(unsigned long long traits);
 
 NS_ASSUME_NONNULL_END
-
-#endif /* FBAccessibilityTraits_h */

--- a/WebDriverAgentLib/Utilities/FBAccessibilityTraits.m
+++ b/WebDriverAgentLib/Utilities/FBAccessibilityTraits.m
@@ -9,7 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-NSArray<NSString *> *fb_accessibilityTraitsToStringsArray(unsigned long long traits) {
+NSArray<NSString *> *FBAccessibilityTraitsToStringsArray(unsigned long long traits) {
     NSMutableArray<NSString *> *traitStringsArray;
     NSNumber *key;
     
@@ -38,8 +38,8 @@ NSArray<NSString *> *fb_accessibilityTraitsToStringsArray(unsigned long long tra
             @(UIAccessibilityTraitTabBar): @"TabBar"
         } mutableCopy];
         
+        #if __clang_major__ >= 15 || (__clang_major__ >= 14 && __clang_minor__ >= 0 && __clang_patchlevel__ >= 3)
         // Add iOS 17.0 specific traits if available
-        #if TARGET_OS_IOS
         if (@available(iOS 17.0, *)) {
             [mapping addEntriesFromDictionary:@{
                 @(UIAccessibilityTraitToggleButton): @"ToggleButton",
@@ -54,7 +54,7 @@ NSArray<NSString *> *fb_accessibilityTraitsToStringsArray(unsigned long long tra
     traitStringsArray = [NSMutableArray array];
     for (key in traitsMapping) {
       if (traits & [key unsignedLongLongValue] && nil != traitsMapping[key]) {
-        [traitStringsArray addObject:traitsMapping[key]];
+        [traitStringsArray addObject:(id)traitsMapping[key]];
       }
     }
 

--- a/WebDriverAgentLib/Utilities/FBAccessibilityTraits.m
+++ b/WebDriverAgentLib/Utilities/FBAccessibilityTraits.m
@@ -11,7 +11,6 @@
 
 NSArray<NSString *> *fb_accessibilityTraitsToStringsArray(unsigned long long traits) {
     NSMutableArray<NSString *> *traitStringsArray;
-    NSString *traitString;
     NSNumber *key;
     
     static NSDictionary<NSNumber *, NSString *> *traitsMapping;
@@ -39,16 +38,9 @@ NSArray<NSString *> *fb_accessibilityTraitsToStringsArray(unsigned long long tra
             @(UIAccessibilityTraitTabBar): @"TabBar"
         } mutableCopy];
         
-        // Add iOS 17.0 and watchOS 10.0 specific traits if available
+        // Add iOS 17.0 specific traits if available
         #if TARGET_OS_IOS
         if (@available(iOS 17.0, *)) {
-            [mapping addEntriesFromDictionary:@{
-                @(UIAccessibilityTraitToggleButton): @"ToggleButton",
-                @(UIAccessibilityTraitSupportsZoom): @"SupportsZoom"
-            }];
-        }
-        #elif TARGET_OS_WATCH
-        if (@available(watchOS 10.0, *)) {
             [mapping addEntriesFromDictionary:@{
                 @(UIAccessibilityTraitToggleButton): @"ToggleButton",
                 @(UIAccessibilityTraitSupportsZoom): @"SupportsZoom"
@@ -61,13 +53,10 @@ NSArray<NSString *> *fb_accessibilityTraitsToStringsArray(unsigned long long tra
 
     traitStringsArray = [NSMutableArray array];
     for (key in traitsMapping) {
-        if (traits & [key unsignedLongLongValue]) {
-            traitString = traitsMapping[key];
-            if (traitString != nil) {
-                [traitStringsArray addObject:traitString];
-            }
-        }
+      if (traits & [key unsignedLongLongValue] && nil != traitsMapping[key]) {
+        [traitStringsArray addObject:traitsMapping[key]];
+      }
     }
 
-    return traitStringsArray;
+    return [traitStringsArray copy];
 }

--- a/WebDriverAgentLib/Utilities/FBAccessibilityTraits.m
+++ b/WebDriverAgentLib/Utilities/FBAccessibilityTraits.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <XCTest/XCTest.h>
+#import "FBAccessibilityTraits.h"
 
 NSArray<NSString *> *FBAccessibilityTraitsToStringsArray(unsigned long long traits) {
     NSMutableArray<NSString *> *traitStringsArray;

--- a/WebDriverAgentLib/Utilities/FBAccessibilityTraits.m
+++ b/WebDriverAgentLib/Utilities/FBAccessibilityTraits.m
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+NSArray<NSString *> *fb_accessibilityTraitsToStringsArray(unsigned long long traits) {
+    NSMutableArray<NSString *> *traitStringsArray;
+    NSString *traitString;
+    NSNumber *key;
+    
+    static NSDictionary<NSNumber *, NSString *> *traitsMapping;
+    static dispatch_once_t onceToken;
+
+    dispatch_once(&onceToken, ^{
+        traitsMapping = @{
+            @(UIAccessibilityTraitNone): @"None",
+            @(UIAccessibilityTraitButton): @"Button",
+            @(UIAccessibilityTraitLink): @"Link",
+            @(UIAccessibilityTraitHeader): @"Header",
+            @(UIAccessibilityTraitSearchField): @"SearchField",
+            @(UIAccessibilityTraitImage): @"Image",
+            @(UIAccessibilityTraitSelected): @"Selected",
+            @(UIAccessibilityTraitPlaysSound): @"PlaysSound",
+            @(UIAccessibilityTraitKeyboardKey): @"KeyboardKey",
+            @(UIAccessibilityTraitStaticText): @"StaticText",
+            @(UIAccessibilityTraitSummaryElement): @"SummaryElement",
+            @(UIAccessibilityTraitNotEnabled): @"NotEnabled",
+            @(UIAccessibilityTraitUpdatesFrequently): @"UpdatesFrequently",
+            @(UIAccessibilityTraitStartsMediaSession): @"StartsMediaSession",
+            @(UIAccessibilityTraitAdjustable): @"Adjustable",
+            @(UIAccessibilityTraitAllowsDirectInteraction): @"AllowsDirectInteraction",
+            @(UIAccessibilityTraitCausesPageTurn): @"CausesPageTurn",
+            @(UIAccessibilityTraitTabBar): @"TabBar",
+            @(UIAccessibilityTraitToggleButton): @"ToggleButton",
+            @(UIAccessibilityTraitSupportsZoom): @"SupportsZoom"
+        };
+    });
+
+    traitStringsArray = [NSMutableArray array];
+    for (key in traitsMapping) {
+        if (traits & [key unsignedLongLongValue]) {
+            traitString = traitsMapping[key];
+            if (traitString != nil) {
+                [traitStringsArray addObject:traitString];
+            }
+        }
+    }
+
+    return traitStringsArray;
+}

--- a/WebDriverAgentLib/Utilities/FBAccessibilityTraits.m
+++ b/WebDriverAgentLib/Utilities/FBAccessibilityTraits.m
@@ -38,7 +38,7 @@ NSArray<NSString *> *FBAccessibilityTraitsToStringsArray(unsigned long long trai
             @(UIAccessibilityTraitTabBar): @"TabBar"
         } mutableCopy];
         
-        #if __clang_major__ >= 15 || (__clang_major__ >= 14 && __clang_minor__ >= 0 && __clang_patchlevel__ >= 3)
+        #if __clang_major__ >= 16
         // Add iOS 17.0 specific traits if available
         if (@available(iOS 17.0, *)) {
             [mapping addEntriesFromDictionary:@{

--- a/WebDriverAgentLib/Utilities/FBAccessibilityTraits.m
+++ b/WebDriverAgentLib/Utilities/FBAccessibilityTraits.m
@@ -18,7 +18,7 @@ NSArray<NSString *> *fb_accessibilityTraitsToStringsArray(unsigned long long tra
     static dispatch_once_t onceToken;
 
     dispatch_once(&onceToken, ^{
-        traitsMapping = @{
+        NSMutableDictionary<NSNumber *, NSString *> *mapping = [@{
             @(UIAccessibilityTraitNone): @"None",
             @(UIAccessibilityTraitButton): @"Button",
             @(UIAccessibilityTraitLink): @"Link",
@@ -36,10 +36,27 @@ NSArray<NSString *> *fb_accessibilityTraitsToStringsArray(unsigned long long tra
             @(UIAccessibilityTraitAdjustable): @"Adjustable",
             @(UIAccessibilityTraitAllowsDirectInteraction): @"AllowsDirectInteraction",
             @(UIAccessibilityTraitCausesPageTurn): @"CausesPageTurn",
-            @(UIAccessibilityTraitTabBar): @"TabBar",
-            @(UIAccessibilityTraitToggleButton): @"ToggleButton",
-            @(UIAccessibilityTraitSupportsZoom): @"SupportsZoom"
-        };
+            @(UIAccessibilityTraitTabBar): @"TabBar"
+        } mutableCopy];
+        
+        // Add iOS 17.0 and watchOS 10.0 specific traits if available
+        #if TARGET_OS_IOS
+        if (@available(iOS 17.0, *)) {
+            [mapping addEntriesFromDictionary:@{
+                @(UIAccessibilityTraitToggleButton): @"ToggleButton",
+                @(UIAccessibilityTraitSupportsZoom): @"SupportsZoom"
+            }];
+        }
+        #elif TARGET_OS_WATCH
+        if (@available(watchOS 10.0, *)) {
+            [mapping addEntriesFromDictionary:@{
+                @(UIAccessibilityTraitToggleButton): @"ToggleButton",
+                @(UIAccessibilityTraitSupportsZoom): @"SupportsZoom"
+            }];
+        }
+        #endif
+        
+        traitsMapping = [mapping copy];
     });
 
     traitStringsArray = [NSMutableArray array];

--- a/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
@@ -97,6 +97,34 @@
   XCTAssertEqual(element2.wdIndex, 0);
 }
 
+- (void)testAccessibilityTraits
+{
+  XCUIElement *button = self.testedApplication.buttons.firstMatch;
+  XCTAssertTrue(button.exists);
+  XCTAssertEqualObjects(button.wdTraits, @"Button");
+  XCTAssertEqualObjects(button.wdType, @"XCUIElementTypeButton");
+  
+  XCUIElement *toggle = self.testedApplication.switches.firstMatch;
+  XCTAssertTrue(toggle.exists);
+  XCTAssertEqualObjects(toggle.wdTraits, @"ToggleButton, Button");
+  XCTAssertEqualObjects(toggle.wdType, @"XCUIElementTypeSwitch");
+  
+  XCUIElement *slider = self.testedApplication.sliders.firstMatch;
+  XCTAssertTrue(slider.exists);
+  XCTAssertEqualObjects(slider.wdTraits, @"Adjustable");
+  XCTAssertEqualObjects(slider.wdType, @"XCUIElementTypeSlider");
+  
+  XCUIElement *picker = self.testedApplication.pickerWheels.firstMatch;
+  XCTAssertTrue(picker.exists);
+  XCTAssertEqualObjects(picker.wdTraits, @"Adjustable");
+  XCTAssertEqualObjects(picker.wdType, @"XCUIElementTypePickerWheel");
+  
+  XCUIElement *pageIndicator = self.testedApplication.pageIndicators.firstMatch;
+  XCTAssertTrue(pageIndicator.exists);
+  XCTAssertEqualObjects(pageIndicator.wdTraits, @"Adjustable, UpdatesFrequently");
+  XCTAssertEqualObjects(pageIndicator.wdType, @"XCUIElementTypePageIndicator");
+}
+
 - (void)testTextFieldAttributes
 {
   XCUIElement *element = self.testedApplication.textFields[@"Value"];

--- a/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
@@ -101,34 +101,50 @@
 {
   XCUIElement *button = self.testedApplication.buttons.firstMatch;
   XCTAssertTrue(button.exists);
-  XCTAssertEqualObjects(button.wdTraits, @"Button");
+  NSArray *buttonTraits = [button.wdTraits componentsSeparatedByString:@", "];
+  NSArray *expectedButtonTraits = @[@"Button"];
+  XCTAssertEqual(buttonTraits.count, expectedButtonTraits.count, @"Button should have exactly 1 trait");
+  XCTAssertEqualObjects(buttonTraits, expectedButtonTraits);
   XCTAssertEqualObjects(button.wdType, @"XCUIElementTypeButton");
   
   XCUIElement *toggle = self.testedApplication.switches.firstMatch;
   XCTAssertTrue(toggle.exists);
   
   // iOS 17.0 specific traits if available
+  NSArray *toggleTraits = [toggle.wdTraits componentsSeparatedByString:@", "];
+  NSArray *expectedToggleTraits;
   if (@available(iOS 17.0, *)) {
-    XCTAssertEqualObjects(toggle.wdTraits, @"ToggleButton, Button");
+    expectedToggleTraits = @[@"ToggleButton", @"Button"];
+    XCTAssertEqual(toggleTraits.count, 2, @"Toggle should have exactly 2 traits on iOS 17+");
   } else {
-    XCTAssertEqualObjects(toggle.wdTraits, @"Button");
+    expectedToggleTraits = @[@"Button"];
+    XCTAssertEqual(toggleTraits.count, 1, @"Toggle should have exactly 1 trait on iOS < 17");
   }
-  
+  XCTAssertEqualObjects(toggleTraits, expectedToggleTraits);
   XCTAssertEqualObjects(toggle.wdType, @"XCUIElementTypeSwitch");
   
   XCUIElement *slider = self.testedApplication.sliders.firstMatch;
   XCTAssertTrue(slider.exists);
-  XCTAssertEqualObjects(slider.wdTraits, @"Adjustable");
+  NSArray *sliderTraits = [slider.wdTraits componentsSeparatedByString:@", "];
+  NSArray *expectedSliderTraits = @[@"Adjustable"];
+  XCTAssertEqual(sliderTraits.count, expectedSliderTraits.count, @"Slider should have exactly 1 trait");
+  XCTAssertEqualObjects(sliderTraits, expectedSliderTraits);
   XCTAssertEqualObjects(slider.wdType, @"XCUIElementTypeSlider");
   
   XCUIElement *picker = self.testedApplication.pickerWheels.firstMatch;
   XCTAssertTrue(picker.exists);
-  XCTAssertEqualObjects(picker.wdTraits, @"Adjustable");
+  NSArray *pickerTraits = [picker.wdTraits componentsSeparatedByString:@", "];
+  NSArray *expectedPickerTraits = @[@"Adjustable"];
+  XCTAssertEqual(pickerTraits.count, expectedPickerTraits.count, @"Picker should have exactly 1 trait");
+  XCTAssertEqualObjects(pickerTraits, expectedPickerTraits);
   XCTAssertEqualObjects(picker.wdType, @"XCUIElementTypePickerWheel");
   
   XCUIElement *pageIndicator = self.testedApplication.pageIndicators.firstMatch;
   XCTAssertTrue(pageIndicator.exists);
-  XCTAssertEqualObjects(pageIndicator.wdTraits, @"Adjustable, UpdatesFrequently");
+  NSArray *pageIndicatorTraits = [pageIndicator.wdTraits componentsSeparatedByString:@", "];
+  NSArray *expectedPageIndicatorTraits = @[@"Adjustable", @"UpdatesFrequently"];
+  XCTAssertEqual(pageIndicatorTraits.count, expectedPageIndicatorTraits.count, @"Page indicator should have exactly 2 traits");
+  XCTAssertEqualObjects(pageIndicatorTraits, expectedPageIndicatorTraits);
   XCTAssertEqualObjects(pageIndicator.wdType, @"XCUIElementTypePageIndicator");
 }
 

--- a/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
@@ -106,7 +106,14 @@
   
   XCUIElement *toggle = self.testedApplication.switches.firstMatch;
   XCTAssertTrue(toggle.exists);
-  XCTAssertEqualObjects(toggle.wdTraits, @"ToggleButton, Button");
+  
+  // iOS 17.0 specific traits if available
+  if (@available(iOS 17.0, *)) {
+    XCTAssertEqualObjects(toggle.wdTraits, @"ToggleButton, Button");
+  } else {
+    XCTAssertEqualObjects(toggle.wdTraits, @"Button");
+  }
+  
   XCTAssertEqualObjects(toggle.wdType, @"XCUIElementTypeSwitch");
   
   XCUIElement *slider = self.testedApplication.sliders.firstMatch;

--- a/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
@@ -113,13 +113,16 @@
   // iOS 17.0 specific traits if available
   NSArray *toggleTraits = [toggle.wdTraits componentsSeparatedByString:@", "];
   NSArray *expectedToggleTraits;
+  
+  #if __clang_major__ >= 16
   if (@available(iOS 17.0, *)) {
     expectedToggleTraits = @[@"ToggleButton", @"Button"];
     XCTAssertEqual(toggleTraits.count, 2, @"Toggle should have exactly 2 traits on iOS 17+");
-  } else {
-    expectedToggleTraits = @[@"Button"];
-    XCTAssertEqual(toggleTraits.count, 1, @"Toggle should have exactly 1 trait on iOS < 17");
   }
+  #else
+  expectedToggleTraits = @[@"Button"];
+  XCTAssertEqual(toggleTraits.count, 1, @"Toggle should have exactly 1 trait on iOS < 17");
+  #endif
   XCTAssertEqualObjects(toggleTraits, expectedToggleTraits);
   XCTAssertEqualObjects(toggle.wdType, @"XCUIElementTypeSwitch");
   
@@ -138,14 +141,6 @@
   XCTAssertEqual(pickerTraits.count, expectedPickerTraits.count, @"Picker should have exactly 1 trait");
   XCTAssertEqualObjects(pickerTraits, expectedPickerTraits);
   XCTAssertEqualObjects(picker.wdType, @"XCUIElementTypePickerWheel");
-  
-  XCUIElement *pageIndicator = self.testedApplication.pageIndicators.firstMatch;
-  XCTAssertTrue(pageIndicator.exists);
-  NSArray *pageIndicatorTraits = [pageIndicator.wdTraits componentsSeparatedByString:@", "];
-  NSArray *expectedPageIndicatorTraits = @[@"Adjustable", @"UpdatesFrequently"];
-  XCTAssertEqual(pageIndicatorTraits.count, expectedPageIndicatorTraits.count, @"Page indicator should have exactly 2 traits");
-  XCTAssertEqualObjects(pageIndicatorTraits, expectedPageIndicatorTraits);
-  XCTAssertEqualObjects(pageIndicator.wdType, @"XCUIElementTypePageIndicator");
 }
 
 - (void)testTextFieldAttributes

--- a/WebDriverAgentTests/UnitTests/Doubles/XCUIElementDouble.h
+++ b/WebDriverAgentTests/UnitTests/Doubles/XCUIElementDouble.h
@@ -37,6 +37,7 @@
 @property (copy, nonnull) NSArray *children;
 @property (nonatomic, readwrite, assign) XCUIElementType elementType;
 @property (nonatomic, readwrite, getter=isWDAccessibilityContainer) BOOL wdAccessibilityContainer;
+@property (nonatomic, copy, readwrite, nullable) NSString *wdTraits;
 
 - (void)resolve;
 - (id _Nonnull)fb_standardSnapshot;

--- a/WebDriverAgentTests/UnitTests/Doubles/XCUIElementDouble.m
+++ b/WebDriverAgentTests/UnitTests/Doubles/XCUIElementDouble.m
@@ -24,6 +24,7 @@
     self.wdLabel = @"testLabel";
     self.wdValue = @"magicValue";
     self.wdPlaceholderValue = @"testPlaceholderValue";
+    self.wdTraits = @"testTraits";
     self.wdVisible = YES;
     self.wdAccessible = YES;
     self.wdEnabled = YES;
@@ -92,6 +93,11 @@
 - (id)fb_uid
 {
   return self.wdUID;
+}
+
+- (NSString *)wdTraits
+{
+  return self.wdTraits;
 }
 
 @end


### PR DESCRIPTION
# Add Accessibility Traits Support

## Overview
This PR adds support for accessibility traits, allowing better accessibility information to be exposed for UI elements. The implementation converts iOS accessibility traits into human-readable strings.

This feature was motivated by the need to surface richer, programmatically accessible metadata that assistive technologies rely on to interpret and interact with user interfaces more effectively.

## Changes
1. Created new files:
   - `FBAccessibilityTraits.h` - Header file defining the trait conversion function
   - `FBAccessibilityTraits.m` - Implementation of trait conversion logic

2. Added `wdTraits` property to `FBElement` protocol to expose accessibility traits

3. Implemented trait conversion in `XCUIElement+FBWebDriverAttributes` that:
   - Converts bitmask traits to human-readable strings
   - Supports multiple traits per element (comma-separated)
   - Maps all standard iOS accessibility traits

4. Added comprehensive test coverage in `FBElementAttributeTests` for various UI elements:
   - Buttons (single trait)
   - Switches (multiple traits: ToggleButton, Button)
   - Sliders (Adjustable trait)
   - Picker Wheels (Adjustable trait)
   - Page Indicators (multiple traits: Adjustable, UpdatesFrequently)

## Supported Traits
The implementation supports all standard iOS accessibility traits including:
- Button
- Link
- Header
- SearchField
- Image
- Selected
- PlaysSound
- KeyboardKey
- StaticText
- SummaryElement
- NotEnabled
- UpdatesFrequently
- StartsMediaSession
- Adjustable
- AllowsDirectInteraction
- CausesPageTurn
- TabBar
- ToggleButton (iOS 17.0+, watchOS 10.0+)
- SupportsZoom (iOS 17.0+, watchOS 10.0+)

## Impact
This change improves accessibility support in WebDriverAgent by:
- Providing more detailed accessibility information
- Making traits human-readable for better debugging
- Maintaining consistency with iOS accessibility standards