### PR TITLE
chore: downgrade conventional-changelog-conventionalcommits to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "appium-xcode": "^6.0.0",
     "chai": "^6.0.0",
     "chai-as-promised": "^8.0.0",
-    "conventional-changelog-conventionalcommits": "^10.2.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "mocha": "^11.0.1",
     "node-simctl": "^8.0.0",
     "prettier": "^3.9.3",


### PR DESCRIPTION
https://github.com/appium/appium-safari-driver/pull/177