### PR TITLE
chore(compile): fix compilation

### DIFF
--- a/PrivateHeaders/XCTest/CDStructures.h
+++ b/PrivateHeaders/XCTest/CDStructures.h
@@ -24,5 +24,8 @@ typedef struct {
     unsigned short _field3[1];
 } CDStruct_27a325c0;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
 int _XCTSetApplicationStateTimeout(double timeout);
 double _XCTApplicationStateTimeout(void);
+#pragma clang diagnostic pop

--- a/PrivateHeaders/XCTest/XCTestCase.h
+++ b/PrivateHeaders/XCTest/XCTestCase.h
@@ -8,7 +8,10 @@
 
 #import <WebDriverAgentLib/CDStructures.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
 @class NSInvocation, XCTestCaseRun, XCTestContext, _XCTestCaseImplementation;
+#pragma clang diagnostic pop
 
 @interface XCTestCase()
 {


### PR DESCRIPTION
This PR fixes compilation with Xcode 26 / iOS SDK 26.2 compatibility issue. The newer clang enforces `-Wreserved-identifier` as an error — identifiers starting with _ followed by a capital letter are reserved by the C standard, and the private headers use them.