### PR TITLE
feat(client): add ability to set headers on requests

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,5 @@
+import {type HTTPHeaders} from '@appium/types';
+
 // WebDriverAgentLib/Utilities/FBSettings.h
 export interface WDASettings {
   elementResponseAttribute?: string;
@@ -92,6 +94,7 @@ export interface WebDriverAgentArgs {
   resultBundleVersion?: string;
   reqBasePath?: string;
   launchTimeout?: number;
+  extraRequestHeaders?: HTTPHeaders;
 }
 
 export interface AppleDevice {
@@ -138,4 +141,5 @@ export interface XcodeBuildArgs {
   allowProvisioningDeviceRegistration?: boolean;
   resultBundlePath?: string;
   resultBundleVersion?: string;
+  extraRequestHeaders?: HTTPHeaders;
 }

--- a/lib/webdriveragent.ts
+++ b/lib/webdriveragent.ts
@@ -346,6 +346,7 @@ export class WebDriverAgent {
       timeout: this.wdaConnectionTimeout,
       keepAlive: true,
       scheme: this.url.protocol ? this.url.protocol.replace(':', '') : 'http',
+      headers: this.args.extraRequestHeaders,
     };
     if (this.args.reqBasePath) {
       proxyOpts.reqBasePath = this.args.reqBasePath;
@@ -560,10 +561,12 @@ export class WebDriverAgent {
    */
   private async getStatus(timeoutMs: number = 0): Promise<StringRecord | null> {
     const noSessionProxy = new NoSessionProxy({
+      scheme: this.url.protocol ? this.url.protocol.replace(':', '') : 'http',
       server: this.url.hostname ?? undefined,
       port: parseInt(this.url.port ?? '', 10) || undefined,
       base: this.basePath,
       timeout: 3000,
+      headers: this.args.extraRequestHeaders,
     });
 
     const sendGetStatus = async () =>

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
-    "@appium/base-driver": "^10.0.0-rc.1",
+    "@appium/base-driver": "^10.3.0",
     "@appium/strongbox": "^1.0.0-rc.1",
     "@appium/support": "^7.0.0-rc.1",
     "appium-ios-device": "^3.0.0",


### PR DESCRIPTION
Helps to let clients add headers to the outgoing requests in case they are behind an authenticated proxy. Update of appium-base-driver is needed to get the `headers` field of proxy types.