### PR TITLE
feat: Expose device orientation via /wda/deviceOrientation

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.h
@@ -33,10 +33,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, readonly) NSDictionary *fb_rotationMapping;
 
 /**
- The current physical device orientation represented as a WebDriver orientation string,
- e.g. PORTRAIT, LANDSCAPE, UIA_DEVICE_ORIENTATION_LANDSCAPERIGHT or
- UIA_DEVICE_ORIENTATION_PORTRAIT_UPSIDEDOWN. Returns UNKNOWN if the device orientation
- cannot be mapped (e.g. face up/face down/unknown).
+ The current physical device orientation as the raw UIDeviceOrientation name string,
+ e.g. UIDeviceOrientationPortrait, UIDeviceOrientationLandscapeLeft,
+ UIDeviceOrientationFaceUp. Returns UIDeviceOrientationUnknown if the orientation
+ cannot be determined.
  */
 @property (copy, nonatomic, readonly) NSString *fb_deviceOrientation;
 

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.h
@@ -32,6 +32,14 @@ NS_ASSUME_NONNULL_BEGIN
 /*! The UIDeviceOrientation to rotation mappings */
 @property (strong, nonatomic, readonly) NSDictionary *fb_rotationMapping;
 
+/**
+ The current physical device orientation represented as a WebDriver orientation string,
+ e.g. PORTRAIT, LANDSCAPE, UIA_DEVICE_ORIENTATION_LANDSCAPERIGHT or
+ UIA_DEVICE_ORIENTATION_PORTRAIT_UPSIDEDOWN. Returns UNKNOWN if the device orientation
+ cannot be mapped (e.g. face up/face down/unknown).
+ */
+@property (copy, nonatomic, readonly) NSString *fb_deviceOrientation;
+
 @end
 #endif
 

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.m
@@ -67,8 +67,6 @@ static UIInterfaceOrientation FBInterfaceOrientationFromDeviceOrientation(UIDevi
 - (NSString *)fb_deviceOrientation
 {
   switch (self.orientation) {
-    case UIDeviceOrientationUnknown:
-      return @"UIDeviceOrientationUnknown";
     case UIDeviceOrientationPortrait:
       return @"UIDeviceOrientationPortrait";
     case UIDeviceOrientationPortraitUpsideDown:
@@ -81,6 +79,7 @@ static UIInterfaceOrientation FBInterfaceOrientationFromDeviceOrientation(UIDevi
       return @"UIDeviceOrientationFaceUp";
     case UIDeviceOrientationFaceDown:
       return @"UIDeviceOrientationFaceDown";
+    case UIDeviceOrientationUnknown:
     default:
       return @"UIDeviceOrientationUnknown";
   }

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.m
@@ -64,6 +64,25 @@ static UIInterfaceOrientation FBInterfaceOrientationFromDeviceOrientation(UIDevi
   return application.interfaceOrientation == FBInterfaceOrientationFromDeviceOrientation(orientation);
 }
 
+- (NSString *)fb_deviceOrientation
+{
+  switch (self.orientation) {
+    case UIDeviceOrientationPortrait:
+      return @"PORTRAIT";
+    case UIDeviceOrientationPortraitUpsideDown:
+      return @"UIA_DEVICE_ORIENTATION_PORTRAIT_UPSIDEDOWN";
+    case UIDeviceOrientationLandscapeLeft:
+      return @"LANDSCAPE";
+    case UIDeviceOrientationLandscapeRight:
+      return @"UIA_DEVICE_ORIENTATION_LANDSCAPERIGHT";
+    case UIDeviceOrientationUnknown:
+    case UIDeviceOrientationFaceUp:
+    case UIDeviceOrientationFaceDown:
+    default:
+      return @"UNKNOWN";
+  }
+}
+
 - (NSDictionary *)fb_rotationMapping
 {
     static NSDictionary *rotationMap;

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.m
@@ -67,19 +67,22 @@ static UIInterfaceOrientation FBInterfaceOrientationFromDeviceOrientation(UIDevi
 - (NSString *)fb_deviceOrientation
 {
   switch (self.orientation) {
-    case UIDeviceOrientationPortrait:
-      return @"PORTRAIT";
-    case UIDeviceOrientationPortraitUpsideDown:
-      return @"UIA_DEVICE_ORIENTATION_PORTRAIT_UPSIDEDOWN";
-    case UIDeviceOrientationLandscapeLeft:
-      return @"LANDSCAPE";
-    case UIDeviceOrientationLandscapeRight:
-      return @"UIA_DEVICE_ORIENTATION_LANDSCAPERIGHT";
     case UIDeviceOrientationUnknown:
+      return @"UIDeviceOrientationUnknown";
+    case UIDeviceOrientationPortrait:
+      return @"UIDeviceOrientationPortrait";
+    case UIDeviceOrientationPortraitUpsideDown:
+      return @"UIDeviceOrientationPortraitUpsideDown";
+    case UIDeviceOrientationLandscapeLeft:
+      return @"UIDeviceOrientationLandscapeLeft";
+    case UIDeviceOrientationLandscapeRight:
+      return @"UIDeviceOrientationLandscapeRight";
     case UIDeviceOrientationFaceUp:
+      return @"UIDeviceOrientationFaceUp";
     case UIDeviceOrientationFaceDown:
+      return @"UIDeviceOrientationFaceDown";
     default:
-      return @"UNKNOWN";
+      return @"UIDeviceOrientationUnknown";
   }
 }
 

--- a/WebDriverAgentLib/Commands/FBOrientationCommands.m
+++ b/WebDriverAgentLib/Commands/FBOrientationCommands.m
@@ -47,6 +47,8 @@ const struct FBWDOrientationValues FBWDOrientationValues = {
     [[FBRoute GET:@"/rotation"].withoutSession respondWithTarget:self action:@selector(handleGetRotation:)],
     [[FBRoute POST:@"/rotation"] respondWithTarget:self action:@selector(handleSetRotation:)],
     [[FBRoute POST:@"/rotation"].withoutSession respondWithTarget:self action:@selector(handleSetRotation:)],
+    [[FBRoute GET:@"/wda/deviceOrientation"] respondWithTarget:self action:@selector(handleGetDeviceOrientation:)],
+    [[FBRoute GET:@"/wda/deviceOrientation"].withoutSession respondWithTarget:self action:@selector(handleGetDeviceOrientation:)],
   ];
 }
 
@@ -113,8 +115,25 @@ const struct FBWDOrientationValues FBWDOrientationValues = {
   return FBResponseWithOK();
 }
 
++ (id<FBResponsePayload>)handleGetDeviceOrientation:(FBRouteRequest *)request
+{
+  return FBResponseWithObject([self.class deviceOrientationForDevice:XCUIDevice.sharedDevice]);
+}
+
 
 #pragma mark - Helpers
+
++ (NSString *)deviceOrientationForDevice:(XCUIDevice *)device
+{
+  NSNumber *orientation = @(device.orientation);
+  NSSet *keys = [[self _orientationsMapping] keysOfEntriesPassingTest:^BOOL(id key, NSNumber *obj, BOOL *stop) {
+    return [obj isEqualToNumber:orientation];
+  }];
+  if (keys.count == 0) {
+    return @"UNKNOWN";
+  }
+  return keys.anyObject;
+}
 
 + (NSString *)interfaceOrientationForApplication:(XCUIApplication *)application
 {

--- a/WebDriverAgentLib/Commands/FBOrientationCommands.m
+++ b/WebDriverAgentLib/Commands/FBOrientationCommands.m
@@ -117,23 +117,11 @@ const struct FBWDOrientationValues FBWDOrientationValues = {
 
 + (id<FBResponsePayload>)handleGetDeviceOrientation:(FBRouteRequest *)request
 {
-  return FBResponseWithObject([self.class deviceOrientationForDevice:XCUIDevice.sharedDevice]);
+  return FBResponseWithObject(XCUIDevice.sharedDevice.fb_deviceOrientation);
 }
 
 
 #pragma mark - Helpers
-
-+ (NSString *)deviceOrientationForDevice:(XCUIDevice *)device
-{
-  NSNumber *orientation = @(device.orientation);
-  NSSet *keys = [[self _orientationsMapping] keysOfEntriesPassingTest:^BOOL(id key, NSNumber *obj, BOOL *stop) {
-    return [obj isEqualToNumber:orientation];
-  }];
-  if (keys.count == 0) {
-    return @"UNKNOWN";
-  }
-  return keys.anyObject;
-}
 
 + (NSString *)interfaceOrientationForApplication:(XCUIApplication *)application
 {

--- a/WebDriverAgentTests/IntegrationTests/XCUIDeviceRotationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIDeviceRotationTests.m
@@ -69,6 +69,27 @@
   XCTAssertTrue(self.testedApplication.staticTexts[@"LandscapeRight"].exists);
 }
 
+- (void)testGetDeviceOrientationInPortrait
+{
+  BOOL success = [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:UIDeviceOrientationPortrait];
+  XCTAssertTrue(success, @"Device should support Portrait");
+  XCTAssertEqualObjects([XCUIDevice sharedDevice].fb_deviceOrientation, @"PORTRAIT");
+}
+
+- (void)testGetDeviceOrientationInLandscapeLeft
+{
+  BOOL success = [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:UIDeviceOrientationLandscapeLeft];
+  XCTAssertTrue(success, @"Device should support LandscapeLeft");
+  XCTAssertEqualObjects([XCUIDevice sharedDevice].fb_deviceOrientation, @"LANDSCAPE");
+}
+
+- (void)testGetDeviceOrientationInLandscapeRight
+{
+  BOOL success = [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:UIDeviceOrientationLandscapeRight];
+  XCTAssertTrue(success, @"Device should support LandscapeRight");
+  XCTAssertEqualObjects([XCUIDevice sharedDevice].fb_deviceOrientation, @"UIA_DEVICE_ORIENTATION_LANDSCAPERIGHT");
+}
+
 - (void)testRotationTiltRotation
 {
   UIDeviceOrientation currentRotation = [XCUIDevice sharedDevice].orientation;

--- a/WebDriverAgentTests/IntegrationTests/XCUIDeviceRotationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIDeviceRotationTests.m
@@ -73,21 +73,21 @@
 {
   BOOL success = [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:UIDeviceOrientationPortrait];
   XCTAssertTrue(success, @"Device should support Portrait");
-  XCTAssertEqualObjects([XCUIDevice sharedDevice].fb_deviceOrientation, @"PORTRAIT");
+  XCTAssertEqualObjects([XCUIDevice sharedDevice].fb_deviceOrientation, @"UIDeviceOrientationPortrait");
 }
 
 - (void)testGetDeviceOrientationInLandscapeLeft
 {
   BOOL success = [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:UIDeviceOrientationLandscapeLeft];
   XCTAssertTrue(success, @"Device should support LandscapeLeft");
-  XCTAssertEqualObjects([XCUIDevice sharedDevice].fb_deviceOrientation, @"LANDSCAPE");
+  XCTAssertEqualObjects([XCUIDevice sharedDevice].fb_deviceOrientation, @"UIDeviceOrientationLandscapeLeft");
 }
 
 - (void)testGetDeviceOrientationInLandscapeRight
 {
   BOOL success = [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:UIDeviceOrientationLandscapeRight];
   XCTAssertTrue(success, @"Device should support LandscapeRight");
-  XCTAssertEqualObjects([XCUIDevice sharedDevice].fb_deviceOrientation, @"UIA_DEVICE_ORIENTATION_LANDSCAPERIGHT");
+  XCTAssertEqualObjects([XCUIDevice sharedDevice].fb_deviceOrientation, @"UIDeviceOrientationLandscapeRight");
 }
 
 - (void)testRotationTiltRotation


### PR DESCRIPTION
### Summary
Adds a new `GET /wda/deviceOrientation` endpoint that returns the current physical device orientation.

### Motivation
The existing `GET /orientation` reports the **app's interface orientation** (`application.interfaceOrientation`) and collapses everything to `PORTRAIT`/`LANDSCAPE`. This new endpoint exposes the raw physical `UIDeviceOrientation` (`XCUIDevice.orientation`), which is useful when an app locks its UI but the device is physically rotated. It also covers orientations that have no interface equivalent: `FaceUp`, `FaceDown`, and `Unknown`.

### Changes
- Add `GET /wda/deviceOrientation` route (with and without session) in `FBOrientationCommands`
- Add `fb_deviceOrientation` property to the `XCUIDevice (FBRotation)` category, returning the raw `UIDeviceOrientation` name string (same `switch` style as the existing `FBInterfaceOrientationFromDeviceOrientation`)
- `handleGetDeviceOrientation:` delegates to `XCUIDevice.sharedDevice.fb_deviceOrientation`
- Add integration tests for portrait / landscape-left / landscape-right in `XCUIDeviceRotationTests`

### Possible return values
`UIDeviceOrientationPortrait`, `UIDeviceOrientationPortraitUpsideDown`, `UIDeviceOrientationLandscapeLeft`, `UIDeviceOrientationLandscapeRight`, `UIDeviceOrientationFaceUp`, `UIDeviceOrientationFaceDown`, `UIDeviceOrientationUnknown`

### How to test
`GET /wda/deviceOrientation` → returns the current physical device orientation as a raw `UIDeviceOrientation` name string.