### PR TITLE
feat: Let binding IP address to be configurable via USE_IP environment variable

### DIFF
--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
@@ -67,6 +67,11 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
+            key = "USE_IP"
+            value = "$(USE_IP)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
             key = "UPGRADE_TIMESTAMP"
             value = "$(UPGRADE_TIMESTAMP)"
             isEnabled = "YES">

--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner_tvOS.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner_tvOS.xcscheme
@@ -76,6 +76,11 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
+            key = "USE_IP"
+            value = "$(USE_IP)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
             key = "UPGRADE_TIMESTAMP"
             value = "$(UPGRADE_TIMESTAMP)"
             isEnabled = "YES">

--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -117,7 +117,9 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
     [FBLogger logFmt:@"Last attempt to start web server failed with error %@", [error description]];
     abort();
   }
-  [FBLogger logFmt:@"%@http://%@:%d%@", FBServerURLBeginMarker, [XCUIDevice sharedDevice].fb_wifiIPAddress ?: @"localhost", [self.server port], FBServerURLEndMarker];
+  
+  NSString *serverHost = bindingIP ?: ([XCUIDevice sharedDevice].fb_wifiIPAddress ?: @"127.0.0.1");
+  [FBLogger logFmt:@"%@http://%@:%d%@", FBServerURLBeginMarker, serverHost, [self.server port], FBServerURLEndMarker];
 }
 
 - (void)initScreenshotsBroadcaster

--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -92,6 +92,12 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   [self registerServerKeyRouteHandlers];
 
   NSRange serverPortRange = FBConfiguration.bindingPortRange;
+  NSString *bindingIP = FBConfiguration.bindingIPAddress;
+  if (bindingIP != nil) {
+    [self.server setInterface:bindingIP];
+    [FBLogger logFmt:@"Using custom binding IP address: %@", bindingIP];
+  }
+  
   NSError *error;
   BOOL serverStarted = NO;
 

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -125,6 +125,12 @@ extern NSString *const FBSnapshotMaxDepthKey;
 + (NSRange)bindingPortRange;
 
 /**
+ The IP address that the HTTP Server should bind to on launch.
+ Returns nil if not specified, which causes the server to listen on all interfaces.
+ */
++ (NSString * _Nullable)bindingIPAddress;
+
+/**
  The port number where the background screenshots broadcaster is supposed to run
  */
 + (NSInteger)mjpegServerPort;

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -137,6 +137,17 @@ static BOOL FBShouldIncludeMinMaxValueInPageSource = NO;
   return NSMakeRange(DefaultStartingPort, DefaultPortRange);
 }
 
++ (NSString *)bindingIPAddress
+{
+  // Existence of USE_IP in the environment allows specifying which interface to bind to
+  if (NSProcessInfo.processInfo.environment[@"USE_IP"] &&
+      [NSProcessInfo.processInfo.environment[@"USE_IP"] length] > 0) {
+    return NSProcessInfo.processInfo.environment[@"USE_IP"];
+  }
+
+  return nil;
+}
+
 + (NSInteger)mjpegServerPort
 {
   if (self.mjpegServerPortFromArguments != NSNotFound) {

--- a/WebDriverAgentTests/UnitTests/FBConfigurationTests.m
+++ b/WebDriverAgentTests/UnitTests/FBConfigurationTests.m
@@ -20,6 +20,7 @@
 {
   [super setUp];
   unsetenv("USE_PORT");
+  unsetenv("USE_IP");
   unsetenv("VERBOSE_LOGGING");
 }
 
@@ -43,6 +44,17 @@
 {
   setenv("VERBOSE_LOGGING", "YES", 1);
   XCTAssertTrue([FBConfiguration verboseLoggingEnabled]);
+}
+
+- (void)testBindingIPDefault
+{
+  XCTAssertNil([FBConfiguration bindingIPAddress]);
+}
+
+- (void)testBindingIPEnvironmentOverwrite
+{
+  setenv("USE_IP", "192.168.1.100", 1);
+  XCTAssertEqualObjects([FBConfiguration bindingIPAddress], @"192.168.1.100");
 }
 
 @end

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -64,6 +64,7 @@ export interface WebDriverAgentArgs {
   wdaLocalPort?: number;
   wdaRemotePort?: number;
   wdaBaseUrl?: string;
+  wdaBindingIP?: string;
   prebuildWDA?: boolean;
   webDriverAgentUrl?: string;
   wdaConnectionTimeout?: number;
@@ -116,6 +117,7 @@ export interface XcodeBuildArgs {
   useXctestrunFile?: boolean;
   launchTimeout?: number;
   wdaRemotePort?: number;
+  wdaBindingIP?: string;
   updatedWDABundleId?: string;
   derivedDataPath?: string;
   mjpegServerPort?: number;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -174,7 +174,7 @@ async function setRealDeviceSecurity (keychainPath, keychainPassword) {
  * @property {string} sdkVersion - The Xcode SDK version of OS.
  * @property {string} bootstrapPath - The folder path containing xctestrun file.
  * @property {number|string} wdaRemotePort - The remote port WDA is listening on.
- * @property {string|undefined} wdaBindingIP - The IP address to bind to. If not given, it binds to all interfaces.
+ * @property {string} [wdaBindingIP] - The IP address to bind to. If not given, it binds to all interfaces.
  */
 /**
  * Creates xctestrun file per device & platform version.
@@ -205,7 +205,7 @@ async function setXctestrunFile (args) {
  * Return the WDA object which appends existing xctest runner content
  * @param {string} platformName - The name of the platform
  * @param {number|string} wdaRemotePort - The remote port number
- * @param {string|undefined} wdaBindingIP - The IP address to bind to. If not given, it binds to all interfaces.
+ * @param {string} [wdaBindingIP] - The IP address to bind to. If not given, it binds to all interfaces.
  * @return {object} returns a runner object which has USE_PORT and optionally USE_IP
  */
 function getAdditionalRunContent (platformName, wdaRemotePort, wdaBindingIP) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -166,6 +166,16 @@ async function setRealDeviceSecurity (keychainPath, keychainPassword) {
  * @property {string} platformVersion - The platform version of OS.
  * @property {string} platformName - The platform name of iOS, tvOS
 */
+
+/**
+ * Arguments for setting xctestrun file
+ * @typedef {Object} XctestrunFileArgs
+ * @property {DeviceInfo} deviceInfo - Information of the device under test
+ * @property {string} sdkVersion - The Xcode SDK version of OS.
+ * @property {string} bootstrapPath - The folder path containing xctestrun file.
+ * @property {number|string} wdaRemotePort - The remote port WDA is listening on.
+ * @property {string|undefined} wdaBindingIP - The IP address to bind to. If not given, it binds to all interfaces.
+ */
 /**
  * Creates xctestrun file per device & platform version.
  * We expects to have WebDriverAgentRunner_iphoneos${sdkVersion|platformVersion}-arm64.xctestrun for real device
@@ -174,19 +184,17 @@ async function setRealDeviceSecurity (keychainPath, keychainPassword) {
  * e.g. Xcode which has iOS SDK Version 12.2 on an intel Mac host machine generates WebDriverAgentRunner_iphonesimulator.2-x86_64.xctestrun
  *      even if the cap has platform version 11.4
  *
- * @param {DeviceInfo} deviceInfo
- * @param {string} sdkVersion - The Xcode SDK version of OS.
- * @param {string} bootstrapPath - The folder path containing xctestrun file.
- * @param {number|string} wdaRemotePort - The remote port WDA is listening on.
+ * @param {XctestrunFileArgs} args
  * @return {Promise<string>} returns xctestrunFilePath for given device
  * @throws if WebDriverAgentRunner_iphoneos${sdkVersion|platformVersion}-arm64.xctestrun for real device
  * or WebDriverAgentRunner_iphonesimulator${sdkVersion|platformVersion}-x86_64.xctestrun for simulator is not found @bootstrapPath,
- * then it will throw file not found exception
+ * then it will throw a file not found exception
  */
-async function setXctestrunFile (deviceInfo, sdkVersion, bootstrapPath, wdaRemotePort) {
+async function setXctestrunFile (args) {
+  const {deviceInfo, sdkVersion, bootstrapPath, wdaRemotePort, wdaBindingIP} = args;
   const xctestrunFilePath = await getXctestrunFilePath(deviceInfo, sdkVersion, bootstrapPath);
   const xctestRunContent = await plist.parsePlistFile(xctestrunFilePath);
-  const updateWDAPort = getAdditionalRunContent(deviceInfo.platformName, wdaRemotePort);
+  const updateWDAPort = getAdditionalRunContent(deviceInfo.platformName, wdaRemotePort, wdaBindingIP);
   const newXctestRunContent = _.merge(xctestRunContent, updateWDAPort);
   await plist.updatePlistFile(xctestrunFilePath, newXctestRunContent, true);
 
@@ -197,16 +205,17 @@ async function setXctestrunFile (deviceInfo, sdkVersion, bootstrapPath, wdaRemot
  * Return the WDA object which appends existing xctest runner content
  * @param {string} platformName - The name of the platform
  * @param {number|string} wdaRemotePort - The remote port number
- * @return {object} returns a runner object which has USE_PORT
+ * @param {string|undefined} wdaBindingIP - The IP address to bind to. If not given, it binds to all interfaces.
+ * @return {object} returns a runner object which has USE_PORT and optionally USE_IP
  */
-function getAdditionalRunContent (platformName, wdaRemotePort) {
+function getAdditionalRunContent (platformName, wdaRemotePort, wdaBindingIP) {
   const runner = `WebDriverAgentRunner${isTvOS(platformName) ? '_tvOS' : ''}`;
-
   return {
     [runner]: {
       EnvironmentVariables: {
         // USE_PORT must be 'string'
-        USE_PORT: `${wdaRemotePort}`
+        USE_PORT: `${wdaRemotePort}`,
+        ...(wdaBindingIP ? { USE_IP: wdaBindingIP } : {}),
       }
     }
   };

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -60,7 +60,7 @@ export class WebDriverAgent {
     this.wdaRemotePort = ((this.isRealDevice ? args.wdaRemotePort : null) ?? args.wdaLocalPort)
       || WDA_AGENT_PORT;
     this.wdaBaseUrl = args.wdaBaseUrl || WDA_BASE_URL;
-
+    this.wdaBindingIP = args.wdaBindingIP;
     this.prebuildWDA = args.prebuildWDA;
 
     // this.args.webDriverAgentUrl guiarantees the capabilities acually
@@ -104,6 +104,7 @@ export class WebDriverAgent {
         updatedWDABundleId: this.updatedWDABundleId,
         launchTimeout: this.wdaLaunchTimeout,
         wdaRemotePort: this.wdaRemotePort,
+        wdaBindingIP: this.wdaBindingIP,
         useXctestrunFile: this.useXctestrunFile,
         derivedDataPath: args.derivedDataPath,
         mjpegServerPort: this.mjpegServerPort,
@@ -389,6 +390,9 @@ export class WebDriverAgent {
     };
     if (this.mjpegServerPort) {
       xctestEnv.MJPEG_SERVER_PORT = this.mjpegServerPort;
+    }
+    if (this.wdaBindingIP) {
+      xctestEnv.USE_IP = this.wdaBindingIP;
     }
     this.log.info('Launching WebDriverAgent on the device without xcodebuild');
     if (this.isRealDevice) {

--- a/lib/xcodebuild.js
+++ b/lib/xcodebuild.js
@@ -83,6 +83,7 @@ export class XcodeBuild {
     this.launchTimeout = args.launchTimeout;
 
     this.wdaRemotePort = args.wdaRemotePort;
+    this.wdaBindingIP = args.wdaBindingIP;
 
     this.updatedWDABundleId = args.updatedWDABundleId;
     this.derivedDataPath = args.derivedDataPath;
@@ -116,12 +117,13 @@ export class XcodeBuild {
         platformVersion: this.platformVersion || '',
         platformName: this.platformName || ''
       };
-      this.xctestrunFilePath = await setXctestrunFile(
-        deviceInfo,
-        this.iosSdkVersion || '',
-        this.bootstrapPath,
-        this.wdaRemotePort || 8100
-      );
+      this.xctestrunFilePath = await setXctestrunFile({
+          deviceInfo,
+          sdkVersion: this.iosSdkVersion || '',
+          bootstrapPath: this.bootstrapPath,
+          wdaRemotePort: this.wdaRemotePort || 8100,
+          wdaBindingIP: this.wdaBindingIP
+        });
       return;
     }
 


### PR DESCRIPTION
We run multiple instances of iOS Simulator on the same macOS host and each gets an IP address from a central IP address management for all simulators in the network, but when they all start WebDriverAgent, they get "address in use" errors as expected.

The suggested way of preventing this is to use `USE_PORT` but that introduces two challenges:
* We need synchronization and lock for the instances running on the same host apart from IP management we already have,
* The host must communicate back and tell which port belongs to which iOS simulator instance. With IP, we already have that information centrally so we'd always keep going to `:8100` for WebDriverAgent.

This change introduces `USE_IP` environment variable where users can optionally change the IP that the RoutingHTTPServer binds to remove the need for host-wide synchronization for port number in scenarios where each simulator already has a known IP.

Here is how I tested it:
1. Add the custom IP to `lo0` interface so WDA can bind.
   ```bash
   sudo ifconfig lo0 alias 10.244.1.2
   ```
1. Run it in a simulator with the following command:
   ```bash
   xcodebuild test \
     -project WebDriverAgent.xcodeproj \
     -scheme WebDriverAgentRunner \
     -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
     USE_IP=10.244.1.2
   ```
1. Once up and running, you'll see these log lines:
   ```
   2025-10-30 22:48:37.208232+0300 WebDriverAgentRunner-Runner[52590:11285751] Using custom binding IP address: 10.244.1.2
   2025-10-30 22:48:37.208485+0300 WebDriverAgentRunner-Runner[52590:11285751] ServerURLHere->http://10.244.1.2:8100<-ServerURLHere
   ```
1. Test if it serves only on this custom IP:
   ```bash
   curl http://10.244.1.2:8100/health
   <!DOCTYPE html><html><title>Health Check</title><body><p>I-AM-ALIVE</p></body></html>
   ```
   ```
   curl http://127.0.0.1:8100/health
   curl: (7) Failed to connect to 127.0.0.1 port 8100 after 0 ms: Couldn't connect to server
   ```

When I run it with the following command, e.g. no override, I see usual behavior.
```bash
xcodebuild test \
  -project WebDriverAgent.xcodeproj \
  -scheme WebDriverAgentRunner \
  -destination 'platform=iOS Simulator,name=iPhone 16 Pro'
```
```
2025-10-30 22:53:28.503846+0300 WebDriverAgentRunner-Runner[57207:11300071] Built at Oct 30 2025 22:48:25
2025-10-30 22:53:28.517162+0300 WebDriverAgentRunner-Runner[57207:11300071] ServerURLHere->http://192.168.1.110:8100<-ServerURLHere
```
```bash
curl http://127.0.0.1:8100/health
<!DOCTYPE html><html><title>Health Check</title><body><p>I-AM-ALIVE</p></body></html>
```
```bash
curl http://192.168.1.110:8100/health
<!DOCTYPE html><html><title>Health Check</title><body><p>I-AM-ALIVE</p></body></html>
```