### PR TITLE
fix: update xcodebuild commands for the new binding ip capability

### DIFF
--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -517,6 +517,9 @@ export class WebDriverAgent {
     if (this.mjpegServerPort) {
       env.MJPEG_SERVER_PORT = this.mjpegServerPort;
     }
+    if (this.wdaBindingIP) {
+      env.USE_IP = this.wdaBindingIP;
+    }
 
     return await this.idb.runXCUITest(wdaBundleId, wdaBundleId, testBundleId, {env});
   }
@@ -648,7 +651,7 @@ export class WebDriverAgent {
       } else {
         const port = this.wdaLocalPort || WDA_AGENT_PORT;
         const {protocol, hostname} = url.parse(this.wdaBaseUrl || WDA_BASE_URL);
-        this._url = url.parse(`${protocol}//${hostname}:${port}`);
+        this._url = url.parse(`${protocol}//${this.wdaBindingIP || hostname}:${port}`);
       }
     }
     return this._url;

--- a/lib/xcodebuild.js
+++ b/lib/xcodebuild.js
@@ -324,6 +324,9 @@ export class XcodeBuild {
       // https://github.com/appium/WebDriverAgent/pull/105
       env.MJPEG_SERVER_PORT = this.mjpegServerPort;
     }
+    if (this.wdaBindingIP) {
+      env.USE_IP = this.wdaBindingIP;
+    }
     const upgradeTimestamp = await getWDAUpgradeTimestamp();
     if (upgradeTimestamp) {
       env.UPGRADE_TIMESTAMP = upgradeTimestamp;


### PR DESCRIPTION
While testing https://github.com/appium/WebDriverAgent/pull/1066 with the driver, I noticed the binding IP is not propagated in some cases. I validated this PR together with https://github.com/appium/appium-xcuitest-driver/pull/2645 with the following test:
```js
const {remote} = require('webdriverio');

const capabilities = {
  platformName: 'iOS',
  'appium:automationName': 'XCUITest',
  'appium:deviceName': 'iPhone 16 Pro',
  'appium:app': 'com.apple.mobilesafari',
  'appium:wdaBindingIP': "10.244.1.3",
  'appium:wdaRemotePort': 8100,
};

const wdOpts = {
  hostname: process.env.APPIUM_HOST || 'localhost',
  port: parseInt(process.env.APPIUM_PORT, 10) || 4723,
  logLevel: 'info',
  capabilities,
};

async function runTest() {
  const driver = await remote(wdOpts);
  try {
    const batteryItem = await driver.$('//*[@text="Battery"]');
    await batteryItem.click();
  } finally {
    await driver.pause(1000);
    await driver.deleteSession();
  }
}

runTest().catch(console.error);
```

In the logs I see the custom IP is used and `127.0.0.1:8100` does not answer which is the expected behavior.