### PR TITLE
chore: address runtime version rather than Xcode for selector based methods

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.h
@@ -169,7 +169,7 @@ typedef NS_ENUM(NSUInteger, FBUIInterfaceAppearance) {
 #if !TARGET_OS_TV
 /**
  Allows to set a simulated geolocation coordinates.
- Only works since Xcode 14.3/iOS 16.4
+ Only works since iOS 16.4 runtime
 
  @param location The simlated location coordinates to set
  @param error If there is an error, upon return contains an NSError object that describes the problem.
@@ -179,7 +179,7 @@ typedef NS_ENUM(NSUInteger, FBUIInterfaceAppearance) {
 
 /**
  Allows to get a simulated geolocation coordinates.
- Only works since Xcode 14.3/iOS 16.4
+ Only works since iOS 16.4 runtime
 
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return The current simulated location or nil in case of failure or if no location has previously been seet
@@ -189,7 +189,7 @@ typedef NS_ENUM(NSUInteger, FBUIInterfaceAppearance) {
 
 /**
  Allows to clear a previosuly set simulated geolocation coordinates.
- Only works since Xcode 14.3/iOS 16.4
+ Only works since iOS 16.4 runtime
 
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return YES if the simulated location has been successfully cleared

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -229,7 +229,7 @@ static bool fb_isLocked;
     return [self fb_activateSiriVoiceRecognitionWithText:[NSString stringWithFormat:@"Open {%@}", url] error:error];
   }
 
-  NSString *description = [NSString stringWithFormat:@"Cannot open '%@' with the default application assigned for it. Consider upgrading to Xcode 14.3+/iOS 16.4+", url];
+  NSString *description = [NSString stringWithFormat:@"Cannot open '%@' with the default application assigned for it. This API requires an iOS 16.4+ runtime", url];
   return [[[FBErrorBuilder builder]
            withDescriptionFormat:@"%@", description]
           buildError:error];

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.h
@@ -13,14 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
 @interface XCUIDevice (FBVoiceOver)
 
 /**
- Whether VoiceOver control APIs are available in the current Xcode SDK.
+ Whether VoiceOver control APIs are available in the current OS runtime.
 
  @return YES if the VoiceOver service is exposed by XCUIDevice
  */
 - (BOOL)fb_isVoiceOverServiceAvailable;
 
 /**
- Enable VoiceOver. Only works since Xcode 27/iOS 27.
+ Enable VoiceOver. Only works since iOS 27 runtime.
 
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return YES if VoiceOver has been successfully enabled
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)fb_enableVoiceOver:(NSError **)error;
 
 /**
- Disable VoiceOver. Only works since Xcode 27/iOS 27.
+ Disable VoiceOver. Only works since iOS 27 runtime.
 
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return YES if VoiceOver has been successfully disabled
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)fb_disableVoiceOver:(NSError **)error;
 
 /**
- Whether VoiceOver is currently enabled. Only works since Xcode 27/iOS 27.
+ Whether VoiceOver is currently enabled. Only works since iOS 27 runtime.
 
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return YES if VoiceOver is enabled
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Move VoiceOver focus and return speech for the newly focused element.
- Only works since Xcode 27/iOS 27.
+ Only works since iOS 27 runtime.
 
  @param direction One of: forward, backward, in (iOS only), out (iOS only)
  @param error If there is an error, upon return contains an NSError object that describes the problem.
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)fb_voiceOverMove:(NSString *)direction error:(NSError **)error;
 
 /**
- Return the speech for the currently focused element. Only works since Xcode 27/iOS 27.
+ Return the speech for the currently focused element. Only works since iOS 27 runtime.
 
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return The spoken utterance or nil in case of failure

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBVoiceOver.m
@@ -11,7 +11,7 @@
 #import "FBErrorBuilder.h"
 
 static NSString *const FBVoiceOverSDKUnsupportedError =
-@"The current Xcode SDK does not support VoiceOver control. Consider upgrading to Xcode 27+/iOS 27+";
+@"The current OS runtime does not support VoiceOver control. This API requires an iOS 27+ runtime";
 
 static BOOL FBVoiceOverBuildSDKUnsupportedError(NSError **error)
 {

--- a/WebDriverAgentLib/Utilities/FBCapabilities.h
+++ b/WebDriverAgentLib/Utilities/FBCapabilities.h
@@ -24,7 +24,7 @@ extern NSString* const FB_CAP_BUNDLE_ID;
  Usually an URL used as initial link to run Mobile Safari, but could be any other deep link.
  This might also work together with `FB_CAP_BUNLDE_ID`, which tells XCTest to open
  the given deep link in the particular app.
- Only works since iOS 16.4
+ Only works since iOS 16.4 runtime
  */
 extern NSString* const FB_CAP_INITIAL_URL;
 /** Whether to enforrce (re)start of the application under test on session startup */

--- a/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.m
@@ -134,7 +134,7 @@ static void swizzledLaunchApp(id self, SEL _cmd, NSString *path, NSString *bundl
   XCTRunnerDaemonSession *session = [XCTRunnerDaemonSession sharedSession];
   if (![session respondsToSelector:@selector(openURL:usingApplication:completion:)]) {
     return [[[FBErrorBuilder builder]
-      withDescriptionFormat:@"The current Xcode SDK does not support opening of URLs with given application"]
+      withDescriptionFormat:@"The current OS runtime does not support opening URLs with a given application"]
      buildError:error];
   }
 
@@ -161,7 +161,7 @@ static void swizzledLaunchApp(id self, SEL _cmd, NSString *path, NSString *bundl
   XCTRunnerDaemonSession *session = [XCTRunnerDaemonSession sharedSession];
   if (![session respondsToSelector:@selector(openDefaultApplicationForURL:completion:)]) {
     return [[[FBErrorBuilder builder]
-      withDescriptionFormat:@"The current Xcode SDK does not support opening of URLs. Consider upgrading to Xcode 14.3+/iOS 16.4+"]
+      withDescriptionFormat:@"The current OS runtime does not support opening URLs. This API requires an iOS 16.4+ runtime"]
      buildError:error];
   }
 
@@ -189,7 +189,7 @@ static void swizzledLaunchApp(id self, SEL _cmd, NSString *path, NSString *bundl
   XCTRunnerDaemonSession *session = [XCTRunnerDaemonSession sharedSession];
   if (![session respondsToSelector:@selector(setSimulatedLocation:completion:)]) {
     return [[[FBErrorBuilder builder]
-      withDescriptionFormat:@"The current Xcode SDK does not support location simulation. Consider upgrading to Xcode 14.3+/iOS 16.4+"]
+      withDescriptionFormat:@"The current OS runtime does not support location simulation. This API requires an iOS 16.4+ runtime"]
      buildError:error];
   }
   if (![session supportsLocationSimulation]) {
@@ -221,7 +221,7 @@ static void swizzledLaunchApp(id self, SEL _cmd, NSString *path, NSString *bundl
   XCTRunnerDaemonSession *session = [XCTRunnerDaemonSession sharedSession];
   if (![session respondsToSelector:@selector(getSimulatedLocationWithReply:)]) {
     [[[FBErrorBuilder builder]
-      withDescriptionFormat:@"The current Xcode SDK does not support location simulation. Consider upgrading to Xcode 14.3+/iOS 16.4+"]
+      withDescriptionFormat:@"The current OS runtime does not support location simulation. This API requires an iOS 16.4+ runtime"]
      buildError:error];
     return nil;
   }
@@ -255,7 +255,7 @@ static void swizzledLaunchApp(id self, SEL _cmd, NSString *path, NSString *bundl
   XCTRunnerDaemonSession *session = [XCTRunnerDaemonSession sharedSession];
   if (![session respondsToSelector:@selector(clearSimulatedLocationWithReply:)]) {
     return [[[FBErrorBuilder builder]
-        withDescriptionFormat:@"The current Xcode SDK does not support location simulation. Consider upgrading to Xcode 14.3+/iOS 16.4+"]
+        withDescriptionFormat:@"The current OS runtime does not support location simulation. This API requires an iOS 16.4+ runtime"]
        buildError:error];
   }
   if (![session supportsLocationSimulation]) {
@@ -289,7 +289,7 @@ static void swizzledLaunchApp(id self, SEL _cmd, NSString *path, NSString *bundl
   XCTRunnerDaemonSession *session = [XCTRunnerDaemonSession sharedSession];
   if (![session respondsToSelector:@selector(startScreenRecordingWithRequest:withReply:)]) {
     [[[FBErrorBuilder builder]
-      withDescriptionFormat:@"The current Xcode SDK does not support screen recording. Consider upgrading to Xcode 15+/iOS 17+"]
+      withDescriptionFormat:@"The current OS runtime does not support screen recording. This API requires an iOS 17+ runtime"]
      buildError:error];
     return nil;
   }
@@ -331,7 +331,7 @@ static void swizzledLaunchApp(id self, SEL _cmd, NSString *path, NSString *bundl
   XCTRunnerDaemonSession *session = [XCTRunnerDaemonSession sharedSession];
   if (![session respondsToSelector:@selector(stopScreenRecordingWithUUID:withReply:)]) {
     return [[[FBErrorBuilder builder]
-        withDescriptionFormat:@"The current Xcode SDK does not support screen recording. Consider upgrading to Xcode 15+/iOS 17+"]
+        withDescriptionFormat:@"The current OS runtime does not support screen recording. This API requires an iOS 17+ runtime"]
        buildError:error];
 
   }

--- a/WebDriverAgentTests/IntegrationTests/FBVoiceOverTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBVoiceOverTests.m
@@ -29,7 +29,7 @@
   [super tearDown];
 }
 
-- (void)testVoiceOverUnavailableOnOlderRuntime
+- (void)testVoiceOverUnavailableOnOlderSDK
 {
   if ([XCUIDevice.sharedDevice fb_isVoiceOverServiceAvailable]) {
     return;

--- a/WebDriverAgentTests/IntegrationTests/FBVoiceOverTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBVoiceOverTests.m
@@ -29,7 +29,7 @@
   [super tearDown];
 }
 
-- (void)testVoiceOverUnavailableOnOlderSDK
+- (void)testVoiceOverUnavailableOnOlderRuntime
 {
   if ([XCUIDevice.sharedDevice fb_isVoiceOverServiceAvailable]) {
     return;
@@ -38,7 +38,7 @@
   NSError *error = nil;
   XCTAssertFalse([XCUIDevice.sharedDevice fb_enableVoiceOver:&error]);
   XCTAssertNotNil(error);
-  XCTAssertTrue([error.localizedDescription containsString:@"Xcode 27"]);
+  XCTAssertTrue([error.localizedDescription containsString:@"iOS 27"]);
 }
 
 - (void)testVoiceOverEnableDisableAndNavigation


### PR DESCRIPTION
Selector-based method calls dependent methods that depend on the runtime version rather than Xcode's embedded SDK version. After having a conversation with LLM, maybe addressing the runtime would be more accurate rather than the runtime SDK, SDK, like that.

This will be helpful mostly for real device users