### PR TITLE
fix: ship Scripts/embed-runner-icon.sh in the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "lib",
     "build/lib",
     "Scripts/build.sh",
+    "Scripts/embed-runner-icon.sh",
     "Scripts/*.mjs",
     "Configurations",
     "PrivateHeaders",


### PR DESCRIPTION
### Summary

#1138 added `Scripts/embed-runner-icon.sh` and wired it as a `WebDriverAgentRunner` build post-action, but the `files` allowlist in `package.json` only ships `Scripts/build.sh` and `Scripts/*.mjs`. `embed-runner-icon.sh` matches neither pattern, so it is **excluded from the published npm tarball**.

As a result, builds from the published `appium-webdriveragent` package run the scheme post-action against a missing script — the Appium app icon is never embedded into `Runner.app`, and `WebDriverAgentRunner` installs on the home screen with a blank/white icon.

### Fix

Add an explicit `Scripts/embed-runner-icon.sh` entry to `files` so the script ships in the package.