### PR TITLE
feat: Add VoiceOver automation support

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -472,11 +472,6 @@
 		71B49EC71ED1A58100D51AD6 /* XCUIElement+FBUID.h in Headers */ = {isa = PBXBuildFile; fileRef = 71B49EC51ED1A58100D51AD6 /* XCUIElement+FBUID.h */; };
 		71B49EC81ED1A58100D51AD6 /* XCUIElement+FBUID.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B49EC61ED1A58100D51AD6 /* XCUIElement+FBUID.m */; };
 		71BB58DE2B9631B700CB9BFE /* FBVideoRecordingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BB58DD2B9631B700CB9BFE /* FBVideoRecordingTests.m */; };
-		A1B2C3D41F001A00A1B0004 /* XCUIDevice+FBVoiceOver.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A1B2C3D41F001A00A1B0005 /* XCUIDevice+FBVoiceOver.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0002 /* XCUIDevice+FBVoiceOver.m */; };
-		A1B2C3D41F001A00A1B0006 /* XCUIDevice+FBVoiceOver.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A1B2C3D41F001A00A1B0007 /* XCUIDevice+FBVoiceOver.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0002 /* XCUIDevice+FBVoiceOver.m */; };
-		A1B2C3D41F001A00A1B0008 /* FBVoiceOverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0003 /* FBVoiceOverTests.m */; };
 		71BB58E12B9631F100CB9BFE /* FBScreenRecordingPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BB58DF2B9631F100CB9BFE /* FBScreenRecordingPromise.h */; };
 		71BB58E22B9631F100CB9BFE /* FBScreenRecordingPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BB58DF2B9631F100CB9BFE /* FBScreenRecordingPromise.h */; };
 		71BB58E32B9631F100CB9BFE /* FBScreenRecordingPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BB58E02B9631F100CB9BFE /* FBScreenRecordingPromise.m */; };
@@ -540,6 +535,11 @@
 		71F5BE50252F14EB00EE9EBA /* FBExceptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 71F5BE4D252F14EB00EE9EBA /* FBExceptions.h */; };
 		71F5BE51252F14EB00EE9EBA /* FBExceptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 71F5BE4E252F14EB00EE9EBA /* FBExceptions.m */; };
 		71F5BE52252F14EB00EE9EBA /* FBExceptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 71F5BE4E252F14EB00EE9EBA /* FBExceptions.m */; };
+		A1B2C3D41F001A00A1B0004 /* XCUIDevice+FBVoiceOver.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A1B2C3D41F001A00A1B0005 /* XCUIDevice+FBVoiceOver.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0002 /* XCUIDevice+FBVoiceOver.m */; };
+		A1B2C3D41F001A00A1B0006 /* XCUIDevice+FBVoiceOver.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A1B2C3D41F001A00A1B0007 /* XCUIDevice+FBVoiceOver.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0002 /* XCUIDevice+FBVoiceOver.m */; };
+		A1B2C3D41F001A00A1B0008 /* FBVoiceOverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0003 /* FBVoiceOverTests.m */; };
 		A1B2C3D4E5F600000000001B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000001A /* Assets.xcassets */; };
 		AABBCCDDEEFF001122334457 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AABBCCDDEEFF001122334456 /* SceneDelegate.m */; };
 		AD35D06C1CF1C35500870A75 /* WebDriverAgentLib.framework in Copy frameworks */ = {isa = PBXBuildFile; fileRef = EE158A991CBD452B00A3E3F0 /* WebDriverAgentLib.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -1130,15 +1130,15 @@
 		71F5BE33252E5B2200EE9EBA /* FBElementSwipingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBElementSwipingTests.m; sourceTree = "<group>"; };
 		71F5BE4D252F14EB00EE9EBA /* FBExceptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBExceptions.h; sourceTree = "<group>"; };
 		71F5BE4E252F14EB00EE9EBA /* FBExceptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBExceptions.m; sourceTree = "<group>"; };
+		A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCUIDevice+FBVoiceOver.h"; sourceTree = "<group>"; };
+		A1B2C3D41F001A00A1B0002 /* XCUIDevice+FBVoiceOver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCUIDevice+FBVoiceOver.m"; sourceTree = "<group>"; };
+		A1B2C3D41F001A00A1B0003 /* FBVoiceOverTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBVoiceOverTests.m; sourceTree = "<group>"; };
 		A1B2C3D4E5F600000000001A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = WebDriverAgentRunner/Assets.xcassets; sourceTree = SOURCE_ROOT; };
 		AABBCCDDEEFF001122334455 /* SceneDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
 		AABBCCDDEEFF001122334456 /* SceneDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SceneDelegate.m; sourceTree = "<group>"; };
 		AD42DD2A1CF121E600806E5D /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		AD6C26921CF2379700F8B5FF /* FBAlert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FBAlert.h; path = WebDriverAgentLib/FBAlert.h; sourceTree = SOURCE_ROOT; };
 		AD6C26931CF2379700F8B5FF /* FBAlert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = FBAlert.m; path = WebDriverAgentLib/FBAlert.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCUIDevice+FBVoiceOver.h"; sourceTree = "<group>"; };
-		A1B2C3D41F001A00A1B0002 /* XCUIDevice+FBVoiceOver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCUIDevice+FBVoiceOver.m"; sourceTree = "<group>"; };
-		A1B2C3D41F001A00A1B0003 /* FBVoiceOverTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBVoiceOverTests.m; sourceTree = "<group>"; };
 		AD6C26961CF2481700F8B5FF /* XCUIDevice+FBHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCUIDevice+FBHelpers.h"; sourceTree = "<group>"; };
 		AD6C26971CF2481700F8B5FF /* XCUIDevice+FBHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCUIDevice+FBHelpers.m"; sourceTree = "<group>"; };
 		AD6C269A1CF2494200F8B5FF /* XCUIApplication+FBHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCUIApplication+FBHelpers.h"; sourceTree = "<group>"; };
@@ -4316,7 +4316,7 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = WebDriverAgentTests/IntegrationApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4333,7 +4333,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = WebDriverAgentTests/IntegrationApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -472,6 +472,11 @@
 		71B49EC71ED1A58100D51AD6 /* XCUIElement+FBUID.h in Headers */ = {isa = PBXBuildFile; fileRef = 71B49EC51ED1A58100D51AD6 /* XCUIElement+FBUID.h */; };
 		71B49EC81ED1A58100D51AD6 /* XCUIElement+FBUID.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B49EC61ED1A58100D51AD6 /* XCUIElement+FBUID.m */; };
 		71BB58DE2B9631B700CB9BFE /* FBVideoRecordingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BB58DD2B9631B700CB9BFE /* FBVideoRecordingTests.m */; };
+		A1B2C3D41F001A00A1B0004 /* XCUIDevice+FBVoiceOver.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A1B2C3D41F001A00A1B0005 /* XCUIDevice+FBVoiceOver.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0002 /* XCUIDevice+FBVoiceOver.m */; };
+		A1B2C3D41F001A00A1B0006 /* XCUIDevice+FBVoiceOver.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A1B2C3D41F001A00A1B0007 /* XCUIDevice+FBVoiceOver.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0002 /* XCUIDevice+FBVoiceOver.m */; };
+		A1B2C3D41F001A00A1B0008 /* FBVoiceOverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0003 /* FBVoiceOverTests.m */; };
 		71BB58E12B9631F100CB9BFE /* FBScreenRecordingPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BB58DF2B9631F100CB9BFE /* FBScreenRecordingPromise.h */; };
 		71BB58E22B9631F100CB9BFE /* FBScreenRecordingPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BB58DF2B9631F100CB9BFE /* FBScreenRecordingPromise.h */; };
 		71BB58E32B9631F100CB9BFE /* FBScreenRecordingPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BB58E02B9631F100CB9BFE /* FBScreenRecordingPromise.m */; };
@@ -1131,6 +1136,9 @@
 		AD42DD2A1CF121E600806E5D /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		AD6C26921CF2379700F8B5FF /* FBAlert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FBAlert.h; path = WebDriverAgentLib/FBAlert.h; sourceTree = SOURCE_ROOT; };
 		AD6C26931CF2379700F8B5FF /* FBAlert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = FBAlert.m; path = WebDriverAgentLib/FBAlert.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCUIDevice+FBVoiceOver.h"; sourceTree = "<group>"; };
+		A1B2C3D41F001A00A1B0002 /* XCUIDevice+FBVoiceOver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCUIDevice+FBVoiceOver.m"; sourceTree = "<group>"; };
+		A1B2C3D41F001A00A1B0003 /* FBVoiceOverTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBVoiceOverTests.m; sourceTree = "<group>"; };
 		AD6C26961CF2481700F8B5FF /* XCUIDevice+FBHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCUIDevice+FBHelpers.h"; sourceTree = "<group>"; };
 		AD6C26971CF2481700F8B5FF /* XCUIDevice+FBHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCUIDevice+FBHelpers.m"; sourceTree = "<group>"; };
 		AD6C269A1CF2494200F8B5FF /* XCUIApplication+FBHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCUIApplication+FBHelpers.h"; sourceTree = "<group>"; };
@@ -1798,6 +1806,8 @@
 				EEDFE1201D9C06F800E6FFE5 /* XCUIDevice+FBHealthCheck.m */,
 				AD6C26961CF2481700F8B5FF /* XCUIDevice+FBHelpers.h */,
 				AD6C26971CF2481700F8B5FF /* XCUIDevice+FBHelpers.m */,
+				A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */,
+				A1B2C3D41F001A00A1B0002 /* XCUIDevice+FBVoiceOver.m */,
 				EEE3763D1D59F81400ED88DD /* XCUIDevice+FBRotation.h */,
 				EEE3763E1D59F81400ED88DD /* XCUIDevice+FBRotation.m */,
 				EE9AB7451CAEDF0C008C271F /* XCUIElement+FBAccessibility.h */,
@@ -2070,6 +2080,7 @@
 				AD76723F1D6B826F00610457 /* FBTypingTest.m */,
 				714CA3C61DC23186000F12C9 /* FBXPathIntegrationTests.m */,
 				71BB58DD2B9631B700CB9BFE /* FBVideoRecordingTests.m */,
+				A1B2C3D41F001A00A1B0003 /* FBVoiceOverTests.m */,
 				71241D7D1FAF084E00B9559F /* FBW3CTouchActionsIntegrationTests.m */,
 				71241D7F1FAF087500B9559F /* FBW3CMultiTouchActionsIntegrationTests.m */,
 				7136C0F8243A182400921C76 /* FBW3CTypeActionsTests.m */,
@@ -2513,6 +2524,7 @@
 				71822777258744CE00661B83 /* DDNumber.h in Headers */,
 				641EE6C82240C5CA00173FCB /* XCTKVOExpectation.h in Headers */,
 				641EE6C92240C5CA00173FCB /* XCUIDevice+FBRotation.h in Headers */,
+				A1B2C3D41F001A00A1B0004 /* XCUIDevice+FBVoiceOver.h in Headers */,
 				641EE6CA2240C5CA00173FCB /* XCEventGenerator.h in Headers */,
 				719DCF162601EAFB000E765F /* FBNotificationsHelper.h in Headers */,
 				71414ED52670A1EE003A8C5D /* LRUCache.h in Headers */,
@@ -2760,6 +2772,7 @@
 				EE35AD591E3B77D600A02D78 /* XCTKVOExpectation.h in Headers */,
 				13DE7A43287C2A8D003243C6 /* FBXCAccessibilityElement.h in Headers */,
 				EEE376431D59F81400ED88DD /* XCUIDevice+FBRotation.h in Headers */,
+				A1B2C3D41F001A00A1B0006 /* XCUIDevice+FBVoiceOver.h in Headers */,
 				EE35AD2E1E3B77D600A02D78 /* XCEventGenerator.h in Headers */,
 				EE9B76A61CF7A43900275851 /* FBConfiguration.h in Headers */,
 				EE35AD571E3B77D600A02D78 /* XCTestSuiteRun.h in Headers */,
@@ -3206,6 +3219,7 @@
 				641EE5F22240C5CA00173FCB /* NSPredicate+FBFormat.m in Sources */,
 				718F49CA23087AD30045FE8B /* FBProtocolHelpers.m in Sources */,
 				641EE5F42240C5CA00173FCB /* XCUIDevice+FBRotation.m in Sources */,
+				A1B2C3D41F001A00A1B0005 /* XCUIDevice+FBVoiceOver.m in Sources */,
 				13815F722328D20400CDAB61 /* FBActiveAppDetectionPoint.m in Sources */,
 				71D475C52538F5A8008D9401 /* XCUIApplicationProcess+FBQuiescence.m in Sources */,
 				641EE5F52240C5CA00173FCB /* XCUIElement+FBUID.m in Sources */,
@@ -3333,6 +3347,7 @@
 				71A224E61DE2F56600844D55 /* NSPredicate+FBFormat.m in Sources */,
 				E444DC85249131B10060D7EB /* DDNumber.m in Sources */,
 				EEE376441D59F81400ED88DD /* XCUIDevice+FBRotation.m in Sources */,
+				A1B2C3D41F001A00A1B0007 /* XCUIDevice+FBVoiceOver.m in Sources */,
 				13815F712328D20400CDAB61 /* FBActiveAppDetectionPoint.m in Sources */,
 				71B49EC81ED1A58100D51AD6 /* XCUIElement+FBUID.m in Sources */,
 				EE158AE21CBD456F00A3E3F0 /* FBRouteRequest.m in Sources */,
@@ -3422,6 +3437,7 @@
 			files = (
 				71241D801FAF087500B9559F /* FBW3CMultiTouchActionsIntegrationTests.m in Sources */,
 				71BB58DE2B9631B700CB9BFE /* FBVideoRecordingTests.m in Sources */,
+				A1B2C3D41F001A00A1B0008 /* FBVoiceOverTests.m in Sources */,
 				71241D7E1FAF084E00B9559F /* FBW3CTouchActionsIntegrationTests.m in Sources */,
 				63FD950221F9D06100A3E356 /* FBImageProcessorTests.m in Sources */,
 				719CD8FF2126C90200C7D0C2 /* FBAutoAlertsHandlerTests.m in Sources */,

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.h
@@ -44,20 +44,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)fb_isVoiceOverEnabled:(NSError **)error;
 
 /**
- Move VoiceOver to the next element and return its speech. Only works since Xcode 27/iOS 27.
+ Move VoiceOver focus and return speech for the newly focused element.
+ Only works since Xcode 27/iOS 27.
 
+ @param direction One of: forward, backward, in (iOS only), out (iOS only)
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return The spoken utterance or nil in case of failure
  */
-- (nullable NSString *)fb_voiceOverMoveForward:(NSError **)error;
-
-/**
- Move VoiceOver to the previous element and return its speech. Only works since Xcode 27/iOS 27.
-
- @param error If there is an error, upon return contains an NSError object that describes the problem.
- @return The spoken utterance or nil in case of failure
- */
-- (nullable NSString *)fb_voiceOverMoveBackward:(NSError **)error;
+- (nullable NSString *)fb_voiceOverMove:(NSString *)direction error:(NSError **)error;
 
 /**
  Return the speech for the currently focused element. Only works since Xcode 27/iOS 27.
@@ -66,24 +60,6 @@ NS_ASSUME_NONNULL_BEGIN
  @return The spoken utterance or nil in case of failure
  */
 - (nullable NSString *)fb_voiceOverCurrentSpeech:(NSError **)error;
-
-#if TARGET_OS_IOS
-/**
- Move VoiceOver into the current container and return its speech. Only works since Xcode 27/iOS 27.
-
- @param error If there is an error, upon return contains an NSError object that describes the problem.
- @return The spoken utterance or nil in case of failure
- */
-- (nullable NSString *)fb_voiceOverMoveIn:(NSError **)error;
-
-/**
- Move VoiceOver out of the current container and return its speech. Only works since Xcode 27/iOS 27.
-
- @param error If there is an error, upon return contains an NSError object that describes the problem.
- @return The spoken utterance or nil in case of failure
- */
-- (nullable NSString *)fb_voiceOverMoveOut:(NSError **)error;
-#endif
 
 @end
 

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.h
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <XCTest/XCTest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface XCUIDevice (FBVoiceOver)
+
+/**
+ Whether VoiceOver control APIs are available in the current Xcode SDK.
+
+ @return YES if the VoiceOver service is exposed by XCUIDevice
+ */
+- (BOOL)fb_isVoiceOverServiceAvailable;
+
+/**
+ Enable VoiceOver. Only works since Xcode 27/iOS 27.
+
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return YES if VoiceOver has been successfully enabled
+ */
+- (BOOL)fb_enableVoiceOver:(NSError **)error;
+
+/**
+ Disable VoiceOver. Only works since Xcode 27/iOS 27.
+
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return YES if VoiceOver has been successfully disabled
+ */
+- (BOOL)fb_disableVoiceOver:(NSError **)error;
+
+/**
+ Whether VoiceOver is currently enabled. Only works since Xcode 27/iOS 27.
+
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return YES if VoiceOver is enabled
+ */
+- (BOOL)fb_isVoiceOverEnabled:(NSError **)error;
+
+/**
+ Move VoiceOver to the next element and return its speech. Only works since Xcode 27/iOS 27.
+
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return The spoken utterance or nil in case of failure
+ */
+- (nullable NSString *)fb_voiceOverMoveForward:(NSError **)error;
+
+/**
+ Move VoiceOver to the previous element and return its speech. Only works since Xcode 27/iOS 27.
+
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return The spoken utterance or nil in case of failure
+ */
+- (nullable NSString *)fb_voiceOverMoveBackward:(NSError **)error;
+
+/**
+ Return the speech for the currently focused element. Only works since Xcode 27/iOS 27.
+
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return The spoken utterance or nil in case of failure
+ */
+- (nullable NSString *)fb_voiceOverCurrentSpeech:(NSError **)error;
+
+#if TARGET_OS_IOS
+/**
+ Move VoiceOver into the current container and return its speech. Only works since Xcode 27/iOS 27.
+
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return The spoken utterance or nil in case of failure
+ */
+- (nullable NSString *)fb_voiceOverMoveIn:(NSError **)error;
+
+/**
+ Move VoiceOver out of the current container and return its speech. Only works since Xcode 27/iOS 27.
+
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return The spoken utterance or nil in case of failure
+ */
+- (nullable NSString *)fb_voiceOverMoveOut:(NSError **)error;
+#endif
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.m
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "XCUIDevice+FBVoiceOver.h"
+
+#import "FBErrorBuilder.h"
+
+static NSString *const FBVoiceOverSDKUnsupportedError =
+@"The current Xcode SDK does not support VoiceOver control. Consider upgrading to Xcode 27+/iOS 27+";
+
+static BOOL FBVoiceOverBuildSDKUnsupportedError(NSError **error)
+{
+  return [[[FBErrorBuilder builder]
+           withDescription:FBVoiceOverSDKUnsupportedError]
+          buildError:error];
+}
+
+static BOOL isVoiceOverServiceAvailable = NO;
+static dispatch_once_t voiceOverServiceOnceToken;
+
+static void FBInitializeVoiceOverServiceAvailability(void)
+{
+  dispatch_once(&voiceOverServiceOnceToken, ^{
+    isVoiceOverServiceAvailable = [XCUIDevice.sharedDevice respondsToSelector:NSSelectorFromString(@"voiceOverService")];
+  });
+}
+
+static id FBVoiceOverService(NSError **error)
+{
+  FBInitializeVoiceOverServiceAvailability();
+  if (!isVoiceOverServiceAvailable) {
+    FBVoiceOverBuildSDKUnsupportedError(error);
+    return nil;
+  }
+  return [XCUIDevice.sharedDevice valueForKey:@"voiceOverService"];
+}
+
+static BOOL FBInvokeVoiceOverBoolMethod(id voiceOverService,
+                                        SEL selector,
+                                        NSError **error)
+{
+  if (![voiceOverService respondsToSelector:selector]) {
+    return FBVoiceOverBuildSDKUnsupportedError(error);
+  }
+
+  NSMethodSignature *signature = [voiceOverService methodSignatureForSelector:selector];
+  NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+  [invocation setSelector:selector];
+  [invocation setTarget:voiceOverService];
+  NSError *invokeError = nil;
+  [invocation setArgument:&invokeError atIndex:2];
+  [invocation invoke];
+  if (nil != invokeError) {
+    if (error) {
+      *error = invokeError;
+    }
+    return NO;
+  }
+
+  BOOL result = NO;
+  [invocation getReturnValue:&result];
+  return result;
+}
+
+static id FBInvokeVoiceOverOutputMethod(id voiceOverService,
+                                        SEL selector,
+                                        NSError **error)
+{
+  if (![voiceOverService respondsToSelector:selector]) {
+    FBVoiceOverBuildSDKUnsupportedError(error);
+    return nil;
+  }
+
+  NSMethodSignature *signature = [voiceOverService methodSignatureForSelector:selector];
+  NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+  [invocation setSelector:selector];
+  [invocation setTarget:voiceOverService];
+  NSError *invokeError = nil;
+  [invocation setArgument:&invokeError atIndex:2];
+  [invocation invoke];
+  if (nil != invokeError) {
+    if (error) {
+      *error = invokeError;
+    }
+    return nil;
+  }
+
+  id __unsafe_unretained output = nil;
+  [invocation getReturnValue:&output];
+  return output;
+}
+
+static NSString *FBUtteranceFromVoiceOverOutput(id output, NSError **error)
+{
+  if (nil == output) {
+    return nil;
+  }
+
+  if (![output respondsToSelector:NSSelectorFromString(@"utterance")]) {
+    [[[FBErrorBuilder builder]
+      withDescription:@"VoiceOver output does not provide an utterance"]
+     buildError:error];
+    return nil;
+  }
+
+  id utterance = [output valueForKey:@"utterance"];
+  return [utterance isKindOfClass:NSString.class] ? utterance : nil;
+}
+
+static NSString *FBVoiceOverSpeechFromSelector(SEL selector, NSError **error)
+{
+  id service = FBVoiceOverService(error);
+  if (nil == service) {
+    return nil;
+  }
+
+  id output = FBInvokeVoiceOverOutputMethod(service, selector, error);
+  if (nil != error && nil != *error) {
+    return nil;
+  }
+  return FBUtteranceFromVoiceOverOutput(output, error);
+}
+
+@implementation XCUIDevice (FBVoiceOver)
+
+- (BOOL)fb_isVoiceOverServiceAvailable
+{
+  FBInitializeVoiceOverServiceAvailability();
+  return isVoiceOverServiceAvailable;
+}
+
+- (BOOL)fb_enableVoiceOver:(NSError **)error
+{
+  id service = FBVoiceOverService(error);
+  if (nil == service) {
+    return NO;
+  }
+  return FBInvokeVoiceOverBoolMethod(service,
+                                     NSSelectorFromString(@"enableAndReturnError:"),
+                                     error);
+}
+
+- (BOOL)fb_disableVoiceOver:(NSError **)error
+{
+  id service = FBVoiceOverService(error);
+  if (nil == service) {
+    return NO;
+  }
+  return FBInvokeVoiceOverBoolMethod(service,
+                                     NSSelectorFromString(@"disableAndReturnError:"),
+                                     error);
+}
+
+- (BOOL)fb_isVoiceOverEnabled:(NSError **)error
+{
+  id service = FBVoiceOverService(error);
+  if (nil == service) {
+    return NO;
+  }
+
+  if (![service respondsToSelector:NSSelectorFromString(@"isEnabled")]) {
+    return FBVoiceOverBuildSDKUnsupportedError(error);
+  }
+
+  return [[service valueForKey:@"enabled"] boolValue];
+}
+
+- (nullable NSString *)fb_voiceOverMoveForward:(NSError **)error
+{
+  return FBVoiceOverSpeechFromSelector(NSSelectorFromString(@"moveForwardAndReturnError:"), error);
+}
+
+- (nullable NSString *)fb_voiceOverMoveBackward:(NSError **)error
+{
+  return FBVoiceOverSpeechFromSelector(NSSelectorFromString(@"moveBackwardAndReturnError:"), error);
+}
+
+- (nullable NSString *)fb_voiceOverCurrentSpeech:(NSError **)error
+{
+  return FBVoiceOverSpeechFromSelector(NSSelectorFromString(@"currentSpeechAndReturnError:"), error);
+}
+
+#if TARGET_OS_IOS
+- (nullable NSString *)fb_voiceOverMoveIn:(NSError **)error
+{
+  return FBVoiceOverSpeechFromSelector(NSSelectorFromString(@"moveInAndReturnError:"), error);
+}
+
+- (nullable NSString *)fb_voiceOverMoveOut:(NSError **)error
+{
+  return FBVoiceOverSpeechFromSelector(NSSelectorFromString(@"moveOutAndReturnError:"), error);
+}
+#endif
+
+@end

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.m
@@ -179,7 +179,8 @@ static NSDictionary<NSString *, NSString *> *FBVoiceOverMoveSelectors(void)
     return NO;
   }
 
-  if (![service respondsToSelector:NSSelectorFromString(@"isEnabled")]) {
+  if (![service respondsToSelector:NSSelectorFromString(@"isEnabled")] &&
+      ![service respondsToSelector:NSSelectorFromString(@"enabled")]) {
     return FBVoiceOverBuildSDKUnsupportedError(error);
   }
 

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.m
@@ -126,6 +126,24 @@ static NSString *FBVoiceOverSpeechFromSelector(SEL selector, NSError **error)
   return FBUtteranceFromVoiceOverOutput(output, error);
 }
 
+static NSDictionary<NSString *, NSString *> *FBVoiceOverMoveSelectors(void)
+{
+  static NSDictionary<NSString *, NSString *> *selectors = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSMutableDictionary<NSString *, NSString *> *mapping = [@{
+      @"forward": @"moveForwardAndReturnError:",
+      @"backward": @"moveBackwardAndReturnError:",
+    } mutableCopy];
+#if TARGET_OS_IOS
+    mapping[@"in"] = @"moveInAndReturnError:";
+    mapping[@"out"] = @"moveOutAndReturnError:";
+#endif
+    selectors = mapping.copy;
+  });
+  return selectors;
+}
+
 @implementation XCUIDevice (FBVoiceOver)
 
 - (BOOL)fb_isVoiceOverServiceAvailable
@@ -170,31 +188,30 @@ static NSString *FBVoiceOverSpeechFromSelector(SEL selector, NSError **error)
   return [[service valueForKey:@"enabled"] boolValue];
 }
 
-- (nullable NSString *)fb_voiceOverMoveForward:(NSError **)error
+- (nullable NSString *)fb_voiceOverMove:(NSString *)direction error:(NSError **)error
 {
-  return FBVoiceOverSpeechFromSelector(NSSelectorFromString(@"moveForwardAndReturnError:"), error);
-}
+  if (![direction isKindOfClass:NSString.class] || 0 == direction.length) {
+    return [[[FBErrorBuilder builder]
+             withDescription:@"VoiceOver move direction must be a non-empty string"]
+            buildError:error], nil;
+  }
 
-- (nullable NSString *)fb_voiceOverMoveBackward:(NSError **)error
-{
-  return FBVoiceOverSpeechFromSelector(NSSelectorFromString(@"moveBackwardAndReturnError:"), error);
+  NSString *normalizedDirection = direction.lowercaseString;
+  NSString *selectorName = FBVoiceOverMoveSelectors()[normalizedDirection];
+  if (nil == selectorName) {
+    NSArray *supportedDirections = [FBVoiceOverMoveSelectors().allKeys sortedArrayUsingSelector:@selector(compare:)];
+    return [[[FBErrorBuilder builder]
+             withDescriptionFormat:@"Unsupported VoiceOver move direction '%@'. Supported directions: %@",
+             direction, supportedDirections]
+            buildError:error], nil;
+  }
+
+  return FBVoiceOverSpeechFromSelector(NSSelectorFromString(selectorName), error);
 }
 
 - (nullable NSString *)fb_voiceOverCurrentSpeech:(NSError **)error
 {
   return FBVoiceOverSpeechFromSelector(NSSelectorFromString(@"currentSpeechAndReturnError:"), error);
 }
-
-#if TARGET_OS_IOS
-- (nullable NSString *)fb_voiceOverMoveIn:(NSError **)error
-{
-  return FBVoiceOverSpeechFromSelector(NSSelectorFromString(@"moveInAndReturnError:"), error);
-}
-
-- (nullable NSString *)fb_voiceOverMoveOut:(NSError **)error
-{
-  return FBVoiceOverSpeechFromSelector(NSSelectorFromString(@"moveOutAndReturnError:"), error);
-}
-#endif
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.m
@@ -20,20 +20,19 @@ static BOOL FBVoiceOverBuildSDKUnsupportedError(NSError **error)
           buildError:error];
 }
 
-static BOOL isVoiceOverServiceAvailable = NO;
-static dispatch_once_t voiceOverServiceOnceToken;
-
-static void FBInitializeVoiceOverServiceAvailability(void)
+static BOOL FBIsVoiceOverServiceAvailable(void)
 {
-  dispatch_once(&voiceOverServiceOnceToken, ^{
-    isVoiceOverServiceAvailable = [XCUIDevice.sharedDevice respondsToSelector:NSSelectorFromString(@"voiceOverService")];
+  static BOOL isAvailable = NO;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    isAvailable = [XCUIDevice.sharedDevice respondsToSelector:NSSelectorFromString(@"voiceOverService")];
   });
+  return isAvailable;
 }
 
 static id FBVoiceOverService(NSError **error)
 {
-  FBInitializeVoiceOverServiceAvailability();
-  if (!isVoiceOverServiceAvailable) {
+  if (!FBIsVoiceOverServiceAvailable()) {
     FBVoiceOverBuildSDKUnsupportedError(error);
     return nil;
   }
@@ -148,8 +147,7 @@ static NSDictionary<NSString *, NSString *> *FBVoiceOverMoveSelectors(void)
 
 - (BOOL)fb_isVoiceOverServiceAvailable
 {
-  FBInitializeVoiceOverServiceAvailability();
-  return isVoiceOverServiceAvailable;
+  return FBIsVoiceOverServiceAvailable();
 }
 
 - (BOOL)fb_enableVoiceOver:(NSError **)error

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -26,6 +26,7 @@
 #import "XCUIApplication.h"
 #import "XCUIApplication+FBHelpers.h"
 #import "XCUIDevice+FBHelpers.h"
+#import "XCUIDevice+FBVoiceOver.h"
 #import "XCUIElement.h"
 #import "XCUIElement+FBIsVisible.h"
 #import "XCUIElementQuery.h"
@@ -80,6 +81,24 @@
     [[FBRoute POST:@"/wda/simulatedLocation"].withoutSession respondWithTarget:self action:@selector(handleSetSimulatedLocation:)],
     [[FBRoute DELETE:@"/wda/simulatedLocation"] respondWithTarget:self action:@selector(handleClearSimulatedLocation:)],
     [[FBRoute DELETE:@"/wda/simulatedLocation"].withoutSession respondWithTarget:self action:@selector(handleClearSimulatedLocation:)],
+#endif
+    [[FBRoute POST:@"/wda/voiceOver/enable"] respondWithTarget:self action:@selector(handleVoiceOverEnable:)],
+    [[FBRoute POST:@"/wda/voiceOver/enable"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverEnable:)],
+    [[FBRoute POST:@"/wda/voiceOver/disable"] respondWithTarget:self action:@selector(handleVoiceOverDisable:)],
+    [[FBRoute POST:@"/wda/voiceOver/disable"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverDisable:)],
+    [[FBRoute GET:@"/wda/voiceOver/enabled"] respondWithTarget:self action:@selector(handleVoiceOverEnabled:)],
+    [[FBRoute GET:@"/wda/voiceOver/enabled"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverEnabled:)],
+    [[FBRoute POST:@"/wda/voiceOver/moveForward"] respondWithTarget:self action:@selector(handleVoiceOverMoveForward:)],
+    [[FBRoute POST:@"/wda/voiceOver/moveForward"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverMoveForward:)],
+    [[FBRoute POST:@"/wda/voiceOver/moveBackward"] respondWithTarget:self action:@selector(handleVoiceOverMoveBackward:)],
+    [[FBRoute POST:@"/wda/voiceOver/moveBackward"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverMoveBackward:)],
+    [[FBRoute GET:@"/wda/voiceOver/currentSpeech"] respondWithTarget:self action:@selector(handleVoiceOverCurrentSpeech:)],
+    [[FBRoute GET:@"/wda/voiceOver/currentSpeech"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverCurrentSpeech:)],
+#if TARGET_OS_IOS
+    [[FBRoute POST:@"/wda/voiceOver/moveIn"] respondWithTarget:self action:@selector(handleVoiceOverMoveIn:)],
+    [[FBRoute POST:@"/wda/voiceOver/moveIn"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverMoveIn:)],
+    [[FBRoute POST:@"/wda/voiceOver/moveOut"] respondWithTarget:self action:@selector(handleVoiceOverMoveOut:)],
+    [[FBRoute POST:@"/wda/voiceOver/moveOut"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverMoveOut:)],
 #endif
     [[FBRoute OPTIONS:@"/*"].withoutSession respondWithTarget:self action:@selector(handlePingCommand:)],
   ];
@@ -609,6 +628,86 @@
   return FBResponseWithOK();
 }
 #endif
+#endif
+
++ (id<FBResponsePayload>)fb_handleVoiceOverSpeechResponse:(nullable NSString *)utterance
+                                                      error:(NSError *)error
+{
+  if (nil != error) {
+    return FBResponseWithStatus([FBCommandStatus unknownErrorWithMessage:error.description
+                                                               traceback:nil]);
+  }
+  return FBResponseWithObject(@{
+    @"utterance": utterance ?: NSNull.null,
+  });
+}
+
++ (id<FBResponsePayload>)handleVoiceOverEnable:(FBRouteRequest *)request
+{
+  NSError *error;
+  if (![XCUIDevice.sharedDevice fb_enableVoiceOver:&error]) {
+    return FBResponseWithStatus([FBCommandStatus unknownErrorWithMessage:error.description
+                                                               traceback:nil]);
+  }
+  return FBResponseWithOK();
+}
+
++ (id<FBResponsePayload>)handleVoiceOverDisable:(FBRouteRequest *)request
+{
+  NSError *error;
+  if (![XCUIDevice.sharedDevice fb_disableVoiceOver:&error]) {
+    return FBResponseWithStatus([FBCommandStatus unknownErrorWithMessage:error.description
+                                                               traceback:nil]);
+  }
+  return FBResponseWithOK();
+}
+
++ (id<FBResponsePayload>)handleVoiceOverEnabled:(FBRouteRequest *)request
+{
+  NSError *error;
+  BOOL isEnabled = [XCUIDevice.sharedDevice fb_isVoiceOverEnabled:&error];
+  if (nil != error) {
+    return FBResponseWithStatus([FBCommandStatus unknownErrorWithMessage:error.description
+                                                               traceback:nil]);
+  }
+  return FBResponseWithObject(@{@"enabled": @(isEnabled)});
+}
+
++ (id<FBResponsePayload>)handleVoiceOverMoveForward:(FBRouteRequest *)request
+{
+  NSError *error;
+  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverMoveForward:&error];
+  return [self fb_handleVoiceOverSpeechResponse:utterance error:error];
+}
+
++ (id<FBResponsePayload>)handleVoiceOverMoveBackward:(FBRouteRequest *)request
+{
+  NSError *error;
+  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverMoveBackward:&error];
+  return [self fb_handleVoiceOverSpeechResponse:utterance error:error];
+}
+
++ (id<FBResponsePayload>)handleVoiceOverCurrentSpeech:(FBRouteRequest *)request
+{
+  NSError *error;
+  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverCurrentSpeech:&error];
+  return [self fb_handleVoiceOverSpeechResponse:utterance error:error];
+}
+
+#if TARGET_OS_IOS
++ (id<FBResponsePayload>)handleVoiceOverMoveIn:(FBRouteRequest *)request
+{
+  NSError *error;
+  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverMoveIn:&error];
+  return [self fb_handleVoiceOverSpeechResponse:utterance error:error];
+}
+
++ (id<FBResponsePayload>)handleVoiceOverMoveOut:(FBRouteRequest *)request
+{
+  NSError *error;
+  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverMoveOut:&error];
+  return [self fb_handleVoiceOverSpeechResponse:utterance error:error];
+}
 #endif
 
 + (id<FBResponsePayload>)handlePerformAccessibilityAudit:(FBRouteRequest *)request

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -88,18 +88,10 @@
     [[FBRoute POST:@"/wda/voiceOver/disable"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverDisable:)],
     [[FBRoute GET:@"/wda/voiceOver/enabled"] respondWithTarget:self action:@selector(handleVoiceOverEnabled:)],
     [[FBRoute GET:@"/wda/voiceOver/enabled"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverEnabled:)],
-    [[FBRoute POST:@"/wda/voiceOver/moveForward"] respondWithTarget:self action:@selector(handleVoiceOverMoveForward:)],
-    [[FBRoute POST:@"/wda/voiceOver/moveForward"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverMoveForward:)],
-    [[FBRoute POST:@"/wda/voiceOver/moveBackward"] respondWithTarget:self action:@selector(handleVoiceOverMoveBackward:)],
-    [[FBRoute POST:@"/wda/voiceOver/moveBackward"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverMoveBackward:)],
+    [[FBRoute POST:@"/wda/voiceOver/move"] respondWithTarget:self action:@selector(handleVoiceOverMove:)],
+    [[FBRoute POST:@"/wda/voiceOver/move"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverMove:)],
     [[FBRoute GET:@"/wda/voiceOver/currentSpeech"] respondWithTarget:self action:@selector(handleVoiceOverCurrentSpeech:)],
     [[FBRoute GET:@"/wda/voiceOver/currentSpeech"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverCurrentSpeech:)],
-#if TARGET_OS_IOS
-    [[FBRoute POST:@"/wda/voiceOver/moveIn"] respondWithTarget:self action:@selector(handleVoiceOverMoveIn:)],
-    [[FBRoute POST:@"/wda/voiceOver/moveIn"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverMoveIn:)],
-    [[FBRoute POST:@"/wda/voiceOver/moveOut"] respondWithTarget:self action:@selector(handleVoiceOverMoveOut:)],
-    [[FBRoute POST:@"/wda/voiceOver/moveOut"].withoutSession respondWithTarget:self action:@selector(handleVoiceOverMoveOut:)],
-#endif
     [[FBRoute OPTIONS:@"/*"].withoutSession respondWithTarget:self action:@selector(handlePingCommand:)],
   ];
 }
@@ -673,18 +665,23 @@
   return FBResponseWithObject(@{@"enabled": @(isEnabled)});
 }
 
-+ (id<FBResponsePayload>)handleVoiceOverMoveForward:(FBRouteRequest *)request
++ (id<FBResponsePayload>)handleVoiceOverMove:(FBRouteRequest *)request
 {
-  NSError *error;
-  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverMoveForward:&error];
-  return [self fb_handleVoiceOverSpeechResponse:utterance error:error];
-}
+  NSString *direction = request.arguments[@"direction"];
+  if (nil == direction) {
+    return FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"The 'direction' argument must be provided"
+                                                                       traceback:nil]);
+  }
 
-+ (id<FBResponsePayload>)handleVoiceOverMoveBackward:(FBRouteRequest *)request
-{
   NSError *error;
-  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverMoveBackward:&error];
-  return [self fb_handleVoiceOverSpeechResponse:utterance error:error];
+  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverMove:direction error:&error];
+  if (nil != error) {
+    FBCommandStatus *status = [error.localizedDescription containsString:@"Unsupported VoiceOver move direction"]
+      ? [FBCommandStatus invalidArgumentErrorWithMessage:error.description traceback:nil]
+      : [FBCommandStatus unknownErrorWithMessage:error.description traceback:nil];
+    return FBResponseWithStatus(status);
+  }
+  return [self fb_handleVoiceOverSpeechResponse:utterance error:nil];
 }
 
 + (id<FBResponsePayload>)handleVoiceOverCurrentSpeech:(FBRouteRequest *)request
@@ -693,22 +690,6 @@
   NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverCurrentSpeech:&error];
   return [self fb_handleVoiceOverSpeechResponse:utterance error:error];
 }
-
-#if TARGET_OS_IOS
-+ (id<FBResponsePayload>)handleVoiceOverMoveIn:(FBRouteRequest *)request
-{
-  NSError *error;
-  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverMoveIn:&error];
-  return [self fb_handleVoiceOverSpeechResponse:utterance error:error];
-}
-
-+ (id<FBResponsePayload>)handleVoiceOverMoveOut:(FBRouteRequest *)request
-{
-  NSError *error;
-  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverMoveOut:&error];
-  return [self fb_handleVoiceOverSpeechResponse:utterance error:error];
-}
-#endif
 
 + (id<FBResponsePayload>)handlePerformAccessibilityAudit:(FBRouteRequest *)request
 {

--- a/WebDriverAgentLib/WebDriverAgentLib.h
+++ b/WebDriverAgentLib/WebDriverAgentLib.h
@@ -48,6 +48,7 @@ FOUNDATION_EXPORT const unsigned char WebDriverAgentLib_VersionString[];
 #import <WebDriverAgentLib/XCUIApplication+FBHelpers.h>
 #import <WebDriverAgentLib/XCUIDevice+FBHelpers.h>
 #import <WebDriverAgentLib/XCUIDevice+FBRotation.h>
+#import <WebDriverAgentLib/XCUIDevice+FBVoiceOver.h>
 #import <WebDriverAgentLib/XCUIElement.h>
 #import <WebDriverAgentLib/XCUIElement+FBAccessibility.h>
 #import <WebDriverAgentLib/XCUIElement+FBFind.h>

--- a/WebDriverAgentTests/IntegrationTests/FBVoiceOverTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBVoiceOverTests.m
@@ -58,7 +58,7 @@
   XCTAssertTrue([XCUIDevice.sharedDevice fb_isVoiceOverEnabled:&error]);
   XCTAssertNil(error);
 
-  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverMoveForward:&error];
+  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverMove:@"forward" error:&error];
   XCTAssertNil(error);
   XCTAssertNotNil(utterance);
   XCTAssertTrue(utterance.length > 0);
@@ -90,10 +90,10 @@
   XCTAssertTrue([XCUIDevice.sharedDevice fb_enableVoiceOver:&error]);
   XCTAssertNil(error);
 
-  XCTAssertNotNil([XCUIDevice.sharedDevice fb_voiceOverMoveForward:&error]);
+  XCTAssertNotNil([XCUIDevice.sharedDevice fb_voiceOverMove:@"forward" error:&error]);
   XCTAssertNil(error);
 
-  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverMoveBackward:&error];
+  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverMove:@"backward" error:&error];
   XCTAssertNil(error);
   XCTAssertNotNil(utterance);
   XCTAssertTrue(utterance.length > 0);

--- a/WebDriverAgentTests/IntegrationTests/FBVoiceOverTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBVoiceOverTests.m
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FBIntegrationTestCase.h"
+#import "FBMacros.h"
+#import "FBTestMacros.h"
+#import "XCUIDevice+FBVoiceOver.h"
+
+@interface FBVoiceOverTests : FBIntegrationTestCase
+@end
+
+@implementation FBVoiceOverTests
+
+- (void)tearDown
+{
+  if ([XCUIDevice.sharedDevice fb_isVoiceOverServiceAvailable]) {
+    NSError *error = nil;
+    if ([XCUIDevice.sharedDevice fb_isVoiceOverEnabled:&error] && nil == error) {
+      [XCUIDevice.sharedDevice fb_disableVoiceOver:&error];
+    }
+  }
+  [super tearDown];
+}
+
+- (void)testVoiceOverUnavailableOnOlderSDK
+{
+  if ([XCUIDevice.sharedDevice fb_isVoiceOverServiceAvailable]) {
+    return;
+  }
+
+  NSError *error = nil;
+  XCTAssertFalse([XCUIDevice.sharedDevice fb_enableVoiceOver:&error]);
+  XCTAssertNotNil(error);
+  XCTAssertTrue([error.localizedDescription containsString:@"Xcode 27"]);
+}
+
+- (void)testVoiceOverEnableDisableAndNavigation
+{
+  if (SYSTEM_VERSION_LESS_THAN(@"27.0")) {
+    return;
+  }
+  if (![XCUIDevice.sharedDevice fb_isVoiceOverServiceAvailable]) {
+    return;
+  }
+
+  [self launchApplication];
+
+  NSError *error = nil;
+  XCTAssertTrue([XCUIDevice.sharedDevice fb_enableVoiceOver:&error]);
+  XCTAssertNil(error);
+  XCTAssertTrue([XCUIDevice.sharedDevice fb_isVoiceOverEnabled:&error]);
+  XCTAssertNil(error);
+
+  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverMoveForward:&error];
+  XCTAssertNil(error);
+  XCTAssertNotNil(utterance);
+  XCTAssertTrue(utterance.length > 0);
+
+  NSString *currentSpeech = [XCUIDevice.sharedDevice fb_voiceOverCurrentSpeech:&error];
+  XCTAssertNil(error);
+  XCTAssertNotNil(currentSpeech);
+  XCTAssertEqualObjects(currentSpeech, utterance);
+
+  XCTAssertTrue([XCUIDevice.sharedDevice fb_disableVoiceOver:&error]);
+  XCTAssertNil(error);
+  XCTAssertFalse([XCUIDevice.sharedDevice fb_isVoiceOverEnabled:&error]);
+  XCTAssertNil(error);
+}
+
+#if TARGET_OS_IOS
+- (void)testVoiceOverMoveBackward
+{
+  if (SYSTEM_VERSION_LESS_THAN(@"27.0")) {
+    return;
+  }
+  if (![XCUIDevice.sharedDevice fb_isVoiceOverServiceAvailable]) {
+    return;
+  }
+
+  [self launchApplication];
+
+  NSError *error = nil;
+  XCTAssertTrue([XCUIDevice.sharedDevice fb_enableVoiceOver:&error]);
+  XCTAssertNil(error);
+
+  XCTAssertNotNil([XCUIDevice.sharedDevice fb_voiceOverMoveForward:&error]);
+  XCTAssertNil(error);
+
+  NSString *utterance = [XCUIDevice.sharedDevice fb_voiceOverMoveBackward:&error];
+  XCTAssertNil(error);
+  XCTAssertNotNil(utterance);
+  XCTAssertTrue(utterance.length > 0);
+}
+#endif
+
+@end


### PR DESCRIPTION
## Summary

Adds WebDriverAgent support for the new XCTest VoiceOver APIs introduced in Xcode 27 (`XCUIDevice.voiceOverService` / `XCUIVoiceOverService`). Exposes programmatic VoiceOver control over HTTP so it can later be wired into `mobile:` helpers in appium-xcuitest-driver.

## Motivation

Xcode 27 adds first-class VoiceOver automation in XCTest (enable/disable, navigation, speech output). WDA previously had no way to drive these APIs. This PR bridges that gap while remaining buildable on older Xcode versions.

## Changes

### `XCUIDevice+FBVoiceOver` category
Wraps `XCUIVoiceOverService` APIs accessed via `XCUIDevice.sharedDevice`:

| WDA helper | XCTest API |
|---|---|
| `fb_enableVoiceOver:` | `enableAndReturnError:` |
| `fb_disableVoiceOver:` | `disableAndReturnError:` |
| `fb_isVoiceOverEnabled:` | `enabled` |
| `fb_voiceOverMove:error:` | `moveForward` / `moveBackward` / `moveIn` / `moveOut` |
| `fb_voiceOverCurrentSpeech:` | `currentSpeechAndReturnError:` |

Navigation is unified in `fb_voiceOverMove:error:` with a `direction` argument: `forward`, `backward`, `in` (iOS only), `out` (iOS only).

### HTTP routes (`FBCustomCommands`)
New `/wda/voiceOver/*` endpoints (session and `.withoutSession` variants):

| Route | Method | Body | Response |
|---|---|---|---|
| `/wda/voiceOver/enable` | POST | — | `200 OK` |
| `/wda/voiceOver/disable` | POST | — | `200 OK` |
| `/wda/voiceOver/enabled` | GET | — | `{ "enabled": true/false }` |
| `/wda/voiceOver/move` | POST | `{ "direction": "forward" }` | `{ "utterance": "..." }` |
| `/wda/voiceOver/currentSpeech` | GET | — | `{ "utterance": "..." }` |

**Move directions:** `forward`, `backward`, `in`, `out` (case-insensitive; `in`/`out` iOS only).

### Backward compatibility
- No direct references to Xcode 27 SDK symbols at compile time
- API availability detected once via `respondsToSelector:` (`dispatch_once`)
- Property access uses KVC (`valueForKey:`), matching the existing `siriService` pattern
- Method calls use `NSInvocation` with per-method availability checks
- Unsupported SDKs receive:
  > The current Xcode SDK does not support VoiceOver control. Consider upgrading to Xcode 27+/iOS 27+

### Integration tests (`FBVoiceOverTests`, `IntegrationTests_3`)
- `testVoiceOverUnavailableOnOlderSDK` — verifies compatibility error when API is absent
- `testVoiceOverEnableDisableAndNavigation` — enable → move forward → current speech → disable *(iOS 27+)*
- `testVoiceOverMoveBackward` — forward then backward navigation *(iOS 27+)*
- `tearDown` always disables VoiceOver if left enabled

## Follow-up (out of scope)

appium-xcuitest-driver `mobile:` helpers can proxy to these routes:

```js
await driver.execute('mobile: enableVoiceOver');
await driver.execute('mobile: voiceOverMove', { direction: 'forward' }); // → { utterance: "Alerts, button" }
await driver.execute('mobile: voiceOverCurrentSpeech');
await driver.execute('mobile: disableVoiceOver');
```
