### PR TITLE
fix: lock screen via IOHID Power press on iOS 27

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -123,7 +123,17 @@ static bool fb_isLocked;
   if (fb_isLocked) {
     return YES;
   }
-  [self pressLockButton];
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"27.0")) {
+    // iOS 27: pressLockButton no longer locks; use a direct IOHID Power press (0x0C/0x30, ~0.5s hold).
+    if (![self fb_performIOHIDEventWithPage:0x0C
+                                      usage:0x30
+                                   duration:0.5
+                                      error:error]) {
+      return NO;
+    }
+  } else {
+    [self pressLockButton];
+  }
   return [[[[FBRunLoopSpinner new]
             timeout:FBScreenLockTimeout]
            timeoutErrorMessage:@"Timed out while waiting until the screen gets locked"]


### PR DESCRIPTION
## Problem

On iOS 27, `[XCUIDevice pressLockButton]` no longer locks the screen. It routes
through `testmanagerd`, which waits on a `ButtonEventsCompleted` confirmation
that iOS 27 never fires — so it times out and never locks, and `POST /wda/lock`
fails with `Timed out while waiting until the screen gets locked`.

testmanagerd <Error>: Timed out after waiting 5.0s for ButtonEventsCompleted,
event will be implicitly confirmed with no error other than this log message.

## Fix

On iOS 27+, lock via a direct IOHID Power press (`fb_performIOHIDEventWithPage:`,
page `0x0C` / usage `0x30`, `0.5s`) instead of `pressLockButton`. Older iOS is
unchanged. The existing `FBRunLoopSpinner` wait on the
`com.apple.springboard.lockstate` notification stays, so success is still
confirmed by the screen actually locking. Scoped to `fb_lockScreen:`.

## Testing

Verified on a physical iOS 27 device: unlocked (`/wda/locked` → `false`),
`POST /wda/lock` returned 200 in ~2s (no timeout), `/wda/locked` → `true`.

Syslog on the fixed path — the injected event (`page 12`/`usage 48` = `0x0C`/`0x30`,
`0.50s`) is confirmed cleanly and the device locks:

```SpringBoard   Lock button single press recognized.
SpringBoard   performSleep: locking the device with lock button source
testmanagerd  Event <XCDeviceEvent page 12 usage 48 duration 0.50s> confirmed by ButtonEventsCompleted.
identityservicesd System did lock
SpringBoard   UILocked: 1
coreauthd     Did receive notification com.apple.springboard.lockstate```