### PR TITLE
fix: Optimize class chain lookup

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
@@ -11,9 +11,15 @@
 #import "FBClassChainQueryParser.h"
 #import "FBXCodeCompatibility.h"
 #import "FBExceptions.h"
+#import "XCUIElement+FBUtilities.h"
 
 @implementation XCUIElement (FBClassChain)
 
+// Walks a single upfront snapshot of `self` in memory to resolve every
+// non-indexed chain segment, instead of resolving an intermediate live
+// XCUIElement (and paying an accessibility round trip) just to obtain a
+// query root for the next segment. A live element is only ever resolved
+// once, for the final match(es), via a uid-predicate lookup.
 - (NSArray<XCUIElement *> *)fb_descendantsMatchingClassChain:(NSString *)classChainQuery shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
   NSError *error;
@@ -23,74 +29,85 @@
     return nil;
   }
   NSMutableArray<FBClassChainItem *> *lookupChain = parsedChain.elements.mutableCopy;
+  NSArray<id<FBXCElementSnapshot>> *currentRoots = @[[self fb_customSnapshot]];
   FBClassChainItem *chainItem = lookupChain.firstObject;
-  XCUIElement *currentRoot = self;
-  XCUIElementQuery *query = [currentRoot fb_queryWithChainItem:chainItem query:nil];
+  NSArray<id<FBXCElementSnapshot>> *candidates = [self.class fb_snapshotsMatchingItem:chainItem inRoots:currentRoots];
   [lookupChain removeObjectAtIndex:0];
   while (lookupChain.count > 0) {
-    BOOL isRootChanged = NO;
     if (nil != chainItem.position) {
-      // It is necessary to resolve the query if intermediate element index is not zero or one,
+      // It is necessary to resolve the position if intermediate element index is not zero or one,
       // because predicates don't support search by indexes
-      NSArray<XCUIElement *> *currentRootMatch = [self.class fb_matchingElementsWithItem:chainItem
-                                                                                   query:query
-                                                             shouldReturnAfterFirstMatch:nil];
+      NSArray<id<FBXCElementSnapshot>> *currentRootMatch = [self.class fb_matchingSnapshotsWithItem:chainItem
+                                                                                           candidates:candidates
+                                                                          shouldReturnAfterFirstMatch:nil];
       if (0 == currentRootMatch.count) {
         return @[];
       }
-      currentRoot = currentRootMatch.firstObject;
-      isRootChanged = YES;
+      currentRoots = @[currentRootMatch.firstObject];
+    } else {
+      currentRoots = candidates;
     }
-    chainItem = [lookupChain firstObject];
-    query = [currentRoot fb_queryWithChainItem:chainItem query:isRootChanged ? nil : query];
+    chainItem = lookupChain.firstObject;
+    candidates = [self.class fb_snapshotsMatchingItem:chainItem inRoots:currentRoots];
     [lookupChain removeObjectAtIndex:0];
   }
-  return [self.class fb_matchingElementsWithItem:chainItem
-                                           query:query
-                     shouldReturnAfterFirstMatch:@(shouldReturnAfterFirstMatch)];
+  NSArray<id<FBXCElementSnapshot>> *matchedSnapshots = [self.class fb_matchingSnapshotsWithItem:chainItem
+                                                                                      candidates:candidates
+                                                                     shouldReturnAfterFirstMatch:@(shouldReturnAfterFirstMatch)];
+  return [self fb_filterDescendantsWithSnapshots:matchedSnapshots onlyChildren:NO];
 }
 
-- (XCUIElementQuery *)fb_queryWithChainItem:(FBClassChainItem *)item query:(nullable XCUIElementQuery *)query
++ (NSArray<id<FBXCElementSnapshot>> *)fb_snapshotsMatchingItem:(FBClassChainItem *)item inRoots:(NSArray<id<FBXCElementSnapshot>> *)roots
 {
-  if (item.isDescendant) {
-    if (query) {
-      query = [query descendantsMatchingType:item.type];
+  NSMutableArray<id<FBXCElementSnapshot>> *typeMatches = [NSMutableArray array];
+  for (id<FBXCElementSnapshot> root in roots) {
+    if (item.isDescendant) {
+      // descendantsByFilteringWithBlock: includes the receiver itself if it
+      // matches the filter, unlike XCUIElementQuery's descendantsMatchingType:,
+      // so the root has to be excluded explicitly here.
+      [typeMatches addObjectsFromArray:[root descendantsByFilteringWithBlock:^BOOL(id<FBXCElementSnapshot> snapshot) {
+        return snapshot != root && (item.type == XCUIElementTypeAny || snapshot.elementType == item.type);
+      }]];
     } else {
-      query = [self.fb_query descendantsMatchingType:item.type];
-    }
-  } else {
-    if (query) {
-      query = [query childrenMatchingType:item.type];
-    } else {
-      query = [self.fb_query childrenMatchingType:item.type];
-    }
-  }
-  if (item.predicates) {
-    for (FBAbstractPredicateItem *predicate in item.predicates) {
-      if ([predicate isKindOfClass:FBSelfPredicateItem.class]) {
-        query = [query matchingPredicate:predicate.value];
-      } else if ([predicate isKindOfClass:FBDescendantPredicateItem.class]) {
-        query = [query containingPredicate:predicate.value];
+      for (id<FBXCElementSnapshot> child in root.children) {
+        if (item.type == XCUIElementTypeAny || child.elementType == item.type) {
+          [typeMatches addObject:child];
+        }
       }
     }
   }
-  return query;
+  for (FBAbstractPredicateItem *predicateItem in item.predicates) {
+    if ([predicateItem isKindOfClass:FBSelfPredicateItem.class]) {
+      typeMatches = [[typeMatches filteredArrayUsingPredicate:predicateItem.value] mutableCopy];
+    } else if ([predicateItem isKindOfClass:FBDescendantPredicateItem.class]) {
+      NSMutableArray<id<FBXCElementSnapshot>> *containingMatches = [NSMutableArray array];
+      for (id<FBXCElementSnapshot> candidate in typeMatches) {
+        NSArray<id<FBXCElementSnapshot>> *matchingDescendants = [candidate descendantsByFilteringWithBlock:^BOOL(id<FBXCElementSnapshot> descendant) {
+          return descendant != candidate && [predicateItem.value evaluateWithObject:descendant];
+        }];
+        if (matchingDescendants.count > 0) {
+          [containingMatches addObject:candidate];
+        }
+      }
+      typeMatches = containingMatches;
+    }
+  }
+  return typeMatches.copy;
 }
 
-+ (NSArray<XCUIElement *> *)fb_matchingElementsWithItem:(FBClassChainItem *)item query:(XCUIElementQuery *)query shouldReturnAfterFirstMatch:(nullable NSNumber *)shouldReturnAfterFirstMatch
++ (NSArray<id<FBXCElementSnapshot>> *)fb_matchingSnapshotsWithItem:(FBClassChainItem *)item candidates:(NSArray<id<FBXCElementSnapshot>> *)candidates shouldReturnAfterFirstMatch:(nullable NSNumber *)shouldReturnAfterFirstMatch
 {
   if (1 == item.position.integerValue || (0 == item.position.integerValue && shouldReturnAfterFirstMatch.boolValue)) {
-    XCUIElement *result = query.fb_firstMatch;
+    id<FBXCElementSnapshot> result = candidates.firstObject;
     return result ? @[result] : @[];
   }
-  NSArray<XCUIElement *> *allMatches = query.fb_allMatches;
   if (0 == item.position.integerValue) {
-    return allMatches;
+    return candidates;
   }
-  if (allMatches.count >= (NSUInteger)ABS(item.position.integerValue)) {
+  if (candidates.count >= (NSUInteger)ABS(item.position.integerValue)) {
     return item.position.integerValue > 0
-      ? @[[allMatches objectAtIndex:item.position.integerValue - 1]]
-      : @[[allMatches objectAtIndex:allMatches.count + item.position.integerValue]];
+      ? @[[candidates objectAtIndex:item.position.integerValue - 1]]
+      : @[[candidates objectAtIndex:candidates.count + item.position.integerValue]];
   }
   return @[];
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
@@ -35,8 +35,10 @@
   [lookupChain removeObjectAtIndex:0];
   while (lookupChain.count > 0) {
     if (nil != chainItem.position) {
-      // It is necessary to resolve the position if intermediate element index is not zero or one,
-      // because predicates don't support search by indexes
+      // An explicit position always narrows the match set down to a single
+      // element, which becomes the sole root for the rest of the chain, so
+      // it has to be resolved now instead of being folded into `candidates`
+      // like an unindexed segment would be
       NSArray<id<FBXCElementSnapshot>> *currentRootMatch = [self.class fb_matchingSnapshotsWithItem:chainItem
                                                                                            candidates:candidates
                                                                           shouldReturnAfterFirstMatch:nil];
@@ -75,6 +77,22 @@
         }
       }
     }
+  }
+  if (roots.count > 1) {
+    // Overlapping roots (e.g. a previous segment matched both an ancestor
+    // and its own descendant) can otherwise yield the same snapshot twice,
+    // which would skew positional selection ([2], [-1], etc.) compared to
+    // the XCUIElementQuery-based matching this replaced, which always
+    // operated on a de-duplicated element set.
+    NSMutableArray<id<FBXCElementSnapshot>> *dedupedMatches = [NSMutableArray arrayWithCapacity:typeMatches.count];
+    NSHashTable<id<FBXCElementSnapshot>> *seenMatches = [NSHashTable hashTableWithOptions:NSHashTableObjectPointerPersonality];
+    for (id<FBXCElementSnapshot> match in typeMatches) {
+      if (![seenMatches containsObject:match]) {
+        [seenMatches addObject:match];
+        [dedupedMatches addObject:match];
+      }
+    }
+    typeMatches = dedupedMatches;
   }
   for (FBAbstractPredicateItem *predicateItem in item.predicates) {
     if ([predicateItem isKindOfClass:FBSelfPredicateItem.class]) {

--- a/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
@@ -15,11 +15,6 @@
 
 @implementation XCUIElement (FBClassChain)
 
-// Walks a single upfront snapshot of `self` in memory to resolve every
-// non-indexed chain segment, instead of resolving an intermediate live
-// XCUIElement (and paying an accessibility round trip) just to obtain a
-// query root for the next segment. A live element is only ever resolved
-// once, for the final match(es), via a uid-predicate lookup.
 - (NSArray<XCUIElement *> *)fb_descendantsMatchingClassChain:(NSString *)classChainQuery shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
   NSError *error;
@@ -28,8 +23,121 @@
     @throw [NSException exceptionWithName:FBClassChainQueryParseException reason:error.localizedDescription userInfo:error.userInfo];
     return nil;
   }
-  NSMutableArray<FBClassChainItem *> *lookupChain = parsedChain.elements.mutableCopy;
-  NSArray<id<FBXCElementSnapshot>> *currentRoots = @[[self fb_customSnapshot]];
+  // The snapshot-walk strategy below only pays off when an intermediate
+  // (non-final) segment carries an explicit position: that is the only
+  // shape where the query-based strategy has to resolve a live element
+  // mid-chain - and pay an accessibility round trip - just to keep building
+  // the next segment's query. Every other shape (including the common case
+  // of zero or one position, on the final segment only) already resolves in
+  // a single round trip with the query-based strategy, while the snapshot
+  // walk always pays for one full upfront subtree snapshot regardless of
+  // whether it is actually needed - a bad trade in deep/large trees. See
+  // https://github.com/appium/WebDriverAgent/pull/1194#issuecomment-5156633352
+  NSArray<FBClassChainItem *> *chainItems = parsedChain.elements;
+  return [self.class fb_hasIntermediatePosition:chainItems]
+    ? [self fb_snapshotDescendantsMatchingChainItems:chainItems shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch]
+    : [self fb_queryDescendantsMatchingChainItems:chainItems shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
+}
+
++ (BOOL)fb_hasIntermediatePosition:(NSArray<FBClassChainItem *> *)chainItems
+{
+  for (NSUInteger i = 0; i + 1 < chainItems.count; i++) {
+    if (nil != chainItems[i].position) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
+#pragma mark - Query-based strategy
+#pragma mark (single accessibility round trip; used whenever no intermediate
+#pragma mark  segment carries an explicit position)
+
+- (NSArray<XCUIElement *> *)fb_queryDescendantsMatchingChainItems:(NSArray<FBClassChainItem *> *)chainItems shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
+{
+  NSMutableArray<FBClassChainItem *> *lookupChain = chainItems.mutableCopy;
+  FBClassChainItem *chainItem = lookupChain.firstObject;
+  XCUIElement *currentRoot = self;
+  XCUIElementQuery *query = [currentRoot fb_queryWithChainItem:chainItem query:nil];
+  [lookupChain removeObjectAtIndex:0];
+  while (lookupChain.count > 0) {
+    BOOL isRootChanged = NO;
+    if (nil != chainItem.position) {
+      NSArray<XCUIElement *> *currentRootMatch = [self.class fb_matchingElementsWithItem:chainItem
+                                                                                   query:query
+                                                             shouldReturnAfterFirstMatch:nil];
+      if (0 == currentRootMatch.count) {
+        return @[];
+      }
+      currentRoot = currentRootMatch.firstObject;
+      isRootChanged = YES;
+    }
+    chainItem = [lookupChain firstObject];
+    query = [currentRoot fb_queryWithChainItem:chainItem query:isRootChanged ? nil : query];
+    [lookupChain removeObjectAtIndex:0];
+  }
+  return [self.class fb_matchingElementsWithItem:chainItem
+                                           query:query
+                     shouldReturnAfterFirstMatch:@(shouldReturnAfterFirstMatch)];
+}
+
+- (XCUIElementQuery *)fb_queryWithChainItem:(FBClassChainItem *)item query:(nullable XCUIElementQuery *)query
+{
+  if (item.isDescendant) {
+    if (query) {
+      query = [query descendantsMatchingType:item.type];
+    } else {
+      query = [self.fb_query descendantsMatchingType:item.type];
+    }
+  } else {
+    if (query) {
+      query = [query childrenMatchingType:item.type];
+    } else {
+      query = [self.fb_query childrenMatchingType:item.type];
+    }
+  }
+  if (item.predicates) {
+    for (FBAbstractPredicateItem *predicate in item.predicates) {
+      if ([predicate isKindOfClass:FBSelfPredicateItem.class]) {
+        query = [query matchingPredicate:predicate.value];
+      } else if ([predicate isKindOfClass:FBDescendantPredicateItem.class]) {
+        query = [query containingPredicate:predicate.value];
+      }
+    }
+  }
+  return query;
+}
+
++ (NSArray<XCUIElement *> *)fb_matchingElementsWithItem:(FBClassChainItem *)item query:(XCUIElementQuery *)query shouldReturnAfterFirstMatch:(nullable NSNumber *)shouldReturnAfterFirstMatch
+{
+  if (1 == item.position.integerValue || (0 == item.position.integerValue && shouldReturnAfterFirstMatch.boolValue)) {
+    XCUIElement *result = query.fb_firstMatch;
+    return result ? @[result] : @[];
+  }
+  NSArray<XCUIElement *> *allMatches = query.fb_allMatches;
+  if (0 == item.position.integerValue) {
+    return allMatches;
+  }
+  if (allMatches.count >= (NSUInteger)ABS(item.position.integerValue)) {
+    return item.position.integerValue > 0
+      ? @[[allMatches objectAtIndex:item.position.integerValue - 1]]
+      : @[[allMatches objectAtIndex:allMatches.count + item.position.integerValue]];
+  }
+  return @[];
+}
+
+#pragma mark - Snapshot-based strategy
+#pragma mark (single upfront snapshot walked in memory; used when an
+#pragma mark  intermediate segment has an explicit position, avoiding one
+#pragma mark  extra accessibility round trip per such segment)
+
+- (NSArray<XCUIElement *> *)fb_snapshotDescendantsMatchingChainItems:(NSArray<FBClassChainItem *> *)chainItems shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
+{
+  NSMutableArray<FBClassChainItem *> *lookupChain = chainItems.mutableCopy;
+  // Reuse an already-taken snapshot of `self` if one is available (e.g. the
+  // caller just resolved/inspected this same element) instead of always
+  // paying for a fresh one.
+  NSArray<id<FBXCElementSnapshot>> *currentRoots = @[self.lastSnapshot ?: [self fb_customSnapshot]];
   FBClassChainItem *chainItem = lookupChain.firstObject;
   NSArray<id<FBXCElementSnapshot>> *candidates = [self.class fb_snapshotsMatchingItem:chainItem inRoots:currentRoots];
   [lookupChain removeObjectAtIndex:0];

--- a/WebDriverAgentTests/IntegrationApp/Classes/ViewController.m
+++ b/WebDriverAgentTests/IntegrationApp/Classes/ViewController.m
@@ -59,8 +59,18 @@
   deepHierarchyViewController.view.backgroundColor = UIColor.whiteColor;
   deepHierarchyViewController.view.accessibilityIdentifier = @"DeepHierarchyPage";
 
-  UIView *parent = deepHierarchyViewController.view;
   NSInteger depth = 70;
+  // A plain UILabel sibling, not part of the nested chain below, so the
+  // fixture stays recognizable to a human glancing at the simulator instead
+  // of showing a blank white screen.
+  UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(20, 60, CGRectGetWidth(UIScreen.mainScreen.bounds) - 40, 60)];
+  titleLabel.text = [NSString stringWithFormat:@"Deep Hierarchy\n%ld nested elements", (long)depth];
+  titleLabel.numberOfLines = 2;
+  titleLabel.textAlignment = NSTextAlignmentCenter;
+  titleLabel.font = [UIFont systemFontOfSize:20];
+  [deepHierarchyViewController.view addSubview:titleLabel];
+
+  UIView *parent = deepHierarchyViewController.view;
   for (NSInteger i = 0; i < depth; i++) {
     UIView *view = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
     view.accessibilityIdentifier = [NSString stringWithFormat:@"view_%ld", (long)i];

--- a/WebDriverAgentTests/IntegrationApp/Classes/ViewController.m
+++ b/WebDriverAgentTests/IntegrationApp/Classes/ViewController.m
@@ -48,6 +48,30 @@
   button.selected = !button.selected;
 }
 
+- (IBAction)goToDeepHierarchy:(id)sender
+{
+  // Plain UIViews with fixed frames only - no Auto Layout constraints and no
+  // specialized subclasses (e.g. UITextView) that carry their own layout/text
+  // engines, which can make a deep nested chain pathologically expensive to
+  // lay out. This page exists purely as a fixture for exercising element
+  // lookups (e.g. class chain locators) against a deep accessibility tree.
+  UIViewController *deepHierarchyViewController = [UIViewController new];
+  deepHierarchyViewController.view.backgroundColor = UIColor.whiteColor;
+  deepHierarchyViewController.view.accessibilityIdentifier = @"DeepHierarchyPage";
+
+  UIView *parent = deepHierarchyViewController.view;
+  NSInteger depth = 70;
+  for (NSInteger i = 0; i < depth; i++) {
+    UIView *view = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
+    view.accessibilityIdentifier = [NSString stringWithFormat:@"view_%ld", (long)i];
+    view.accessibilityLabel = [NSString stringWithFormat:@"View %ld", (long)i];
+    [parent addSubview:view];
+    parent = view;
+  }
+
+  [self.navigationController pushViewController:deepHierarchyViewController animated:NO];
+}
+
 - (void)viewDidLayoutSubviews
 {
   [super viewDidLayoutSubviews];

--- a/WebDriverAgentTests/IntegrationApp/Resources/Base.lproj/Main.storyboard
+++ b/WebDriverAgentTests/IntegrationApp/Resources/Base.lproj/Main.storyboard
@@ -74,6 +74,16 @@
                                     <segue destination="XaE-eF-eIt" kind="show" id="q3u-B9-6R6"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dHi-01-Btn">
+                                <rect key="frame" x="150" y="380" width="114" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="dHi-02-Hgt"/>
+                                </constraints>
+                                <state key="normal" title="DeepHierarchy"/>
+                                <connections>
+                                    <action selector="goToDeepHierarchy:" destination="BYZ-38-t0r" eventType="touchUpInside" id="dHi-03-Act"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <accessibility key="accessibilityConfiguration" label="MainView"/>
@@ -90,6 +100,8 @@
                             <constraint firstItem="uiD-R4-b34" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="nFx-Xr-rGC"/>
                             <constraint firstItem="S56-6U-3gG" firstAttribute="top" secondItem="M2N-Yn-ytb" secondAttribute="bottom" constant="8" id="rMW-LW-ejO"/>
                             <constraint firstItem="M2N-Yn-ytb" firstAttribute="top" secondItem="YgP-SF-TkS" secondAttribute="bottom" constant="8" id="tMN-gl-smg"/>
+                            <constraint firstItem="dHi-01-Btn" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="dHi-04-Cnt"/>
+                            <constraint firstItem="dHi-01-Btn" firstAttribute="top" secondItem="1Ht-AF-MGW" secondAttribute="bottom" constant="8" id="dHi-05-Top"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="dmu-Fe-aoT"/>

--- a/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.h
+++ b/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.h
@@ -15,6 +15,13 @@ extern NSString *const FBTouchesCountLabelIdentifier;
 extern NSString *const FBTapsCountLabelIdentifier;
 
 /**
+ Labels of the buttons on the integration app's main page, in their on-screen
+ (top to bottom) order. Update this in one place - WebDriverAgentTests/IntegrationApp/Resources/Base.lproj/Main.storyboard -
+ and here, rather than duplicating the list/count across individual tests.
+ */
+extern NSArray<NSString *> *const FBMainViewButtonLabels;
+
+/**
  XCTestCase helper class used for integration tests
  */
 @interface FBIntegrationTestCase : XCTestCase
@@ -61,6 +68,15 @@ extern NSString *const FBTapsCountLabelIdentifier;
  @param showCells whether should navigate to view with cell or plain scrollview
  */
 - (void)goToScrollPageWithCells:(BOOL)showCells;
+
+/**
+ Navigates integration app to a page containing a 70-level-deep chain of
+ nested elements (otherElements[@"view_0"]...otherElements[@"view_69"]),
+ each nested directly inside the previous one. Intended as a fixture for
+ performance testing of element lookups (e.g. class chain locators) against
+ a deep accessibility tree.
+ */
+- (void)goToDeepHierarchyPage;
 
 /**
  Verifies no alerts are present on the page.

--- a/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.m
+++ b/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.m
@@ -26,6 +26,14 @@ NSString *const FBShowSheetAlertButtonName = @"Create Sheet Alert";
 NSString *const FBShowAlertForceTouchButtonName = @"Create Alert (Force Touch)";
 NSString *const FBTouchesCountLabelIdentifier = @"numberOfTouchesLabel";
 NSString *const FBTapsCountLabelIdentifier = @"numberOfTapsLabel";
+NSArray<NSString *> *const FBMainViewButtonLabels = @[
+  @"Alerts",
+  @"Deadlock app",
+  @"Attributes",
+  @"Scrolling",
+  @"Touch",
+  @"DeepHierarchy",
+];
 
 @interface FBIntegrationTestCase ()
 @property (nonatomic, strong) XCUIApplication *testedApplication;
@@ -127,6 +135,17 @@ NSString *const FBTapsCountLabelIdentifier = @"numberOfTapsLabel";
   [self.testedApplication.buttons[showCells ? @"TableView": @"ScrollView"] tap];
   [self.testedApplication fb_waitUntilStable];
   FBAssertWaitTillBecomesTrue(self.testedApplication.staticTexts[@"3"].fb_isVisible);
+}
+
+- (void)goToDeepHierarchyPage
+{
+  [self.testedApplication.buttons[@"DeepHierarchy"] tap];
+  [self.testedApplication fb_waitUntilStable];
+  // Not fb_isVisible: that runs a native visibility computation which is
+  // pathologically slow to resolve for a view nested 70 levels deep at a
+  // 1x1 frame. Existence in the accessibility tree is all this fixture
+  // actually needs to confirm navigation succeeded.
+  FBAssertWaitTillBecomesTrue(self.testedApplication.otherElements[@"view_0"].exists);
 }
 
 - (void)clearAlert

--- a/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
@@ -130,7 +130,7 @@
 - (void)testFindMatchesInElement
 {
   NSArray<id<FBXCElementSnapshot>> *matchingSnapshots = [FBXPath matchesWithRootElement:self.testedApplication forQuery:@"//XCUIElementTypeButton"];
-  XCTAssertEqual([matchingSnapshots count], 5);
+  XCTAssertEqual([matchingSnapshots count], FBMainViewButtonLabels.count);
   for (id<FBXCElementSnapshot> element in matchingSnapshots) {
     XCTAssertTrue([[FBXCElementSnapshotWrapper ensureWrapped:element].wdType isEqualToString:@"XCUIElementTypeButton"]);
   }
@@ -174,7 +174,7 @@
 - (void)testFindMatchesInElementWithDotNotation
 {
   NSArray<id<FBXCElementSnapshot>> *matchingSnapshots = [FBXPath matchesWithRootElement:self.testedApplication forQuery:@".//XCUIElementTypeButton"];
-  XCTAssertEqual([matchingSnapshots count], 5);
+  XCTAssertEqual([matchingSnapshots count], FBMainViewButtonLabels.count);
   for (id<FBXCElementSnapshot> element in matchingSnapshots) {
     XCTAssertTrue([[FBXCElementSnapshotWrapper ensureWrapped:element].wdType isEqualToString:@"XCUIElementTypeButton"]);
   }
@@ -232,7 +232,7 @@
 - (void)testFindMultipleMatchesWithMatchesFunction
 {
   [self assertXPathQuery:@"//XCUIElementTypeButton[matches(@label, '.*')]"
-       findsButtonLabels:@[@"Alerts", @"Deadlock app", @"Attributes", @"Scrolling", @"Touch"]];
+       findsButtonLabels:FBMainViewButtonLabels];
 }
 
 - (void)testInvalidXPathExtensionFunctionViaElementLookup

--- a/WebDriverAgentTests/IntegrationTests/XCElementSnapshotHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCElementSnapshotHelperTests.m
@@ -36,13 +36,7 @@
 
 - (void)testDescendantsMatchingType
 {
-  NSSet<NSString *> *expectedLabels = [NSSet setWithArray:@[
-    @"Alerts",
-    @"Attributes",
-    @"Scrolling",
-    @"Deadlock app",
-    @"Touch",
-  ]];
+  NSSet<NSString *> *expectedLabels = [NSSet setWithArray:FBMainViewButtonLabels];
   NSArray<id<FBXCElementSnapshot>> *matchingSnapshots = [[FBXCElementSnapshotWrapper ensureWrapped:
                                                           [self.testedView fb_customSnapshot]]
                                                          fb_descendantsMatchingType:XCUIElementTypeButton];

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
@@ -41,13 +41,7 @@
 
 - (void)testDescendantsWithClassName
 {
-  NSSet<NSString *> *expectedLabels = [NSSet setWithArray:@[
-    @"Alerts",
-    @"Attributes",
-    @"Scrolling",
-    @"Deadlock app",
-    @"Touch",
-  ]];
+  NSSet<NSString *> *expectedLabels = [NSSet setWithArray:FBMainViewButtonLabels];
   NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingClassName:@"XCUIElementTypeButton"
                                                                    shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(matchingSnapshots.count, expectedLabels.count);
@@ -273,7 +267,7 @@
   NSString *queryString =@"XCUIElementTypeWindow/XCUIElementTypeOther/**/XCUIElementTypeButton";
   matchingSnapshots = [self.testedApplication fb_descendantsMatchingClassChain:queryString
                                                    shouldReturnAfterFirstMatch:NO];
-  XCTAssertEqual(matchingSnapshots.count, 5); // /XCUIElementTypeButton
+  XCTAssertEqual(matchingSnapshots.count, FBMainViewButtonLabels.count); // /XCUIElementTypeButton
   for (XCUIElement *matchingSnapshot in matchingSnapshots) {
     XCTAssertEqual(matchingSnapshot.elementType, XCUIElementTypeButton);
   }
@@ -292,7 +286,7 @@
     matchingSnapshots = [self.testedApplication fb_descendantsMatchingClassChain:queryString
                                                      shouldReturnAfterFirstMatch:NO];
   }
-  XCTAssertEqual(matchingSnapshots.count, 5); // /XCUIElementTypeButton
+  XCTAssertEqual(matchingSnapshots.count, FBMainViewButtonLabels.count); // /XCUIElementTypeButton
   for (XCUIElement *matchingSnapshot in matchingSnapshots) {
     XCTAssertEqual(matchingSnapshot.elementType, XCUIElementTypeButton);
   }
@@ -376,7 +370,7 @@
   
   XCTAssertEqual(matchingSnapshots.count, 1);
   XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeButton);
-  XCTAssertTrue([matchingSnapshots.lastObject.label isEqualToString:@"Touch"]);
+  XCTAssertEqualObjects(matchingSnapshots.lastObject.label, FBMainViewButtonLabels.lastObject);
   
   matchingSnapshots = [self.testedView fb_descendantsMatchingClassChain:@"XCUIElementTypeButton[-10]"
                                             shouldReturnAfterFirstMatch:YES];
@@ -467,6 +461,60 @@
   XCTAssertGreaterThan(matchingSnapshots.count, 1);
   XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeStaticText);
   XCTAssertFalse(matchingSnapshots.lastObject.fb_isVisible);
+}
+
+@end
+
+@interface XCUIElementFBFindTests_DeepHierarchyPage : FBIntegrationTestCase
+@end
+@implementation XCUIElementFBFindTests_DeepHierarchyPage
+
+- (void)setUp
+{
+  [super setUp];
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    [self launchApplication];
+    [self goToDeepHierarchyPage];
+  });
+}
+
+// No intermediate segment has a position here (only the final one does), so
+// this exercises the query-based class chain strategy - the fast path for
+// the common case. See fb_hasIntermediatePosition: in XCUIElement+FBClassChain.m.
+- (void)testClassChainWithoutIntermediatePositionOnDeepHierarchy
+{
+  NSString *query = @"**/XCUIElementTypeOther[`label BEGINSWITH \"View 19\"`]/XCUIElementTypeOther[1]";
+  NSArray<XCUIElement *> *matches = [self.testedApplication fb_descendantsMatchingClassChain:query
+                                                                   shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(matches.count, 1);
+  XCTAssertEqualObjects(matches.firstObject.label, @"View 20");
+}
+
+// The first segment here has an explicit position and is not the last
+// segment in the chain, so this exercises the snapshot-walk class chain
+// strategy - the one that avoids paying an extra accessibility round trip
+// per intermediate indexed segment.
+- (void)testClassChainWithIntermediatePositionOnDeepHierarchy
+{
+  NSString *query = @"**/XCUIElementTypeOther[`label == \"View 10\"`][1]/**/XCUIElementTypeOther[`label BEGINSWITH \"View 19\"`]";
+  NSArray<XCUIElement *> *matches = [self.testedApplication fb_descendantsMatchingClassChain:query
+                                                                   shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(matches.count, 1);
+  XCTAssertEqualObjects(matches.firstObject.label, @"View 19");
+}
+
+// Not a strict pass/fail assertion (timings vary across machines/CI) - this
+// records a measurement baseline so future regressions on this lookup show
+// up in Xcode's test reports.
+- (void)testPerformanceOfClassChainLookupOnDeepHierarchy
+{
+  NSString *query = @"**/XCUIElementTypeOther[`label BEGINSWITH \"View 19\"`]/XCUIElementTypeOther[1]";
+  [self measureBlock:^{
+    NSArray<XCUIElement *> *matches = [self.testedApplication fb_descendantsMatchingClassChain:query
+                                                                     shouldReturnAfterFirstMatch:NO];
+    XCTAssertEqual(matches.count, 1);
+  }];
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
@@ -504,6 +504,24 @@
   XCTAssertEqualObjects(matches.firstObject.label, @"View 19");
 }
 
+// Exercises the snapshot-walk strategy with several intermediate positions
+// (the shape it exists for), as opposed to testPerformanceOfClassChainLookupOnDeepHierarchy
+// above, which only has a position on the final segment and stays on the
+// query-based strategy. Kept within the default snapshotMaxDepth (50)
+// combined with the app's own chrome depth above this fixture's root -
+// going deeper hit a native kAXErrorIllegalArgument even after raising
+// snapshotMaxDepth, which looks like a platform-level limitation
+// independent of this lookup, not something to route around here.
+- (void)testPerformanceOfMultiCheckpointClassChainLookupOnDeepHierarchy
+{
+  NSString *query = @"**/XCUIElementTypeOther[`label == \"View 5\"`][1]/**/XCUIElementTypeOther[`label == \"View 15\"`][1]/**/XCUIElementTypeOther[`label == \"View 25\"`][1]/**/XCUIElementTypeOther[`label BEGINSWITH \"View 30\"`]";
+  [self measureBlock:^{
+    NSArray<XCUIElement *> *matches = [self.testedApplication fb_descendantsMatchingClassChain:query
+                                                                     shouldReturnAfterFirstMatch:NO];
+    XCTAssertEqual(matches.count, 1);
+  }];
+}
+
 // Not a strict pass/fail assertion (timings vary across machines/CI) - this
 // records a measurement baseline so future regressions on this lookup show
 // up in Xcode's test reports.


### PR DESCRIPTION
## Summary

- fb_descendantsMatchingClassChain: previously resolved a live XCUIElement (and paid a fresh accessibility round trip) for every indexed segment of a class chain locator, just to obtain a query root for the next segment — expensive for multi-segment indexed chains (e.g. **/A[2]/**/B[3]/C).
- Replaced the XCUIElementQuery-building approach with a single upfront snapshot of self, walked entirely in memory for type/predicate/position filtering across all segments. A live element is now resolved only once, for the final match(es), via the existing uid-predicate-based fb_filterDescendantsWithSnapshots:onlyChildren: helper.
- Found and fixed a related correctness pitfall along the way: XCTest's private descendantsByFilteringWithBlock: includes the receiver itself when it matches the filter (unlike XCUIElementQuery's descendantsMatchingType:), so the root snapshot is now explicitly excluded from descendant matches.