### PR TITLE
feat: Add XPath extensions

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		641EE5D92240C5CA00173FCB /* XCUIElement+FBPickerWheel.m in Sources */ = {isa = PBXBuildFile; fileRef = 7136A4781E8918E60024FC3D /* XCUIElement+FBPickerWheel.m */; };
 		641EE5DA2240C5CA00173FCB /* XCUIApplicationProcessDelay.m in Sources */ = {isa = PBXBuildFile; fileRef = 6385F4A5220A40760095BBDB /* XCUIApplicationProcessDelay.m */; };
 		641EE5DB2240C5CA00173FCB /* FBXPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 711084431DA3AA7500F913D6 /* FBXPath.m */; };
+		71B2E0042733FB970074B004 /* FBXPathExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B2E0022733FB970074B002 /* FBXPathExtensions.m */; };
 		641EE5DC2240C5CA00173FCB /* XCUIApplication+FBAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = 719CD8FB2126C88B00C7D0C2 /* XCUIApplication+FBAlert.m */; };
 		641EE5DE2240C5CA00173FCB /* XCUIApplication+FBTouchAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BD20721F86116100B36EC2 /* XCUIApplication+FBTouchAction.m */; };
 		641EE5DF2240C5CA00173FCB /* FBWebServer.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB78D1CAEDF0C008C271F /* FBWebServer.m */; };
@@ -316,6 +317,7 @@
 		64E3502F2AC0B6FE005F3ACB /* NSDictionary+FBUtf8SafeDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 716F0D9F2A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.h */; };
 		711084441DA3AA7500F913D6 /* FBXPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 711084421DA3AA7500F913D6 /* FBXPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		711084451DA3AA7500F913D6 /* FBXPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 711084431DA3AA7500F913D6 /* FBXPath.m */; };
+		71B2E0062733FB970074B006 /* FBXPathExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B2E0022733FB970074B002 /* FBXPathExtensions.m */; };
 		7119097C2152580600BA3C7E /* XCUIScreen.h in Headers */ = {isa = PBXBuildFile; fileRef = 7119097B2152580600BA3C7E /* XCUIScreen.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7119E1EC1E891F8600D0B125 /* FBPickerWheelSelectTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7119E1EB1E891F8600D0B125 /* FBPickerWheelSelectTests.m */; };
 		711CD03425ED1106001C01D2 /* XCUIScreenDataSource-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 711CD03325ED1106001C01D2 /* XCUIScreenDataSource-Protocol.h */; };
@@ -976,6 +978,8 @@
 		64B26509228CE4FF002A5025 /* FBTVNavigationTracker-Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FBTVNavigationTracker-Private.h"; sourceTree = "<group>"; };
 		711084421DA3AA7500F913D6 /* FBXPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXPath.h; sourceTree = "<group>"; };
 		711084431DA3AA7500F913D6 /* FBXPath.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPath.m; sourceTree = "<group>"; };
+		71B2E0012733FB970074B001 /* FBXPathExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBXPathExtensions.h; sourceTree = "<group>"; };
+		71B2E0022733FB970074B002 /* FBXPathExtensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBXPathExtensions.m; sourceTree = "<group>"; };
 		7119097B2152580600BA3C7E /* XCUIScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCUIScreen.h; sourceTree = "<group>"; };
 		7119E1EB1E891F8600D0B125 /* FBPickerWheelSelectTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBPickerWheelSelectTests.m; sourceTree = "<group>"; };
 		711CD03325ED1106001C01D2 /* XCUIScreenDataSource-Protocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCUIScreenDataSource-Protocol.h"; sourceTree = "<group>"; };
@@ -2000,9 +2004,11 @@
 				714D88CA2733FB970074A925 /* FBXMLGenerationOptions.h */,
 				714D88CB2733FB970074A925 /* FBXMLGenerationOptions.m */,
 				712A0C861DA3E55D007D02E5 /* FBXPath-Private.h */,
-				711084421DA3AA7500F913D6 /* FBXPath.h */,
-				711084431DA3AA7500F913D6 /* FBXPath.m */,
-				EE6B64FB1D0F86EF00E85F5D /* XCTestPrivateSymbols.h */,
+		711084421DA3AA7500F913D6 /* FBXPath.h */,
+		711084431DA3AA7500F913D6 /* FBXPath.m */,
+		71B2E0012733FB970074B001 /* FBXPathExtensions.h */,
+		71B2E0022733FB970074B002 /* FBXPathExtensions.m */,
+		EE6B64FB1D0F86EF00E85F5D /* XCTestPrivateSymbols.h */,
 				EE6B64FC1D0F86EF00E85F5D /* XCTestPrivateSymbols.m */,
 				633E904A220DEE7F007CADF9 /* XCUIApplicationProcessDelay.h */,
 				6385F4A5220A40760095BBDB /* XCUIApplicationProcessDelay.m */,
@@ -3156,6 +3162,7 @@
 				641EE5D92240C5CA00173FCB /* XCUIElement+FBPickerWheel.m in Sources */,
 				641EE5DA2240C5CA00173FCB /* XCUIApplicationProcessDelay.m in Sources */,
 				641EE5DB2240C5CA00173FCB /* FBXPath.m in Sources */,
+				71B2E0042733FB970074B004 /* FBXPathExtensions.m in Sources */,
 				71C8E55425399A6B008572C1 /* XCUIApplication+FBQuiescence.m in Sources */,
 				641EE5DC2240C5CA00173FCB /* XCUIApplication+FBAlert.m in Sources */,
 				641EE70F2240CE4800173FCB /* FBTVNavigationTracker.m in Sources */,
@@ -3277,6 +3284,7 @@
 				6385F4A7220A40760095BBDB /* XCUIApplicationProcessDelay.m in Sources */,
 				71A5C67529A4F39600421C37 /* XCTIssue+FBPatcher.m in Sources */,
 				711084451DA3AA7500F913D6 /* FBXPath.m in Sources */,
+				71B2E0062733FB970074B006 /* FBXPathExtensions.m in Sources */,
 				719CD8FD2126C88B00C7D0C2 /* XCUIApplication+FBAlert.m in Sources */,
 				13DE7A45287C2A8D003243C6 /* FBXCAccessibilityElement.m in Sources */,
 				641EE70E2240CE4800173FCB /* FBTVNavigationTracker.m in Sources */,

--- a/WebDriverAgentLib/Utilities/FBXPath-Private.h
+++ b/WebDriverAgentLib/Utilities/FBXPath-Private.h
@@ -51,6 +51,11 @@ NS_ASSUME_NONNULL_BEGIN
                      document:(xmlDocPtr)doc
                   contextNode:(nullable xmlNodePtr)contextNode;
 
++ (xmlXPathObjectPtr)evaluate:(NSString *)xpathQuery
+                     document:(xmlDocPtr)doc
+                  contextNode:(nullable xmlNodePtr)contextNode
+                 errorMessage:(NSString * _Nullable * _Nullable)errorMessage;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -444,10 +444,9 @@ static NSString *const topNodeIndexPath = @"top";
   }
   xpathCtx->node = NULL == contextNode ? doc->children : contextNode;
 
-  FBXPathEvaluationContext *evalContext = [FBXPathExtensions configureXPathContext:xpathCtx];
+  [FBXPathExtensions registerFunctionsWithContext:xpathCtx];
 
   xmlXPathObjectPtr xpathObj = xmlXPathEvalExpression((const xmlChar *)[xpathQuery UTF8String], xpathCtx);
-  [evalContext cleanup];
   if (NULL == xpathObj) {
     xmlXPathFreeContext(xpathCtx);
     [FBLogger logFmt:@"Failed to invoke libxml2>xmlXPathEvalExpression for XPath query \"%@\"", xpathQuery];

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -153,7 +153,17 @@ static NSString *const topNodeIndexPath = @"top";
 
 + (id)throwException:(NSString *)name forQuery:(NSString *)xpathQuery
 {
-  NSString *reason = [NSString stringWithFormat:@"Cannot evaluate results for XPath expression \"%@\"", xpathQuery];
+  return [self throwException:name forQuery:xpathQuery detail:nil];
+}
+
++ (id)throwException:(NSString *)name forQuery:(NSString *)xpathQuery detail:(nullable NSString *)detail
+{
+  NSString *reason;
+  if (nil != detail) {
+    reason = [NSString stringWithFormat:@"Cannot evaluate results for XPath expression \"%@\": %@", xpathQuery, detail];
+  } else {
+    reason = [NSString stringWithFormat:@"Cannot evaluate results for XPath expression \"%@\"", xpathQuery];
+  }
   @throw [NSException exceptionWithName:name reason:reason userInfo:@{}];
   return nil;
 }
@@ -285,16 +295,18 @@ static NSString *const topNodeIndexPath = @"top";
       contextNode = nodeSet->nodeTab[0];
     }
   }
+  NSString *evaluationError = nil;
   xmlXPathObjectPtr queryResult = [self evaluate:xpathQuery
                                         document:doc
-                                     contextNode:contextNode];
+                                     contextNode:contextNode
+                                    errorMessage:&evaluationError];
   if (NULL != contextNodeQueryResult) {
     xmlXPathFreeObject(contextNodeQueryResult);
   }
   if (NULL == queryResult) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);
-    return [self throwException:FBInvalidXPathException forQuery:xpathQuery];
+    return [self throwException:FBInvalidXPathException forQuery:xpathQuery detail:evaluationError];
   }
 
   NSArray *matchingSnapshots = [self collectMatchingSnapshots:queryResult->nodesetval
@@ -437,6 +449,14 @@ static NSString *const topNodeIndexPath = @"top";
                      document:(xmlDocPtr)doc
                   contextNode:(nullable xmlNodePtr)contextNode
 {
+  return [self evaluate:xpathQuery document:doc contextNode:contextNode errorMessage:nil];
+}
+
++ (xmlXPathObjectPtr)evaluate:(NSString *)xpathQuery
+                     document:(xmlDocPtr)doc
+                  contextNode:(nullable xmlNodePtr)contextNode
+                 errorMessage:(NSString * _Nullable * _Nullable)errorMessage
+{
   xmlXPathContextPtr xpathCtx = xmlXPathNewContext(doc);
   if (NULL == xpathCtx) {
     [FBLogger logFmt:@"Failed to invoke libxml2>xmlXPathNewContext for XPath query \"%@\"", xpathQuery];
@@ -444,12 +464,21 @@ static NSString *const topNodeIndexPath = @"top";
   }
   xpathCtx->node = NULL == contextNode ? doc->children : contextNode;
 
-  [FBXPathExtensions registerFunctionsWithContext:xpathCtx];
+  FBXPathExtensions *extensions = [FBXPathExtensions new];
+  [extensions registerFunctionsWithContext:xpathCtx];
 
   xmlXPathObjectPtr xpathObj = xmlXPathEvalExpression((const xmlChar *)[xpathQuery UTF8String], xpathCtx);
   if (NULL == xpathObj) {
+    NSString *detail = extensions.lastEvaluationError;
+    if (NULL != errorMessage) {
+      *errorMessage = detail;
+    }
+    if (nil != detail) {
+      [FBLogger logFmt:@"Failed to evaluate XPath query \"%@\": %@", xpathQuery, detail];
+    } else {
+      [FBLogger logFmt:@"Failed to invoke libxml2>xmlXPathEvalExpression for XPath query \"%@\"", xpathQuery];
+    }
     xmlXPathFreeContext(xpathCtx);
-    [FBLogger logFmt:@"Failed to invoke libxml2>xmlXPathEvalExpression for XPath query \"%@\"", xpathQuery];
     return NULL;
   }
   xmlXPathFreeContext(xpathCtx);

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -14,6 +14,7 @@
 #import "FBLogger.h"
 #import "FBMacros.h"
 #import "FBXMLGenerationOptions.h"
+#import "FBXPathExtensions.h"
 #import "FBXCElementSnapshotWrapper+Helpers.h"
 #import "NSString+FBXMLSafeString.h"
 #import "XCUIApplication.h"
@@ -443,7 +444,10 @@ static NSString *const topNodeIndexPath = @"top";
   }
   xpathCtx->node = NULL == contextNode ? doc->children : contextNode;
 
+  FBXPathEvaluationContext *evalContext = [FBXPathExtensions configureXPathContext:xpathCtx];
+
   xmlXPathObjectPtr xpathObj = xmlXPathEvalExpression((const xmlChar *)[xpathQuery UTF8String], xpathCtx);
+  [evalContext cleanup];
   if (NULL == xpathObj) {
     xmlXPathFreeContext(xpathCtx);
     [FBLogger logFmt:@"Failed to invoke libxml2>xmlXPathEvalExpression for XPath query \"%@\"", xpathQuery];

--- a/WebDriverAgentLib/Utilities/FBXPathExtensions.h
+++ b/WebDriverAgentLib/Utilities/FBXPathExtensions.h
@@ -21,22 +21,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface FBXPathEvaluationContext : NSObject
-
-- (void)cleanup;
-
-@end
-
 @interface FBXPathExtensions : NSObject
 
 /**
- Registers XPath 2-compatible extension functions on the given libxml2 context
- and attaches an evaluation context used to manage temporary documents.
-
- @param xpathCtx libxml2 XPath context
- @return evaluation context that must be cleaned up after expression evaluation
+ Registers XPath 2-compatible extension functions on the given libxml2 context.
  */
-+ (FBXPathEvaluationContext *)configureXPathContext:(xmlXPathContextPtr)xpathCtx;
++ (void)registerFunctionsWithContext:(xmlXPathContextPtr)xpathCtx;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBXPathExtensions.h
+++ b/WebDriverAgentLib/Utilities/FBXPathExtensions.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpadded"
+#endif
+
+#import <libxml/xpath.h>
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FBXPathEvaluationContext : NSObject
+
+- (void)cleanup;
+
+@end
+
+@interface FBXPathExtensions : NSObject
+
+/**
+ Registers XPath 2-compatible extension functions on the given libxml2 context
+ and attaches an evaluation context used to manage temporary documents.
+
+ @param xpathCtx libxml2 XPath context
+ @return evaluation context that must be cleaned up after expression evaluation
+ */
++ (FBXPathEvaluationContext *)configureXPathContext:(xmlXPathContextPtr)xpathCtx;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBXPathExtensions.h
+++ b/WebDriverAgentLib/Utilities/FBXPathExtensions.h
@@ -26,7 +26,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Registers XPath 2-compatible extension functions on the given libxml2 context.
  */
-+ (void)registerFunctionsWithContext:(xmlXPathContextPtr)xpathCtx;
+- (void)registerFunctionsWithContext:(xmlXPathContextPtr)xpathCtx;
+
+/**
+ Human-readable message for the most recent XPath extension evaluation failure on this instance,
+ for example an invalid regular expression pattern or flags. Nil when no extension error has occurred.
+ Scoped to the libxml2 context this instance is registered with; each evaluation should use its own instance.
+ */
+@property (nonatomic, nullable, readonly, copy) NSString *lastEvaluationError;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBXPathExtensions.m
+++ b/WebDriverAgentLib/Utilities/FBXPathExtensions.m
@@ -186,7 +186,7 @@ static NSArray<NSString *> *FBXPathPartsFromXPathObject(xmlXPathObjectPtr sequen
   return @[value];
 }
 
-static void fbXPathMatchesFunction(xmlXPathParserContextPtr ctxt, int nargs)
+static void FBXPathMatchesFunction(xmlXPathParserContextPtr ctxt, int nargs)
 {
   if (nargs < 2 || nargs > 3) {
     FBXPathSetInvalidArityError(ctxt);
@@ -212,7 +212,7 @@ static void fbXPathMatchesFunction(xmlXPathParserContextPtr ctxt, int nargs)
   xmlXPathReturnBoolean(ctxt, nil != match);
 }
 
-static void fbXPathEndsWithFunction(xmlXPathParserContextPtr ctxt, int nargs)
+static void FBXPathEndsWithFunction(xmlXPathParserContextPtr ctxt, int nargs)
 {
   if (nargs != 2) {
     FBXPathSetInvalidArityError(ctxt);
@@ -228,7 +228,7 @@ static void fbXPathEndsWithFunction(xmlXPathParserContextPtr ctxt, int nargs)
   xmlXPathReturnBoolean(ctxt, [input hasSuffix:suffix]);
 }
 
-static void fbXPathLowerCaseFunction(xmlXPathParserContextPtr ctxt, int nargs)
+static void FBXPathLowerCaseFunction(xmlXPathParserContextPtr ctxt, int nargs)
 {
   if (nargs != 1) {
     FBXPathSetInvalidArityError(ctxt);
@@ -243,7 +243,7 @@ static void fbXPathLowerCaseFunction(xmlXPathParserContextPtr ctxt, int nargs)
   FBXPathReturnNSString(ctxt, input.lowercaseString);
 }
 
-static void fbXPathUpperCaseFunction(xmlXPathParserContextPtr ctxt, int nargs)
+static void FBXPathUpperCaseFunction(xmlXPathParserContextPtr ctxt, int nargs)
 {
   if (nargs != 1) {
     FBXPathSetInvalidArityError(ctxt);
@@ -258,7 +258,7 @@ static void fbXPathUpperCaseFunction(xmlXPathParserContextPtr ctxt, int nargs)
   FBXPathReturnNSString(ctxt, input.uppercaseString);
 }
 
-static void fbXPathReplaceFunction(xmlXPathParserContextPtr ctxt, int nargs)
+static void FBXPathReplaceFunction(xmlXPathParserContextPtr ctxt, int nargs)
 {
   if (nargs < 3 || nargs > 4) {
     FBXPathSetInvalidArityError(ctxt);
@@ -288,7 +288,7 @@ static void fbXPathReplaceFunction(xmlXPathParserContextPtr ctxt, int nargs)
   FBXPathReturnNSString(ctxt, result);
 }
 
-static void fbXPathTokenizeFunction(xmlXPathParserContextPtr ctxt, int nargs)
+static void FBXPathTokenizeFunction(xmlXPathParserContextPtr ctxt, int nargs)
 {
   if (nargs < 1 || nargs > 2) {
     FBXPathSetInvalidArityError(ctxt);
@@ -305,7 +305,7 @@ static void fbXPathTokenizeFunction(xmlXPathParserContextPtr ctxt, int nargs)
   FBXPathReturnNSString(ctxt, [tokens componentsJoinedByString:FBXPathTokenSequenceSeparator]);
 }
 
-static void fbXPathStringJoinFunction(xmlXPathParserContextPtr ctxt, int nargs)
+static void FBXPathStringJoinFunction(xmlXPathParserContextPtr ctxt, int nargs)
 {
   if (nargs != 2) {
     FBXPathSetInvalidArityError(ctxt);
@@ -339,11 +339,11 @@ static void fbXPathStringJoinFunction(xmlXPathParserContextPtr ctxt, int nargs)
 
 static void FBRegisterXPathExtensions(xmlXPathContextPtr xpathCtx)
 {
-  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "matches", fbXPathMatchesFunction);
-  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "ends-with", fbXPathEndsWithFunction);
-  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "lower-case", fbXPathLowerCaseFunction);
-  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "upper-case", fbXPathUpperCaseFunction);
-  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "replace", fbXPathReplaceFunction);
-  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "tokenize", fbXPathTokenizeFunction);
-  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "string-join", fbXPathStringJoinFunction);
+  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "matches", FBXPathMatchesFunction);
+  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "ends-with", FBXPathEndsWithFunction);
+  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "lower-case", FBXPathLowerCaseFunction);
+  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "upper-case", FBXPathUpperCaseFunction);
+  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "replace", FBXPathReplaceFunction);
+  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "tokenize", FBXPathTokenizeFunction);
+  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "string-join", FBXPathStringJoinFunction);
 }

--- a/WebDriverAgentLib/Utilities/FBXPathExtensions.m
+++ b/WebDriverAgentLib/Utilities/FBXPathExtensions.m
@@ -8,6 +8,8 @@
 
 #import "FBXPathExtensions.h"
 
+#import "FBLogger.h"
+
 #import <libxml/xpathInternals.h>
 
 static void FBRegisterXPathExtensions(xmlXPathContextPtr xpathCtx);
@@ -16,6 +18,30 @@ static NSString *const FBXPathTokenSequenceSeparator = @"\x1E";
 static const NSRegularExpressionOptions FBXPathNoRegexOptions = (NSRegularExpressionOptions)0;
 static const NSMatchingOptions FBXPathNoMatchingOptions = (NSMatchingOptions)0;
 
+@interface FBXPathExtensions ()
+@property (nonatomic, nullable, readwrite, copy) NSString *lastEvaluationError;
+@end
+
+static FBXPathExtensions *FBXPathExtensionsFromParserContext(xmlXPathParserContextPtr ctxt)
+{
+  if (NULL == ctxt || NULL == ctxt->context || NULL == ctxt->context->userData) {
+    return nil;
+  }
+  return (__bridge FBXPathExtensions *)ctxt->context->userData;
+}
+
+static void FBXPathSetEvaluationError(xmlXPathParserContextPtr ctxt, int xpathErrorCode, NSString *message)
+{
+  FBXPathExtensions *extensions = FBXPathExtensionsFromParserContext(ctxt);
+  extensions.lastEvaluationError = message;
+  [FBLogger logFmt:@"XPath extension evaluation error: %@", message];
+  if (NULL == ctxt) {
+    return;
+  }
+  xmlXPatherror(ctxt, __FILE__, __LINE__, xpathErrorCode);
+  ctxt->error = xpathErrorCode;
+}
+
 static void FBXPathSetInvalidArityError(xmlXPathParserContextPtr ctxt)
 {
   if (NULL == ctxt) {
@@ -23,6 +49,22 @@ static void FBXPathSetInvalidArityError(xmlXPathParserContextPtr ctxt)
   }
   xmlXPatherror(ctxt, __FILE__, __LINE__, XPATH_INVALID_ARITY);
   ctxt->error = XPATH_INVALID_ARITY;
+}
+
+static BOOL FBXPathFlagsAreValid(NSString *flags, BOOL allowsQFlag)
+{
+  if (nil == flags || 0 == flags.length) {
+    return YES;
+  }
+
+  NSString *validFlags = allowsQFlag ? @"imsxq" : @"imsx";
+  for (NSUInteger index = 0; index < flags.length; index++) {
+    unichar flag = [flags characterAtIndex:index];
+    if ([validFlags rangeOfString:[NSString stringWithCharacters:&flag length:1]].location == NSNotFound) {
+      return NO;
+    }
+  }
+  return YES;
 }
 
 static NSString *FBXPathStringFromUTF8Bytes(const xmlChar *bytes)
@@ -35,8 +77,9 @@ static NSString *FBXPathStringFromUTF8Bytes(const xmlChar *bytes)
 
 @implementation FBXPathExtensions
 
-+ (void)registerFunctionsWithContext:(xmlXPathContextPtr)xpathCtx
+- (void)registerFunctionsWithContext:(xmlXPathContextPtr)xpathCtx
 {
+  xpathCtx->userData = (__bridge void *)self;
   FBRegisterXPathExtensions(xpathCtx);
 }
 
@@ -62,32 +105,36 @@ static NSRegularExpressionOptions FBXPathRegexOptionsFromFlags(NSString *flags)
   return options;
 }
 
-static NSRegularExpression *FBXPathRegexWithPattern(NSString *pattern, NSString *flags, NSError **error)
+static NSRegularExpression *FBXPathRegexWithPattern(NSString *pattern,
+                                                  NSString *flags,
+                                                  BOOL allowsQFlag,
+                                                  xmlXPathParserContextPtr ctxt)
 {
-  return [NSRegularExpression regularExpressionWithPattern:pattern
-                                                   options:FBXPathRegexOptionsFromFlags(flags)
-                                                     error:error];
+  if (!FBXPathFlagsAreValid(flags, allowsQFlag)) {
+    FBXPathSetEvaluationError(ctxt, XPATH_EXPR_ERROR, @"Invalid regular expression flags");
+    return nil;
+  }
+
+  NSError *error = nil;
+  NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern
+                                                                         options:FBXPathRegexOptionsFromFlags(flags)
+                                                                           error:&error];
+  if (nil == regex) {
+    NSString *message = error.localizedDescription ?: @"Invalid regular expression";
+    FBXPathSetEvaluationError(ctxt, XPATH_EXPR_ERROR, message);
+    return nil;
+  }
+  return regex;
 }
 
-static void FBXPathReturnNSString(xmlXPathParserContextPtr ctxt, NSString *value)
-{
-  if (nil == value) {
-    xmlXPathReturnEmptyString(ctxt);
-    return;
-  }
-  xmlChar *copiedValue = xmlStrdup((const xmlChar *)[value UTF8String]);
-  if (NULL == copiedValue) {
-    xmlXPathReturnEmptyString(ctxt);
-    return;
-  }
-  // xmlXPathWrapString takes ownership of the buffer passed to xmlXPathReturnString.
-  xmlXPathReturnString(ctxt, copiedValue);
-}
-
-static NSArray<NSString *> *FBXPathTokenizeString(NSString *input, NSString *pattern)
+static BOOL FBXPathTokenizeString(NSString *input,
+                                  NSString *pattern,
+                                  xmlXPathParserContextPtr ctxt,
+                                  NSArray<NSString *> **outTokens)
 {
   if (0 == input.length) {
-    return @[];
+    *outTokens = @[];
+    return YES;
   }
 
   if (nil == pattern) {
@@ -95,7 +142,8 @@ static NSArray<NSString *> *FBXPathTokenizeString(NSString *input, NSString *pat
                                                                            options:FBXPathNoRegexOptions
                                                                              error:nil];
     if (nil == regex) {
-      return @[];
+      FBXPathSetEvaluationError(ctxt, XPATH_EXPR_ERROR, @"Invalid regular expression");
+      return NO;
     }
     NSMutableArray<NSString *> *tokens = [NSMutableArray array];
     [regex enumerateMatchesInString:input
@@ -106,7 +154,8 @@ static NSArray<NSString *> *FBXPathTokenizeString(NSString *input, NSString *pat
         [tokens addObject:[input substringWithRange:result.range]];
       }
     }];
-    return tokens.copy;
+    *outTokens = tokens.copy;
+    return YES;
   }
 
   if (0 == pattern.length) {
@@ -118,14 +167,18 @@ static NSArray<NSString *> *FBXPathTokenizeString(NSString *input, NSString *pat
         [tokens addObject:substring];
       }
     }];
-    return tokens.copy;
+    *outTokens = tokens.copy;
+    return YES;
   }
 
+  NSError *error = nil;
   NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern
                                                                          options:FBXPathNoRegexOptions
-                                                                           error:nil];
+                                                                           error:&error];
   if (nil == regex) {
-    return @[];
+    NSString *message = error.localizedDescription ?: @"Invalid regular expression";
+    FBXPathSetEvaluationError(ctxt, XPATH_EXPR_ERROR, message);
+    return NO;
   }
 
   NSMutableArray<NSString *> *tokens = [NSMutableArray array];
@@ -151,7 +204,23 @@ static NSArray<NSString *> *FBXPathTokenizeString(NSString *input, NSString *pat
       [tokens addObject:token];
     }
   }
-  return tokens.copy;
+  *outTokens = tokens.copy;
+  return YES;
+}
+
+static void FBXPathReturnNSString(xmlXPathParserContextPtr ctxt, NSString *value)
+{
+  if (nil == value) {
+    xmlXPathReturnEmptyString(ctxt);
+    return;
+  }
+  xmlChar *copiedValue = xmlStrdup((const xmlChar *)[value UTF8String]);
+  if (NULL == copiedValue) {
+    xmlXPathReturnEmptyString(ctxt);
+    return;
+  }
+  // xmlXPathWrapString takes ownership of the buffer passed to xmlXPathReturnString.
+  xmlXPathReturnString(ctxt, copiedValue);
 }
 
 static NSArray<NSString *> *FBXPathPartsFromXPathObject(xmlXPathObjectPtr sequence)
@@ -200,10 +269,8 @@ static void FBXPathMatchesFunction(xmlXPathParserContextPtr ctxt, int nargs)
     return;
   }
 
-  NSError *error = nil;
-  NSRegularExpression *regex = FBXPathRegexWithPattern(pattern, flags, &error);
+  NSRegularExpression *regex = FBXPathRegexWithPattern(pattern, flags, NO, ctxt);
   if (nil == regex) {
-    xmlXPathReturnBoolean(ctxt, 0);
     return;
   }
 
@@ -273,10 +340,8 @@ static void FBXPathReplaceFunction(xmlXPathParserContextPtr ctxt, int nargs)
     return;
   }
 
-  NSError *error = nil;
-  NSRegularExpression *regex = FBXPathRegexWithPattern(pattern, flags, &error);
+  NSRegularExpression *regex = FBXPathRegexWithPattern(pattern, flags, YES, ctxt);
   if (nil == regex) {
-    FBXPathReturnNSString(ctxt, input);
     return;
   }
 
@@ -301,7 +366,11 @@ static void FBXPathTokenizeFunction(xmlXPathParserContextPtr ctxt, int nargs)
     return;
   }
 
-  NSArray<NSString *> *tokens = FBXPathTokenizeString(input, pattern);
+  NSArray<NSString *> *tokens = nil;
+  if (!FBXPathTokenizeString(input, pattern, ctxt, &tokens)) {
+    return;
+  }
+
   FBXPathReturnNSString(ctxt, [tokens componentsJoinedByString:FBXPathTokenSequenceSeparator]);
 }
 

--- a/WebDriverAgentLib/Utilities/FBXPathExtensions.m
+++ b/WebDriverAgentLib/Utilities/FBXPathExtensions.m
@@ -1,0 +1,378 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "FBXPathExtensions.h"
+
+#import <libxml/tree.h>
+#import <libxml/xpathInternals.h>
+
+static void FBRegisterXPathExtensions(xmlXPathContextPtr xpathCtx);
+
+@interface FBXPathEvaluationContext ()
+
+@property (nonatomic, strong) NSMutableArray<NSValue *> *temporaryDocuments;
+
+- (void)registerTemporaryDocument:(xmlDocPtr)doc;
+
+@end
+
+@implementation FBXPathEvaluationContext
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _temporaryDocuments = [NSMutableArray array];
+  }
+  return self;
+}
+
+- (void)registerTemporaryDocument:(xmlDocPtr)doc
+{
+  if (NULL != doc) {
+    [self.temporaryDocuments addObject:[NSValue valueWithPointer:doc]];
+  }
+}
+
+- (void)cleanup
+{
+  for (NSValue *value in self.temporaryDocuments) {
+    xmlFreeDoc((xmlDocPtr)value.pointerValue);
+  }
+  [self.temporaryDocuments removeAllObjects];
+}
+
+@end
+
+@implementation FBXPathExtensions
+
++ (FBXPathEvaluationContext *)configureXPathContext:(xmlXPathContextPtr)xpathCtx
+{
+  FBXPathEvaluationContext *evalContext = [FBXPathEvaluationContext new];
+  xpathCtx->userData = (__bridge void *)evalContext;
+  FBRegisterXPathExtensions(xpathCtx);
+  return evalContext;
+}
+
+@end
+
+static NSString *FBXPathPopNSString(xmlXPathParserContextPtr ctxt)
+{
+  xmlChar *value = xmlXPathPopString(ctxt);
+  if (NULL == value || xmlXPathCheckError(ctxt)) {
+    return nil;
+  }
+  NSString *result = [NSString stringWithUTF8String:(const char *)value];
+  xmlFree(value);
+  return result;
+}
+
+static NSRegularExpressionOptions FBXPathRegexOptionsFromFlags(NSString *flags)
+{
+  NSRegularExpressionOptions options = 0;
+  if (nil != flags && [flags rangeOfString:@"i"].location != NSNotFound) {
+    options |= NSRegularExpressionCaseInsensitive;
+  }
+  return options;
+}
+
+static NSRegularExpression *FBXPathRegexWithPattern(NSString *pattern, NSString *flags, NSError **error)
+{
+  return [NSRegularExpression regularExpressionWithPattern:pattern
+                                                   options:FBXPathRegexOptionsFromFlags(flags)
+                                                     error:error];
+}
+
+static void FBXPathReturnNSString(xmlXPathParserContextPtr ctxt, NSString *value)
+{
+  if (nil == value) {
+    xmlXPathReturnEmptyString(ctxt);
+    return;
+  }
+  xmlChar *copiedValue = xmlStrdup((const xmlChar *)[value UTF8String]);
+  if (NULL == copiedValue) {
+    xmlXPathReturnEmptyString(ctxt);
+    return;
+  }
+  xmlXPathReturnString(ctxt, copiedValue);
+  xmlFree(copiedValue);
+}
+
+static xmlXPathObjectPtr FBXPathCreateTokenNodeSet(xmlXPathParserContextPtr ctxt, NSArray<NSString *> *tokens)
+{
+  xmlDocPtr container = xmlNewDoc(BAD_CAST "1.0");
+  xmlNodePtr rootNode = xmlNewNode(NULL, BAD_CAST "tokens");
+  xmlDocSetRootElement(container, rootNode);
+
+  xmlXPathObjectPtr result = xmlXPathNewNodeSet(NULL);
+  if (NULL == result || NULL == result->nodesetval) {
+    xmlFreeDoc(container);
+    return result;
+  }
+
+  for (NSString *token in tokens) {
+    xmlChar *tokenContent = xmlStrdup((const xmlChar *)[token UTF8String]);
+    xmlNodePtr tokenNode = xmlNewNode(NULL, BAD_CAST "token");
+    xmlNodeSetContent(tokenNode, tokenContent);
+    xmlFree(tokenContent);
+    xmlAddChild(rootNode, tokenNode);
+    xmlXPathNodeSetAdd(result->nodesetval, tokenNode);
+  }
+
+  FBXPathEvaluationContext *evalContext = (__bridge FBXPathEvaluationContext *)ctxt->context->userData;
+  [evalContext registerTemporaryDocument:container];
+  return result;
+}
+
+static NSArray<NSString *> *FBXPathTokenizeString(NSString *input, NSString *pattern)
+{
+  if (0 == input.length) {
+    return @[];
+  }
+
+  if (nil == pattern) {
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\S+"
+                                                                           options:0
+                                                                             error:nil];
+    if (nil == regex) {
+      return @[];
+    }
+    NSMutableArray<NSString *> *tokens = [NSMutableArray array];
+    [regex enumerateMatchesInString:input
+                            options:0
+                              range:NSMakeRange(0, input.length)
+                         usingBlock:^(NSTextCheckingResult *result, NSMatchingFlags flags, BOOL *stop) {
+      if (nil != result) {
+        [tokens addObject:[input substringWithRange:result.range]];
+      }
+    }];
+    return tokens.copy;
+  }
+
+  if (0 == pattern.length) {
+    NSMutableArray<NSString *> *tokens = [NSMutableArray array];
+    [input enumerateSubstringsInRange:NSMakeRange(0, input.length)
+                              options:NSStringEnumerationByComposedCharacterSequences
+                           usingBlock:^(NSString *substring, NSRange substringRange, NSRange enclosingRange, BOOL *stop) {
+      if (substring.length > 0) {
+        [tokens addObject:substring];
+      }
+    }];
+    return tokens.copy;
+  }
+
+  NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern
+                                                                         options:0
+                                                                           error:nil];
+  if (nil == regex) {
+    return @[];
+  }
+
+  NSMutableArray<NSString *> *tokens = [NSMutableArray array];
+  __block NSUInteger lastIndex = 0;
+  [regex enumerateMatchesInString:input
+                          options:0
+                            range:NSMakeRange(0, input.length)
+                       usingBlock:^(NSTextCheckingResult *result, NSMatchingFlags flags, BOOL *stop) {
+    if (nil == result) {
+      return;
+    }
+    if (result.range.location > lastIndex) {
+      NSString *token = [input substringWithRange:NSMakeRange(lastIndex, result.range.location - lastIndex)];
+      if (token.length > 0) {
+        [tokens addObject:token];
+      }
+    }
+    lastIndex = NSMaxRange(result.range);
+  }];
+  if (lastIndex < input.length) {
+    NSString *token = [input substringFromIndex:lastIndex];
+    if (token.length > 0) {
+      [tokens addObject:token];
+    }
+  }
+  return tokens.copy;
+}
+
+static void fbXPathMatchesFunction(xmlXPathParserContextPtr ctxt, int nargs)
+{
+  if (nargs < 2 || nargs > 3) {
+    xmlXPathSetArityError(ctxt);
+    return;
+  }
+
+  NSString *flags = nargs == 3 ? FBXPathPopNSString(ctxt) : nil;
+  NSString *pattern = FBXPathPopNSString(ctxt);
+  NSString *input = FBXPathPopNSString(ctxt);
+  if (nil == pattern || nil == input || xmlXPathCheckError(ctxt)) {
+    return;
+  }
+
+  NSError *error = nil;
+  NSRegularExpression *regex = FBXPathRegexWithPattern(pattern, flags, &error);
+  if (nil == regex) {
+    xmlXPathReturnBoolean(ctxt, 0);
+    return;
+  }
+
+  NSRange range = NSMakeRange(0, input.length);
+  NSTextCheckingResult *match = [regex firstMatchInString:input options:0 range:range];
+  xmlXPathReturnBoolean(ctxt, nil != match);
+}
+
+static void fbXPathEndsWithFunction(xmlXPathParserContextPtr ctxt, int nargs)
+{
+  if (nargs != 2) {
+    xmlXPathSetArityError(ctxt);
+    return;
+  }
+
+  NSString *suffix = FBXPathPopNSString(ctxt);
+  NSString *input = FBXPathPopNSString(ctxt);
+  if (nil == suffix || nil == input || xmlXPathCheckError(ctxt)) {
+    return;
+  }
+
+  xmlXPathReturnBoolean(ctxt, [input hasSuffix:suffix]);
+}
+
+static void fbXPathLowerCaseFunction(xmlXPathParserContextPtr ctxt, int nargs)
+{
+  if (nargs != 1) {
+    xmlXPathSetArityError(ctxt);
+    return;
+  }
+
+  NSString *input = FBXPathPopNSString(ctxt);
+  if (nil == input || xmlXPathCheckError(ctxt)) {
+    return;
+  }
+
+  FBXPathReturnNSString(ctxt, input.lowercaseString);
+}
+
+static void fbXPathUpperCaseFunction(xmlXPathParserContextPtr ctxt, int nargs)
+{
+  if (nargs != 1) {
+    xmlXPathSetArityError(ctxt);
+    return;
+  }
+
+  NSString *input = FBXPathPopNSString(ctxt);
+  if (nil == input || xmlXPathCheckError(ctxt)) {
+    return;
+  }
+
+  FBXPathReturnNSString(ctxt, input.uppercaseString);
+}
+
+static void fbXPathReplaceFunction(xmlXPathParserContextPtr ctxt, int nargs)
+{
+  if (nargs < 3 || nargs > 4) {
+    xmlXPathSetArityError(ctxt);
+    return;
+  }
+
+  NSString *flags = nargs == 4 ? FBXPathPopNSString(ctxt) : nil;
+  NSString *replacement = FBXPathPopNSString(ctxt);
+  NSString *pattern = FBXPathPopNSString(ctxt);
+  NSString *input = FBXPathPopNSString(ctxt);
+  if (nil == replacement || nil == pattern || nil == input || xmlXPathCheckError(ctxt)) {
+    return;
+  }
+
+  NSError *error = nil;
+  NSRegularExpression *regex = FBXPathRegexWithPattern(pattern, flags, &error);
+  if (nil == regex) {
+    FBXPathReturnNSString(ctxt, input);
+    return;
+  }
+
+  NSRange range = NSMakeRange(0, input.length);
+  NSString *result = [regex stringByReplacingMatchesInString:input
+                                                     options:0
+                                                       range:range
+                                                withTemplate:replacement];
+  FBXPathReturnNSString(ctxt, result);
+}
+
+static void fbXPathTokenizeFunction(xmlXPathParserContextPtr ctxt, int nargs)
+{
+  if (nargs < 1 || nargs > 2) {
+    xmlXPathSetArityError(ctxt);
+    return;
+  }
+
+  NSString *pattern = nargs == 2 ? FBXPathPopNSString(ctxt) : nil;
+  NSString *input = FBXPathPopNSString(ctxt);
+  if (nil == input || xmlXPathCheckError(ctxt)) {
+    return;
+  }
+
+  NSArray<NSString *> *tokens = FBXPathTokenizeString(input, pattern);
+  xmlXPathObjectPtr result = FBXPathCreateTokenNodeSet(ctxt, tokens);
+  if (NULL == result) {
+    xmlXPathReturnEmptyNodeSet(ctxt);
+    return;
+  }
+  valuePush(ctxt, result);
+}
+
+static void fbXPathStringJoinFunction(xmlXPathParserContextPtr ctxt, int nargs)
+{
+  if (nargs != 2) {
+    xmlXPathSetArityError(ctxt);
+    return;
+  }
+
+  xmlChar *separatorChars = xmlXPathPopString(ctxt);
+  xmlXPathObjectPtr sequence = valuePop(ctxt);
+  if (xmlXPathCheckError(ctxt) || NULL == sequence || NULL == separatorChars) {
+    if (NULL != separatorChars) {
+      xmlFree(separatorChars);
+    }
+    if (NULL != sequence) {
+      xmlXPathFreeObject(sequence);
+    }
+    return;
+  }
+
+  NSString *separator = [NSString stringWithUTF8String:(const char *)separatorChars];
+  xmlFree(separatorChars);
+
+  NSMutableArray<NSString *> *parts = [NSMutableArray array];
+  if (sequence->type == XPATH_NODESET && NULL != sequence->nodesetval) {
+    for (int index = 0; index < sequence->nodesetval->nodeNr; index++) {
+      xmlChar *content = xmlNodeGetContent(sequence->nodesetval->nodeTab[index]);
+      if (NULL != content) {
+        [parts addObject:[NSString stringWithUTF8String:(const char *)content]];
+        xmlFree(content);
+      }
+    }
+  } else {
+    xmlChar *asString = xmlXPathCastToString(sequence);
+    if (NULL != asString) {
+      [parts addObject:[NSString stringWithUTF8String:(const char *)asString]];
+      xmlFree(asString);
+    }
+  }
+  xmlXPathFreeObject(sequence);
+
+  FBXPathReturnNSString(ctxt, [parts componentsJoinedByString:separator]);
+}
+
+static void FBRegisterXPathExtensions(xmlXPathContextPtr xpathCtx)
+{
+  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "matches", fbXPathMatchesFunction);
+  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "ends-with", fbXPathEndsWithFunction);
+  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "lower-case", fbXPathLowerCaseFunction);
+  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "upper-case", fbXPathUpperCaseFunction);
+  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "replace", fbXPathReplaceFunction);
+  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "tokenize", fbXPathTokenizeFunction);
+  xmlXPathRegisterFunc(xpathCtx, BAD_CAST "string-join", fbXPathStringJoinFunction);
+}

--- a/WebDriverAgentLib/Utilities/FBXPathExtensions.m
+++ b/WebDriverAgentLib/Utilities/FBXPathExtensions.m
@@ -8,55 +8,36 @@
 
 #import "FBXPathExtensions.h"
 
-#import <libxml/tree.h>
 #import <libxml/xpathInternals.h>
 
 static void FBRegisterXPathExtensions(xmlXPathContextPtr xpathCtx);
 
-@interface FBXPathEvaluationContext ()
+static NSString *const FBXPathTokenSequenceSeparator = @"\x1E";
+static const NSRegularExpressionOptions FBXPathNoRegexOptions = (NSRegularExpressionOptions)0;
+static const NSMatchingOptions FBXPathNoMatchingOptions = (NSMatchingOptions)0;
 
-@property (nonatomic, strong) NSMutableArray<NSValue *> *temporaryDocuments;
-
-- (void)registerTemporaryDocument:(xmlDocPtr)doc;
-
-@end
-
-@implementation FBXPathEvaluationContext
-
-- (instancetype)init
+static void FBXPathSetInvalidArityError(xmlXPathParserContextPtr ctxt)
 {
-  self = [super init];
-  if (self) {
-    _temporaryDocuments = [NSMutableArray array];
+  if (NULL == ctxt) {
+    return;
   }
-  return self;
+  xmlXPatherror(ctxt, __FILE__, __LINE__, XPATH_INVALID_ARITY);
+  ctxt->error = XPATH_INVALID_ARITY;
 }
 
-- (void)registerTemporaryDocument:(xmlDocPtr)doc
+static NSString *FBXPathStringFromUTF8Bytes(const xmlChar *bytes)
 {
-  if (NULL != doc) {
-    [self.temporaryDocuments addObject:[NSValue valueWithPointer:doc]];
+  if (NULL == bytes) {
+    return nil;
   }
+  return [NSString stringWithUTF8String:(const char *)bytes];
 }
-
-- (void)cleanup
-{
-  for (NSValue *value in self.temporaryDocuments) {
-    xmlFreeDoc((xmlDocPtr)value.pointerValue);
-  }
-  [self.temporaryDocuments removeAllObjects];
-}
-
-@end
 
 @implementation FBXPathExtensions
 
-+ (FBXPathEvaluationContext *)configureXPathContext:(xmlXPathContextPtr)xpathCtx
++ (void)registerFunctionsWithContext:(xmlXPathContextPtr)xpathCtx
 {
-  FBXPathEvaluationContext *evalContext = [FBXPathEvaluationContext new];
-  xpathCtx->userData = (__bridge void *)evalContext;
   FBRegisterXPathExtensions(xpathCtx);
-  return evalContext;
 }
 
 @end
@@ -74,7 +55,7 @@ static NSString *FBXPathPopNSString(xmlXPathParserContextPtr ctxt)
 
 static NSRegularExpressionOptions FBXPathRegexOptionsFromFlags(NSString *flags)
 {
-  NSRegularExpressionOptions options = 0;
+  NSRegularExpressionOptions options = FBXPathNoRegexOptions;
   if (nil != flags && [flags rangeOfString:@"i"].location != NSNotFound) {
     options |= NSRegularExpressionCaseInsensitive;
   }
@@ -99,34 +80,8 @@ static void FBXPathReturnNSString(xmlXPathParserContextPtr ctxt, NSString *value
     xmlXPathReturnEmptyString(ctxt);
     return;
   }
+  // xmlXPathWrapString takes ownership of the buffer passed to xmlXPathReturnString.
   xmlXPathReturnString(ctxt, copiedValue);
-  xmlFree(copiedValue);
-}
-
-static xmlXPathObjectPtr FBXPathCreateTokenNodeSet(xmlXPathParserContextPtr ctxt, NSArray<NSString *> *tokens)
-{
-  xmlDocPtr container = xmlNewDoc(BAD_CAST "1.0");
-  xmlNodePtr rootNode = xmlNewNode(NULL, BAD_CAST "tokens");
-  xmlDocSetRootElement(container, rootNode);
-
-  xmlXPathObjectPtr result = xmlXPathNewNodeSet(NULL);
-  if (NULL == result || NULL == result->nodesetval) {
-    xmlFreeDoc(container);
-    return result;
-  }
-
-  for (NSString *token in tokens) {
-    xmlChar *tokenContent = xmlStrdup((const xmlChar *)[token UTF8String]);
-    xmlNodePtr tokenNode = xmlNewNode(NULL, BAD_CAST "token");
-    xmlNodeSetContent(tokenNode, tokenContent);
-    xmlFree(tokenContent);
-    xmlAddChild(rootNode, tokenNode);
-    xmlXPathNodeSetAdd(result->nodesetval, tokenNode);
-  }
-
-  FBXPathEvaluationContext *evalContext = (__bridge FBXPathEvaluationContext *)ctxt->context->userData;
-  [evalContext registerTemporaryDocument:container];
-  return result;
 }
 
 static NSArray<NSString *> *FBXPathTokenizeString(NSString *input, NSString *pattern)
@@ -137,14 +92,14 @@ static NSArray<NSString *> *FBXPathTokenizeString(NSString *input, NSString *pat
 
   if (nil == pattern) {
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\S+"
-                                                                           options:0
+                                                                           options:FBXPathNoRegexOptions
                                                                              error:nil];
     if (nil == regex) {
       return @[];
     }
     NSMutableArray<NSString *> *tokens = [NSMutableArray array];
     [regex enumerateMatchesInString:input
-                            options:0
+                            options:FBXPathNoMatchingOptions
                               range:NSMakeRange(0, input.length)
                          usingBlock:^(NSTextCheckingResult *result, NSMatchingFlags flags, BOOL *stop) {
       if (nil != result) {
@@ -167,7 +122,7 @@ static NSArray<NSString *> *FBXPathTokenizeString(NSString *input, NSString *pat
   }
 
   NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern
-                                                                         options:0
+                                                                         options:FBXPathNoRegexOptions
                                                                            error:nil];
   if (nil == regex) {
     return @[];
@@ -176,7 +131,7 @@ static NSArray<NSString *> *FBXPathTokenizeString(NSString *input, NSString *pat
   NSMutableArray<NSString *> *tokens = [NSMutableArray array];
   __block NSUInteger lastIndex = 0;
   [regex enumerateMatchesInString:input
-                          options:0
+                          options:FBXPathNoMatchingOptions
                             range:NSMakeRange(0, input.length)
                        usingBlock:^(NSTextCheckingResult *result, NSMatchingFlags flags, BOOL *stop) {
     if (nil == result) {
@@ -199,10 +154,42 @@ static NSArray<NSString *> *FBXPathTokenizeString(NSString *input, NSString *pat
   return tokens.copy;
 }
 
+static NSArray<NSString *> *FBXPathPartsFromXPathObject(xmlXPathObjectPtr sequence)
+{
+  if (sequence->type == XPATH_NODESET && NULL != sequence->nodesetval) {
+    NSMutableArray<NSString *> *parts = [NSMutableArray array];
+    for (int index = 0; index < sequence->nodesetval->nodeNr; index++) {
+      xmlChar *content = xmlNodeGetContent(sequence->nodesetval->nodeTab[index]);
+      if (NULL != content) {
+        NSString *part = FBXPathStringFromUTF8Bytes(content);
+        xmlFree(content);
+        if (nil != part) {
+          [parts addObject:part];
+        }
+      }
+    }
+    return parts.copy;
+  }
+
+  xmlChar *asString = xmlXPathCastToString(sequence);
+  if (NULL == asString) {
+    return @[];
+  }
+  NSString *value = FBXPathStringFromUTF8Bytes(asString);
+  xmlFree(asString);
+  if (nil == value || 0 == value.length) {
+    return @[];
+  }
+  if ([value rangeOfString:FBXPathTokenSequenceSeparator].location != NSNotFound) {
+    return [value componentsSeparatedByString:FBXPathTokenSequenceSeparator];
+  }
+  return @[value];
+}
+
 static void fbXPathMatchesFunction(xmlXPathParserContextPtr ctxt, int nargs)
 {
   if (nargs < 2 || nargs > 3) {
-    xmlXPathSetArityError(ctxt);
+    FBXPathSetInvalidArityError(ctxt);
     return;
   }
 
@@ -221,14 +208,14 @@ static void fbXPathMatchesFunction(xmlXPathParserContextPtr ctxt, int nargs)
   }
 
   NSRange range = NSMakeRange(0, input.length);
-  NSTextCheckingResult *match = [regex firstMatchInString:input options:0 range:range];
+  NSTextCheckingResult *match = [regex firstMatchInString:input options:FBXPathNoMatchingOptions range:range];
   xmlXPathReturnBoolean(ctxt, nil != match);
 }
 
 static void fbXPathEndsWithFunction(xmlXPathParserContextPtr ctxt, int nargs)
 {
   if (nargs != 2) {
-    xmlXPathSetArityError(ctxt);
+    FBXPathSetInvalidArityError(ctxt);
     return;
   }
 
@@ -244,7 +231,7 @@ static void fbXPathEndsWithFunction(xmlXPathParserContextPtr ctxt, int nargs)
 static void fbXPathLowerCaseFunction(xmlXPathParserContextPtr ctxt, int nargs)
 {
   if (nargs != 1) {
-    xmlXPathSetArityError(ctxt);
+    FBXPathSetInvalidArityError(ctxt);
     return;
   }
 
@@ -259,7 +246,7 @@ static void fbXPathLowerCaseFunction(xmlXPathParserContextPtr ctxt, int nargs)
 static void fbXPathUpperCaseFunction(xmlXPathParserContextPtr ctxt, int nargs)
 {
   if (nargs != 1) {
-    xmlXPathSetArityError(ctxt);
+    FBXPathSetInvalidArityError(ctxt);
     return;
   }
 
@@ -274,7 +261,7 @@ static void fbXPathUpperCaseFunction(xmlXPathParserContextPtr ctxt, int nargs)
 static void fbXPathReplaceFunction(xmlXPathParserContextPtr ctxt, int nargs)
 {
   if (nargs < 3 || nargs > 4) {
-    xmlXPathSetArityError(ctxt);
+    FBXPathSetInvalidArityError(ctxt);
     return;
   }
 
@@ -295,7 +282,7 @@ static void fbXPathReplaceFunction(xmlXPathParserContextPtr ctxt, int nargs)
 
   NSRange range = NSMakeRange(0, input.length);
   NSString *result = [regex stringByReplacingMatchesInString:input
-                                                     options:0
+                                                     options:FBXPathNoMatchingOptions
                                                        range:range
                                                 withTemplate:replacement];
   FBXPathReturnNSString(ctxt, result);
@@ -304,7 +291,7 @@ static void fbXPathReplaceFunction(xmlXPathParserContextPtr ctxt, int nargs)
 static void fbXPathTokenizeFunction(xmlXPathParserContextPtr ctxt, int nargs)
 {
   if (nargs < 1 || nargs > 2) {
-    xmlXPathSetArityError(ctxt);
+    FBXPathSetInvalidArityError(ctxt);
     return;
   }
 
@@ -315,18 +302,13 @@ static void fbXPathTokenizeFunction(xmlXPathParserContextPtr ctxt, int nargs)
   }
 
   NSArray<NSString *> *tokens = FBXPathTokenizeString(input, pattern);
-  xmlXPathObjectPtr result = FBXPathCreateTokenNodeSet(ctxt, tokens);
-  if (NULL == result) {
-    xmlXPathReturnEmptyNodeSet(ctxt);
-    return;
-  }
-  valuePush(ctxt, result);
+  FBXPathReturnNSString(ctxt, [tokens componentsJoinedByString:FBXPathTokenSequenceSeparator]);
 }
 
 static void fbXPathStringJoinFunction(xmlXPathParserContextPtr ctxt, int nargs)
 {
   if (nargs != 2) {
-    xmlXPathSetArityError(ctxt);
+    FBXPathSetInvalidArityError(ctxt);
     return;
   }
 
@@ -342,25 +324,14 @@ static void fbXPathStringJoinFunction(xmlXPathParserContextPtr ctxt, int nargs)
     return;
   }
 
-  NSString *separator = [NSString stringWithUTF8String:(const char *)separatorChars];
+  NSString *separator = FBXPathStringFromUTF8Bytes(separatorChars);
   xmlFree(separatorChars);
-
-  NSMutableArray<NSString *> *parts = [NSMutableArray array];
-  if (sequence->type == XPATH_NODESET && NULL != sequence->nodesetval) {
-    for (int index = 0; index < sequence->nodesetval->nodeNr; index++) {
-      xmlChar *content = xmlNodeGetContent(sequence->nodesetval->nodeTab[index]);
-      if (NULL != content) {
-        [parts addObject:[NSString stringWithUTF8String:(const char *)content]];
-        xmlFree(content);
-      }
-    }
-  } else {
-    xmlChar *asString = xmlXPathCastToString(sequence);
-    if (NULL != asString) {
-      [parts addObject:[NSString stringWithUTF8String:(const char *)asString]];
-      xmlFree(asString);
-    }
+  if (nil == separator) {
+    xmlXPathFreeObject(sequence);
+    return;
   }
+
+  NSArray<NSString *> *parts = FBXPathPartsFromXPathObject(sequence);
   xmlXPathFreeObject(sequence);
 
   FBXPathReturnNSString(ctxt, [parts componentsJoinedByString:separator]);

--- a/WebDriverAgentLib/Utilities/XCTestPrivateSymbols.m
+++ b/WebDriverAgentLib/Utilities/XCTestPrivateSymbols.m
@@ -35,10 +35,15 @@ NSArray<NSNumber *> *(*XCAXAccessibilityAttributesForStringAttributes)(id);
 
 @implementation FBXCTestSymbolsLoader
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-load-method"
+
 + (void)load
 {
   FBLoadXCTestSymbols();
 }
+
+#pragma clang diagnostic pop
 
 @end
 

--- a/WebDriverAgentLib/Vendor/CocoaHTTPServer/Responses/HTTPErrorResponse.m
+++ b/WebDriverAgentLib/Vendor/CocoaHTTPServer/Responses/HTTPErrorResponse.m
@@ -22,9 +22,7 @@
   return 0;
 }
 
-- (void)setOffset:(UInt64)offset {
-  ;
-}
+- (void)setOffset:(UInt64)offset {}
 
 - (NSData*) readDataOfLength:(NSUInteger)length {
   return nil;

--- a/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
@@ -9,6 +9,7 @@
 #import <XCTest/XCTest.h>
 
 #import "FBIntegrationTestCase.h"
+#import "FBExceptions.h"
 #import "FBMacros.h"
 #import "FBTestMacros.h"
 #import "FBXPath.h"
@@ -232,6 +233,14 @@
 {
   [self assertXPathQuery:@"//XCUIElementTypeButton[matches(@label, '.*')]"
        findsButtonLabels:@[@"Alerts", @"Deadlock app", @"Attributes", @"Scrolling", @"Touch"]];
+}
+
+- (void)testInvalidXPathExtensionFunctionViaElementLookup
+{
+  XCTAssertThrowsSpecificNamed([self.testedView fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButton[matches(@label)]"
+                                                      shouldReturnAfterFirstMatch:NO],
+                               NSException,
+                               FBInvalidXPathException);
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
@@ -51,6 +51,31 @@
   return snapshot;
 }
 
+- (NSSet<NSString *> *)labelsForMatchingSnapshots:(NSArray<id<FBXCElementSnapshot>> *)matchingSnapshots
+{
+  NSMutableSet<NSString *> *labels = [NSMutableSet set];
+  for (id<FBXCElementSnapshot> snapshot in matchingSnapshots) {
+    NSString *label = [FBXCElementSnapshotWrapper ensureWrapped:snapshot].wdLabel;
+    if (nil != label) {
+      [labels addObject:label];
+    }
+  }
+  return labels.copy;
+}
+
+- (void)assertXPathQuery:(NSString *)query findsButtonLabels:(NSArray<NSString *> *)expectedLabels
+{
+  NSArray<id<FBXCElementSnapshot>> *matchingSnapshots = [FBXPath matchesWithRootElement:self.testedApplication
+                                                                               forQuery:query];
+  NSSet<NSString *> *foundLabels = [self labelsForMatchingSnapshots:matchingSnapshots];
+  NSSet<NSString *> *expectedLabelSet = [NSSet setWithArray:expectedLabels];
+  XCTAssertEqual(foundLabels.count, expectedLabelSet.count);
+  XCTAssertEqualObjects(foundLabels, expectedLabelSet);
+  for (id<FBXCElementSnapshot> snapshot in matchingSnapshots) {
+    XCTAssertEqualObjects([FBXCElementSnapshotWrapper ensureWrapped:snapshot].wdType, @"XCUIElementTypeButton");
+  }
+}
+
 - (void)testApplicationNodeXMLRepresentation
 {
   id<FBXCElementSnapshot> snapshot = [self.testedApplication fb_customSnapshot];
@@ -152,6 +177,61 @@
   for (id<FBXCElementSnapshot> element in matchingSnapshots) {
     XCTAssertTrue([[FBXCElementSnapshotWrapper ensureWrapped:element].wdType isEqualToString:@"XCUIElementTypeButton"]);
   }
+}
+
+- (void)testFindMatchesWithMatchesFunction
+{
+  [self assertXPathQuery:@"//XCUIElementTypeButton[matches(@label, '^Alerts$')]"
+       findsButtonLabels:@[@"Alerts"]];
+}
+
+- (void)testFindMatchesWithMatchesFunctionCaseInsensitive
+{
+  [self assertXPathQuery:@"//XCUIElementTypeButton[matches(@label, '^alerts$', 'i')]"
+       findsButtonLabels:@[@"Alerts"]];
+}
+
+- (void)testFindMatchesWithEndsWithFunction
+{
+  [self assertXPathQuery:@"//XCUIElementTypeButton[ends-with(@label, 'ing')]"
+       findsButtonLabels:@[@"Scrolling"]];
+}
+
+- (void)testFindMatchesWithLowerCaseFunction
+{
+  [self assertXPathQuery:@"//XCUIElementTypeButton[lower-case(@label)='alerts']"
+       findsButtonLabels:@[@"Alerts"]];
+}
+
+- (void)testFindMatchesWithUpperCaseFunction
+{
+  [self assertXPathQuery:@"//XCUIElementTypeButton[upper-case(@label)='TOUCH']"
+       findsButtonLabels:@[@"Touch"]];
+}
+
+- (void)testFindMatchesWithReplaceFunction
+{
+  [self assertXPathQuery:@"//XCUIElementTypeButton[replace(@label, ' ', '')='Deadlockapp']"
+       findsButtonLabels:@[@"Deadlock app"]];
+}
+
+- (void)testFindMatchesWithTokenizeAndStringJoinFunctions
+{
+  [self assertXPathQuery:@"//XCUIElementTypeButton[string-join(tokenize(@label, ' '), '-')='Deadlock-app']"
+       findsButtonLabels:@[@"Deadlock app"]];
+}
+
+- (void)testFindMatchesWithExtensionFunctionsNoMatches
+{
+  NSArray<id<FBXCElementSnapshot>> *matchingSnapshots = [FBXPath matchesWithRootElement:self.testedApplication
+                                                                               forQuery:@"//XCUIElementTypeButton[matches(@label, '^NoSuchButton$')]"];
+  XCTAssertEqual(matchingSnapshots.count, 0);
+}
+
+- (void)testFindMultipleMatchesWithMatchesFunction
+{
+  [self assertXPathQuery:@"//XCUIElementTypeButton[matches(@label, '.*')]"
+       findsButtonLabels:@[@"Alerts", @"Deadlock app", @"Attributes", @"Scrolling", @"Touch"]];
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
@@ -243,4 +243,18 @@
                                FBInvalidXPathException);
 }
 
+- (void)testInvalidXPathExtensionRegexpViaElementLookup
+{
+  NSException *exception = nil;
+  @try {
+    [self.testedView fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButton[matches(@label, '[')]"
+                             shouldReturnAfterFirstMatch:NO];
+  } @catch (NSException *caughtException) {
+    exception = caughtException;
+  }
+  XCTAssertEqualObjects(exception.name, FBInvalidXPathException);
+  XCTAssertTrue([exception.reason containsString:@"Cannot evaluate results for XPath expression"]);
+  XCTAssertTrue([exception.reason rangeOfString:@"invalid" options:NSCaseInsensitiveSearch].location != NSNotFound);
+}
+
 @end

--- a/WebDriverAgentTests/UnitTests/FBXPathTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXPathTests.m
@@ -224,6 +224,25 @@
   }
 }
 
+- (void)testInvalidXPathExtensionRegexp
+{
+  XCElementSnapshotDouble *snapshot = [XCElementSnapshotDouble new];
+  snapshot.label = @"Hello World";
+  snapshot.value = @"One-Two-Three";
+
+  xmlDocPtr doc = [self documentForSnapshot:snapshot query:@"//*[@label and @name and @value]"];
+
+  @try {
+    [self assertXPathEvaluationFailsForQuery:@"matches(//XCUIElementTypeOther/@label, '[')" document:doc];
+    [self assertXPathEvaluationFailsForQuery:@"replace(//XCUIElementTypeOther/@label, '[', '')" document:doc];
+    [self assertXPathEvaluationFailsForQuery:@"tokenize(//XCUIElementTypeOther/@value, '[')" document:doc];
+    [self assertXPathEvaluationFailsForQuery:@"matches(//XCUIElementTypeOther/@label, 'a', 'z')" document:doc];
+    [self assertXPathEvaluationFailsForQuery:@"//XCUIElementTypeOther[matches(@label, '[')]" document:doc];
+  } @finally {
+    xmlFreeDoc(doc);
+  }
+}
+
 - (void)assertXPathEvaluationFailsForQuery:(NSString *)query document:(xmlDocPtr)doc
 {
   xmlXPathObjectPtr queryResult = [FBXPath evaluate:query document:doc contextNode:NULL];

--- a/WebDriverAgentTests/UnitTests/FBXPathTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXPathTests.m
@@ -152,4 +152,74 @@
   XCTAssertEqual(1, [matchingSnapshots count]);
 }
 
+- (NSString *)xpathStringResultForQuery:(NSString *)query document:(xmlDocPtr)doc
+{
+  xmlXPathObjectPtr queryResult = [FBXPath evaluate:query document:doc contextNode:NULL];
+  if (NULL == queryResult) {
+    return nil;
+  }
+  xmlChar *stringValue = xmlXPathCastToString(queryResult);
+  xmlXPathFreeObject(queryResult);
+  if (NULL == stringValue) {
+    return nil;
+  }
+  NSString *result = [NSString stringWithUTF8String:(const char *)stringValue];
+  xmlFree(stringValue);
+  return result;
+}
+
+- (BOOL)xpathBooleanResultForQuery:(NSString *)query document:(xmlDocPtr)doc
+{
+  xmlXPathObjectPtr queryResult = [FBXPath evaluate:query document:doc contextNode:NULL];
+  if (NULL == queryResult) {
+    return NO;
+  }
+  BOOL result = queryResult->boolval;
+  xmlXPathFreeObject(queryResult);
+  return result;
+}
+
+- (xmlDocPtr)documentForSnapshot:(XCElementSnapshotDouble *)snapshot query:(NSString *)query
+{
+  xmlDocPtr doc;
+  xmlTextWriterPtr writer = xmlNewTextWriterDoc(&doc, 0);
+  NSMutableDictionary *elementStore = [NSMutableDictionary dictionary];
+  id<FBElement> root = (id<FBElement>)[FBXCElementSnapshotWrapper ensureWrapped:(id)snapshot];
+  int rc = xmlTextWriterStartDocument(writer, NULL, "UTF-8", NULL);
+  if (rc >= 0) {
+    rc = [FBXPath xmlRepresentationWithRootElement:(id<FBXCElementSnapshot>)root
+                                            writer:writer
+                                      elementStore:elementStore
+                                             query:query
+                               excludingAttributes:nil];
+    if (rc >= 0) {
+      rc = xmlTextWriterEndDocument(writer);
+    }
+  }
+  xmlFreeTextWriter(writer);
+  XCTAssertTrue(rc >= 0);
+  return doc;
+}
+
+- (void)testXPathExtensionFunctions
+{
+  XCElementSnapshotDouble *snapshot = [XCElementSnapshotDouble new];
+  snapshot.label = @"Hello World";
+  snapshot.value = @"One-Two-Three";
+
+  xmlDocPtr doc = [self documentForSnapshot:snapshot query:@"//*[@label and @name and @value]"];
+
+  XCTAssertTrue([self xpathBooleanResultForQuery:@"matches(//XCUIElementTypeOther/@label, 'Hello.*')" document:doc]);
+  XCTAssertFalse([self xpathBooleanResultForQuery:@"matches(//XCUIElementTypeOther/@label, 'hello.*')" document:doc]);
+  XCTAssertTrue([self xpathBooleanResultForQuery:@"matches(//XCUIElementTypeOther/@label, 'hello.*', 'i')" document:doc]);
+  XCTAssertTrue([self xpathBooleanResultForQuery:@"ends-with(//XCUIElementTypeOther/@name, 'Name')" document:doc]);
+  XCTAssertFalse([self xpathBooleanResultForQuery:@"ends-with(//XCUIElementTypeOther/@name, 'Foo')" document:doc]);
+  XCTAssertEqualObjects([self xpathStringResultForQuery:@"lower-case(//XCUIElementTypeOther/@label)" document:doc], @"hello world");
+  XCTAssertEqualObjects([self xpathStringResultForQuery:@"upper-case(//XCUIElementTypeOther/@name)" document:doc], @"TESTNAME");
+  XCTAssertEqualObjects([self xpathStringResultForQuery:@"replace(//XCUIElementTypeOther/@value, '-', '_')" document:doc], @"One_Two_Three");
+  XCTAssertEqualObjects([self xpathStringResultForQuery:@"string-join(tokenize(//XCUIElementTypeOther/@value, '-'), '|')" document:doc], @"One|Two|Three");
+
+  xmlFreeDoc(doc);
+}
+
 @end

--- a/WebDriverAgentTests/UnitTests/FBXPathTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXPathTests.m
@@ -209,25 +209,30 @@
 
   xmlDocPtr doc = [self documentForSnapshot:snapshot query:@"//*[@label and @name and @value]"];
 
-  XCTAssertTrue([self xpathBooleanResultForQuery:@"matches(//XCUIElementTypeOther/@label, 'Hello.*')" document:doc]);
-  XCTAssertFalse([self xpathBooleanResultForQuery:@"matches(//XCUIElementTypeOther/@label, 'hello.*')" document:doc]);
-  XCTAssertTrue([self xpathBooleanResultForQuery:@"matches(//XCUIElementTypeOther/@label, 'hello.*', 'i')" document:doc]);
-  XCTAssertTrue([self xpathBooleanResultForQuery:@"ends-with(//XCUIElementTypeOther/@name, 'Name')" document:doc]);
-  XCTAssertFalse([self xpathBooleanResultForQuery:@"ends-with(//XCUIElementTypeOther/@name, 'Foo')" document:doc]);
-  XCTAssertEqualObjects([self xpathStringResultForQuery:@"lower-case(//XCUIElementTypeOther/@label)" document:doc], @"hello world");
-  XCTAssertEqualObjects([self xpathStringResultForQuery:@"upper-case(//XCUIElementTypeOther/@name)" document:doc], @"TESTNAME");
-  XCTAssertEqualObjects([self xpathStringResultForQuery:@"replace(//XCUIElementTypeOther/@value, '-', '_')" document:doc], @"One_Two_Three");
-  XCTAssertEqualObjects([self xpathStringResultForQuery:@"string-join(tokenize(//XCUIElementTypeOther/@value, '-'), '|')" document:doc], @"One|Two|Three");
-
-  xmlFreeDoc(doc);
+  @try {
+    XCTAssertTrue([self xpathBooleanResultForQuery:@"matches(//XCUIElementTypeOther/@label, 'Hello.*')" document:doc]);
+    XCTAssertFalse([self xpathBooleanResultForQuery:@"matches(//XCUIElementTypeOther/@label, 'hello.*')" document:doc]);
+    XCTAssertTrue([self xpathBooleanResultForQuery:@"matches(//XCUIElementTypeOther/@label, 'hello.*', 'i')" document:doc]);
+    XCTAssertTrue([self xpathBooleanResultForQuery:@"ends-with(//XCUIElementTypeOther/@name, 'Name')" document:doc]);
+    XCTAssertFalse([self xpathBooleanResultForQuery:@"ends-with(//XCUIElementTypeOther/@name, 'Foo')" document:doc]);
+    XCTAssertEqualObjects([self xpathStringResultForQuery:@"lower-case(//XCUIElementTypeOther/@label)" document:doc], @"hello world");
+    XCTAssertEqualObjects([self xpathStringResultForQuery:@"upper-case(//XCUIElementTypeOther/@name)" document:doc], @"TESTNAME");
+    XCTAssertEqualObjects([self xpathStringResultForQuery:@"replace(//XCUIElementTypeOther/@value, '-', '_')" document:doc], @"One_Two_Three");
+    XCTAssertEqualObjects([self xpathStringResultForQuery:@"string-join(tokenize(//XCUIElementTypeOther/@value, '-'), '|')" document:doc], @"One|Two|Three");
+  } @finally {
+    xmlFreeDoc(doc);
+  }
 }
 
 - (void)assertXPathEvaluationFailsForQuery:(NSString *)query document:(xmlDocPtr)doc
 {
   xmlXPathObjectPtr queryResult = [FBXPath evaluate:query document:doc contextNode:NULL];
-  XCTAssertEqual(NULL, queryResult);
-  if (NULL != queryResult) {
-    xmlXPathFreeObject(queryResult);
+  @try {
+    XCTAssertEqual(NULL, queryResult);
+  } @finally {
+    if (NULL != queryResult) {
+      xmlXPathFreeObject(queryResult);
+    }
   }
 }
 
@@ -239,16 +244,18 @@
 
   xmlDocPtr doc = [self documentForSnapshot:snapshot query:@"//*[@label and @name and @value]"];
 
-  [self assertXPathEvaluationFailsForQuery:@"matches(//XCUIElementTypeOther/@label)" document:doc];
-  [self assertXPathEvaluationFailsForQuery:@"lower-case()" document:doc];
-  [self assertXPathEvaluationFailsForQuery:@"string-join(//XCUIElementTypeOther/@label)" document:doc];
-  [self assertXPathEvaluationFailsForQuery:@"replace(//XCUIElementTypeOther/@label, '-')" document:doc];
-  [self assertXPathEvaluationFailsForQuery:@"//XCUIElementTypeOther[matches(@label)]" document:doc];
-  [self assertXPathEvaluationFailsForQuery:@"//XCUIElementTypeOther[lower-case()]" document:doc];
-  [self assertXPathEvaluationFailsForQuery:@"//XCUIElementTypeOther[string-join(@label)]" document:doc];
-  [self assertXPathEvaluationFailsForQuery:@"//XCUIElementTypeOther[replace(@label, '-')]" document:doc];
-
-  xmlFreeDoc(doc);
+  @try {
+    [self assertXPathEvaluationFailsForQuery:@"matches(//XCUIElementTypeOther/@label)" document:doc];
+    [self assertXPathEvaluationFailsForQuery:@"lower-case()" document:doc];
+    [self assertXPathEvaluationFailsForQuery:@"string-join(//XCUIElementTypeOther/@label)" document:doc];
+    [self assertXPathEvaluationFailsForQuery:@"replace(//XCUIElementTypeOther/@label, '-')" document:doc];
+    [self assertXPathEvaluationFailsForQuery:@"//XCUIElementTypeOther[matches(@label)]" document:doc];
+    [self assertXPathEvaluationFailsForQuery:@"//XCUIElementTypeOther[lower-case()]" document:doc];
+    [self assertXPathEvaluationFailsForQuery:@"//XCUIElementTypeOther[string-join(@label)]" document:doc];
+    [self assertXPathEvaluationFailsForQuery:@"//XCUIElementTypeOther[replace(@label, '-')]" document:doc];
+  } @finally {
+    xmlFreeDoc(doc);
+  }
 }
 
 @end

--- a/WebDriverAgentTests/UnitTests/FBXPathTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXPathTests.m
@@ -222,4 +222,33 @@
   xmlFreeDoc(doc);
 }
 
+- (void)assertXPathEvaluationFailsForQuery:(NSString *)query document:(xmlDocPtr)doc
+{
+  xmlXPathObjectPtr queryResult = [FBXPath evaluate:query document:doc contextNode:NULL];
+  XCTAssertEqual(NULL, queryResult);
+  if (NULL != queryResult) {
+    xmlXPathFreeObject(queryResult);
+  }
+}
+
+- (void)testInvalidXPathExtensionFunctionArity
+{
+  XCElementSnapshotDouble *snapshot = [XCElementSnapshotDouble new];
+  snapshot.label = @"Hello World";
+  snapshot.value = @"One-Two-Three";
+
+  xmlDocPtr doc = [self documentForSnapshot:snapshot query:@"//*[@label and @name and @value]"];
+
+  [self assertXPathEvaluationFailsForQuery:@"matches(//XCUIElementTypeOther/@label)" document:doc];
+  [self assertXPathEvaluationFailsForQuery:@"lower-case()" document:doc];
+  [self assertXPathEvaluationFailsForQuery:@"string-join(//XCUIElementTypeOther/@label)" document:doc];
+  [self assertXPathEvaluationFailsForQuery:@"replace(//XCUIElementTypeOther/@label, '-')" document:doc];
+  [self assertXPathEvaluationFailsForQuery:@"//XCUIElementTypeOther[matches(@label)]" document:doc];
+  [self assertXPathEvaluationFailsForQuery:@"//XCUIElementTypeOther[lower-case()]" document:doc];
+  [self assertXPathEvaluationFailsForQuery:@"//XCUIElementTypeOther[string-join(@label)]" document:doc];
+  [self assertXPathEvaluationFailsForQuery:@"//XCUIElementTypeOther[replace(@label, '-')]" document:doc];
+
+  xmlFreeDoc(doc);
+}
+
 @end


### PR DESCRIPTION
## Summary

Adds XPath 2–style string extension functions to WebDriverAgent’s libxml2 XPath 1.0 evaluator so locators can use richer string matching without leaving XPath.

- Introduces `FBXPathExtensions` (`FBXPathExtensions.h` / `.m`) and registers seven functions on each evaluation context via `xmlXPathRegisterFunc`: `matches`, `ends-with`, `lower-case`, `upper-case`, `replace`, `tokenize`, and `string-join`.
- Wires registration into `+[FBXPath evaluate:document:contextNode:]` so extensions are available for element lookup and predicate evaluation.
- Implements `matches` / `replace` with `NSRegularExpression` (optional `i` flag for case-insensitive `matches`); `tokenize` returns an internal delimiter-separated string consumed by `string-join` (avoids temporary XML node-sets that caused use-after-free crashes).
- Fixes a double-free in string return handling: `xmlXPathReturnString` takes ownership of the buffer, so callers must not `xmlFree` after returning.
- Adds unit tests in `FBXPathTests` for function behavior and invalid arity (standalone and predicate forms).
- Adds integration tests in `FBXPathIntegrationTests` for real UI matching and one end-to-end check that bad arity surfaces `FBInvalidXPathException` via `fb_descendantsMatchingXPathQuery:`.
- Silences `-Wobjc-load-method` around `+load` in `XCTestPrivateSymbols.m` (consistent with other WDA files).

**Note:** `HTTPErrorResponse.m` has a one-line style-only change (`setOffset:` body); unrelated to XPath but included in the branch.
