### PR TITLE
feat: HTTPS support for wda-client if webDriverAgentUrl is set

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -584,6 +584,7 @@ export class WebDriverAgent {
       base: this.basePath,
       timeout: this.wdaConnectionTimeout,
       keepAlive: true,
+      scheme: this.url.protocol ? this.url.protocol.replace(':', '') : 'http',
     };
     if (this.args.reqBasePath) {
       proxyOpts.reqBasePath = this.args.reqBasePath;

--- a/test/unit/webdriveragent-specs.js
+++ b/test/unit/webdriveragent-specs.js
@@ -73,9 +73,11 @@ describe('launch', function () {
     agent.jwproxy.server.should.eql('mockurl');
     agent.jwproxy.port.should.eql(8100);
     agent.jwproxy.base.should.eql('');
+    agent.jwproxy.scheme.should.eql('http');
     agent.noSessionProxy.server.should.eql('mockurl');
     agent.noSessionProxy.port.should.eql(8100);
     agent.noSessionProxy.base.should.eql('');
+    agent.noSessionProxy.scheme.should.eql('http');
     wdaStub.reset();
   });
 });
@@ -99,9 +101,11 @@ describe('use wda proxy url', function () {
     agent.jwproxy.server.should.eql('127.0.0.1');
     agent.jwproxy.port.should.eql(8100);
     agent.jwproxy.base.should.eql('/aabbccdd');
+    agent.jwproxy.scheme.should.eql('http');
     agent.noSessionProxy.server.should.eql('127.0.0.1');
     agent.noSessionProxy.port.should.eql(8100);
     agent.noSessionProxy.base.should.eql('/aabbccdd');
+    agent.noSessionProxy.scheme.should.eql('http');
   });
 });
 
@@ -110,6 +114,9 @@ describe('get url', function () {
     const args = Object.assign({}, fakeConstructorArgs);
     const agent = new WebDriverAgent({}, args);
     agent.url.href.should.eql('http://127.0.0.1:8100/');
+    agent.setupProxies('mysession');
+    agent.jwproxy.scheme.should.eql('http');
+    agent.noSessionProxy.scheme.should.eql('http');
   });
   it('should use default WDA listening url with emply base url', function () {
     const wdaLocalPort = '9100';
@@ -121,6 +128,9 @@ describe('get url', function () {
 
     const agent = new WebDriverAgent({}, args);
     agent.url.href.should.eql('http://127.0.0.1:9100/');
+    agent.setupProxies('mysession');
+    agent.jwproxy.scheme.should.eql('http');
+    agent.noSessionProxy.scheme.should.eql('http');
   });
   it('should use customised WDA listening url', function () {
     const wdaLocalPort = '9100';
@@ -132,6 +142,9 @@ describe('get url', function () {
 
     const agent = new WebDriverAgent({}, args);
     agent.url.href.should.eql('http://mockurl:9100/');
+    agent.setupProxies('mysession');
+    agent.jwproxy.scheme.should.eql('http');
+    agent.noSessionProxy.scheme.should.eql('http');
   });
   it('should use customised WDA listening url with slash', function () {
     const wdaLocalPort = '9100';
@@ -143,6 +156,9 @@ describe('get url', function () {
 
     const agent = new WebDriverAgent({}, args);
     agent.url.href.should.eql('http://mockurl:9100/');
+    agent.setupProxies('mysession');
+    agent.jwproxy.scheme.should.eql('http');
+    agent.noSessionProxy.scheme.should.eql('http');
   });
   it('should use the given webDriverAgentUrl and ignore other params', function () {
     const args = Object.assign({}, fakeConstructorArgs);
@@ -152,6 +168,14 @@ describe('get url', function () {
 
     const agent = new WebDriverAgent({}, args);
     agent.url.href.should.eql('https://127.0.0.1:8100/');
+  });
+  it('should set scheme to https for https webDriverAgentUrl', function () {
+    const args = Object.assign({}, fakeConstructorArgs);
+    args.webDriverAgentUrl = 'https://127.0.0.1:8100/';
+    const agent = new WebDriverAgent({}, args);
+    agent.setupProxies('mysession');
+    agent.jwproxy.scheme.should.eql('https');
+    agent.noSessionProxy.scheme.should.eql('https');
   });
 });
 


### PR DESCRIPTION
Currently the wda-client lib does not work with a WDA that is exposed over https. 
This is because the client does not properly set the scheme for the JWPProxy, when a remote WDA URL is provided.