### PR TITLE
ci: use xcode 16 for wda-package.yml

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -10,14 +10,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
 
     env:
-      XCODE_VERSION: 15.3
-      ZIP_PKG_NAME_IOS: "WebDriverAgentRunner-Runner.zip"
-      PKG_PATH_IOS: "appium_wda_ios"
-      ZIP_PKG_NAME_TVOS: "WebDriverAgentRunner_tvOS-Runner.zip"
-      PKG_PATH_TVOS: "appium_wda_tvos"
+      XCODE_VERSION: 16.3
 
     steps:
     - uses: actions/checkout@v2
@@ -36,36 +32,22 @@ jobs:
       name: Run test
 
     # building WDA packages
-    - name: Build iOS
-      run: |
-        xcodebuild clean build-for-testing \
-          -project WebDriverAgent.xcodeproj \
-          -derivedDataPath $PKG_PATH_IOS \
-          -scheme WebDriverAgentRunner \
-          -destination generic/platform=iOS \
-          CODE_SIGNING_ALLOWED=NO ARCHS=arm64
-    - name: Creating a zip of WebDriverAgentRunner-Runner.app for iOS after removing test frameworks
-      run: |
-        pushd appium_wda_ios/Build/Products/Debug-iphoneos
-        rm -rf WebDriverAgentRunner-Runner.app/Frameworks/XC*.framework
-        zip -r $ZIP_PKG_NAME_IOS WebDriverAgentRunner-Runner.app
-        popd
-        mv $PKG_PATH_IOS/Build/Products/Debug-iphoneos/$ZIP_PKG_NAME_IOS ./
-    - name: Build tvOS
-      run: |
-        xcodebuild clean build-for-testing \
-          -project WebDriverAgent.xcodeproj \
-          -derivedDataPath $PKG_PATH_TVOS \
-          -scheme WebDriverAgentRunner_tvOS \
-          -destination generic/platform=tvOS \
-          CODE_SIGNING_ALLOWED=NO ARCHS=arm64
-    - name: Creating a zip of WebDriverAgentRunner-Runner.app for tvOS after removing test frameworks
-      run: |
-        pushd appium_wda_tvos/Build/Products/Debug-appletvos
-        rm -rf WebDriverAgentRunner_tvOS-Runner.app/Frameworks/XC*.framework
-        zip -r $ZIP_PKG_NAME_TVOS WebDriverAgentRunner_tvOS-Runner.app
-        popd
-        mv $PKG_PATH_TVOS/Build/Products/Debug-appletvos/$ZIP_PKG_NAME_TVOS ./
+    - name: Building iOS
+      run: sh $GITHUB_WORKSPACE/Scripts/ci/build-real.sh
+      env:
+        DERIVED_DATA_PATH: appium_wda_ios
+        SCHEME: WebDriverAgentRunner
+        DESTINATION: generic/platform=iOS
+        WD: appium_wda_ios/Build/Products/Debug-iphoneos
+        ZIP_PKG_NAME: WebDriverAgentRunner-Runner.zip
+    - name: Building tvOS
+      run: sh $GITHUB_WORKSPACE/Scripts/ci/build-real.sh
+      env:
+        DERIVED_DATA_PATH: appium_wda_tvos
+        SCHEME: WebDriverAgentRunner_tvOS
+        DESTINATION: generic/platform=tvOS
+        WD: appium_wda_tvos/Build/Products/Debug-appletvos
+        ZIP_PKG_NAME: WebDriverAgentRunner_tvOS-Runner.zip
 
     # release tasks
     - run: npx semantic-release

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -8,9 +8,9 @@ on:
       - completed
 
 env:
-  HOST: macos-14
-  XCODE_VERSION: 15.3
-  DESTINATION_SIM: platform=iOS Simulator,name=iPhone 15 Pro
+  HOST: macos-15
+  XCODE_VERSION: 16.3
+  DESTINATION_SIM: platform=iOS Simulator,name=iPhone 16 Plus
   DESTINATION_SIM_tvOS: platform=tvOS Simulator,name=Apple TV 4K (3rd generation)
 
 jobs:
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "${{ env.XCODE_VERSION }}"

--- a/Scripts/ci/build-real.sh
+++ b/Scripts/ci/build-real.sh
@@ -18,8 +18,14 @@ pushd $WD
 # XCUIAutomation.framework, XCUnit.framework
 rm -rf $SCHEME-Runner.app/Frameworks/XC*.framework
 
-# Xcode 16 started generating Testing.framework but it might not be necessary for WDA
+# Xcode 16 started generating 5.9MB of 'Testing.framework', but it might not be necessary for WDA
 rm -rf $SCHEME-Runner.app/Frameworks/Testing.framework
+
+# This library is used for Swift testing. WDA doesn't include Swift stuff, thus this is not needed.
+# Xcode 16 generates a 2.6 MB file size. Xcode 15 was a 1 MB file size.
+rm -rf $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
+
+
 
 zip -r $ZIP_PKG_NAME $SCHEME-Runner.app
 popd

--- a/Scripts/ci/build-real.sh
+++ b/Scripts/ci/build-real.sh
@@ -18,6 +18,9 @@ pushd $WD
 # XCUIAutomation.framework, XCUnit.framework
 rm -rf $SCHEME-Runner.app/Frameworks/XC*.framework
 
+# Xcode 16 started generating Testing.framework but it might not be necessary for WDA
+rm -rf $SCHEME-Runner.app/Frameworks/Testing.framework
+
 zip -r $ZIP_PKG_NAME $SCHEME-Runner.app
 popd
 mv $WD/$ZIP_PKG_NAME ./


### PR DESCRIPTION
Xcode 16 built test bundle includes dependencies, which don't work on iOS 14 and lower versions. As https://appium.github.io/appium-xcuitest-driver/latest/installation/requirements/, we no longer support iOS 14 and lower so this should not be an issue.

> The Xcode 16 release supports on-device debugging in iOS 15 and later, tvOS 15 and later, watchOS 7 and later, and visionOS.

https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes


The module included `Testing.framework`, but that usage was `@Test` for example. So, possibly we don't need them as well.

Not new, but I assume libXCTestSwiftSupport.dylib can also be removed.

I have tested the removed WDAs worked on iOS/tvOS. I'll address this additional removal thing in https://appium.github.io/appium-xcuitest-driver/latest/guides/run-preinstalled-wda/#additional-requirement-for-ios-17tvos17 as an advise to reduce the amount of WDA ipa file size.