### PR TITLE
ci: run with xcode 26 and ios 26

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         test_targets:
-          - HOST_OS: 'macos-26'
+          - HOST_OS: 'macos-15'
             XCODE_VERSION: '26.0'
             IOS_VERSION: '26.0'
             IOS_MODEL: iPhone 17

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -12,6 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         test_targets:
+          - HOST_OS: 'macos-26'
+            XCODE_VERSION: '26.0'
+            IOS_VERSION: '26.0'
+            IOS_MODEL: iPhone 17
           - HOST_OS: 'macos-15'
             XCODE_VERSION: '16.4'
             IOS_VERSION: '18.4'


### PR DESCRIPTION
- https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
- https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md

It looks like macos 15 is stabler for Xcode/iOS 26 right now