### PR TITLE
feat: Limit the maximum request body size

### DIFF
--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -39,6 +39,11 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   [super handleResourceNotFound];
 }
 
+- (UInt64)maxRequestBodySize
+{
+  return FBConfiguration.httpRequestBodySizeLimit;
+}
+
 @end
 
 

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -133,6 +133,12 @@ extern NSString *const FBSnapshotMaxDepthKey;
 + (NSInteger)mjpegServerPort;
 
 /**
+ The maximum allowed HTTP request body size in bytes.
+ Defaults to 1GB and can be overridden with the MAX_HTTP_REQUEST_BODY_SIZE environment variable.
+ */
++ (UInt64)httpRequestBodySizeLimit;
+
+/**
  The scaling factor for frames of the mjpeg stream. The default (and maximum) value is 100,
  which does not perform any scaling. The minimum value must be greater than zero.
  ! Setting this to a value less than 100, especially together with orientation fixing enabled

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -26,6 +26,7 @@
 static NSUInteger const DefaultStartingPort = 8100;
 static NSUInteger const DefaultMjpegServerPort = 9100;
 static NSUInteger const DefaultPortRange = 100;
+static UInt64 const DefaultHttpRequestBodySizeLimit = 1024ull * 1024ull * 1024ull;
 
 static char const *const controllerPrefBundlePath = "/System/Library/PrivateFrameworks/TextInput.framework/TextInput";
 static NSString *const controllerClassName = @"TIPreferencesController";
@@ -162,6 +163,19 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
   }
 
   return DefaultMjpegServerPort;
+}
+
++ (UInt64)httpRequestBodySizeLimit
+{
+  NSString *limit = NSProcessInfo.processInfo.environment[@"MAX_HTTP_REQUEST_BODY_SIZE"];
+  if (limit.length > 0) {
+    long long parsedLimit = [limit longLongValue];
+    if (parsedLimit > 0) {
+      return (UInt64)parsedLimit;
+    }
+  }
+
+  return DefaultHttpRequestBodySizeLimit;
 }
 
 + (CGFloat)mjpegScalingFactor

--- a/WebDriverAgentLib/Vendor/CocoaHTTPServer/HTTPConnection.h
+++ b/WebDriverAgentLib/Vendor/CocoaHTTPServer/HTTPConnection.h
@@ -85,8 +85,10 @@
 - (void)prepareForBodyWithSize:(UInt64)contentLength;
 - (void)processBodyData:(NSData *)postDataChunk;
 - (void)finishBody;
+- (UInt64)maxRequestBodySize;
 
 - (void)handleVersionNotSupported:(NSString *)version;
+- (void)handleRequestBodyTooLarge;
 - (void)handleResourceNotFound;
 - (void)handleInvalidRequest:(NSData *)data;
 - (void)handleUnknownMethod:(NSString *)method;

--- a/WebDriverAgentLib/Vendor/CocoaHTTPServer/HTTPConnection.m
+++ b/WebDriverAgentLib/Vendor/CocoaHTTPServer/HTTPConnection.m
@@ -1301,6 +1301,14 @@ static const int httpLogLevel = HTTP_LOG_LEVEL_WARN; // | HTTP_LOG_FLAG_TRACE;
   // the hook to flush any pending data to disk and maybe close the file.
 }
 
+/**
+ * Returns the maximum request body size this connection accepts.
+ **/
+- (UInt64)maxRequestBodySize
+{
+  return (UInt64)-1;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Errors
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1322,6 +1330,21 @@ static const int httpLogLevel = HTTP_LOG_LEVEL_WARN; // | HTTP_LOG_FLAG_TRACE;
   NSData *responseData = [self preprocessErrorResponse:response];
   [asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_ERROR tag:HTTP_RESPONSE];
   
+}
+
+/**
+ * Called if the HTTP request body is larger than the configured limit.
+ **/
+- (void)handleRequestBodyTooLarge
+{
+  HTTPLogWarn(@"HTTP Server: Error 413 - Request Entity Too Large (%@)", [self requestURI]);
+  
+  HTTPMessage *response = [[HTTPMessage alloc] initResponseWithStatusCode:413 description:nil version:HTTPVersion1_1];
+  [response setHeaderField:@"Content-Length" value:@"0"];
+  [response setHeaderField:@"Connection" value:@"close"];
+  
+  NSData *responseData = [self preprocessErrorResponse:response];
+  [asyncSocket writeData:responseData withTimeout:TIMEOUT_WRITE_ERROR tag:HTTP_FINAL_RESPONSE];
 }
 
 /**
@@ -1617,6 +1640,15 @@ static const int httpLogLevel = HTTP_LOG_LEVEL_WARN; // | HTTP_LOG_FLAG_TRACE;
             [self handleInvalidRequest:nil];
             return;
           }
+          
+          if (requestContentLength > [self maxRequestBodySize])
+          {
+            HTTPLogWarn(@"%@[%p]: Request body size %llu exceeds the configured limit %llu",
+                        THIS_FILE, self, requestContentLength, [self maxRequestBodySize]);
+            
+            [self handleRequestBodyTooLarge];
+            return;
+          }
         }
       }
       else
@@ -1749,6 +1781,17 @@ static const int httpLogLevel = HTTP_LOG_LEVEL_WARN; // | HTTP_LOG_FLAG_TRACE;
       
       if (requestChunkSize > 0)
       {
+        UInt64 maxRequestBodySize = [self maxRequestBodySize];
+        if (requestChunkSize > maxRequestBodySize ||
+            requestContentLengthReceived > maxRequestBodySize - requestChunkSize)
+        {
+          HTTPLogWarn(@"%@[%p]: Chunked request body exceeds the configured limit %llu",
+                      THIS_FILE, self, maxRequestBodySize);
+          
+          [self handleRequestBodyTooLarge];
+          return;
+        }
+        
         NSUInteger bytesToRead;
         bytesToRead = (requestChunkSize < POST_CHUNKSIZE) ? (NSUInteger)requestChunkSize : POST_CHUNKSIZE;
         

--- a/WebDriverAgentTests/UnitTests/FBConfigurationTests.m
+++ b/WebDriverAgentTests/UnitTests/FBConfigurationTests.m
@@ -22,6 +22,7 @@
   unsetenv("USE_PORT");
   unsetenv("USE_IP");
   unsetenv("VERBOSE_LOGGING");
+  unsetenv("MAX_HTTP_REQUEST_BODY_SIZE");
 }
 
 - (void)testBindingPortDefault
@@ -55,6 +56,17 @@
 {
   setenv("USE_IP", "192.168.1.100", 1);
   XCTAssertEqualObjects([FBConfiguration bindingIPAddress], @"192.168.1.100");
+}
+
+- (void)testHttpRequestBodySizeLimitDefault
+{
+  XCTAssertEqual([FBConfiguration httpRequestBodySizeLimit], 1024ull * 1024ull * 1024ull);
+}
+
+- (void)testHttpRequestBodySizeLimitEnvironmentOverwrite
+{
+  setenv("MAX_HTTP_REQUEST_BODY_SIZE", "1024", 1);
+  XCTAssertEqual([FBConfiguration httpRequestBodySizeLimit], 1024ull);
 }
 
 @end

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -80,6 +80,7 @@ export interface WebDriverAgentArgs {
   usePrebuiltWDA?: boolean;
   derivedDataPath?: string;
   mjpegServerPort?: number;
+  maxHttpRequestBodySize?: number;
   updatedWDABundleId?: string;
   wdaLaunchTimeout?: number;
   usePreinstalledWDA?: boolean;
@@ -167,6 +168,7 @@ export interface XcodeBuildArgs {
   updatedWDABundleId?: string;
   derivedDataPath?: string;
   mjpegServerPort?: number;
+  maxHttpRequestBodySize?: number;
   prebuildDelay?: number;
   allowProvisioningDeviceRegistration?: boolean;
   resultBundlePath?: string;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -60,6 +60,7 @@ export interface XctestrunFileArgs {
   bootstrapPath: string;
   wdaRemotePort: number | string;
   wdaBindingIP?: string;
+  maxHttpRequestBodySize?: number | string;
 }
 
 /**
@@ -146,13 +147,21 @@ export async function setRealDeviceSecurity(
  * then it will throw a file not found exception
  */
 export async function setXctestrunFile(args: XctestrunFileArgs): Promise<string> {
-  const {deviceInfo, sdkVersion, bootstrapPath, wdaRemotePort, wdaBindingIP} = args;
+  const {
+    deviceInfo,
+    sdkVersion,
+    bootstrapPath,
+    wdaRemotePort,
+    wdaBindingIP,
+    maxHttpRequestBodySize,
+  } = args;
   const xctestrunFilePath = await getXctestrunFilePath(deviceInfo, sdkVersion, bootstrapPath);
   const xctestRunContent = await plist.parsePlistFile(xctestrunFilePath);
   const updateWDAPort = getAdditionalRunContent(
     deviceInfo.platformName,
     wdaRemotePort,
     wdaBindingIP,
+    maxHttpRequestBodySize,
   );
   const newXctestRunContent = mergeObjects(xctestRunContent, updateWDAPort);
   await plist.updatePlistFile(xctestrunFilePath, newXctestRunContent, true);
@@ -165,12 +174,14 @@ export async function setXctestrunFile(args: XctestrunFileArgs): Promise<string>
  * @param platformName - The name of the platform
  * @param wdaRemotePort - The remote port number
  * @param wdaBindingIP - The IP address to bind to. If not given, it binds to all interfaces.
+ * @param maxHttpRequestBodySize - The maximum HTTP request body size in bytes.
  * @return returns a runner object which has USE_PORT and optionally USE_IP
  */
 export function getAdditionalRunContent(
   platformName: string,
   wdaRemotePort: number | string,
   wdaBindingIP?: string,
+  maxHttpRequestBodySize?: number | string,
 ): Record<string, any> {
   const runner = `WebDriverAgentRunner${isTvOS(platformName) ? '_tvOS' : ''}`;
   return {
@@ -179,6 +190,9 @@ export function getAdditionalRunContent(
         // USE_PORT must be 'string'
         USE_PORT: `${wdaRemotePort}`,
         ...(wdaBindingIP ? {USE_IP: wdaBindingIP} : {}),
+        ...(maxHttpRequestBodySize
+          ? {MAX_HTTP_REQUEST_BODY_SIZE: `${maxHttpRequestBodySize}`}
+          : {}),
       },
     },
   };

--- a/lib/webdriveragent.ts
+++ b/lib/webdriveragent.ts
@@ -62,6 +62,7 @@ export class WebDriverAgent {
   private readonly useXctestrunFile?: boolean;
   private readonly usePrebuiltWDA?: boolean;
   private readonly mjpegServerPort?: number;
+  private readonly maxHttpRequestBodySize?: number;
   private readonly wdaLaunchTimeout: number;
   private readonly usePreinstalledWDA?: boolean;
   private readonly updatedWDABundleIdSuffix: string;
@@ -105,6 +106,7 @@ export class WebDriverAgent {
     this.useXctestrunFile = args.useXctestrunFile;
     this.usePrebuiltWDA = args.usePrebuiltWDA;
     this.mjpegServerPort = args.mjpegServerPort;
+    this.maxHttpRequestBodySize = args.maxHttpRequestBodySize;
 
     this.updatedWDABundleId = args.updatedWDABundleId;
 
@@ -138,6 +140,7 @@ export class WebDriverAgent {
             useXctestrunFile: this.useXctestrunFile,
             derivedDataPath: args.derivedDataPath,
             mjpegServerPort: this.mjpegServerPort,
+            maxHttpRequestBodySize: this.maxHttpRequestBodySize,
             allowProvisioningDeviceRegistration: args.allowProvisioningDeviceRegistration,
             resultBundlePath: args.resultBundlePath,
             resultBundleVersion: args.resultBundleVersion,
@@ -702,6 +705,9 @@ export class WebDriverAgent {
     }
     if (this.wdaBindingIP) {
       xctestEnv.USE_IP = this.wdaBindingIP;
+    }
+    if (this.maxHttpRequestBodySize) {
+      xctestEnv.MAX_HTTP_REQUEST_BODY_SIZE = this.maxHttpRequestBodySize;
     }
     this.log.info('Launching WebDriverAgent on the device without xcodebuild');
     if (this.isRealDevice) {

--- a/lib/xcodebuild.ts
+++ b/lib/xcodebuild.ts
@@ -72,6 +72,7 @@ export class XcodeBuild {
   private readonly wdaBindingIP?: string;
   private readonly updatedWDABundleId?: string;
   private readonly mjpegServerPort?: number;
+  private readonly maxHttpRequestBodySize?: number;
   private readonly prebuildDelay: number;
   private readonly allowProvisioningDeviceRegistration?: boolean;
   private readonly resultBundlePath?: string;
@@ -126,6 +127,7 @@ export class XcodeBuild {
     this.derivedDataPath = args.derivedDataPath;
 
     this.mjpegServerPort = args.mjpegServerPort;
+    this.maxHttpRequestBodySize = args.maxHttpRequestBodySize;
 
     this.prebuildDelay =
       typeof args.prebuildDelay === 'number' ? args.prebuildDelay : PREBUILD_DELAY;
@@ -160,6 +162,7 @@ export class XcodeBuild {
         bootstrapPath: this.bootstrapPath,
         wdaRemotePort: this.wdaRemotePort || 8100,
         wdaBindingIP: this.wdaBindingIP,
+        maxHttpRequestBodySize: this.maxHttpRequestBodySize,
       });
       return;
     }
@@ -445,6 +448,10 @@ export class XcodeBuild {
       USE_PORT: this.wdaRemotePort,
       WDA_PRODUCT_BUNDLE_IDENTIFIER: this.updatedWDABundleId || WDA_RUNNER_BUNDLE_ID,
     });
+    delete env.MAX_HTTP_REQUEST_BODY_SIZE;
+    if (this.maxHttpRequestBodySize) {
+      env.MAX_HTTP_REQUEST_BODY_SIZE = this.maxHttpRequestBodySize;
+    }
     if (this.mjpegServerPort) {
       // https://github.com/appium/WebDriverAgent/pull/105
       env.MJPEG_SERVER_PORT = this.mjpegServerPort;

--- a/test/unit/utils-specs.ts
+++ b/test/unit/utils-specs.ts
@@ -181,6 +181,13 @@ describe('utils', function () {
       const wdaPort = getAdditionalRunContent(PLATFORM_NAME_TVOS, '9000');
       expect(wdaPort.WebDriverAgentRunner_tvOS.EnvironmentVariables.USE_PORT).to.equal('9000');
     });
+
+    it('should include max HTTP request body size if provided', function () {
+      const runContent = getAdditionalRunContent(PLATFORM_NAME_IOS, 8000, undefined, 1024);
+      expect(
+        runContent.WebDriverAgentRunner.EnvironmentVariables.MAX_HTTP_REQUEST_BODY_SIZE,
+      ).to.equal('1024');
+    });
   });
 
   describe('#getXctestrunFileName', function () {


### PR DESCRIPTION
## Summary

- Add a 1GB default maximum HTTP request body size in WDA (same as WDProxy default), configurable via `MAX_HTTP_REQUEST_BODY_SIZE`.
- Reject oversized fixed-length and chunked request bodies at the HTTP boundary with `413 Request Entity Too Large`.
- Thread optional `maxHttpRequestBodySize` through WDA launch paths, including xcodebuild, preinstalled WDA, and xctestrun generation.
