### PR TITLE
chore: use any iphone/tvos simulator devices to build WDA for sim

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       XCODE_VERSION: 16.3
       # Available destination for simulators depend on Xcode version.
-      DESTINATION_SIM: platform=iOS Simulator,name=iPhone 16 Plus
+      DESTINATION_SIM: platform=iOS Simulator,name=iPhone 17
       DESTINATION_SIM_TVOS: platform=tvOS Simulator,name=Apple TV 4K (3rd generation)
 
     steps:

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -10,8 +10,8 @@ on:
 env:
   HOST: macos-15
   XCODE_VERSION: 16.3
-  DESTINATION_SIM: platform=iOS Simulator,name=Any iOS Simulator Device
-  DESTINATION_SIM_tvOS: platform=tvOS Simulator,name=Any tvOS Simulator Device
+  DESTINATION_SIM: platform=iOS Simulator,name=Any iOS Simulator Device,id=id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder
+  DESTINATION_SIM_tvOS: platform=tvOS Simulator,name=Any tvOS Simulator Device,id=dvtdevice-DVTiOSDeviceSimulatorPlaceholder-appletvsimulator:placeholder
 
 jobs:
   host_machine:

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -10,8 +10,8 @@ on:
 env:
   HOST: macos-15
   XCODE_VERSION: 16.3
-  DESTINATION_SIM: platform=iOS Simulator,name=iPhone 16 Plus
-  DESTINATION_SIM_tvOS: platform=tvOS Simulator,name=Apple TV 4K (3rd generation)
+  DESTINATION_SIM: platform=iOS Simulator,name=Any iOS Simulator Device
+  DESTINATION_SIM_tvOS: platform=tvOS Simulator,name=Any tvOS Simulator Device
 
 jobs:
   host_machine:

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -10,8 +10,8 @@ on:
 env:
   HOST: macos-15
   XCODE_VERSION: 16.3
-  DESTINATION_SIM: platform=iOS Simulator,name=Any iOS Simulator Device,id=id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder
-  DESTINATION_SIM_tvOS: platform=tvOS Simulator,name=Any tvOS Simulator Device,id=dvtdevice-DVTiOSDeviceSimulatorPlaceholder-appletvsimulator:placeholder
+  DESTINATION_SIM: platform=iOS Simulator,name=Any iOS Simulator Device,os=26.1
+  DESTINATION_SIM_tvOS: platform=tvOS Simulator,name=Any tvOS Simulator Device,os=26.1
 
 jobs:
   host_machine:

--- a/.github/workflows/wda-package.yml
+++ b/.github/workflows/wda-package.yml
@@ -10,8 +10,8 @@ on:
 env:
   HOST: macos-15
   XCODE_VERSION: 16.3
-  DESTINATION_SIM: platform=iOS Simulator,name=Any iOS Simulator Device,os=26.1
-  DESTINATION_SIM_tvOS: platform=tvOS Simulator,name=Any tvOS Simulator Device,os=26.1
+  DESTINATION_SIM: platform=iOS Simulator,name=iPhone 17
+  DESTINATION_SIM_tvOS: platform=tvOS Simulator,name=Apple TV 4K (3rd generation)
 
 jobs:
   host_machine:


### PR DESCRIPTION
Let me see how they will be.

They were available with:

```
xcodebuild -scheme WebDriverAgentRunner -showdestinations
xcodebuild -scheme WebDriverAgentRunner_tvOS -showdestinations
```

https://github.com/appium/WebDriverAgent/actions/runs/19865510962


I hope this will avoid https://github.com/appium/WebDriverAgent/actions/runs/19856758298/job/56896514185 kind of error. Maybe the error was OS instance dependent

---
note: it looks like xcodebuild automatically adds `os:latest` for `platform=iOS Simulator,name=Any iOS Simulator Device`