### PR TITLE
chore: Cache application instances for their PIDs

### DIFF
--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
                                      attributes:(NSArray *)attributes
                                           error:(NSError**)error;
 
-- (XCUIApplication *)monitoredApplicationWithProcessIdentifier:(int)pid;
+- (nullable XCUIApplication *)monitoredApplicationWithProcessIdentifier:(int)pid;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
@@ -14,8 +14,15 @@
 #import "FBMacros.h"
 #import "XCAXClient_iOS+FBSnapshotReqParams.h"
 #import "XCUIDevice.h"
+#import "XCUIApplication.h"
 
 static id FBAXClient = nil;
+
+@interface FBXCAXClientProxy ()
+
+@property (nonatomic) NSMutableDictionary<NSNumber *, XCUIApplication *> *appsCache;
+
+@end
 
 @implementation FBXCAXClientProxy
 
@@ -25,6 +32,7 @@ static id FBAXClient = nil;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     instance = [[self alloc] init];
+    instance.appsCache = [NSMutableDictionary dictionary];
     FBAXClient = [XCUIDevice.sharedDevice accessibilityInterface];
   });
   return instance;
@@ -85,7 +93,28 @@ static id FBAXClient = nil;
 
 - (XCUIApplication *)monitoredApplicationWithProcessIdentifier:(int)pid
 {
-  return [[FBAXClient applicationProcessTracker] monitoredApplicationWithProcessIdentifier:pid];
+  NSMutableSet *terminatedAppIds = [NSMutableSet set];
+  for (NSNumber *appPid in self.appsCache) {
+    if (![self.appsCache[appPid] running]) {
+      [terminatedAppIds addObject:appPid];
+    }
+  }
+  for (NSNumber *appPid in terminatedAppIds) {
+    [self.appsCache removeObjectForKey:appPid];
+  }
+
+  XCUIApplication *result = [self.appsCache objectForKey:@(pid)];
+  if (nil != result) {
+    return result;
+  }
+
+  XCUIApplication *app = [[FBAXClient applicationProcessTracker]
+                          monitoredApplicationWithProcessIdentifier:pid];
+  if (nil == app) {
+    return nil;
+  }
+  [self.appsCache setObject:app forKey:@(pid)];
+  return app;
 }
 
 @end


### PR DESCRIPTION
Should partially address https://github.com/appium/WebDriverAgent/issues/1048 by creating less XCUIApplication instances