### PR TITLE
feat: Add callback for server startup failure

### DIFF
--- a/WebDriverAgentLib/Routing/FBWebServer.h
+++ b/WebDriverAgentLib/Routing/FBWebServer.h
@@ -24,7 +24,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) id<FBWebServerDelegate> delegate;
 
 /**
- Starts WebDriverAgent service by booting HTTP and USB server
+ Starts WebDriverAgent service by booting HTTP and USB server.
+ If the HTTP server fails to bind (for example the whole configured port range
+ is already occupied), the failure is reported to the delegate via
+ `webServer:didFailToStartWithError:`. If the delegate does not implement that
+ method the process is aborted, as before.
  */
 - (void)startServing;
 
@@ -46,6 +50,18 @@ NS_ASSUME_NONNULL_BEGIN
  @param webServer Server instance.
  */
 - (void)webServerDidRequestShutdown:(FBWebServer *)webServer;
+
+@optional
+/**
+ Called when the server failed to start the HTTP listener, for example because
+ none of the ports in the configured binding range could be bound.
+ If this method is not implemented by the delegate then the process is aborted,
+ preserving the previous behavior.
+
+ @param webServer Server instance.
+ @param error The actual error, that caused the server startup to fail.
+ */
+- (void)webServer:(FBWebServer *)webServer didFailToStartWithError:(NSError *)error;
 
 @end
 

--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -81,7 +81,9 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
 {
   [FBLogger logFmt:@"Built at %s %s", __DATE__, __TIME__];
   self.exceptionHandler = [FBExceptionHandler new];
-  [self startHTTPServer];
+  if (![self startHTTPServer]) {
+    return;
+  }
   [self initScreenshotsBroadcaster];
 
   self.keepAlive = YES;
@@ -90,7 +92,7 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
          [runLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]]);
 }
 
-- (void)startHTTPServer
+- (BOOL)startHTTPServer
 {
   self.server = [[RoutingHTTPServer alloc] init];
   [self.server setRouteQueue:dispatch_get_main_queue()];
@@ -126,11 +128,16 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
 
   if (!serverStarted) {
     [FBLogger logFmt:@"Last attempt to start web server failed with error %@", [error description]];
+    if ([self.delegate respondsToSelector:@selector(webServer:didFailToStartWithError:)]) {
+      [self.delegate webServer:self didFailToStartWithError:(NSError * _Nonnull)error];
+      return NO;
+    }
     abort();
   }
 
   NSString *serverHost = bindingIP ?: ([XCUIDevice sharedDevice].fb_wifiIPAddress ?: @"127.0.0.1");
   [FBLogger logFmt:@"%@http://%@:%d%@", FBServerURLBeginMarker, serverHost, [self.server port], FBServerURLEndMarker];
+  return YES;
 }
 
 - (void)initScreenshotsBroadcaster


### PR DESCRIPTION
## Summary

FBWebServer.startServing currently has no way to report a failure to bind the HTTP listener (e.g. every port in the configured binding range is already in use) other than calling abort(), killing the whole process with no structured error. This makes it impossible for any embedder/subclass to handle the failure gracefully (log it, retry, fail a test cleanly, etc.).

This adds an optional FBWebServerDelegate callback, webServer:didFailToStartWithError:, that is invoked with the underlying NSError when the HTTP server fails to start. If the delegate doesn't implement it, the existing abort() behavior is preserved, so this is fully backward compatible.

## Changes

- FBWebServer.h: added @optional -webServer:didFailToStartWithError: to FBWebServerDelegate; updated startServing's doc comment to describe the new contract.
- FBWebServer.m: startHTTPServer now returns BOOL and notifies the delegate (if implemented) instead of unconditionally aborting; startServing bails out early if startup failed rather than proceeding to init the mjpeg broadcaster and enter the run loop.