### PR TITLE
feat: add `action` and `camera` values for `mobile: pressButton`

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
@@ -96,14 +96,6 @@ typedef NS_ENUM(NSUInteger, FBUIInterfaceAppearance) {
 - (BOOL)fb_openUrl:(NSString *)url withApplication:(NSString *)bundleId error:(NSError **)error;
 
 /**
- Checks if the device has a specific hardware button available.
-
- @param buttonName The name of the button to check (e.g., "home", "volumeUp", "volumeDown", "action", "camera")
- @return YES if the button is available on the device, otherwise NO
- */
-- (BOOL)fb_hasButton:(NSString *)buttonName;
-
-/**
  Presses the corresponding hardware button on the device with duration.
 
  @param buttonName One of the supported button names: volumeUp (real devices only), volumeDown (real device only),

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
@@ -98,7 +98,8 @@ typedef NS_ENUM(NSUInteger, FBUIInterfaceAppearance) {
 /**
  Presses the corresponding hardware button on the device with duration.
 
- @param buttonName One of the supported button names: volumeUp (real devices only), volumeDown (real device only), home
+ @param buttonName One of the supported button names: volumeUp (real devices only), volumeDown (real device only),
+                   camera (supported iOS 16+ real devices only), action (supported iOS 16+ devices only), home
  @param duration Duration in seconds or nil.
                 This argument works only on tvOS. When this argument is nil on tvOS,
                 https://developer.apple.com/documentation/xctest/xcuiremote/1627476-pressbutton will be called.

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
@@ -96,6 +96,14 @@ typedef NS_ENUM(NSUInteger, FBUIInterfaceAppearance) {
 - (BOOL)fb_openUrl:(NSString *)url withApplication:(NSString *)bundleId error:(NSError **)error;
 
 /**
+ Checks if the device has a specific hardware button available.
+
+ @param buttonName The name of the button to check (e.g., "home", "volumeUp", "volumeDown", "action", "camera")
+ @return YES if the button is available on the device, otherwise NO
+ */
+- (BOOL)fb_hasButton:(NSString *)buttonName;
+
+/**
  Presses the corresponding hardware button on the device with duration.
 
  @param buttonName One of the supported button names: volumeUp (real devices only), volumeDown (real device only),

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -225,20 +225,22 @@ static bool fb_isLocked;
   }
 #endif
   
-#if __clang_major__ >= 17 || (__clang_major__ == 16 && __clang_minor__ >= 3)
   if (@available(iOS 16.0, *)) {
+#if defined(XCUIDeviceButtonAction)
     if ([buttonNameLC isEqualToString:@"action"]) {
       return [self hasHardwareButton:XCUIDeviceButtonAction];
     }
+#endif
+#if defined(XCUIDeviceButtonCamera)
 #if !TARGET_OS_SIMULATOR
     if ([buttonNameLC isEqualToString:@"camera"]) {
       return [self hasHardwareButton:XCUIDeviceButtonCamera];
     }
 #endif
+#endif
   }
 #endif
-#endif
-  
+
   return NO;
 }
 
@@ -338,11 +340,11 @@ static bool fb_isLocked;
   if ([buttonNameLC isEqualToString:@"home"]) {
     dstButton = XCUIDeviceButtonHome;
   }
-  #if __clang_major__ >= 17 || (__clang_major__ == 16 && __clang_minor__ >= 3)
+#if defined(XCUIDeviceButtonAction)
   if ([buttonNameLC isEqualToString:@"action"] && [self fb_hasButton:@"action"]) {
     dstButton = XCUIDeviceButtonAction;
   }
-  #endif
+#endif
 #if !TARGET_OS_SIMULATOR
   if ([buttonNameLC isEqualToString:@"volumeup"]) {
     dstButton = XCUIDeviceButtonVolumeUp;
@@ -350,11 +352,11 @@ static bool fb_isLocked;
   if ([buttonNameLC isEqualToString:@"volumedown"]) {
     dstButton = XCUIDeviceButtonVolumeDown;
   }
-  #if __clang_major__ >= 17 || (__clang_major__ == 16 && __clang_minor__ >= 3)
+#if defined(XCUIDeviceButtonCamera)
   if ([buttonNameLC isEqualToString:@"camera"] && [self fb_hasButton:@"camera"]) {
     dstButton = XCUIDeviceButtonCamera;
   }
-  #endif
+#endif
 #endif
 
   [self fb_addButtonsIfAvailable:@[@"home", @"action", @"volumeUp", @"volumeDown", @"camera"]

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -297,14 +297,14 @@ static bool fb_isLocked;
   }
   [supportedButtonNames addObject:@"home"];
 
-  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"16.0")) {
-    if ([self hasHardwareButton:XCUIDeviceButtonAction]) {
-      if ([buttonName.lowercaseString isEqualToString:@"action"]) {
-        dstButton = XCUIDeviceButtonAction;
-      }
-      [supportedButtonNames addObject:@"action"];
+  #if __clang_major__ >= 17 || (__clang_major__ == 16 && __clang_minor__ >= 3)
+  if (@available(iOS 16.0, *) && [self hasHardwareButton:XCUIDeviceButtonAction]) {
+    if ([buttonName.lowercaseString isEqualToString:@"action"]) {
+      dstButton = XCUIDeviceButtonAction;
     }
+    [supportedButtonNames addObject:@"action"];
   }
+  #endif
 #if !TARGET_OS_SIMULATOR
   if ([buttonName.lowercaseString isEqualToString:@"volumeup"]) {
     dstButton = XCUIDeviceButtonVolumeUp;
@@ -316,14 +316,14 @@ static bool fb_isLocked;
   }
   [supportedButtonNames addObject:@"volumeDown"];
 
-  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"16.0")) {
-    if ([self hasHardwareButton:XCUIDeviceButtonCamera]) {
-      if ([buttonName.lowercaseString isEqualToString:@"camera"]) {
-        dstButton = XCUIDeviceButtonCamera;
-      }
-      [supportedButtonNames addObject:@"camera"];
+  #if __clang_major__ >= 17 || (__clang_major__ == 16 && __clang_minor__ >= 3)
+  if (@available(iOS 16.0, *) && [self hasHardwareButton:XCUIDeviceButtonCamera]) {
+    if ([buttonName.lowercaseString isEqualToString:@"camera"]) {
+      dstButton = XCUIDeviceButtonCamera;
     }
+    [supportedButtonNames addObject:@"camera"];
   }
+  #endif
 #endif
 
   if (dstButton == 0) {

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -244,16 +244,6 @@ static bool fb_isLocked;
   return NO;
 }
 
-- (void)fb_addButtonsIfAvailable:(NSArray<NSString *> *)buttonNames
-          toSupportedButtonNames:(NSMutableArray<NSString *> *)supportedButtonNames
-{
-  for (NSString *buttonName in buttonNames) {
-    if ([self fb_hasButton:buttonName]) {
-      [supportedButtonNames addObject:buttonName];
-    }
-  }
-}
-
 - (BOOL)fb_pressButton:(NSString *)buttonName
            forDuration:(nullable NSNumber *)duration
                  error:(NSError **)error
@@ -439,5 +429,15 @@ static bool fb_isLocked;
   return [FBXCTestDaemonsProxy clearSimulatedLocation:error];
 }
 #endif
+
+- (void)fb_addButtonsIfAvailable:(NSArray<NSString *> *)buttonNames
+          toSupportedButtonNames:(NSMutableArray<NSString *> *)supportedButtonNames
+{
+  for (NSString *buttonName in buttonNames) {
+    if ([self fb_hasButton:buttonName]) {
+      [supportedButtonNames addObject:buttonName];
+    }
+  }
+}
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -210,6 +210,48 @@ static bool fb_isLocked;
   }
 }
 
+- (BOOL)fb_hasButton:(NSString *)buttonName
+{
+  NSString *buttonNameLC = buttonName.lowercaseString;
+  
+  if ([buttonNameLC isEqualToString:@"home"]) {
+    return YES;
+  }
+  
+#if !TARGET_OS_TV
+#if !TARGET_OS_SIMULATOR
+  if ([buttonNameLC isEqualToString:@"volumeup"] || [buttonNameLC isEqualToString:@"volumedown"]) {
+    return YES;
+  }
+#endif
+  
+#if __clang_major__ >= 17 || (__clang_major__ == 16 && __clang_minor__ >= 3)
+  if (@available(iOS 16.0, *)) {
+    if ([buttonNameLC isEqualToString:@"action"]) {
+      return [self hasHardwareButton:XCUIDeviceButtonAction];
+    }
+#if !TARGET_OS_SIMULATOR
+    if ([buttonNameLC isEqualToString:@"camera"]) {
+      return [self hasHardwareButton:XCUIDeviceButtonCamera];
+    }
+#endif
+  }
+#endif
+#endif
+  
+  return NO;
+}
+
+- (void)fb_addButtonsIfAvailable:(NSArray<NSString *> *)buttonNames
+          toSupportedButtonNames:(NSMutableArray<NSString *> *)supportedButtonNames
+{
+  for (NSString *buttonName in buttonNames) {
+    if ([self fb_hasButton:buttonName]) {
+      [supportedButtonNames addObject:buttonName];
+    }
+  }
+}
+
 - (BOOL)fb_pressButton:(NSString *)buttonName
            forDuration:(nullable NSNumber *)duration
                  error:(NSError **)error
@@ -290,41 +332,33 @@ static bool fb_isLocked;
 - (BOOL)fb_pressButton:(NSString *)buttonName
                  error:(NSError **)error
 {
+  NSString *buttonNameLC = buttonName.lowercaseString;
   NSMutableArray<NSString *> *supportedButtonNames = [NSMutableArray array];
   XCUIDeviceButton dstButton = 0;
-  if ([buttonName.lowercaseString isEqualToString:@"home"]) {
+  if ([buttonNameLC isEqualToString:@"home"]) {
     dstButton = XCUIDeviceButtonHome;
   }
-  [supportedButtonNames addObject:@"home"];
-
   #if __clang_major__ >= 17 || (__clang_major__ == 16 && __clang_minor__ >= 3)
-  if (@available(iOS 16.0, *) && [self hasHardwareButton:XCUIDeviceButtonAction]) {
-    if ([buttonName.lowercaseString isEqualToString:@"action"]) {
-      dstButton = XCUIDeviceButtonAction;
-    }
-    [supportedButtonNames addObject:@"action"];
+  if ([buttonNameLC isEqualToString:@"action"] && [self fb_hasButton:@"action"]) {
+    dstButton = XCUIDeviceButtonAction;
   }
   #endif
 #if !TARGET_OS_SIMULATOR
-  if ([buttonName.lowercaseString isEqualToString:@"volumeup"]) {
+  if ([buttonNameLC isEqualToString:@"volumeup"]) {
     dstButton = XCUIDeviceButtonVolumeUp;
   }
-  [supportedButtonNames addObject:@"volumeUp"];
-
-  if ([buttonName.lowercaseString isEqualToString:@"volumedown"]) {
+  if ([buttonNameLC isEqualToString:@"volumedown"]) {
     dstButton = XCUIDeviceButtonVolumeDown;
   }
-  [supportedButtonNames addObject:@"volumeDown"];
-
   #if __clang_major__ >= 17 || (__clang_major__ == 16 && __clang_minor__ >= 3)
-  if (@available(iOS 16.0, *) && [self hasHardwareButton:XCUIDeviceButtonCamera]) {
-    if ([buttonName.lowercaseString isEqualToString:@"camera"]) {
-      dstButton = XCUIDeviceButtonCamera;
-    }
-    [supportedButtonNames addObject:@"camera"];
+  if ([buttonNameLC isEqualToString:@"camera"] && [self fb_hasButton:@"camera"]) {
+    dstButton = XCUIDeviceButtonCamera;
   }
   #endif
 #endif
+
+  [self fb_addButtonsIfAvailable:@[@"home", @"action", @"volumeUp", @"volumeDown", @"camera"]
+          toSupportedButtonNames:supportedButtonNames];
 
   if (dstButton == 0) {
     return [[[FBErrorBuilder builder]

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -26,6 +26,41 @@
 static const NSTimeInterval FBHomeButtonCoolOffTime = 1.;
 static const NSTimeInterval FBScreenLockTimeout = 5.;
 
+NSDictionary<NSString *, NSNumber *> *availableButtonNames(void) {
+  static dispatch_once_t onceToken;
+  static NSDictionary *result;
+  dispatch_once(&onceToken, ^{
+    NSMutableDictionary *buttons = [NSMutableDictionary dictionary];
+    
+    // Home button is always available
+    buttons[@"home"] = @(XCUIDeviceButtonHome);
+    
+#if !TARGET_OS_TV
+#if !TARGET_OS_SIMULATOR
+    buttons[@"volumeup"] = @(XCUIDeviceButtonVolumeUp);
+    buttons[@"volumedown"] = @(XCUIDeviceButtonVolumeDown);
+#endif
+    
+    if (@available(iOS 16.0, *)) {
+#if defined(XCUIDeviceButtonAction)
+      if ([XCUIDevice.sharedDevice hasHardwareButton:XCUIDeviceButtonAction]) {
+        buttons[@"action"] = @(XCUIDeviceButtonAction);
+      }
+#endif
+#if defined(XCUIDeviceButtonCamera)
+#if !TARGET_OS_SIMULATOR
+      if ([XCUIDevice.sharedDevice hasHardwareButton:XCUIDeviceButtonCamera]) {
+        buttons[@"camera"] = @(XCUIDeviceButtonCamera);
+      }
+#endif
+#endif
+    }
+#endif
+    result = [buttons copy];
+  });
+  return result;
+}
+
 @implementation XCUIDevice (FBHelpers)
 
 static bool fb_isLocked;
@@ -212,36 +247,7 @@ static bool fb_isLocked;
 
 - (BOOL)fb_hasButton:(NSString *)buttonName
 {
-  NSString *buttonNameLC = buttonName.lowercaseString;
-  
-  if ([buttonNameLC isEqualToString:@"home"]) {
-    return YES;
-  }
-  
-#if !TARGET_OS_TV
-#if !TARGET_OS_SIMULATOR
-  if ([buttonNameLC isEqualToString:@"volumeup"] || [buttonNameLC isEqualToString:@"volumedown"]) {
-    return YES;
-  }
-#endif
-  
-  if (@available(iOS 16.0, *)) {
-#if defined(XCUIDeviceButtonAction)
-    if ([buttonNameLC isEqualToString:@"action"]) {
-      return [self hasHardwareButton:XCUIDeviceButtonAction];
-    }
-#endif
-#if defined(XCUIDeviceButtonCamera)
-#if !TARGET_OS_SIMULATOR
-    if ([buttonNameLC isEqualToString:@"camera"]) {
-      return [self hasHardwareButton:XCUIDeviceButtonCamera];
-    }
-#endif
-#endif
-  }
-#endif
-
-  return NO;
+  return availableButtonNames()[buttonName.lowercaseString] != nil;
 }
 
 - (BOOL)fb_pressButton:(NSString *)buttonName
@@ -304,7 +310,7 @@ static bool fb_isLocked;
 
   if (remoteButton == -1) {
     return [[[FBErrorBuilder builder]
-             withDescriptionFormat:@"The button '%@' is unknown. Only the following button names are supported: %@", buttonName, supportedButtonNames]
+             withDescriptionFormat:@"The button '%@' is not supported. The device under test only supports the following buttons: %@", buttonName, supportedButtonNames]
             buildError:error];
   }
 
@@ -324,40 +330,15 @@ static bool fb_isLocked;
 - (BOOL)fb_pressButton:(NSString *)buttonName
                  error:(NSError **)error
 {
-  NSString *buttonNameLC = buttonName.lowercaseString;
-  NSMutableArray<NSString *> *supportedButtonNames = [NSMutableArray array];
-  XCUIDeviceButton dstButton = 0;
-  if ([buttonNameLC isEqualToString:@"home"]) {
-    dstButton = XCUIDeviceButtonHome;
-  }
-#if defined(XCUIDeviceButtonAction)
-  if ([buttonNameLC isEqualToString:@"action"] && [self fb_hasButton:@"action"]) {
-    dstButton = XCUIDeviceButtonAction;
-  }
-#endif
-#if !TARGET_OS_SIMULATOR
-  if ([buttonNameLC isEqualToString:@"volumeup"]) {
-    dstButton = XCUIDeviceButtonVolumeUp;
-  }
-  if ([buttonNameLC isEqualToString:@"volumedown"]) {
-    dstButton = XCUIDeviceButtonVolumeDown;
-  }
-#if defined(XCUIDeviceButtonCamera)
-  if ([buttonNameLC isEqualToString:@"camera"] && [self fb_hasButton:@"camera"]) {
-    dstButton = XCUIDeviceButtonCamera;
-  }
-#endif
-#endif
-
-  [self fb_addButtonsIfAvailable:@[@"home", @"action", @"volumeUp", @"volumeDown", @"camera"]
-          toSupportedButtonNames:supportedButtonNames];
-
-  if (dstButton == 0) {
+  NSDictionary<NSString *, NSNumber *> *availableButtons = availableButtonNames();
+  NSNumber *buttonValue = availableButtons[buttonName.lowercaseString];
+  
+  if (!buttonValue) {
     return [[[FBErrorBuilder builder]
-             withDescriptionFormat:@"The button '%@' is unknown. Only the following button names are supported: %@", buttonName, supportedButtonNames]
+             withDescriptionFormat:@"The button '%@' is not supported. The device under test only supports the following buttons: %@", buttonName, availableButtons.allKeys]
             buildError:error];
   }
-  [self pressButton:dstButton];
+  [self pressButton:(XCUIDeviceButton)[buttonValue unsignedIntegerValue]];
   return YES;
 }
 #endif
@@ -429,15 +410,5 @@ static bool fb_isLocked;
   return [FBXCTestDaemonsProxy clearSimulatedLocation:error];
 }
 #endif
-
-- (void)fb_addButtonsIfAvailable:(NSArray<NSString *> *)buttonNames
-          toSupportedButtonNames:(NSMutableArray<NSString *> *)supportedButtonNames
-{
-  for (NSString *buttonName in buttonNames) {
-    if ([self fb_hasButton:buttonName]) {
-      [supportedButtonNames addObject:buttonName];
-    }
-  }
-}
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -296,15 +296,34 @@ static bool fb_isLocked;
     dstButton = XCUIDeviceButtonHome;
   }
   [supportedButtonNames addObject:@"home"];
+
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"16.0")) {
+    if ([self hasHardwareButton:XCUIDeviceButtonAction]) {
+      if ([buttonName.lowercaseString isEqualToString:@"action"]) {
+        dstButton = XCUIDeviceButtonAction;
+      }
+      [supportedButtonNames addObject:@"action"];
+    }
+  }
 #if !TARGET_OS_SIMULATOR
   if ([buttonName.lowercaseString isEqualToString:@"volumeup"]) {
     dstButton = XCUIDeviceButtonVolumeUp;
   }
+  [supportedButtonNames addObject:@"volumeUp"];
+
   if ([buttonName.lowercaseString isEqualToString:@"volumedown"]) {
     dstButton = XCUIDeviceButtonVolumeDown;
   }
-  [supportedButtonNames addObject:@"volumeUp"];
   [supportedButtonNames addObject:@"volumeDown"];
+
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"16.0")) {
+    if ([self hasHardwareButton:XCUIDeviceButtonCamera]) {
+      if ([buttonName.lowercaseString isEqualToString:@"camera"]) {
+        dstButton = XCUIDeviceButtonCamera;
+      }
+      [supportedButtonNames addObject:@"camera"];
+    }
+  }
 #endif
 
   if (dstButton == 0) {

--- a/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
@@ -186,6 +186,23 @@
   XCTAssertNil(error);
 }
 
+- (void)testPressingDeviceSpecificButton
+{
+  NSError *error;
+  BOOL hasActionButton = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"16.0")
+    && [XCUIDevice.sharedDevice hasHardwareButton:XCUIDeviceButtonAction];
+  BOOL didPressButton = [XCUIDevice.sharedDevice fb_pressButton:@"action"
+                                                     forDuration:nil
+                                                           error:&error];
+  if (hasActionButton) {
+    XCTAssertTrue(didPressButton);
+    XCTAssertNil(error);
+  } else {
+    XCTAssertFalse(didPressButton);
+    XCTAssertNotNil(error);
+  }
+}
+
 - (void)testPressingSupportedButtonNumber
 {
   NSError *error;

--- a/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
@@ -186,12 +186,10 @@
   XCTAssertNil(error);
 }
 
-#if __clang_major__ >= 17 || (__clang_major__ == 16 && __clang_minor__ >= 3)
 - (void)testPressingDeviceSpecificButton
 {
   NSError *error;
-  BOOL hasActionButton = @available(iOS 16.0, *)
-    && [XCUIDevice.sharedDevice hasHardwareButton:XCUIDeviceButtonAction];
+  BOOL hasActionButton = [XCUIDevice.sharedDevice fb_hasButton:@"action"];
   BOOL didPressButton = [XCUIDevice.sharedDevice fb_pressButton:@"action"
                                                      forDuration:nil
                                                            error:&error];
@@ -203,7 +201,6 @@
     XCTAssertNotNil(error);
   }
 }
-#endif
 
 - (void)testPressingSupportedButtonNumber
 {

--- a/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIDeviceHelperTests.m
@@ -186,10 +186,11 @@
   XCTAssertNil(error);
 }
 
+#if __clang_major__ >= 17 || (__clang_major__ == 16 && __clang_minor__ >= 3)
 - (void)testPressingDeviceSpecificButton
 {
   NSError *error;
-  BOOL hasActionButton = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"16.0")
+  BOOL hasActionButton = @available(iOS 16.0, *)
     && [XCUIDevice.sharedDevice hasHardwareButton:XCUIDeviceButtonAction];
   BOOL didPressButton = [XCUIDevice.sharedDevice fb_pressButton:@"action"
                                                      forDuration:nil
@@ -202,6 +203,7 @@
     XCTAssertNotNil(error);
   }
 }
+#endif
 
 - (void)testPressingSupportedButtonNumber
 {


### PR DESCRIPTION
Currently WDA only supports the `home`, `volumeUp` and `volumeDown` buttons for iOS, but Apple's documentation also lists `action` and `camera`. This PR adds support for them.
Since not all devices have these buttons, their use is guarded behind the `hasHardwareButton:` check, which itself requires iOS 16, so a second guard was also added.

(I don't actually have a way to test this, so any validation would be appreciated)

Reference: https://developer.apple.com/documentation/xcuiautomation/xcuidevice/button?language=objc