### PR TITLE
fix: fix type and mark deprecated as no usage for unused xcodeVersion and deprecated idb

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -94,6 +94,7 @@ export interface AppleDevice {
   udid: string;
   simctl?: any;
   devicectl?: any;
+  /** @deprecated We'll stop supporting idb */
   idb?: any;
   [key: string]: any;
 }

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -510,7 +510,7 @@ export class WebDriverAgent {
    */
   async startWithIDB () {
     this.log.info('Will launch WDA with idb instead of xcodebuild since the corresponding flag is enabled');
-    const {wdaBundleId, testBundleId} = await this.prepareWDAWithIdb();
+    const {wdaBundleId, testBundleId} = await this.prepareWDA();
     const env = {
       USE_PORT: this.wdaRemotePort,
       WDA_PRODUCT_BUNDLE_IDENTIFIER: this.bundleIdForXctest,
@@ -543,7 +543,7 @@ export class WebDriverAgent {
    * @deprecated We'll stop using idb
    * @returns {Promise<{wdaBundleId: string, testBundleId: string, wdaBundlePath: string}>}
    */
-  async prepareWDAWithIdb () {
+  async prepareWDA () {
     const wdaBundlePath = this.wdaBundlePath || await this.fetchWDABundle();
     const wdaBundleId = await this.parseBundleId(wdaBundlePath);
     if (!await this.device.isAppInstalled(wdaBundleId)) {

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -35,7 +35,7 @@ export class WebDriverAgent {
   agentPath;
 
   /**
-   * @param {import('appium-xcode').XcodeVersion} xcodeVersion
+   * @param {import('appium-xcode').XcodeVersion | undefined} xcodeVersion @deprecated Will be removed as no actual usage.
    * @param {import('./types').WebDriverAgentArgs} args
    * @param {import('@appium/types').AppiumLogger?} [log=null]
    */

--- a/lib/webdriveragent.js
+++ b/lib/webdriveragent.js
@@ -51,6 +51,7 @@ export class WebDriverAgent {
     this.iosSdkVersion = args.iosSdkVersion;
     this.host = args.host;
     this.isRealDevice = !!args.realDevice;
+    /** @deprecated We'll stop supporting idb */
     this.idb = args.device.idb;
     this.wdaBundlePath = args.wdaBundlePath;
 
@@ -509,7 +510,7 @@ export class WebDriverAgent {
    */
   async startWithIDB () {
     this.log.info('Will launch WDA with idb instead of xcodebuild since the corresponding flag is enabled');
-    const {wdaBundleId, testBundleId} = await this.prepareWDA();
+    const {wdaBundleId, testBundleId} = await this.prepareWDAWithIdb();
     const env = {
       USE_PORT: this.wdaRemotePort,
       WDA_PRODUCT_BUNDLE_IDENTIFIER: this.bundleIdForXctest,
@@ -539,9 +540,10 @@ export class WebDriverAgent {
   }
 
   /**
+   * @deprecated We'll stop using idb
    * @returns {Promise<{wdaBundleId: string, testBundleId: string, wdaBundlePath: string}>}
    */
-  async prepareWDA () {
+  async prepareWDAWithIdb () {
     const wdaBundlePath = this.wdaBundlePath || await this.fetchWDABundle();
     const wdaBundleId = await this.parseBundleId(wdaBundlePath);
     if (!await this.device.isAppInstalled(wdaBundleId)) {

--- a/lib/xcodebuild.js
+++ b/lib/xcodebuild.js
@@ -46,7 +46,7 @@ export class XcodeBuild {
   xcodebuild;
 
   /**
-   * @param {import('appium-xcode').XcodeVersion} xcodeVersion
+   * @param {import('appium-xcode').XcodeVersion | undefined} xcodeVersion @deprecated Will be removed as no actual usage.
    * @param {import('./types').AppleDevice} device
    * @param {import('./types').XcodeBuildArgs} args
    * @param {import('@appium/types').AppiumLogger | null} [log=null]


### PR DESCRIPTION
Previously, they can be undefined for `webDriverAgentUrl` / `usePreinstalledWDA` usage, but it looks like the xcodeVersion can be undefined for WebDriverAgent today. So, we'll be able to drop the first argument completely in the future - when we bump this major version

```
kazu $ git grep 'xcodeVersion' lib 
lib/webdriveragent.js:   * @param {import('appium-xcode').XcodeVersion | undefined} xcodeVersion
lib/webdriveragent.js:  constructor (xcodeVersion, args, log = null) {
lib/webdriveragent.js:    this.xcodeVersion = xcodeVersion;
lib/webdriveragent.js:    : new XcodeBuild(this.xcodeVersion, this.device, {
lib/xcodebuild.js:   * @param {import('appium-xcode').XcodeVersion | undefined} xcodeVersion
lib/xcodebuild.js:  constructor (xcodeVersion, device, args, log = null) {
lib/xcodebuild.js:    this.xcodeVersion = xcodeVersion;
kazu $ 
```

Also, I didn't see this `xcodeVersion` reference from xcuitest driver.