### PR TITLE
fix: use double instead of CGFloat for mjpegScalingFactor public API

### DIFF
--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -144,8 +144,8 @@ extern NSString *const FBSnapshotMaxDepthKey;
  ! Setting this to a value less than 100, especially together with orientation fixing enabled
  ! may lead to WDA process termination because of an excessive CPU usage.
  */
-+ (CGFloat)mjpegScalingFactor;
-+ (void)setMjpegScalingFactor:(CGFloat)scalingFactor;
++ (double)mjpegScalingFactor;
++ (void)setMjpegScalingFactor:(double)scalingFactor;
 
 /**
  YES if verbose logging is enabled. NO otherwise.

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -37,7 +37,7 @@ static NSString *const axSettingsClassName = @"AXSettings";
 static BOOL FBShouldUseSingletonTestManager = YES;
 static BOOL FBShouldRespectSystemAlerts = NO;
 
-static CGFloat FBMjpegScalingFactor = 100.0;
+static double FBMjpegScalingFactor = 100.0;
 static BOOL FBMjpegShouldFixOrientation = NO;
 static NSUInteger FBMjpegServerScreenshotQuality = 25;
 static NSUInteger FBMjpegServerFramerate = 10;
@@ -178,12 +178,12 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
   return DefaultHttpRequestBodySizeLimit;
 }
 
-+ (CGFloat)mjpegScalingFactor
++ (double)mjpegScalingFactor
 {
   return FBMjpegScalingFactor;
 }
 
-+ (void)setMjpegScalingFactor:(CGFloat)scalingFactor {
++ (void)setMjpegScalingFactor:(double)scalingFactor {
   FBMjpegScalingFactor = scalingFactor;
 }
 


### PR DESCRIPTION
### Problem
`FBConfiguration.h` exposed `CGFloat` in its **public** interface:

```objc
+ (CGFloat)mjpegScalingFactor;
+ (void)setMjpegScalingFactor:(CGFloat)scalingFactor;
```

`CGFloat` is a CoreGraphics type, so the header depended on CoreGraphics even though it only imports
Foundation (it compiled only via a transitive `Foundation → NSGeometry → CoreGraphics` chain).

### Fix (updated per review)
Rather than import CoreGraphics to prop up a `CGFloat` public API, switch the public getter/setter — and the
backing static — to **`double`**. `CGFloat` stays out of the public settings surface entirely, and the header
becomes self-contained with no CoreGraphics dependency.

```objc
+ (double)mjpegScalingFactor;
+ (void)setMjpegScalingFactor:(double)scalingFactor;
```

No behaviour change (`CGFloat` is `double` on 64-bit). Files: `FBConfiguration.{h,m}`.
