### PR TITLE
ci: sim remove unnecessary files

### DIFF
--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -76,9 +76,19 @@ jobs:
 
     strategy:
       matrix:
-        # '' is for iOS
-        target: ['', '_tvOS']
-        arch: [x86_64, arm64]
+        include:
+          - target: ''
+            arch: x86_64
+            simulator_name: Debug-iphonesimulator
+          - target: ''
+            arch: arm64
+            simulator_name: Debug-iphonesimulator
+          - target: '_tvOS'
+            arch: x86_64
+            simulator_name: Debug-appletvsimulator
+          - target: '_tvOS'
+            arch: arm64
+            simulator_name: Debug-appletvsimulator
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -89,10 +99,11 @@ jobs:
         run: |
           DESTINATION=$DESTINATION_SIM${{ matrix.target }} sh $GITHUB_WORKSPACE/Scripts/ci/build-sim.sh
         env:
-          TARGET: ${{ matrix.target }}
           SCHEME: WebDriverAgentRunner${{ matrix.target }}
           ARCHS: ${{ matrix.arch }}
           ZIP_PKG_NAME: "WebDriverAgentRunner${{ matrix.target }}-Build-Sim-${{ matrix.arch }}.zip"
+          DERIVED_DATA_PATH: wda_build
+          WD: wda_build/Build/Products/${{ matrix.simulator_name }}
       - name: Upload the built generic app package for WebDriverAgentRunner${{ matrix.target }} with ${{ matrix.arch }}
         uses: actions/upload-artifact@master
         with:

--- a/Scripts/ci/build-real.sh
+++ b/Scripts/ci/build-real.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# To run build script for CI
-
 xcodebuild clean build-for-testing \
   -project WebDriverAgent.xcodeproj \
   -derivedDataPath $DERIVED_DATA_PATH \
@@ -9,25 +7,18 @@ xcodebuild clean build-for-testing \
   -destination "$DESTINATION" \
   CODE_SIGNING_ALLOWED=NO ARCHS=arm64
 
-# Only .app is needed.
-
 pushd $WD
 
-# # to remove test packages to refer to the device local instead of embedded ones
-# # XCTAutomationSupport.framework, XCTest.framewor, XCTestCore.framework,
-# # XCUIAutomation.framework, XCUnit.framework
-# rm -rf $SCHEME-Runner.app/Frameworks/XC*.framework \
-#        # Xcode 16 started generating 5.9MB of 'Testing.framework', but it might not be necessary for WDA
-#        $SCHEME-Runner.app/Frameworks/Testing.framework \
-#        # This library is used for Swift testing. WDA doesn't include Swift stuff, thus this is not needed.
-#        # Xcode 16 generates a 2.6 MB file size. Xcode 15 was a 1 MB file size.
-#        $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
-
+# The reason why here excludes several frameworks are:
+# - to remove test packages to refer to the device local instead of embedded ones
+#   XCTAutomationSupport.framework, XCTest.framewor, XCTestCore.framework,
+#   XCUIAutomation.framework, XCUnit.framework.
+#   This can be excluded only for real devices.
+# - Xcode 16 started generating 5.9MB of 'Testing.framework', but it might not be necessary for WDA.
+# - libXCTestSwiftSupport is used for Swift testing. WDA doesn't include Swift stuff, thus this is not needed.
 zip -r $ZIP_PKG_NAME $SCHEME-Runner.app \
-  -x $SCHEME-Runner.app/Frameworks/XC*.framework \
-     $SCHEME-Runner.app/Frameworks/XC*.framework/* \
-     $SCHEME-Runner.app/Frameworks/Testing.framework \
-     $SCHEME-Runner.app/Frameworks/Testing.framework/* \
-     $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
+    -x "$SCHEME-Runner.app/Frameworks/XC*.framework*" \
+       "$SCHEME-Runner.app/Frameworks/Testing.framework*" \
+       "$SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib"
 popd
 mv $WD/$ZIP_PKG_NAME ./

--- a/Scripts/ci/build-real.sh
+++ b/Scripts/ci/build-real.sh
@@ -24,8 +24,10 @@ pushd $WD
 #        $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
 
 zip -r $ZIP_PKG_NAME $SCHEME-Runner.app \
-  -x $SCHEME-Runner.app/Frameworks/XC*.framework* \
-     $SCHEME-Runner.app/Frameworks/Testing.framework* \
+  -x $SCHEME-Runner.app/Frameworks/XC*.framework \
+     $SCHEME-Runner.app/Frameworks/XC*.framework/* \
+     $SCHEME-Runner.app/Frameworks/Testing.framework \
+     $SCHEME-Runner.app/Frameworks/Testing.framework/* \
      $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
 popd
 mv $WD/$ZIP_PKG_NAME ./

--- a/Scripts/ci/build-real.sh
+++ b/Scripts/ci/build-real.sh
@@ -24,8 +24,8 @@ pushd $WD
 #        $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
 
 zip -r $ZIP_PKG_NAME $SCHEME-Runner.app \
-    -x $SCHEME-Runner.app/Frameworks/XC*.framework/* \
-       $SCHEME-Runner.app/Frameworks/Testing.framework/* \
-       $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
+  -x $SCHEME-Runner.app/Frameworks/XC*.framework* \
+     $SCHEME-Runner.app/Frameworks/Testing.framework* \
+     $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
 popd
 mv $WD/$ZIP_PKG_NAME ./

--- a/Scripts/ci/build-real.sh
+++ b/Scripts/ci/build-real.sh
@@ -13,20 +13,19 @@ xcodebuild clean build-for-testing \
 
 pushd $WD
 
-# to remove test packages to refer to the device local instead of embedded ones
-# XCTAutomationSupport.framework, XCTest.framewor, XCTestCore.framework,
-# XCUIAutomation.framework, XCUnit.framework
-rm -rf $SCHEME-Runner.app/Frameworks/XC*.framework
+# # to remove test packages to refer to the device local instead of embedded ones
+# # XCTAutomationSupport.framework, XCTest.framewor, XCTestCore.framework,
+# # XCUIAutomation.framework, XCUnit.framework
+# rm -rf $SCHEME-Runner.app/Frameworks/XC*.framework \
+#        # Xcode 16 started generating 5.9MB of 'Testing.framework', but it might not be necessary for WDA
+#        $SCHEME-Runner.app/Frameworks/Testing.framework \
+#        # This library is used for Swift testing. WDA doesn't include Swift stuff, thus this is not needed.
+#        # Xcode 16 generates a 2.6 MB file size. Xcode 15 was a 1 MB file size.
+#        $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
 
-# Xcode 16 started generating 5.9MB of 'Testing.framework', but it might not be necessary for WDA
-rm -rf $SCHEME-Runner.app/Frameworks/Testing.framework
-
-# This library is used for Swift testing. WDA doesn't include Swift stuff, thus this is not needed.
-# Xcode 16 generates a 2.6 MB file size. Xcode 15 was a 1 MB file size.
-rm -rf $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
-
-
-
-zip -r $ZIP_PKG_NAME $SCHEME-Runner.app
+zip -r $ZIP_PKG_NAME $SCHEME-Runner.app \
+    -x $SCHEME-Runner.app/Frameworks/XC*.framework \
+       $SCHEME-Runner.app/Frameworks/Testing.framework \
+       $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
 popd
 mv $WD/$ZIP_PKG_NAME ./

--- a/Scripts/ci/build-real.sh
+++ b/Scripts/ci/build-real.sh
@@ -24,8 +24,8 @@ pushd $WD
 #        $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
 
 zip -r $ZIP_PKG_NAME $SCHEME-Runner.app \
-    -x $SCHEME-Runner.app/Frameworks/XC*.framework \
-       $SCHEME-Runner.app/Frameworks/Testing.framework \
+    -x $SCHEME-Runner.app/Frameworks/XC*.framework/* \
+       $SCHEME-Runner.app/Frameworks/Testing.framework/* \
        $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
 popd
 mv $WD/$ZIP_PKG_NAME ./

--- a/Scripts/ci/build-sim.sh
+++ b/Scripts/ci/build-sim.sh
@@ -9,15 +9,11 @@ xcodebuild clean build-for-testing \
   -derivedDataPath wda_build \
   -scheme $SCHEME \
   -destination "$DESTINATION" \
-  CODE_SIGNING_ALLOWED=NO ARCHS=$ARCHS &
-
-# CI started starting the next `rm` etc BEFORE ending this xcodebuild, which is weird,
-# but to make sure the behavior on ci.
-wait
+  CODE_SIGNING_ALLOWED=NO ARCHS=$ARCHS
 
 # simulator needs to build entire build files
 
-pushd wda_build
+cd wda_build
 # to remove unnecessary space consuming files
 rm -rf Build/Intermediates.noindex
 
@@ -29,5 +25,5 @@ rm -rf Build/**/Frameworks/Testing.framework
 rm -rf Build/**/Frameworks/libXCTestSwiftSupport.dylib
 
 zip -r $ZIP_PKG_NAME Build
-popd
+cd ..
 mv wda_build/$ZIP_PKG_NAME ./

--- a/Scripts/ci/build-sim.sh
+++ b/Scripts/ci/build-sim.sh
@@ -14,7 +14,8 @@ xcodebuild clean build-for-testing \
 pushd $WD
 
 zip -r $ZIP_PKG_NAME $SCHEME-Runner.app \
-    -x $SCHEME-Runner.app/Frameworks/Testing.framework* \
+    -x $SCHEME-Runner.app/Frameworks/Testing.framework \
+       $SCHEME-Runner.app/Frameworks/Testing.framework/* \
        $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
 popd
 mv $WD/$ZIP_PKG_NAME ./

--- a/Scripts/ci/build-sim.sh
+++ b/Scripts/ci/build-sim.sh
@@ -14,7 +14,7 @@ xcodebuild clean build-for-testing \
 pushd $WD
 
 zip -r $ZIP_PKG_NAME $SCHEME-Runner.app \
-    -x "$SCHEME-Runner.app/Frameworks/Testing.framework" \
-       "$SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib"
+    -x $SCHEME-Runner.app/Frameworks/Testing.framework/* \
+       $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
 popd
 mv $WD/$ZIP_PKG_NAME ./

--- a/Scripts/ci/build-sim.sh
+++ b/Scripts/ci/build-sim.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-set -x
-
-# To run build script for CI
-
 xcodebuild clean build-for-testing \
   -project WebDriverAgent.xcodeproj \
   -derivedDataPath $DERIVED_DATA_PATH \
@@ -13,9 +9,11 @@ xcodebuild clean build-for-testing \
 
 pushd $WD
 
+# The reason why here excludes several frameworks are:
+# - Xcode 16 started generating 5.9MB of 'Testing.framework', but it might not be necessary for WDA.
+# - libXCTestSwiftSupport is used for Swift testing. WDA doesn't include Swift stuff, thus this is not needed.
 zip -r $ZIP_PKG_NAME $SCHEME-Runner.app \
-    -x $SCHEME-Runner.app/Frameworks/Testing.framework \
-       $SCHEME-Runner.app/Frameworks/Testing.framework/* \
-       $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
+    -x "$SCHEME-Runner.app/Frameworks/Testing.framework*" \
+       "$SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib"
 popd
 mv $WD/$ZIP_PKG_NAME ./

--- a/Scripts/ci/build-sim.sh
+++ b/Scripts/ci/build-sim.sh
@@ -9,7 +9,11 @@ xcodebuild clean build-for-testing \
   -derivedDataPath wda_build \
   -scheme $SCHEME \
   -destination "$DESTINATION" \
-  CODE_SIGNING_ALLOWED=NO ARCHS=$ARCHS
+  CODE_SIGNING_ALLOWED=NO ARCHS=$ARCHS &
+
+# CI started starting the next `rm` etc BEFORE ending this xcodebuild, which is weird,
+# but to make sure the behavior on ci.
+wait
 
 # simulator needs to build entire build files
 

--- a/Scripts/ci/build-sim.sh
+++ b/Scripts/ci/build-sim.sh
@@ -16,11 +16,11 @@ pushd wda_build
 rm -rf Build/Intermediates.noindex
 
 # Xcode 16 started generating 5.9MB of 'Testing.framework', but it might not be necessary for WDA
-rm -rf Build/**/$SCHEME-Runner.app/Frameworks/Testing.framework
+rm -rf Build/**/Frameworks/Testing.framework
 
 # This library is used for Swift testing. WDA doesn't include Swift stuff, thus this is not needed.
 # Xcode 16 generates a 2.6 MB file size. Xcode 15 was a 1 MB file size.
-rm -rf Build/**/$SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
+rm -rf Build/**/Frameworks/libXCTestSwiftSupport.dylib
 
 zip -r $ZIP_PKG_NAME Build
 popd

--- a/Scripts/ci/build-sim.sh
+++ b/Scripts/ci/build-sim.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 # To run build script for CI
 
 xcodebuild clean build-for-testing \

--- a/Scripts/ci/build-sim.sh
+++ b/Scripts/ci/build-sim.sh
@@ -11,9 +11,12 @@ xcodebuild clean build-for-testing \
   -destination "$DESTINATION" \
   CODE_SIGNING_ALLOWED=NO ARCHS=$ARCHS
 
-pushd WD
+pushd $WD
 
-rm -rf $SCHEME-Runner.app/Frameworks/Testing.framework $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
+       # WDA doesn't use Xcode's testing feature support.
+rm -rf $SCHEME-Runner.app/Frameworks/Testing.framework \
+       # WDA dpesn't use Swift code.
+       $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
 
 zip -r $ZIP_PKG_NAME $SCHEME-Runner.app
 popd

--- a/Scripts/ci/build-sim.sh
+++ b/Scripts/ci/build-sim.sh
@@ -14,6 +14,14 @@ xcodebuild clean build-for-testing \
 pushd wda_build
 # to remove unnecessary space consuming files
 rm -rf Build/Intermediates.noindex
+
+# Xcode 16 started generating 5.9MB of 'Testing.framework', but it might not be necessary for WDA
+rm -rf Build/**/$SCHEME-Runner.app/Frameworks/Testing.framework
+
+# This library is used for Swift testing. WDA doesn't include Swift stuff, thus this is not needed.
+# Xcode 16 generates a 2.6 MB file size. Xcode 15 was a 1 MB file size.
+rm -rf Build/**/$SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
+
 zip -r $ZIP_PKG_NAME Build
 popd
 mv wda_build/$ZIP_PKG_NAME ./

--- a/Scripts/ci/build-sim.sh
+++ b/Scripts/ci/build-sim.sh
@@ -6,24 +6,15 @@ set -x
 
 xcodebuild clean build-for-testing \
   -project WebDriverAgent.xcodeproj \
-  -derivedDataPath wda_build \
+  -derivedDataPath $DERIVED_DATA_PATH \
   -scheme $SCHEME \
   -destination "$DESTINATION" \
   CODE_SIGNING_ALLOWED=NO ARCHS=$ARCHS
 
-# simulator needs to build entire build files
+pushd WD
 
-cd wda_build
-# to remove unnecessary space consuming files
-rm -rf Build/Intermediates.noindex
+rm -rf $SCHEME-Runner.app/Frameworks/Testing.framework $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
 
-# Xcode 16 started generating 5.9MB of 'Testing.framework', but it might not be necessary for WDA
-rm -rf Build/**/Frameworks/Testing.framework
-
-# This library is used for Swift testing. WDA doesn't include Swift stuff, thus this is not needed.
-# Xcode 16 generates a 2.6 MB file size. Xcode 15 was a 1 MB file size.
-rm -rf Build/**/Frameworks/libXCTestSwiftSupport.dylib
-
-zip -r $ZIP_PKG_NAME Build
-cd ..
-mv wda_build/$ZIP_PKG_NAME ./
+zip -r $ZIP_PKG_NAME $SCHEME-Runner.app
+popd
+mv $WD/$ZIP_PKG_NAME ./

--- a/Scripts/ci/build-sim.sh
+++ b/Scripts/ci/build-sim.sh
@@ -14,7 +14,7 @@ xcodebuild clean build-for-testing \
 pushd $WD
 
 zip -r $ZIP_PKG_NAME $SCHEME-Runner.app \
-    -x $SCHEME-Runner.app/Frameworks/Testing.framework/* \
+    -x $SCHEME-Runner.app/Frameworks/Testing.framework* \
        $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
 popd
 mv $WD/$ZIP_PKG_NAME ./

--- a/Scripts/ci/build-sim.sh
+++ b/Scripts/ci/build-sim.sh
@@ -13,11 +13,8 @@ xcodebuild clean build-for-testing \
 
 pushd $WD
 
-       # WDA doesn't use Xcode's testing feature support.
-rm -rf $SCHEME-Runner.app/Frameworks/Testing.framework \
-       # WDA dpesn't use Swift code.
-       $SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib
-
-zip -r $ZIP_PKG_NAME $SCHEME-Runner.app
+zip -r $ZIP_PKG_NAME $SCHEME-Runner.app \
+    -x "$SCHEME-Runner.app/Frameworks/Testing.framework" \
+       "$SCHEME-Runner.app/Frameworks/libXCTestSwiftSupport.dylib"
 popd
 mv $WD/$ZIP_PKG_NAME ./


### PR DESCRIPTION
Similar to https://github.com/appium/WebDriverAgent/pull/1027, we can remove `Testing.framework` and `libXCTestSwiftSupport.dylib` for simulators as well. Other frameworks caused issues on my local, so they should be there.

These removals will reduce the package size by around 7- 8 MB in Xcode 16 build env.


I also figured out the most reliable method right now is using `-x` flag for ZIP to exclude expected files.
https://github.com/appium/WebDriverAgent/actions/runs/15818354239