### PR TITLE
chore: Skip staleness checks for subelement lookups

### DIFF
--- a/WebDriverAgentLib/Commands/FBFindElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBFindElementCommands.m
@@ -94,7 +94,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 {
   FBElementCache *elementCache = request.session.elementCache;
   XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]
-                                       checkStaleness:YES];
+                                       checkStaleness:NO];
   XCUIElement *foundElement = [self.class elementUsing:request.arguments[@"using"]
                                              withValue:request.arguments[@"value"]
                                                  under:element];
@@ -108,7 +108,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 {
   FBElementCache *elementCache = request.session.elementCache;
   XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"]
-                                       checkStaleness:YES];
+                                       checkStaleness:NO];
   NSArray *foundElements = [self.class elementsUsing:request.arguments[@"using"]
                                            withValue:request.arguments[@"value"]
                                                under:element


### PR DESCRIPTION
It should make such requests faster for cases where accessibility hierarchy is big. See the discussion at https://github.com/appium/appium/issues/21637 for more details