### PR TITLE
fix: auto-handle iOS 18+ limited access permission prompt

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.h
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.h
@@ -8,6 +8,8 @@
 
 #import <XCTest/XCTest.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface XCUIApplication (FBAlert)
 
 /* The accessiblity label used for Safari app */
@@ -18,6 +20,16 @@ extern NSString *const FB_SAFARI_APP_NAME;
 
  @return Alert element instance
  */
-- (XCUIElement *)fb_alertElement;
+- (nullable XCUIElement *)fb_alertElement;
+
+/**
+ Retrieve an alert element hosted by the iOS 18+ limited access permission prompt
+ process. See https://github.com/appium/appium/issues/20591
+
+ @return Alert element instance if the prompt is present, otherwise nil
+ */
++ (nullable XCUIElement *)fb_limitedAccessPromptAlertElement;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
@@ -17,8 +17,21 @@
 
 NSString *const FB_SAFARI_APP_NAME = @"Safari";
 
+// The iOS 18+ limited access permission prompt (e.g. the "Select Contacts" view)
+// runs in a dedicated process that is not reported by fb_activeApplications.
+static NSString *const FB_LIMITED_ACCESS_PROMPT_BUNDLE_ID = @"com.apple.ContactsUI.LimitedAccessPromptView";
+
 
 @implementation XCUIApplication (FBAlert)
+
++ (nullable XCUIElement *)fb_limitedAccessPromptAlertElement
+{
+  XCUIApplication *promptApp = [[XCUIApplication alloc] initWithBundleIdentifier:FB_LIMITED_ACCESS_PROMPT_BUNDLE_ID];
+  if (promptApp.state < XCUIApplicationStateRunningForeground) {
+    return nil;
+  }
+  return promptApp.fb_alertElement;
+}
 
 - (nullable XCUIElement *)fb_alertElementFromSafariWithScrollView:(XCUIElement *)scrollView
                                                      viewSnapshot:(id<FBXCElementSnapshot>)viewSnapshot

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -267,6 +267,9 @@
     } else {
       self.element = systemApp.fb_alertElement ?: self.application.fb_alertElement;
     }
+    if (nil == self.element) {
+      self.element = [XCUIApplication fb_limitedAccessPromptAlertElement];
+    }
   }
   return self.element;
 }

--- a/WebDriverAgentLib/Utilities/FBAlertsMonitor.m
+++ b/WebDriverAgentLib/Utilities/FBAlertsMonitor.m
@@ -15,10 +15,6 @@
 
 static const NSTimeInterval FB_MONTORING_INTERVAL = 2.0;
 
-// The iOS 18+ limited access permission prompt runs in a dedicated process that
-// is not reported by fb_activeApplications. See https://github.com/appium/appium/issues/20591
-static NSString *const FB_LIMITED_ACCESS_PROMPT_BUNDLE_ID = @"com.apple.ContactsUI.LimitedAccessPromptView";
-
 @interface FBAlertsMonitor()
 
 @property (atomic) BOOL isMonitoring;
@@ -54,8 +50,9 @@ static NSString *const FB_LIMITED_ACCESS_PROMPT_BUNDLE_ID = @"com.apple.Contacts
   dispatch_async(dispatch_get_main_queue(), ^{
     id<FBAlertsMonitorDelegate> delegate = self.delegate;
     NSArray<XCUIApplication *> *activeApps = XCUIApplication.fb_activeApplications;
-    XCUIElement *alertElement = nil;
+    BOOL didDetectAlert = NO;
     for (XCUIApplication *activeApp in activeApps) {
+      XCUIElement *alertElement = nil;
       @try {
         alertElement = activeApp.fb_alertElement;
         if (nil != alertElement) {
@@ -65,14 +62,19 @@ static NSString *const FB_LIMITED_ACCESS_PROMPT_BUNDLE_ID = @"com.apple.Contacts
         [FBLogger logFmt:@"Got an unexpected exception while monitoring alerts: %@\n%@", e.reason, e.callStackSymbols];
       }
       if (nil != alertElement) {
+        didDetectAlert = YES;
         break;
       }
     }
 
-    if (nil == alertElement) {
-      alertElement = [self fb_alertElementFromLimitedAccessPrompt];
-      if (nil != alertElement) {
-        [delegate didDetectAlert:[FBAlert alertWithElement:alertElement]];
+    if (!didDetectAlert) {
+      @try {
+        XCUIElement *alertElement = [XCUIApplication fb_limitedAccessPromptAlertElement];
+        if (nil != alertElement) {
+          [delegate didDetectAlert:[FBAlert alertWithElement:alertElement]];
+        }
+      } @catch (NSException *e) {
+        [FBLogger logFmt:@"Got an unexpected exception while monitoring alerts: %@\n%@", e.reason, e.callStackSymbols];
       }
     }
 
@@ -82,18 +84,6 @@ static NSString *const FB_LIMITED_ACCESS_PROMPT_BUNDLE_ID = @"com.apple.Contacts
       });
     }
   });
-}
-
-- (XCUIElement *)fb_alertElementFromLimitedAccessPrompt
-{
-  @try {
-    XCUIApplication *promptApp = [[XCUIApplication alloc]
-                                  initWithBundleIdentifier:FB_LIMITED_ACCESS_PROMPT_BUNDLE_ID];
-    return promptApp.fb_alertElement;
-  } @catch (NSException *e) {
-    [FBLogger logFmt:@"Got an unexpected exception while monitoring the limited access prompt: %@\n%@", e.reason, e.callStackSymbols];
-    return nil;
-  }
 }
 
 - (void)enable

--- a/WebDriverAgentLib/Utilities/FBAlertsMonitor.m
+++ b/WebDriverAgentLib/Utilities/FBAlertsMonitor.m
@@ -15,6 +15,10 @@
 
 static const NSTimeInterval FB_MONTORING_INTERVAL = 2.0;
 
+// The iOS 18+ limited access permission prompt runs in a dedicated process that
+// is not reported by fb_activeApplications. See https://github.com/appium/appium/issues/20591
+static NSString *const FB_LIMITED_ACCESS_PROMPT_BUNDLE_ID = @"com.apple.ContactsUI.LimitedAccessPromptView";
+
 @interface FBAlertsMonitor()
 
 @property (atomic) BOOL isMonitoring;
@@ -48,13 +52,14 @@ static const NSTimeInterval FB_MONTORING_INTERVAL = 2.0;
   }
 
   dispatch_async(dispatch_get_main_queue(), ^{
+    id<FBAlertsMonitorDelegate> delegate = self.delegate;
     NSArray<XCUIApplication *> *activeApps = XCUIApplication.fb_activeApplications;
+    XCUIElement *alertElement = nil;
     for (XCUIApplication *activeApp in activeApps) {
-      XCUIElement *alertElement = nil;
       @try {
         alertElement = activeApp.fb_alertElement;
         if (nil != alertElement) {
-          [self.delegate didDetectAlert:[FBAlert alertWithElement:alertElement]];
+          [delegate didDetectAlert:[FBAlert alertWithElement:alertElement]];
         }
       } @catch (NSException *e) {
         [FBLogger logFmt:@"Got an unexpected exception while monitoring alerts: %@\n%@", e.reason, e.callStackSymbols];
@@ -64,12 +69,31 @@ static const NSTimeInterval FB_MONTORING_INTERVAL = 2.0;
       }
     }
 
+    if (nil == alertElement) {
+      alertElement = [self fb_alertElementFromLimitedAccessPrompt];
+      if (nil != alertElement) {
+        [delegate didDetectAlert:[FBAlert alertWithElement:alertElement]];
+      }
+    }
+
     if (self.isMonitoring) {
       dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delta), dispatch_get_main_queue(), ^{
         [self scheduleNextTick];
       });
     }
   });
+}
+
+- (XCUIElement *)fb_alertElementFromLimitedAccessPrompt
+{
+  @try {
+    XCUIApplication *promptApp = [[XCUIApplication alloc]
+                                  initWithBundleIdentifier:FB_LIMITED_ACCESS_PROMPT_BUNDLE_ID];
+    return promptApp.fb_alertElement;
+  } @catch (NSException *e) {
+    [FBLogger logFmt:@"Got an unexpected exception while monitoring the limited access prompt: %@\n%@", e.reason, e.callStackSymbols];
+    return nil;
+  }
 }
 
 - (void)enable


### PR DESCRIPTION
### Problem
- Since iOS 18, when an app requests limited access to a resource (e.g. the "Select Contacts" selection sheet), the system prompt is hosted in a dedicated process `com.apple.ContactsUI.LimitedAccessPromptView`, that is neither SpringBoard nor the app under test.
- `autoAcceptAlerts` / `autoDismissAlerts` never handle this prompt. 
- The reason is in FBAlertsMonitor: its polling loop only iterates `XCUIApplication.fb_activeApplications`, and this
  prompt's process is not reported by that API [appium/appium#20591](https://github.com/appium/appium/issues/20591), XCTest cannot see these elements, and the process is "not springboard nor the application under test". Since the process is never in the active-apps list, the monitor never scans it, never finds the alert, and never accepts/dismisses it.

### Fix
- In `FBAlertsMonitor`, after the active-apps scan finds no alert, also probe the known limited-access prompt process directly by bundle id and route any alert found through the existing `didDetectAlert: delegate` flow.
