### PR TITLE
fix: Reduce the amount of AX calls while determining direction to focused element

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -41,6 +41,9 @@
 		315A15012518CB8700A3A064 /* TouchableView.m in Sources */ = {isa = PBXBuildFile; fileRef = 315A15002518CB8700A3A064 /* TouchableView.m */; };
 		315A15072518CC2800A3A064 /* TouchSpotView.m in Sources */ = {isa = PBXBuildFile; fileRef = 315A15062518CC2800A3A064 /* TouchSpotView.m */; };
 		315A150A2518D6F400A3A064 /* TouchViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 315A15092518D6F400A3A064 /* TouchViewController.m */; };
+		491B4CDEC26699164481DFC0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 722E62C63348A451A351524B /* Foundation.framework */; };
+		5AF49CE43E731B433375C5B7 /* ViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F87CD156E93338642EEFD54 /* ViewController.h */; };
+		5DE3B29128FA52F078160D5B /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A87AE5544E9A5CA7C9168DDF /* SceneDelegate.m */; };
 		6385F4A7220A40760095BBDB /* XCUIApplicationProcessDelay.m in Sources */ = {isa = PBXBuildFile; fileRef = 6385F4A5220A40760095BBDB /* XCUIApplicationProcessDelay.m */; };
 		63CCF91221ECE4C700E94ABD /* FBImageProcessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 63CCF91021ECE4C700E94ABD /* FBImageProcessor.h */; };
 		63CCF91321ECE4C700E94ABD /* FBImageProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 63CCF91121ECE4C700E94ABD /* FBImageProcessor.m */; };
@@ -310,12 +313,11 @@
 		64B264FE228C50E0002A5025 /* WebDriverAgentLib_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 641EE6F82240C5CA00173FCB /* WebDriverAgentLib_tvOS.framework */; };
 		64B26504228C5299002A5025 /* FBTVNavigationTrackerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 64B264F3228C5098002A5025 /* FBTVNavigationTrackerTests.m */; };
 		64B26508228C5514002A5025 /* XCUIElementDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = 64B26507228C5514002A5025 /* XCUIElementDouble.m */; };
-		CB1BAB30928B638B300B4477 /* FBXCAccessibilityElementDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = 16223B3E144418CC980D160E /* FBXCAccessibilityElementDouble.m */; };
-		DE75F01A64FBC6A58012E6B4 /* FBXCElementSnapshotDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = F46F78706C5157469122F730 /* FBXCElementSnapshotDouble.m */; };
 		64B2650A228CE4FF002A5025 /* FBTVNavigationTracker-Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 64B26509228CE4FF002A5025 /* FBTVNavigationTracker-Private.h */; };
 		64B2650B228CE4FF002A5025 /* FBTVNavigationTracker-Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 64B26509228CE4FF002A5025 /* FBTVNavigationTracker-Private.h */; };
 		64E3502E2AC0B6EB005F3ACB /* NSDictionary+FBUtf8SafeDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 716F0DA02A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.m */; };
 		64E3502F2AC0B6FE005F3ACB /* NSDictionary+FBUtf8SafeDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 716F0D9F2A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.h */; };
+		6CE6B9FF16CEAB475B764A92 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DD3770A67ED561EBE5E443A /* main.m */; };
 		711084441DA3AA7500F913D6 /* FBXPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 711084421DA3AA7500F913D6 /* FBXPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		711084451DA3AA7500F913D6 /* FBXPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 711084431DA3AA7500F913D6 /* FBXPath.m */; };
 		7119097C2152580600BA3C7E /* XCUIScreen.h in Headers */ = {isa = PBXBuildFile; fileRef = 7119097B2152580600BA3C7E /* XCUIScreen.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -537,13 +539,18 @@
 		71F5BE50252F14EB00EE9EBA /* FBExceptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 71F5BE4D252F14EB00EE9EBA /* FBExceptions.h */; };
 		71F5BE51252F14EB00EE9EBA /* FBExceptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 71F5BE4E252F14EB00EE9EBA /* FBExceptions.m */; };
 		71F5BE52252F14EB00EE9EBA /* FBExceptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 71F5BE4E252F14EB00EE9EBA /* FBExceptions.m */; };
+		72FE28D00A69D335B463C03A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 721E280BFFEFFD40C89277AF /* AppDelegate.m */; };
+		9BE258E6A383AF8BCB59C475 /* FBTVFocusIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A53731B41356D9B4E723A4D /* FBTVFocusIntegrationTests.m */; };
+		A14CB090646BCB0B50F213CF /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D7DD32943CAC7838F942ED5 /* ViewController.m */; };
 		A1B2C3D41F001A00A1B0004 /* XCUIDevice+FBVoiceOver.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A1B2C3D41F001A00A1B0005 /* XCUIDevice+FBVoiceOver.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0002 /* XCUIDevice+FBVoiceOver.m */; };
 		A1B2C3D41F001A00A1B0006 /* XCUIDevice+FBVoiceOver.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A1B2C3D41F001A00A1B0007 /* XCUIDevice+FBVoiceOver.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0002 /* XCUIDevice+FBVoiceOver.m */; };
 		A1B2C3D41F001A00A1B0008 /* FBVoiceOverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0003 /* FBVoiceOverTests.m */; };
 		A1B2C3D4E5F600000000001B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000001A /* Assets.xcassets */; };
+		AAA213E600F40AB7F43D1015 /* WebDriverAgentLib_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 641EE6F82240C5CA00173FCB /* WebDriverAgentLib_tvOS.framework */; };
 		AABBCCDDEEFF001122334457 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AABBCCDDEEFF001122334456 /* SceneDelegate.m */; };
+		ACA7E8FE7C086A9A6EF7CFDF /* SceneDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F719C2804F6473A9C4D3090 /* SceneDelegate.h */; };
 		AD35D06C1CF1C35500870A75 /* WebDriverAgentLib.framework in Copy frameworks */ = {isa = PBXBuildFile; fileRef = EE158A991CBD452B00A3E3F0 /* WebDriverAgentLib.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AD6C26941CF2379700F8B5FF /* FBAlert.h in Headers */ = {isa = PBXBuildFile; fileRef = AD6C26921CF2379700F8B5FF /* FBAlert.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AD6C26951CF2379700F8B5FF /* FBAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = AD6C26931CF2379700F8B5FF /* FBAlert.m */; };
@@ -562,11 +569,14 @@
 		B316351D2DDF0CF5007D9317 /* FBAccessibilityTraits.m in Sources */ = {isa = PBXBuildFile; fileRef = B316351B2DDF0CF5007D9317 /* FBAccessibilityTraits.m */; };
 		B316351F2DDF0D0B007D9317 /* FBAccessibilityTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = B316351E2DDF0D0B007D9317 /* FBAccessibilityTraits.h */; };
 		B31635202DDF0D0B007D9317 /* FBAccessibilityTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = B316351E2DDF0D0B007D9317 /* FBAccessibilityTraits.h */; };
+		B63FBAF7421417011D724B6F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 722E62C63348A451A351524B /* Foundation.framework */; };
 		C845206222D5E79400EA68CB /* FBUnattachedAppLauncher.h in Headers */ = {isa = PBXBuildFile; fileRef = C8FB547722D4C1FC00B69954 /* FBUnattachedAppLauncher.h */; };
 		C845206322D5E79700EA68CB /* FBUnattachedAppLauncher.m in Sources */ = {isa = PBXBuildFile; fileRef = C8FB547822D4C1FC00B69954 /* FBUnattachedAppLauncher.m */; };
 		C8FB547422D3949C00B69954 /* LSApplicationWorkspace.h in Headers */ = {isa = PBXBuildFile; fileRef = C8FB547322D3949C00B69954 /* LSApplicationWorkspace.h */; };
 		C8FB547922D4C1FC00B69954 /* FBUnattachedAppLauncher.h in Headers */ = {isa = PBXBuildFile; fileRef = C8FB547722D4C1FC00B69954 /* FBUnattachedAppLauncher.h */; };
 		C8FB547A22D4C1FC00B69954 /* FBUnattachedAppLauncher.m in Sources */ = {isa = PBXBuildFile; fileRef = C8FB547822D4C1FC00B69954 /* FBUnattachedAppLauncher.m */; };
+		CB1BAB30928B638B300B4477 /* FBXCAccessibilityElementDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = 16223B3E144418CC980D160E /* FBXCAccessibilityElementDouble.m */; };
+		DE75F01A64FBC6A58012E6B4 /* FBXCElementSnapshotDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = F46F78706C5157469122F730 /* FBXCElementSnapshotDouble.m */; };
 		E444DC65249131890060D7EB /* HTTPErrorResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DC59249131880060D7EB /* HTTPErrorResponse.h */; };
 		E444DC67249131890060D7EB /* HTTPDataResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = E444DC5B249131880060D7EB /* HTTPDataResponse.m */; };
 		E444DC6C249131890060D7EB /* HTTPDataResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DC60249131890060D7EB /* HTTPDataResponse.h */; };
@@ -608,6 +618,7 @@
 		E444DCD224917A5E0060D7EB /* HTTPErrorResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = E444DC61249131890060D7EB /* HTTPErrorResponse.m */; };
 		E444DCD424917A5E0060D7EB /* DDNumber.m in Sources */ = {isa = PBXBuildFile; fileRef = E444DC7F249131B00060D7EB /* DDNumber.m */; };
 		E444DCD624917A5E0060D7EB /* DDRange.m in Sources */ = {isa = PBXBuildFile; fileRef = E444DC7E249131B00060D7EB /* DDRange.m */; };
+		ECC4ABB5477FBA3D442559B1 /* AppDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 242FCA9DD0E30D748E0A1969 /* AppDelegate.h */; };
 		EE006EAD1EB99B15006900A4 /* FBElementVisibilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EE006EAC1EB99B15006900A4 /* FBElementVisibilityTests.m */; };
 		EE05BAFA1D13003C00A3EB00 /* FBKeyboardTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EE05BAF91D13003C00A3EB00 /* FBKeyboardTests.m */; };
 		EE0D1F611EBCDCF7006A3123 /* NSString+FBVisualLength.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0D1F5F1EBCDCF7006A3123 /* NSString+FBVisualLength.h */; };
@@ -857,12 +868,26 @@
 			remoteGlobalIDString = 641EE5D52240C5CA00173FCB;
 			remoteInfo = WebDriverAgentLib_tvOS;
 		};
+		87B9178994EC282C279A8242 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 91F9DAE11B99DBC2001349B2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7C3BE5A1B1A6022529590D15;
+			remoteInfo = IntegrationApp_tvOS;
+		};
 		AD8D96F01D3C12960061268E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 91F9DAE11B99DBC2001349B2 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = EE158A981CBD452B00A3E3F0;
 			remoteInfo = WebDriverAgentLib;
+		};
+		BCF4385789C88C87C38D8ABA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 91F9DAE11B99DBC2001349B2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 641EE5D52240C5CA00173FCB;
+			remoteInfo = WebDriverAgentLib_tvOS;
 		};
 		EE158B5B1CBD462500A3E3F0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -943,6 +968,7 @@
 /* Begin PBXFileReference section */
 		0E0413372DF1E15100AF007C /* XCUIElement+FBMinMax.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIElement+FBMinMax.m"; sourceTree = "<group>"; };
 		0E04133A2DF1E15900AF007C /* XCUIElement+FBMinMax.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIElement+FBMinMax.h"; sourceTree = "<group>"; };
+		0F719C2804F6473A9C4D3090 /* SceneDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
 		1357E295233D05240054BDB8 /* XCUIHitPointResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCUIHitPointResult.h; sourceTree = "<group>"; };
 		13815F6D2328D20400CDAB61 /* FBActiveAppDetectionPoint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBActiveAppDetectionPoint.h; sourceTree = "<group>"; };
 		13815F6E2328D20400CDAB61 /* FBActiveAppDetectionPoint.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBActiveAppDetectionPoint.m; sourceTree = "<group>"; };
@@ -958,14 +984,18 @@
 		13DE7A5A287CA444003243C6 /* FBXCElementSnapshotWrapper+Helpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "FBXCElementSnapshotWrapper+Helpers.m"; sourceTree = "<group>"; };
 		13FFF2F0287DBEE600E561E4 /* XCElementSnapshotDouble.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCElementSnapshotDouble.h; sourceTree = "<group>"; };
 		13FFF2F1287DBEE600E561E4 /* XCElementSnapshotDouble.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XCElementSnapshotDouble.m; sourceTree = "<group>"; };
+		16223B3E144418CC980D160E /* FBXCAccessibilityElementDouble.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBXCAccessibilityElementDouble.m; sourceTree = "<group>"; };
 		1BA7DD8C206D694B007C7C26 /* XCTElementSetTransformer-Protocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCTElementSetTransformer-Protocol.h"; sourceTree = "<group>"; };
+		242FCA9DD0E30D748E0A1969 /* AppDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		315A14FF2518CB8700A3A064 /* TouchableView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TouchableView.h; sourceTree = "<group>"; };
 		315A15002518CB8700A3A064 /* TouchableView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TouchableView.m; sourceTree = "<group>"; };
 		315A15052518CC2800A3A064 /* TouchSpotView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TouchSpotView.h; sourceTree = "<group>"; };
 		315A15062518CC2800A3A064 /* TouchSpotView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TouchSpotView.m; sourceTree = "<group>"; };
 		315A15082518D6F400A3A064 /* TouchViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TouchViewController.h; sourceTree = "<group>"; };
 		315A15092518D6F400A3A064 /* TouchViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TouchViewController.m; sourceTree = "<group>"; };
+		3A53731B41356D9B4E723A4D /* FBTVFocusIntegrationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = FBTVFocusIntegrationTests.m; sourceTree = "<group>"; };
 		44757A831D42CE8300ECF35E /* XCUIDeviceRotationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCUIDeviceRotationTests.m; sourceTree = "<group>"; };
+		5D7DD32943CAC7838F942ED5 /* ViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
 		631B523421F6174300625362 /* FBImageProcessorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBImageProcessorTests.m; sourceTree = "<group>"; };
 		633E904A220DEE7F007CADF9 /* XCUIApplicationProcessDelay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCUIApplicationProcessDelay.h; sourceTree = "<group>"; };
 		6385F4A5220A40760095BBDB /* XCUIApplicationProcessDelay.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XCUIApplicationProcessDelay.m; sourceTree = "<group>"; };
@@ -986,11 +1016,8 @@
 		64B264F9228C50E0002A5025 /* UnitTests_tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests_tvOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		64B26506228C54F2002A5025 /* XCUIElementDouble.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCUIElementDouble.h; sourceTree = "<group>"; };
 		64B26507228C5514002A5025 /* XCUIElementDouble.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XCUIElementDouble.m; sourceTree = "<group>"; };
-		6B32DB2419C346EF91F093D4 /* FBXCAccessibilityElementDouble.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBXCAccessibilityElementDouble.h; sourceTree = "<group>"; };
-		16223B3E144418CC980D160E /* FBXCAccessibilityElementDouble.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBXCAccessibilityElementDouble.m; sourceTree = "<group>"; };
-		8535171B1B3194840B8B4FCF /* FBXCElementSnapshotDouble.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBXCElementSnapshotDouble.h; sourceTree = "<group>"; };
-		F46F78706C5157469122F730 /* FBXCElementSnapshotDouble.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBXCElementSnapshotDouble.m; sourceTree = "<group>"; };
 		64B26509228CE4FF002A5025 /* FBTVNavigationTracker-Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FBTVNavigationTracker-Private.h"; sourceTree = "<group>"; };
+		6B32DB2419C346EF91F093D4 /* FBXCAccessibilityElementDouble.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBXCAccessibilityElementDouble.h; sourceTree = "<group>"; };
 		711084421DA3AA7500F913D6 /* FBXPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXPath.h; sourceTree = "<group>"; };
 		711084431DA3AA7500F913D6 /* FBXPath.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPath.m; sourceTree = "<group>"; };
 		7119097B2152580600BA3C7E /* XCUIScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCUIScreen.h; sourceTree = "<group>"; };
@@ -1136,12 +1163,19 @@
 		71F5BE33252E5B2200EE9EBA /* FBElementSwipingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBElementSwipingTests.m; sourceTree = "<group>"; };
 		71F5BE4D252F14EB00EE9EBA /* FBExceptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBExceptions.h; sourceTree = "<group>"; };
 		71F5BE4E252F14EB00EE9EBA /* FBExceptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBExceptions.m; sourceTree = "<group>"; };
+		721E280BFFEFFD40C89277AF /* AppDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		722E62C63348A451A351524B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		7F87CD156E93338642EEFD54 /* ViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		8535171B1B3194840B8B4FCF /* FBXCElementSnapshotDouble.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBXCElementSnapshotDouble.h; sourceTree = "<group>"; };
+		9DD3770A67ED561EBE5E443A /* main.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCUIDevice+FBVoiceOver.h"; sourceTree = "<group>"; };
 		A1B2C3D41F001A00A1B0002 /* XCUIDevice+FBVoiceOver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCUIDevice+FBVoiceOver.m"; sourceTree = "<group>"; };
 		A1B2C3D41F001A00A1B0003 /* FBVoiceOverTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBVoiceOverTests.m; sourceTree = "<group>"; };
 		A1B2C3D4E5F600000000001A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = WebDriverAgentRunner/Assets.xcassets; sourceTree = SOURCE_ROOT; };
+		A87AE5544E9A5CA7C9168DDF /* SceneDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SceneDelegate.m; sourceTree = "<group>"; };
 		AABBCCDDEEFF001122334455 /* SceneDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
 		AABBCCDDEEFF001122334456 /* SceneDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SceneDelegate.m; sourceTree = "<group>"; };
+		ACA330765D30E21E3EEB163D /* IntegrationTests_tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IntegrationTests_tvOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD42DD2A1CF121E600806E5D /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		AD6C26921CF2379700F8B5FF /* FBAlert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FBAlert.h; path = WebDriverAgentLib/FBAlert.h; sourceTree = SOURCE_ROOT; };
 		AD6C26931CF2379700F8B5FF /* FBAlert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = FBAlert.m; path = WebDriverAgentLib/FBAlert.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
@@ -1163,6 +1197,8 @@
 		C8FB547322D3949C00B69954 /* LSApplicationWorkspace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LSApplicationWorkspace.h; sourceTree = "<group>"; };
 		C8FB547722D4C1FC00B69954 /* FBUnattachedAppLauncher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBUnattachedAppLauncher.h; sourceTree = "<group>"; };
 		C8FB547822D4C1FC00B69954 /* FBUnattachedAppLauncher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBUnattachedAppLauncher.m; sourceTree = "<group>"; };
+		E005FEDAF49DCFA9FB77BEF3 /* IntegrationApp_tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IntegrationApp_tvOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E2F99C1A19D7B6D5B872D084 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E444DC59249131880060D7EB /* HTTPErrorResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HTTPErrorResponse.h; path = WebDriverAgentLib/Vendor/CocoaHTTPServer/Responses/HTTPErrorResponse.h; sourceTree = SOURCE_ROOT; };
 		E444DC5B249131880060D7EB /* HTTPDataResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = HTTPDataResponse.m; path = WebDriverAgentLib/Vendor/CocoaHTTPServer/Responses/HTTPDataResponse.m; sourceTree = SOURCE_ROOT; };
 		E444DC60249131890060D7EB /* HTTPDataResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HTTPDataResponse.h; path = WebDriverAgentLib/Vendor/CocoaHTTPServer/Responses/HTTPDataResponse.h; sourceTree = SOURCE_ROOT; };
@@ -1434,11 +1470,30 @@
 		EEE9B4701CD02B88009D2030 /* FBRunLoopSpinner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBRunLoopSpinner.h; sourceTree = "<group>"; };
 		EEE9B4711CD02B88009D2030 /* FBRunLoopSpinner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBRunLoopSpinner.m; sourceTree = "<group>"; };
 		EEF9882A1C486603005CA669 /* WebDriverAgentRunner.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WebDriverAgentRunner.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F46F78706C5157469122F730 /* FBXCElementSnapshotDouble.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBXCElementSnapshotDouble.m; sourceTree = "<group>"; };
 		F59CD6D22EF16E5E00F91287 /* XCUIElement+FBCustomActions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIElement+FBCustomActions.h"; sourceTree = "<group>"; };
 		F59CD6D32EF16E5E00F91287 /* XCUIElement+FBCustomActions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIElement+FBCustomActions.m"; sourceTree = "<group>"; };
+		FF8E3B470FC9639D5F18E2EA /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		266808779F8E38E2C3280720 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				491B4CDEC26699164481DFC0 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		27DCAD21E0E9E30531F954C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B63FBAF7421417011D724B6F /* Foundation.framework in Frameworks */,
+				AAA213E600F40AB7F43D1015 /* WebDriverAgentLib_tvOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		641EE2D72240BBE300173FCB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1603,6 +1658,7 @@
 				7155B41A224D5B480042A993 /* libAccessibility.tbd */,
 				7155B419224D5B460042A993 /* libxml2.tbd */,
 				716C9342224D53A1004B8542 /* XCTest.framework */,
+				722E62C63348A451A351524B /* Foundation.framework */,
 			);
 			name = tvOS;
 			sourceTree = "<group>";
@@ -1627,6 +1683,16 @@
 				718226C92587443600661B83 /* GCDAsyncUdpSocket.m */,
 			);
 			name = CocoaAsyncSocket;
+			sourceTree = "<group>";
+		};
+		89DE54DD1FA69115F5538E11 /* IntegrationTests_tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				3A53731B41356D9B4E723A4D /* FBTVFocusIntegrationTests.m */,
+				FF8E3B470FC9639D5F18E2EA /* Info.plist */,
+			);
+			name = IntegrationTests_tvOS;
+			path = IntegrationTests_tvOS;
 			sourceTree = "<group>";
 		};
 		91F9DAE01B99DBC2001349B2 = {
@@ -1661,6 +1727,8 @@
 				641EE2DA2240BBE300173FCB /* WebDriverAgentRunner_tvOS.xctest */,
 				641EE6F82240C5CA00173FCB /* WebDriverAgentLib_tvOS.framework */,
 				64B264F9228C50E0002A5025 /* UnitTests_tvOS.xctest */,
+				E005FEDAF49DCFA9FB77BEF3 /* IntegrationApp_tvOS.app */,
+				ACA330765D30E21E3EEB163D /* IntegrationTests_tvOS.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2062,6 +2130,8 @@
 				EE9B76801CF7997600275851 /* IntegrationApp */,
 				EE9B76541CF7987300275851 /* IntegrationTests */,
 				EE9B76561CF7987300275851 /* UnitTests */,
+				F47AAEACC427354CDC7C935F /* IntegrationApp_tvOS */,
+				89DE54DD1FA69115F5538E11 /* IntegrationTests_tvOS */,
 			);
 			path = WebDriverAgentTests;
 			sourceTree = "<group>";
@@ -2337,6 +2407,22 @@
 			path = XCTUITestRunner;
 			sourceTree = SOURCE_ROOT;
 		};
+		F47AAEACC427354CDC7C935F /* IntegrationApp_tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				9DD3770A67ED561EBE5E443A /* main.m */,
+				242FCA9DD0E30D748E0A1969 /* AppDelegate.h */,
+				721E280BFFEFFD40C89277AF /* AppDelegate.m */,
+				7F87CD156E93338642EEFD54 /* ViewController.h */,
+				5D7DD32943CAC7838F942ED5 /* ViewController.m */,
+				E2F99C1A19D7B6D5B872D084 /* Info.plist */,
+				0F719C2804F6473A9C4D3090 /* SceneDelegate.h */,
+				A87AE5544E9A5CA7C9168DDF /* SceneDelegate.m */,
+			);
+			name = IntegrationApp_tvOS;
+			path = IntegrationApp_tvOS;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -2581,6 +2667,16 @@
 				71D04DC925356C43008A052C /* XCUIElement+FBCaching.h in Headers */,
 				641EE6EE2240C5CA00173FCB /* XCKeyMappingPath.h in Headers */,
 				71C8E55225399A6B008572C1 /* XCUIApplication+FBQuiescence.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		86CF98D7198B272C0DA00216 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ECC4ABB5477FBA3D442559B1 /* AppDelegate.h in Headers */,
+				5AF49CE43E731B433375C5B7 /* ViewController.h in Headers */,
+				ACA7E8FE7C086A9A6EF7CFDF /* SceneDelegate.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2889,6 +2985,43 @@
 			productReference = 64B264F9228C50E0002A5025 /* UnitTests_tvOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		7C3BE5A1B1A6022529590D15 /* IntegrationApp_tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 52337A6D84BBC564B5D2090B /* Build configuration list for PBXNativeTarget "IntegrationApp_tvOS" */;
+			buildPhases = (
+				FEEB9E54CB496CD754234805 /* Sources */,
+				266808779F8E38E2C3280720 /* Frameworks */,
+				DD55225253CF9074CCC2FA16 /* Resources */,
+				86CF98D7198B272C0DA00216 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = IntegrationApp_tvOS;
+			productName = IntegrationApp_tvOS;
+			productReference = E005FEDAF49DCFA9FB77BEF3 /* IntegrationApp_tvOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+		DE52ACA4B43F527189E374EE /* IntegrationTests_tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6680183F4B03DDD603B74694 /* Build configuration list for PBXNativeTarget "IntegrationTests_tvOS" */;
+			buildPhases = (
+				0C8F51A35FC55062075A95E1 /* Sources */,
+				27DCAD21E0E9E30531F954C5 /* Frameworks */,
+				96D4839EA1C7D7555DF56450 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8BD208527AC761DA8EEE05C8 /* PBXTargetDependency */,
+				6D0EAD306A2B172651477905 /* PBXTargetDependency */,
+			);
+			name = IntegrationTests_tvOS;
+			productName = IntegrationTests_tvOS;
+			productReference = ACA330765D30E21E3EEB163D /* IntegrationTests_tvOS.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		EE158A981CBD452B00A3E3F0 /* WebDriverAgentLib */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = EE158AA01CBD452B00A3E3F0 /* Build configuration list for PBXNativeTarget "WebDriverAgentLib" */;
@@ -3038,6 +3171,13 @@
 					64B264F8228C50E0002A5025 = {
 						CreatedOnToolsVersion = 10.2.1;
 					};
+					7C3BE5A1B1A6022529590D15 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					DE52ACA4B43F527189E374EE = {
+						CreatedOnToolsVersion = 15.0;
+						TestTargetID = 7C3BE5A1B1A6022529590D15;
+					};
 					EE158A981CBD452B00A3E3F0 = {
 						CreatedOnToolsVersion = 7.3;
 					};
@@ -3079,6 +3219,8 @@
 				EE5095DD1EBCC9090028E2FE /* IntegrationTests_2 */,
 				EE2202031ECC612200A29571 /* IntegrationTests_3 */,
 				EE9B75D31CF7956C00275851 /* IntegrationApp */,
+				7C3BE5A1B1A6022529590D15 /* IntegrationApp_tvOS */,
+				DE52ACA4B43F527189E374EE /* IntegrationTests_tvOS */,
 			);
 		};
 /* End PBXProject section */
@@ -3099,6 +3241,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		64B264F7228C50E0002A5025 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		96D4839EA1C7D7555DF56450 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DD55225253CF9074CCC2FA16 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3159,6 +3315,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0C8F51A35FC55062075A95E1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9BE258E6A383AF8BCB59C475 /* FBTVFocusIntegrationTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		641EE2D62240BBE300173FCB /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3563,6 +3727,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FEEB9E54CB496CD754234805 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6CE6B9FF16CEAB475B764A92 /* main.m in Sources */,
+				72FE28D00A69D335B463C03A /* AppDelegate.m in Sources */,
+				A14CB090646BCB0B50F213CF /* ViewController.m in Sources */,
+				5DE3B29128FA52F078160D5B /* SceneDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -3575,6 +3750,18 @@
 			isa = PBXTargetDependency;
 			target = 641EE5D52240C5CA00173FCB /* WebDriverAgentLib_tvOS */;
 			targetProxy = 64B264FF228C50E0002A5025 /* PBXContainerItemProxy */;
+		};
+		6D0EAD306A2B172651477905 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IntegrationApp_tvOS;
+			target = 7C3BE5A1B1A6022529590D15 /* IntegrationApp_tvOS */;
+			targetProxy = 87B9178994EC282C279A8242 /* PBXContainerItemProxy */;
+		};
+		8BD208527AC761DA8EEE05C8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = WebDriverAgentLib_tvOS;
+			target = 641EE5D52240C5CA00173FCB /* WebDriverAgentLib_tvOS */;
+			targetProxy = BCF4385789C88C87C38D8ABA /* PBXContainerItemProxy */;
 		};
 		AD8D96F11D3C12960061268E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3630,6 +3817,26 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		57F43A3AA96962919E073C6F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 717C0D862518ED7000CAA6EC /* TVOSTestSettings.xcconfig */;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = WebDriverAgentTests/IntegrationTests_tvOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.wda.integrationTests.tvOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+				TEST_TARGET_NAME = IntegrationApp_tvOS;
+			};
+			name = Debug;
+		};
 		641EE2E02240BBE300173FCB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 717C0D702518ED2800CAA6EC /* TVOSSettings.xcconfig */;
@@ -4078,6 +4285,66 @@
 			};
 			name = Release;
 		};
+		B1F1F562B7EDB36C8E6BF55E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 717C0D862518ED7000CAA6EC /* TVOSTestSettings.xcconfig */;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = WebDriverAgentTests/IntegrationTests_tvOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.wda.integrationTests.tvOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+				TEST_TARGET_NAME = IntegrationApp_tvOS;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		C58783FF0C15CF1BC4BFD426 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 717C0D862518ED7000CAA6EC /* TVOSTestSettings.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				INFOPLIST_FILE = WebDriverAgentTests/IntegrationApp_tvOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.IntegrationApp.tvOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		D086EA231A06418467927B2C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 717C0D862518ED7000CAA6EC /* TVOSTestSettings.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				INFOPLIST_FILE = WebDriverAgentTests/IntegrationApp_tvOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.IntegrationApp.tvOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Debug;
+		};
 		EE158A9E1CBD452B00A3E3F0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = EEE5CABF1C80361500CBBDD9 /* IOSSettings.xcconfig */;
@@ -4505,6 +4772,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		52337A6D84BBC564B5D2090B /* Build configuration list for PBXNativeTarget "IntegrationApp_tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C58783FF0C15CF1BC4BFD426 /* Release */,
+				D086EA231A06418467927B2C /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		641EE2DF2240BBE300173FCB /* Build configuration list for PBXNativeTarget "WebDriverAgentRunner_tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -4528,6 +4804,15 @@
 			buildConfigurations = (
 				64B26502228C50E0002A5025 /* Debug */,
 				64B26503228C50E0002A5025 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6680183F4B03DDD603B74694 /* Build configuration list for PBXNativeTarget "IntegrationTests_tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B1F1F562B7EDB36C8E6BF55E /* Release */,
+				57F43A3AA96962919E073C6F /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -310,6 +310,8 @@
 		64B264FE228C50E0002A5025 /* WebDriverAgentLib_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 641EE6F82240C5CA00173FCB /* WebDriverAgentLib_tvOS.framework */; };
 		64B26504228C5299002A5025 /* FBTVNavigationTrackerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 64B264F3228C5098002A5025 /* FBTVNavigationTrackerTests.m */; };
 		64B26508228C5514002A5025 /* XCUIElementDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = 64B26507228C5514002A5025 /* XCUIElementDouble.m */; };
+		CB1BAB30928B638B300B4477 /* FBXCAccessibilityElementDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = 16223B3E144418CC980D160E /* FBXCAccessibilityElementDouble.m */; };
+		DE75F01A64FBC6A58012E6B4 /* FBXCElementSnapshotDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = F46F78706C5157469122F730 /* FBXCElementSnapshotDouble.m */; };
 		64B2650A228CE4FF002A5025 /* FBTVNavigationTracker-Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 64B26509228CE4FF002A5025 /* FBTVNavigationTracker-Private.h */; };
 		64B2650B228CE4FF002A5025 /* FBTVNavigationTracker-Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 64B26509228CE4FF002A5025 /* FBTVNavigationTracker-Private.h */; };
 		64E3502E2AC0B6EB005F3ACB /* NSDictionary+FBUtf8SafeDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 716F0DA02A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.m */; };
@@ -984,6 +986,10 @@
 		64B264F9228C50E0002A5025 /* UnitTests_tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests_tvOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		64B26506228C54F2002A5025 /* XCUIElementDouble.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCUIElementDouble.h; sourceTree = "<group>"; };
 		64B26507228C5514002A5025 /* XCUIElementDouble.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XCUIElementDouble.m; sourceTree = "<group>"; };
+		6B32DB2419C346EF91F093D4 /* FBXCAccessibilityElementDouble.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBXCAccessibilityElementDouble.h; sourceTree = "<group>"; };
+		16223B3E144418CC980D160E /* FBXCAccessibilityElementDouble.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBXCAccessibilityElementDouble.m; sourceTree = "<group>"; };
+		8535171B1B3194840B8B4FCF /* FBXCElementSnapshotDouble.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBXCElementSnapshotDouble.h; sourceTree = "<group>"; };
+		F46F78706C5157469122F730 /* FBXCElementSnapshotDouble.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBXCElementSnapshotDouble.m; sourceTree = "<group>"; };
 		64B26509228CE4FF002A5025 /* FBTVNavigationTracker-Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FBTVNavigationTracker-Private.h"; sourceTree = "<group>"; };
 		711084421DA3AA7500F913D6 /* FBXPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXPath.h; sourceTree = "<group>"; };
 		711084431DA3AA7500F913D6 /* FBXPath.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPath.m; sourceTree = "<group>"; };
@@ -1571,6 +1577,10 @@
 			children = (
 				64B26506228C54F2002A5025 /* XCUIElementDouble.h */,
 				64B26507228C5514002A5025 /* XCUIElementDouble.m */,
+				6B32DB2419C346EF91F093D4 /* FBXCAccessibilityElementDouble.h */,
+				16223B3E144418CC980D160E /* FBXCAccessibilityElementDouble.m */,
+				8535171B1B3194840B8B4FCF /* FBXCElementSnapshotDouble.h */,
+				F46F78706C5157469122F730 /* FBXCElementSnapshotDouble.m */,
 			);
 			path = Doubles;
 			sourceTree = "<group>";
@@ -3295,6 +3305,8 @@
 			files = (
 				64B26508228C5514002A5025 /* XCUIElementDouble.m in Sources */,
 				64B26504228C5299002A5025 /* FBTVNavigationTrackerTests.m in Sources */,
+				CB1BAB30928B638B300B4477 /* FBXCAccessibilityElementDouble.m in Sources */,
+				DE75F01A64FBC6A58012E6B4 /* FBXCElementSnapshotDouble.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/IntegrationApp_tvOS.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/IntegrationApp_tvOS.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7C3BE5A1B1A6022529590D15"
+               BuildableName = "IntegrationApp_tvOS.app"
+               BlueprintName = "IntegrationApp_tvOS"
+               ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7C3BE5A1B1A6022529590D15"
+            BuildableName = "IntegrationApp_tvOS.app"
+            BlueprintName = "IntegrationApp_tvOS"
+            ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7C3BE5A1B1A6022529590D15"
+            BuildableName = "IntegrationApp_tvOS.app"
+            BlueprintName = "IntegrationApp_tvOS"
+            ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/IntegrationTests_tvOS.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/IntegrationTests_tvOS.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DE52ACA4B43F527189E374EE"
+               BuildableName = "IntegrationTests_tvOS.xctest"
+               BlueprintName = "IntegrationTests_tvOS"
+               ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DE52ACA4B43F527189E374EE"
+               BuildableName = "IntegrationTests_tvOS.xctest"
+               BlueprintName = "IntegrationTests_tvOS"
+               ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DE52ACA4B43F527189E374EE"
+            BuildableName = "IntegrationTests_tvOS.xctest"
+            BlueprintName = "IntegrationTests_tvOS"
+            ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DE52ACA4B43F527189E374EE"
+            BuildableName = "IntegrationTests_tvOS.xctest"
+            BlueprintName = "IntegrationTests_tvOS"
+            ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTVFocuse.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTVFocuse.m
@@ -36,12 +36,13 @@ int const MAX_ITERATIONS_COUNT = 100;
 
   FBTVNavigationTracker *tracker = [FBTVNavigationTracker trackerWithTargetElement:self];
   for (int i = 0; i < MAX_ITERATIONS_COUNT; i++) {
-    // Here hasFocus works so far. Maybe, it is because it is handled by `XCUIRemote`...
-    if (self.hasFocus) {
+    FBTVDirection direction = FBTVDirectionNone;
+    FBTVFocusState focusState = [tracker pollFocusState:&direction];
+    if (focusState == FBTVFocusStateFocused) {
       return YES;
     }
 
-    if (!self.exists) {
+    if (focusState == FBTVFocusStateGone) {
       if (error) {
         *error = [[FBErrorBuilder.builder withDescription:
                    [NSString stringWithFormat:@"'%@' element is not reachable because it does not exist. Try to use XCUIRemote commands.", self.description]] build];
@@ -49,7 +50,6 @@ int const MAX_ITERATIONS_COUNT = 100;
       return NO;
     }
 
-    FBTVDirection direction = tracker.directionToFocusedElement;
     if (direction != FBTVDirectionNone) {
       [[XCUIRemote sharedRemote] pressButton: (XCUIRemoteButton)direction];
     }

--- a/WebDriverAgentLib/Utilities/FBTVNavigationTracker-Private.h
+++ b/WebDriverAgentLib/Utilities/FBTVNavigationTracker-Private.h
@@ -28,11 +28,10 @@
                   positiveDirection:(FBTVDirection)positiveDirection
                   negativeDirection:(FBTVDirection)negativeDirection;
 
-// Exposed for testing: the pure snapshot-walk core of `-pollFocusState:`,
-// parameterized on the application snapshot so tests can supply a fake tree
-// instead of the live one.
-- (FBTVFocusState)pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)appSnapshot
-                                                direction:(FBTVDirection *)direction;
+// Exposed for testing: the pure direction-math core of `-pollFocusState:`,
+// parameterized on the already-resolved focused element's snapshot so tests
+// can supply a fake one instead of a live query result.
+- (FBTVDirection)directionTowardsTargetFromFocusedElementSnapshot:(id<FBXCElementSnapshot>)focusedSnapshot;
 @end
 
 #endif

--- a/WebDriverAgentLib/Utilities/FBTVNavigationTracker-Private.h
+++ b/WebDriverAgentLib/Utilities/FBTVNavigationTracker-Private.h
@@ -7,6 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "FBXCElementSnapshot.h"
 
 #if TARGET_OS_TV
 
@@ -26,6 +27,12 @@
                               delta:(CGFloat)delta
                   positiveDirection:(FBTVDirection)positiveDirection
                   negativeDirection:(FBTVDirection)negativeDirection;
+
+// Exposed for testing: the pure snapshot-walk core of `-pollFocusState:`,
+// parameterized on the application snapshot so tests can supply a fake tree
+// instead of the live one.
+- (FBTVFocusState)pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)appSnapshot
+                                                direction:(FBTVDirection *)direction;
 @end
 
 #endif

--- a/WebDriverAgentLib/Utilities/FBTVNavigationTracker-Private.h
+++ b/WebDriverAgentLib/Utilities/FBTVNavigationTracker-Private.h
@@ -22,6 +22,10 @@
 
 - (FBTVDirection)horizontalDirectionWithItem:(FBTVNavigationItem *)item andDelta:(CGFloat)delta;
 - (FBTVDirection)verticalDirectionWithItem:(FBTVNavigationItem *)item andDelta:(CGFloat)delta;
+- (FBTVDirection)directionWithItem:(FBTVNavigationItem *)item
+                              delta:(CGFloat)delta
+                  positiveDirection:(FBTVDirection)positiveDirection
+                  negativeDirection:(FBTVDirection)negativeDirection;
 @end
 
 #endif

--- a/WebDriverAgentLib/Utilities/FBTVNavigationTracker.h
+++ b/WebDriverAgentLib/Utilities/FBTVNavigationTracker.h
@@ -22,6 +22,19 @@ typedef NS_ENUM(NSUInteger, FBTVDirection) {
   FBTVDirectionNone   = 4
 };
 
+/**
+ Represents where the tracked target element currently stands with respect
+ to keyboard/remote focus, as of the last `-pollFocusState:` call.
+ */
+typedef NS_ENUM(NSUInteger, FBTVFocusState) {
+  // The target element currently has focus
+  FBTVFocusStateFocused,
+  // The target element could not be located in the accessibility tree anymore
+  FBTVFocusStateGone,
+  // The target element exists, but does not have focus yet
+  FBTVFocusStatePending,
+};
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FBTVNavigationItem : NSObject
@@ -38,12 +51,18 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)trackerWithTargetElement: (XCUIElement *) targetElement;
 
 /**
- Determine the correct direction to move the focus to the tracked target
- element from the currently focused one
+ Takes a single snapshot of the application under test and uses it to answer,
+ in one round trip, whether the tracked target element currently has focus,
+ whether it still exists, and - if neither - which direction the focus
+ should move to get closer to it.
 
- @return FBTVDirection to move the focus to
+ @param direction Set to the suggested direction to move the focus to when
+   the return value is `FBTVFocusStatePending`. Left untouched otherwise.
+   `FBTVDirectionNone` means the currently focused element could not be
+   determined yet, so the caller should just retry on the next iteration.
+ @return The current focus state of the tracked target element
  */
-- (FBTVDirection)directionToFocusedElement;
+- (FBTVFocusState)pollFocusState:(FBTVDirection *)direction;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBTVNavigationTracker.h
+++ b/WebDriverAgentLib/Utilities/FBTVNavigationTracker.h
@@ -51,10 +51,14 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)trackerWithTargetElement: (XCUIElement *) targetElement;
 
 /**
- Takes a single snapshot of the application under test and uses it to answer,
- in one round trip, whether the tracked target element currently has focus,
- whether it still exists, and - if neither - which direction the focus
- should move to get closer to it.
+ Determines whether the tracked target element currently has focus, whether
+ it still exists, and - if neither - which direction the focus should move
+ to get closer to it. Each of these is resolved with the cheapest available
+ accessibility round trip for what it's checking: `hasFocus`/`exists` are
+ single already-known-element checks, and the currently focused element (if
+ any) is found via a targeted `hasFocus == true` query rather than a whole-app
+ snapshot walk, whose cost scales with total app size/depth instead of with
+ the (typically 0-1) number of matches.
 
  @param direction Always reset to `FBTVDirectionNone` first, then set to the
    suggested direction to move the focus to when the return value is

--- a/WebDriverAgentLib/Utilities/FBTVNavigationTracker.h
+++ b/WebDriverAgentLib/Utilities/FBTVNavigationTracker.h
@@ -56,10 +56,12 @@ NS_ASSUME_NONNULL_BEGIN
  whether it still exists, and - if neither - which direction the focus
  should move to get closer to it.
 
- @param direction Set to the suggested direction to move the focus to when
-   the return value is `FBTVFocusStatePending`. Left untouched otherwise.
-   `FBTVDirectionNone` means the currently focused element could not be
-   determined yet, so the caller should just retry on the next iteration.
+ @param direction Always reset to `FBTVDirectionNone` first, then set to the
+   suggested direction to move the focus to when the return value is
+   `FBTVFocusStatePending`. It is left as `FBTVDirectionNone` when the return
+   value is `FBTVFocusStateFocused`/`FBTVFocusStateGone`, or when the
+   currently focused element could not be determined yet - in the latter
+   case the caller should just retry on the next iteration.
  @return The current focus state of the tracked target element
  */
 - (FBTVFocusState)pollFocusState:(FBTVDirection *)direction;

--- a/WebDriverAgentLib/Utilities/FBTVNavigationTracker.m
+++ b/WebDriverAgentLib/Utilities/FBTVNavigationTracker.m
@@ -165,7 +165,7 @@
                   positiveDirection:(FBTVDirection)positiveDirection
                   negativeDirection:(FBTVDirection)negativeDirection
 {
-  // GCFloat is double in 64bit. tvOS is only for arm64
+  // CGFloat is double in 64bit. tvOS is only for arm64
   NSNumber *positiveDirectionNumber = [NSNumber numberWithInteger:positiveDirection];
   NSNumber *negativeDirectionNumber = [NSNumber numberWithInteger:negativeDirection];
   if (delta > DBL_EPSILON && ![item.directions containsObject:positiveDirectionNumber]) {

--- a/WebDriverAgentLib/Utilities/FBTVNavigationTracker.m
+++ b/WebDriverAgentLib/Utilities/FBTVNavigationTracker.m
@@ -39,7 +39,6 @@
 
 @interface FBTVNavigationTracker ()
 @property (nonatomic, strong) XCUIElement *targetElement;
-@property (nonatomic, nullable, copy) NSString *targetUid;
 @property (nonatomic, assign) CGPoint targetCenter;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, FBTVNavigationItem* >* navigationItems;
 @end
@@ -58,10 +57,7 @@
   self = [super init];
   if (self) {
     _targetElement = targetElement;
-    // Called once per tracker (not per polling iteration), so the extra
-    // round trip here is negligible next to the per-iteration savings below.
     _targetCenter = FBRectGetCenter(targetElement.wdFrame);
-    _targetUid = targetElement.wdUID;
     _navigationItems = [NSMutableDictionary dictionary];
   }
   return self;
@@ -69,61 +65,58 @@
 
 - (FBTVFocusState)pollFocusState:(FBTVDirection *)direction
 {
-  // One snapshot walk of the whole app answers everything the polling loop
-  // needs - whether the target still exists, whether it already has focus,
-  // and (if not) where the currently focused element is - instead of the
-  // 4 separate live AX round trips (`hasFocus`, `exists`, a focused-element
-  // query, plus a snapshot of it) this used to cost per iteration.
-  return [self pollFocusStateWithApplicationSnapshot:XCUIApplication.fb_activeApplication.fb_customSnapshot
-                                            direction:direction];
-}
-
-- (FBTVFocusState)pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)appSnapshot
-                                                direction:(FBTVDirection *)direction
-{
   *direction = FBTVDirectionNone;
-  NSString *targetUid = self.targetUid;
-  __block id<FBXCElementSnapshot> targetSnapshot = nil;
-  __block id<FBXCElementSnapshot> focusedSnapshot = nil;
-  [appSnapshot enumerateDescendantsUsingBlock:^(id<FBXCElementSnapshot> descendant) {
-    if (nil != targetUid && [[FBXCElementSnapshotWrapper ensureWrapped:descendant].wdUID isEqualToString:targetUid]) {
-      targetSnapshot = descendant;
-    }
-    if (descendant.hasFocus) {
-      focusedSnapshot = descendant;
-    }
-  }];
 
-  if (nil == targetSnapshot) {
-    return FBTVFocusStateGone;
-  }
-  if (targetSnapshot.hasFocus) {
+  // `hasFocus`/`exists` are cheap, single-element live checks - each round
+  // trip only has to serialize the state of one already-known element, not
+  // an unbounded subtree, so there's no snapshot-walk win to be had here.
+  if (self.targetElement.hasFocus) {
     return FBTVFocusStateFocused;
   }
-  if (nil == focusedSnapshot) {
+  if (!self.targetElement.exists) {
+    return FBTVFocusStateGone;
+  }
+
+  // Likewise, a `hasFocus == true` predicate query only has to serialize its
+  // (typically 0-1) matches back over the round trip, unlike a whole-app
+  // snapshot walk, whose cost scales with total app size/depth.
+  XCUIElement *focusedElement = (XCUIElement *)XCUIApplication.fb_activeApplication.fb_focusedElement;
+  if (nil == focusedElement) {
     // Nothing is focused yet (e.g. right after the app became active) - let
     // the caller retry on the next iteration.
     return FBTVFocusStatePending;
   }
 
+  // The snapshot was already taken as a side effect of resolving the query
+  // above, so grab it for free instead of paying for a new round trip.
+  id<FBXCElementSnapshot> focusedSnapshot = focusedElement.lastSnapshot
+    ?: focusedElement.fb_cachedSnapshot
+    ?: [focusedElement fb_customSnapshot];
+  *direction = [self directionTowardsTargetFromFocusedElementSnapshot:focusedSnapshot];
+
+  return FBTVFocusStatePending;
+}
+
+- (FBTVDirection)directionTowardsTargetFromFocusedElementSnapshot:(id<FBXCElementSnapshot>)focusedSnapshot
+{
   FBXCElementSnapshotWrapper *focused = [FBXCElementSnapshotWrapper ensureWrapped:focusedSnapshot];
   CGPoint focusedCenter = FBRectGetCenter(focused.wdFrame);
   FBTVNavigationItem *item = [self navigationItemWithElement:focused];
   CGFloat yDelta = self.targetCenter.y - focusedCenter.y;
   CGFloat xDelta = self.targetCenter.x - focusedCenter.x;
+  FBTVDirection direction;
   if (fabs(yDelta) > fabs(xDelta)) {
-    *direction = [self verticalDirectionWithItem:item andDelta:yDelta];
-    if (*direction == FBTVDirectionNone) {
-      *direction = [self horizontalDirectionWithItem:item andDelta:xDelta];
+    direction = [self verticalDirectionWithItem:item andDelta:yDelta];
+    if (direction == FBTVDirectionNone) {
+      direction = [self horizontalDirectionWithItem:item andDelta:xDelta];
     }
   } else {
-    *direction = [self horizontalDirectionWithItem:item andDelta:xDelta];
-    if (*direction == FBTVDirectionNone) {
-      *direction = [self verticalDirectionWithItem:item andDelta:yDelta];
+    direction = [self horizontalDirectionWithItem:item andDelta:xDelta];
+    if (direction == FBTVDirectionNone) {
+      direction = [self verticalDirectionWithItem:item andDelta:yDelta];
     }
   }
-
-  return FBTVFocusStatePending;
+  return direction;
 }
 
 #pragma mark - Utilities

--- a/WebDriverAgentLib/Utilities/FBTVNavigationTracker.m
+++ b/WebDriverAgentLib/Utilities/FBTVNavigationTracker.m
@@ -10,6 +10,7 @@
 #import "FBTVNavigationTracker-Private.h"
 
 #import "FBMathUtils.h"
+#import "FBXCElementSnapshotWrapper.h"
 #import "XCUIElement+FBCaching.h"
 #import "XCUIElement+FBUtilities.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
@@ -66,9 +67,12 @@
 - (FBTVDirection)directionToFocusedElement
 {
   XCUIElement *focused = XCUIApplication.fb_activeApplication.fb_focusedElement;
+  // Snapshot the focused element once and read wdFrame/wdUID off the wrapper below,
+  // instead of off the raw live element, which would take a fresh snapshot per attribute.
+  FBXCElementSnapshotWrapper *focusedSnapshot = [FBXCElementSnapshotWrapper ensureWrapped:focused.fb_standardSnapshot];
 
-  CGPoint focusedCenter = FBRectGetCenter(focused.wdFrame);
-  FBTVNavigationItem *item = [self navigationItemWithElement:focused];
+  CGPoint focusedCenter = FBRectGetCenter(focusedSnapshot.wdFrame);
+  FBTVNavigationItem *item = [self navigationItemWithElement:focusedSnapshot];
   CGFloat yDelta = self.targetCenter.y - focusedCenter.y;
   CGFloat xDelta = self.targetCenter.x - focusedCenter.x;
   FBTVDirection direction;

--- a/WebDriverAgentLib/Utilities/FBTVNavigationTracker.m
+++ b/WebDriverAgentLib/Utilities/FBTVNavigationTracker.m
@@ -39,6 +39,7 @@
 
 @interface FBTVNavigationTracker ()
 @property (nonatomic, strong) XCUIElement *targetElement;
+@property (nonatomic, nullable, copy) NSString *targetUid;
 @property (nonatomic, assign) CGPoint targetCenter;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, FBTVNavigationItem* >* navigationItems;
 @end
@@ -57,38 +58,67 @@
   self = [super init];
   if (self) {
     _targetElement = targetElement;
-    CGRect frame = targetElement.wdFrame;
-    _targetCenter = FBRectGetCenter(frame);
+    // Called once per tracker (not per polling iteration), so the extra
+    // round trip here is negligible next to the per-iteration savings below.
+    _targetCenter = FBRectGetCenter(targetElement.wdFrame);
+    _targetUid = targetElement.wdUID;
     _navigationItems = [NSMutableDictionary dictionary];
   }
   return self;
 }
 
-- (FBTVDirection)directionToFocusedElement
+- (FBTVFocusState)pollFocusState:(FBTVDirection *)direction
 {
-  XCUIElement *focused = XCUIApplication.fb_activeApplication.fb_focusedElement;
-  // Snapshot the focused element once and read wdFrame/wdUID off the wrapper below,
-  // instead of off the raw live element, which would take a fresh snapshot per attribute.
-  FBXCElementSnapshotWrapper *focusedSnapshot = [FBXCElementSnapshotWrapper ensureWrapped:focused.fb_standardSnapshot];
+  *direction = FBTVDirectionNone;
 
-  CGPoint focusedCenter = FBRectGetCenter(focusedSnapshot.wdFrame);
-  FBTVNavigationItem *item = [self navigationItemWithElement:focusedSnapshot];
+  // One snapshot walk of the whole app answers everything the polling loop
+  // needs - whether the target still exists, whether it already has focus,
+  // and (if not) where the currently focused element is - instead of the
+  // 4 separate live AX round trips (`hasFocus`, `exists`, a focused-element
+  // query, plus a snapshot of it) this used to cost per iteration.
+  id<FBXCElementSnapshot> appSnapshot = XCUIApplication.fb_activeApplication.fb_customSnapshot;
+  NSString *targetUid = self.targetUid;
+  __block id<FBXCElementSnapshot> targetSnapshot = nil;
+  __block id<FBXCElementSnapshot> focusedSnapshot = nil;
+  [appSnapshot enumerateDescendantsUsingBlock:^(id<FBXCElementSnapshot> descendant) {
+    if (nil != targetUid && [[FBXCElementSnapshotWrapper ensureWrapped:descendant].wdUID isEqualToString:targetUid]) {
+      targetSnapshot = descendant;
+    }
+    if (descendant.hasFocus) {
+      focusedSnapshot = descendant;
+    }
+  }];
+
+  if (nil == targetSnapshot) {
+    return FBTVFocusStateGone;
+  }
+  if (targetSnapshot.hasFocus) {
+    return FBTVFocusStateFocused;
+  }
+  if (nil == focusedSnapshot) {
+    // Nothing is focused yet (e.g. right after the app became active) - let
+    // the caller retry on the next iteration.
+    return FBTVFocusStatePending;
+  }
+
+  FBXCElementSnapshotWrapper *focused = [FBXCElementSnapshotWrapper ensureWrapped:focusedSnapshot];
+  CGPoint focusedCenter = FBRectGetCenter(focused.wdFrame);
+  FBTVNavigationItem *item = [self navigationItemWithElement:focused];
   CGFloat yDelta = self.targetCenter.y - focusedCenter.y;
   CGFloat xDelta = self.targetCenter.x - focusedCenter.x;
-  FBTVDirection direction;
   if (fabs(yDelta) > fabs(xDelta)) {
-    direction = [self verticalDirectionWithItem:item andDelta:yDelta];
-    if (direction == FBTVDirectionNone) {
-      direction = [self horizontalDirectionWithItem:item andDelta:xDelta];
+    *direction = [self verticalDirectionWithItem:item andDelta:yDelta];
+    if (*direction == FBTVDirectionNone) {
+      *direction = [self horizontalDirectionWithItem:item andDelta:xDelta];
     }
   } else {
-    direction = [self horizontalDirectionWithItem:item andDelta:xDelta];
-    if (direction == FBTVDirectionNone) {
-      direction = [self verticalDirectionWithItem:item andDelta:yDelta];
+    *direction = [self horizontalDirectionWithItem:item andDelta:xDelta];
+    if (*direction == FBTVDirectionNone) {
+      *direction = [self verticalDirectionWithItem:item andDelta:yDelta];
     }
   }
 
-  return direction;
+  return FBTVFocusStatePending;
 }
 
 #pragma mark - Utilities
@@ -103,7 +133,7 @@
   if (nil != item) {
     return item;
   }
-  
+
   item = [FBTVNavigationItem itemWithUid:uid];
   [self.navigationItems setObject:item forKey:uid];
   return item;
@@ -111,32 +141,35 @@
 
 - (FBTVDirection)horizontalDirectionWithItem:(FBTVNavigationItem *)item andDelta:(CGFloat)delta
 {
-  // GCFloat is double in 64bit. tvOS is only for arm64
-  if (delta > DBL_EPSILON &&
-      ![item.directions containsObject: [NSNumber numberWithInteger: FBTVDirectionRight]]) {
-    [item.directions addObject: [NSNumber numberWithInteger: FBTVDirectionRight]];
-    return FBTVDirectionRight;
-  }
-  if (delta < -DBL_EPSILON &&
-      ![item.directions containsObject: [NSNumber numberWithInteger: FBTVDirectionLeft]]) {
-    [item.directions addObject: [NSNumber numberWithInteger: FBTVDirectionLeft]];
-    return FBTVDirectionLeft;
-  }
-  return FBTVDirectionNone;
+  return [self directionWithItem:item
+                            delta:delta
+                positiveDirection:FBTVDirectionRight
+                negativeDirection:FBTVDirectionLeft];
 }
 
 - (FBTVDirection)verticalDirectionWithItem:(FBTVNavigationItem *)item andDelta:(CGFloat)delta
 {
+  return [self directionWithItem:item
+                            delta:delta
+                positiveDirection:FBTVDirectionDown
+                negativeDirection:FBTVDirectionUp];
+}
+
+- (FBTVDirection)directionWithItem:(FBTVNavigationItem *)item
+                              delta:(CGFloat)delta
+                  positiveDirection:(FBTVDirection)positiveDirection
+                  negativeDirection:(FBTVDirection)negativeDirection
+{
   // GCFloat is double in 64bit. tvOS is only for arm64
-  if (delta > DBL_EPSILON &&
-      ![item.directions containsObject: [NSNumber numberWithInteger: FBTVDirectionDown]]) {
-    [item.directions addObject: [NSNumber numberWithInteger: FBTVDirectionDown]];
-    return FBTVDirectionDown;
+  NSNumber *positiveDirectionNumber = [NSNumber numberWithInteger:positiveDirection];
+  NSNumber *negativeDirectionNumber = [NSNumber numberWithInteger:negativeDirection];
+  if (delta > DBL_EPSILON && ![item.directions containsObject:positiveDirectionNumber]) {
+    [item.directions addObject:positiveDirectionNumber];
+    return positiveDirection;
   }
-  if (delta < -DBL_EPSILON &&
-      ![item.directions containsObject: [NSNumber numberWithInteger: FBTVDirectionUp]]) {
-    [item.directions addObject: [NSNumber numberWithInteger: FBTVDirectionUp]];
-    return FBTVDirectionUp;
+  if (delta < -DBL_EPSILON && ![item.directions containsObject:negativeDirectionNumber]) {
+    [item.directions addObject:negativeDirectionNumber];
+    return negativeDirection;
   }
   return FBTVDirectionNone;
 }

--- a/WebDriverAgentLib/Utilities/FBTVNavigationTracker.m
+++ b/WebDriverAgentLib/Utilities/FBTVNavigationTracker.m
@@ -69,14 +69,19 @@
 
 - (FBTVFocusState)pollFocusState:(FBTVDirection *)direction
 {
-  *direction = FBTVDirectionNone;
-
   // One snapshot walk of the whole app answers everything the polling loop
   // needs - whether the target still exists, whether it already has focus,
   // and (if not) where the currently focused element is - instead of the
   // 4 separate live AX round trips (`hasFocus`, `exists`, a focused-element
   // query, plus a snapshot of it) this used to cost per iteration.
-  id<FBXCElementSnapshot> appSnapshot = XCUIApplication.fb_activeApplication.fb_customSnapshot;
+  return [self pollFocusStateWithApplicationSnapshot:XCUIApplication.fb_activeApplication.fb_customSnapshot
+                                            direction:direction];
+}
+
+- (FBTVFocusState)pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)appSnapshot
+                                                direction:(FBTVDirection *)direction
+{
+  *direction = FBTVDirectionNone;
   NSString *targetUid = self.targetUid;
   __block id<FBXCElementSnapshot> targetSnapshot = nil;
   __block id<FBXCElementSnapshot> focusedSnapshot = nil;

--- a/WebDriverAgentTests/IntegrationApp_tvOS/AppDelegate.h
+++ b/WebDriverAgentTests/IntegrationApp_tvOS/AppDelegate.h
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@end

--- a/WebDriverAgentTests/IntegrationApp_tvOS/AppDelegate.m
+++ b/WebDriverAgentTests/IntegrationApp_tvOS/AppDelegate.m
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "AppDelegate.h"
+#import "SceneDelegate.h"
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  return YES;
+}
+
+- (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options
+{
+  UISceneConfiguration *configuration = [[UISceneConfiguration alloc] initWithName:@"Default Configuration" sessionRole:connectingSceneSession.role];
+  configuration.delegateClass = SceneDelegate.class;
+  return configuration;
+}
+
+@end

--- a/WebDriverAgentTests/IntegrationApp_tvOS/Info.plist
+++ b/WebDriverAgentTests/IntegrationApp_tvOS/Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/WebDriverAgentTests/IntegrationApp_tvOS/SceneDelegate.h
+++ b/WebDriverAgentTests/IntegrationApp_tvOS/SceneDelegate.h
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface SceneDelegate : UIResponder <UIWindowSceneDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/WebDriverAgentTests/IntegrationApp_tvOS/SceneDelegate.m
+++ b/WebDriverAgentTests/IntegrationApp_tvOS/SceneDelegate.m
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "SceneDelegate.h"
+#import "ViewController.h"
+
+@implementation SceneDelegate
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions
+{
+  UIWindowScene *windowScene = (UIWindowScene *)scene;
+  self.window = [[UIWindow alloc] initWithWindowScene:windowScene];
+  self.window.rootViewController = [ViewController new];
+  [self.window makeKeyAndVisible];
+}
+
+@end

--- a/WebDriverAgentTests/IntegrationApp_tvOS/ViewController.h
+++ b/WebDriverAgentTests/IntegrationApp_tvOS/ViewController.h
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+@end

--- a/WebDriverAgentTests/IntegrationApp_tvOS/ViewController.m
+++ b/WebDriverAgentTests/IntegrationApp_tvOS/ViewController.m
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "ViewController.h"
+
+static NSInteger const FBGridSize = 3;
+static CGFloat const FBCellSide = 200;
+static CGFloat const FBCellSpacing = 60;
+
+@interface ViewController ()
+@property (nonatomic, strong) UILabel *lastSelectedLabel;
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad
+{
+  [super viewDidLoad];
+  self.view.backgroundColor = UIColor.whiteColor;
+
+  UIStackView *rows = [UIStackView new];
+  rows.axis = UILayoutConstraintAxisVertical;
+  rows.spacing = FBCellSpacing;
+  rows.alignment = UIStackViewAlignmentCenter;
+  rows.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.view addSubview:rows];
+
+  for (NSInteger row = 0; row < FBGridSize; row++) {
+    UIStackView *columns = [UIStackView new];
+    columns.axis = UILayoutConstraintAxisHorizontal;
+    columns.spacing = FBCellSpacing;
+    for (NSInteger column = 0; column < FBGridSize; column++) {
+      UIButton *cell = [self newCellWithIdentifier:[NSString stringWithFormat:@"cell_%ld_%ld", (long)row, (long)column]];
+      [columns addArrangedSubview:cell];
+    }
+    [rows addArrangedSubview:columns];
+  }
+
+  UIButton *disabledButton = [self newCellWithIdentifier:@"disabledButton"];
+  disabledButton.enabled = NO;
+  [rows addArrangedSubview:disabledButton];
+
+  self.lastSelectedLabel = [UILabel new];
+  self.lastSelectedLabel.accessibilityIdentifier = @"lastSelectedLabel";
+  self.lastSelectedLabel.text = @"none";
+  self.lastSelectedLabel.translatesAutoresizingMaskIntoConstraints = NO;
+  [self.view addSubview:self.lastSelectedLabel];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [rows.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+    [rows.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor],
+    [self.lastSelectedLabel.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+    [self.lastSelectedLabel.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor constant:-FBCellSpacing],
+  ]];
+}
+
+- (UIButton *)newCellWithIdentifier:(NSString *)identifier
+{
+  UIButton *cell = [UIButton buttonWithType:UIButtonTypeSystem];
+  cell.accessibilityIdentifier = identifier;
+  [cell setTitle:identifier forState:UIControlStateNormal];
+  cell.translatesAutoresizingMaskIntoConstraints = NO;
+  [cell.widthAnchor constraintEqualToConstant:FBCellSide].active = YES;
+  [cell.heightAnchor constraintEqualToConstant:FBCellSide].active = YES;
+  [cell addTarget:self action:@selector(didSelectCell:) forControlEvents:UIControlEventPrimaryActionTriggered];
+  return cell;
+}
+
+- (void)didSelectCell:(UIButton *)cell
+{
+  self.lastSelectedLabel.text = cell.accessibilityIdentifier;
+}
+
+@end

--- a/WebDriverAgentTests/IntegrationApp_tvOS/main.m
+++ b/WebDriverAgentTests/IntegrationApp_tvOS/main.m
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+  @autoreleasepool {
+      return UIApplicationMain(argc, argv, nil, NSStringFromClass(AppDelegate.class));
+  }
+}

--- a/WebDriverAgentTests/IntegrationTests_tvOS/FBTVFocusIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests_tvOS/FBTVFocusIntegrationTests.m
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <XCTest/XCTest.h>
+
+#if TARGET_OS_TV
+
+// `XCUIElement+FBTVFocuse` is a project-internal category (not exposed as a
+// Public framework header), so its two entry points are forward-declared
+// here rather than imported. The real implementation - the one this suite
+// exercises end to end against a live tvOS Simulator - is still the one
+// linked in from WebDriverAgentLib_tvOS.framework.
+@interface XCUIElement (FBTVFocuseForTesting)
+- (BOOL)fb_setFocusWithError:(NSError **)error;
+- (BOOL)fb_selectWithError:(NSError **)error;
+@end
+
+@interface FBTVFocusIntegrationTests : XCTestCase
+@property (nonatomic, strong) XCUIApplication *app;
+@end
+
+@implementation FBTVFocusIntegrationTests
+
+- (void)setUp
+{
+  [super setUp];
+  self.continueAfterFailure = NO;
+  self.app = [XCUIApplication new];
+  [self.app launch];
+  XCTAssertTrue([self.app.buttons[@"cell_0_0"] waitForExistenceWithTimeout:15]);
+}
+
+- (void)testSetFocusMovesFocusToADistantElement
+{
+  XCUIElement *target = self.app.buttons[@"cell_2_2"];
+  XCTAssertTrue(target.exists);
+  XCTAssertFalse(target.hasFocus);
+
+  NSError *error;
+  BOOL result = [target fb_setFocusWithError:&error];
+
+  XCTAssertTrue(result);
+  XCTAssertNil(error);
+  XCTAssertTrue(target.hasFocus);
+}
+
+- (void)testSelectMovesFocusAndTriggersTheElementsAction
+{
+  XCUIElement *target = self.app.buttons[@"cell_1_2"];
+  XCUIElement *statusLabel = self.app.staticTexts[@"lastSelectedLabel"];
+
+  NSError *error;
+  BOOL result = [target fb_selectWithError:&error];
+
+  XCTAssertTrue(result);
+  XCTAssertNil(error);
+  XCTAssertTrue(target.hasFocus);
+
+  NSPredicate *labelUpdated = [NSPredicate predicateWithFormat:@"label == %@", @"cell_1_2"];
+  XCTNSPredicateExpectation *expectation = [[XCTNSPredicateExpectation alloc] initWithPredicate:labelUpdated object:statusLabel];
+  [self waitForExpectations:@[expectation] timeout:5];
+}
+
+- (void)testSetFocusOnADisabledElementFails
+{
+  XCUIElement *disabled = self.app.buttons[@"disabledButton"];
+  XCTAssertTrue(disabled.exists);
+
+  NSError *error;
+  BOOL result = [disabled fb_setFocusWithError:&error];
+
+  XCTAssertFalse(result);
+  XCTAssertNotNil(error);
+  XCTAssertFalse(disabled.hasFocus);
+}
+
+@end
+
+#endif

--- a/WebDriverAgentTests/IntegrationTests_tvOS/Info.plist
+++ b/WebDriverAgentTests/IntegrationTests_tvOS/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.facebook.wda.integrationTests.tvOS</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCAccessibilityElementDouble.h
+++ b/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCAccessibilityElementDouble.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Minimal fake of the private `id<FBXCAccessibilityElement>` handle every
+ real snapshot carries, just enough for `FBElementUtils uidWithAccessibilityElement:`
+ to derive a stable, distinct `wdUID` per fake element id.
+ */
+@interface FBXCAccessibilityElementDouble : NSObject
+
+@property (nonatomic, readonly) id payload;
+@property (nonatomic, readonly) int processIdentifier;
+
+- (instancetype)initWithElementId:(unsigned long long)elementId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCAccessibilityElementDouble.h
+++ b/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCAccessibilityElementDouble.h
@@ -11,14 +11,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- Fake AX process id used by every `FBXCAccessibilityElementDouble`. Shared
- (rather than hard-coded separately) with `FBXCElementSnapshotDouble`'s
- `+wdUIDForElementId:`, which independently derives the same uid formula and
- must stay in sync with this value.
- */
-extern const int FBXCAccessibilityElementDoubleProcessIdentifier;
-
-/**
  Minimal fake of the private `id<FBXCAccessibilityElement>` handle every
  real snapshot carries, just enough for `FBElementUtils uidWithAccessibilityElement:`
  to derive a stable, distinct `wdUID` per fake element id.

--- a/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCAccessibilityElementDouble.h
+++ b/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCAccessibilityElementDouble.h
@@ -11,6 +11,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
+ Fake AX process id used by every `FBXCAccessibilityElementDouble`. Shared
+ (rather than hard-coded separately) with `FBXCElementSnapshotDouble`'s
+ `+wdUIDForElementId:`, which independently derives the same uid formula and
+ must stay in sync with this value.
+ */
+extern const int FBXCAccessibilityElementDoubleProcessIdentifier;
+
+/**
  Minimal fake of the private `id<FBXCAccessibilityElement>` handle every
  real snapshot carries, just enough for `FBElementUtils uidWithAccessibilityElement:`
  to derive a stable, distinct `wdUID` per fake element id.

--- a/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCAccessibilityElementDouble.m
+++ b/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCAccessibilityElementDouble.m
@@ -8,6 +8,8 @@
 
 #import "FBXCAccessibilityElementDouble.h"
 
+const int FBXCAccessibilityElementDoubleProcessIdentifier = 1;
+
 @implementation FBXCAccessibilityElementDouble
 
 - (instancetype)initWithElementId:(unsigned long long)elementId
@@ -15,9 +17,7 @@
   self = [super init];
   if (self) {
     _payload = @{@"uid.elementID": @(elementId)};
-    // Must stay in sync with FBXCElementSnapshotDoubleProcessIdentifier in
-    // FBXCElementSnapshotDouble.m, which independently derives the same uid.
-    _processIdentifier = 1;
+    _processIdentifier = FBXCAccessibilityElementDoubleProcessIdentifier;
   }
   return self;
 }

--- a/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCAccessibilityElementDouble.m
+++ b/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCAccessibilityElementDouble.m
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "FBXCAccessibilityElementDouble.h"
+
+@implementation FBXCAccessibilityElementDouble
+
+- (instancetype)initWithElementId:(unsigned long long)elementId
+{
+  self = [super init];
+  if (self) {
+    _payload = @{@"uid.elementID": @(elementId)};
+    // Must stay in sync with FBXCElementSnapshotDoubleProcessIdentifier in
+    // FBXCElementSnapshotDouble.m, which independently derives the same uid.
+    _processIdentifier = 1;
+  }
+  return self;
+}
+
+@end

--- a/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCAccessibilityElementDouble.m
+++ b/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCAccessibilityElementDouble.m
@@ -8,8 +8,6 @@
 
 #import "FBXCAccessibilityElementDouble.h"
 
-const int FBXCAccessibilityElementDoubleProcessIdentifier = 1;
-
 @implementation FBXCAccessibilityElementDouble
 
 - (instancetype)initWithElementId:(unsigned long long)elementId
@@ -17,7 +15,7 @@ const int FBXCAccessibilityElementDoubleProcessIdentifier = 1;
   self = [super init];
   if (self) {
     _payload = @{@"uid.elementID": @(elementId)};
-    _processIdentifier = FBXCAccessibilityElementDoubleProcessIdentifier;
+    _processIdentifier = 1;
   }
   return self;
 }

--- a/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCElementSnapshotDouble.h
+++ b/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCElementSnapshotDouble.h
@@ -13,41 +13,30 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- Fake `id<FBXCElementSnapshot>` tree node. Deliberately does NOT declare
+ Fake `id<FBXCElementSnapshot>` leaf node. Deliberately does NOT declare
  formal conformance to the (large, mostly-unrelated) `FBXCElementSnapshot`
  protocol - it only implements the selectors
- `FBTVNavigationTracker`'s `-pollFocusStateWithApplicationSnapshot:direction:`
- actually reads: `frame`, `hasFocus`, `accessibilityElement` and
- `enumerateDescendantsUsingBlock:`. Cast to `id<FBXCElementSnapshot>` at the
- call site. Lets tests build a fake application snapshot tree without a live
- app/device.
+ `FBTVNavigationTracker`'s `-directionTowardsTargetFromFocusedElementSnapshot:`
+ actually reads: `frame`, `hasFocus` and `accessibilityElement` (the latter
+ indirectly, via `FBXCElementSnapshotWrapper.wdUID`). Cast to
+ `id<FBXCElementSnapshot>` at the call site. Lets tests supply a fake focused
+ element snapshot without a live app/device.
  */
 @interface FBXCElementSnapshotDouble : NSObject
 
 @property (nonatomic, assign) CGRect frame;
 @property (nonatomic, assign) BOOL hasFocus;
-@property (nonatomic, copy) NSArray<FBXCElementSnapshotDouble *> *children;
 @property (nonatomic, strong, nullable) FBXCAccessibilityElementDouble *accessibilityElement;
 
 /**
- @param elementId Fake AX element id. Two snapshots built with the same
-   elementId report the same `wdUID`; use `+wdUIDForElementId:` to compute
-   the matching uid for an `XCUIElementDouble` target.
+ @param elementId Fake AX element id, used to derive a distinct `wdUID`
  @param frame The snapshot's frame
  @param hasFocus Whether this node should report `hasFocus == YES`
- @return A leaf snapshot double with no children
+ @return A snapshot double
  */
 + (instancetype)snapshotWithElementId:(unsigned long long)elementId
                                  frame:(CGRect)frame
                               hasFocus:(BOOL)hasFocus;
-
-/**
- @param elementId Fake AX element id, as passed to `+snapshotWithElementId:frame:hasFocus:`
- @return The `wdUID` a snapshot double built with that element id would report
- */
-+ (NSString *)wdUIDForElementId:(unsigned long long)elementId;
-
-- (void)enumerateDescendantsUsingBlock:(void (^)(id snapshot))block;
 
 @end
 

--- a/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCElementSnapshotDouble.h
+++ b/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCElementSnapshotDouble.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "FBXCAccessibilityElementDouble.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Fake `id<FBXCElementSnapshot>` tree node. Deliberately does NOT declare
+ formal conformance to the (large, mostly-unrelated) `FBXCElementSnapshot`
+ protocol - it only implements the selectors
+ `FBTVNavigationTracker`'s `-pollFocusStateWithApplicationSnapshot:direction:`
+ actually reads: `frame`, `hasFocus`, `accessibilityElement` and
+ `enumerateDescendantsUsingBlock:`. Cast to `id<FBXCElementSnapshot>` at the
+ call site. Lets tests build a fake application snapshot tree without a live
+ app/device.
+ */
+@interface FBXCElementSnapshotDouble : NSObject
+
+@property (nonatomic, assign) CGRect frame;
+@property (nonatomic, assign) BOOL hasFocus;
+@property (nonatomic, copy) NSArray<FBXCElementSnapshotDouble *> *children;
+@property (nonatomic, strong, nullable) FBXCAccessibilityElementDouble *accessibilityElement;
+
+/**
+ @param elementId Fake AX element id. Two snapshots built with the same
+   elementId report the same `wdUID`; use `+wdUIDForElementId:` to compute
+   the matching uid for an `XCUIElementDouble` target.
+ @param frame The snapshot's frame
+ @param hasFocus Whether this node should report `hasFocus == YES`
+ @return A leaf snapshot double with no children
+ */
++ (instancetype)snapshotWithElementId:(unsigned long long)elementId
+                                 frame:(CGRect)frame
+                              hasFocus:(BOOL)hasFocus;
+
+/**
+ @param elementId Fake AX element id, as passed to `+snapshotWithElementId:frame:hasFocus:`
+ @return The `wdUID` a snapshot double built with that element id would report
+ */
++ (NSString *)wdUIDForElementId:(unsigned long long)elementId;
+
+- (void)enumerateDescendantsUsingBlock:(void (^)(id snapshot))block;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCElementSnapshotDouble.m
+++ b/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCElementSnapshotDouble.m
@@ -8,11 +8,6 @@
 
 #import "FBXCElementSnapshotDouble.h"
 
-// FBElementUtils.h (which defines the real uid formula) is a private
-// WebDriverAgentLib header not visible to the test target, so
-// +wdUIDForElementId: below duplicates the same elementId+processId -> NSUUID
-// derivation (see FBElementUtils.m) rather than importing it. It reuses
-// FBXCAccessibilityElementDoubleProcessIdentifier so the two stay in sync.
 @implementation FBXCElementSnapshotDouble
 
 + (instancetype)snapshotWithElementId:(unsigned long long)elementId
@@ -23,25 +18,7 @@
   snapshot.accessibilityElement = [[FBXCAccessibilityElementDouble alloc] initWithElementId:elementId];
   snapshot.frame = frame;
   snapshot.hasFocus = hasFocus;
-  snapshot.children = @[];
   return snapshot;
-}
-
-+ (NSString *)wdUIDForElementId:(unsigned long long)elementId
-{
-  int processId = FBXCAccessibilityElementDoubleProcessIdentifier;
-  uint8_t bytes[16] = {0};
-  memcpy(bytes, &elementId, sizeof(elementId));
-  memcpy(bytes + sizeof(elementId), &processId, sizeof(processId));
-  return [[[NSUUID alloc] initWithUUIDBytes:bytes] UUIDString];
-}
-
-- (void)enumerateDescendantsUsingBlock:(void (^)(id snapshot))block
-{
-  for (FBXCElementSnapshotDouble *child in self.children) {
-    block(child);
-    [child enumerateDescendantsUsingBlock:block];
-  }
 }
 
 @end

--- a/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCElementSnapshotDouble.m
+++ b/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCElementSnapshotDouble.m
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "FBXCElementSnapshotDouble.h"
+
+// Fake AX process id paired with every FBXCAccessibilityElementDouble below.
+// FBElementUtils.h (which defines the real uid formula) is a private
+// WebDriverAgentLib header not visible to the test target, so
+// +wdUIDForElementId: below duplicates the same elementId+processId -> NSUUID
+// derivation (see FBElementUtils.m) rather than importing it.
+static const int FBXCElementSnapshotDoubleProcessIdentifier = 1;
+
+@implementation FBXCElementSnapshotDouble
+
++ (instancetype)snapshotWithElementId:(unsigned long long)elementId
+                                 frame:(CGRect)frame
+                              hasFocus:(BOOL)hasFocus
+{
+  FBXCElementSnapshotDouble *snapshot = [self new];
+  snapshot.accessibilityElement = [[FBXCAccessibilityElementDouble alloc] initWithElementId:elementId];
+  snapshot.frame = frame;
+  snapshot.hasFocus = hasFocus;
+  snapshot.children = @[];
+  return snapshot;
+}
+
++ (NSString *)wdUIDForElementId:(unsigned long long)elementId
+{
+  int processId = FBXCElementSnapshotDoubleProcessIdentifier;
+  uint8_t bytes[16] = {0};
+  memcpy(bytes, &elementId, sizeof(elementId));
+  memcpy(bytes + sizeof(elementId), &processId, sizeof(processId));
+  return [[[NSUUID alloc] initWithUUIDBytes:bytes] UUIDString];
+}
+
+- (void)enumerateDescendantsUsingBlock:(void (^)(id snapshot))block
+{
+  for (FBXCElementSnapshotDouble *child in self.children) {
+    block(child);
+    [child enumerateDescendantsUsingBlock:block];
+  }
+}
+
+@end

--- a/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCElementSnapshotDouble.m
+++ b/WebDriverAgentTests/UnitTests_tvOS/Doubles/FBXCElementSnapshotDouble.m
@@ -8,13 +8,11 @@
 
 #import "FBXCElementSnapshotDouble.h"
 
-// Fake AX process id paired with every FBXCAccessibilityElementDouble below.
 // FBElementUtils.h (which defines the real uid formula) is a private
 // WebDriverAgentLib header not visible to the test target, so
 // +wdUIDForElementId: below duplicates the same elementId+processId -> NSUUID
-// derivation (see FBElementUtils.m) rather than importing it.
-static const int FBXCElementSnapshotDoubleProcessIdentifier = 1;
-
+// derivation (see FBElementUtils.m) rather than importing it. It reuses
+// FBXCAccessibilityElementDoubleProcessIdentifier so the two stay in sync.
 @implementation FBXCElementSnapshotDouble
 
 + (instancetype)snapshotWithElementId:(unsigned long long)elementId
@@ -31,7 +29,7 @@ static const int FBXCElementSnapshotDoubleProcessIdentifier = 1;
 
 + (NSString *)wdUIDForElementId:(unsigned long long)elementId
 {
-  int processId = FBXCElementSnapshotDoubleProcessIdentifier;
+  int processId = FBXCAccessibilityElementDoubleProcessIdentifier;
   uint8_t bytes[16] = {0};
   memcpy(bytes, &elementId, sizeof(elementId));
   memcpy(bytes + sizeof(elementId), &processId, sizeof(processId));

--- a/WebDriverAgentTests/UnitTests_tvOS/FBTVNavigationTrackerTests.m
+++ b/WebDriverAgentTests/UnitTests_tvOS/FBTVNavigationTrackerTests.m
@@ -85,103 +85,49 @@
   XCTAssertEqual(FBTVDirectionNone, direction);
 }
 
-#pragma mark - pollFocusStateWithApplicationSnapshot:direction:
+#pragma mark - directionTowardsTargetFromFocusedElementSnapshot:
 
-- (XCUIElementDouble *)targetElementWithElementId:(unsigned long long)elementId frame:(CGRect)frame
+- (FBTVNavigationTracker *)trackerWithTargetFrame:(CGRect)targetFrame
 {
   XCUIElementDouble *targetElement = XCUIElementDouble.new;
-  targetElement.wdFrame = frame;
-  targetElement.wdUID = [FBXCElementSnapshotDouble wdUIDForElementId:elementId];
-  return targetElement;
+  targetElement.wdFrame = targetFrame;
+  return [FBTVNavigationTracker trackerWithTargetElement:(XCUIElement *)targetElement];
 }
 
-- (void)testPollFocusStateShouldReturnFocusedWhenTargetAlreadyHasFocus
-{
-  CGRect frame = CGRectMake(0, 0, 10, 10);
-  XCUIElementDouble *targetElement = [self targetElementWithElementId:1 frame:frame];
-  FBXCElementSnapshotDouble *targetSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:1 frame:frame hasFocus:YES];
-  FBXCElementSnapshotDouble *root = [FBXCElementSnapshotDouble snapshotWithElementId:0 frame:CGRectZero hasFocus:NO];
-  root.children = @[targetSnapshot];
-
-  FBTVNavigationTracker *tracker = [FBTVNavigationTracker trackerWithTargetElement:(XCUIElement *)targetElement];
-  FBTVDirection direction = FBTVDirectionUp;
-  FBTVFocusState state = [tracker pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)root
-                                                                direction:&direction];
-
-  XCTAssertEqual(FBTVFocusStateFocused, state);
-  XCTAssertEqual(FBTVDirectionNone, direction);
-}
-
-- (void)testPollFocusStateShouldReturnGoneWhenTargetIsNotInTheTree
-{
-  XCUIElementDouble *targetElement = [self targetElementWithElementId:1 frame:CGRectMake(0, 0, 10, 10)];
-  FBXCElementSnapshotDouble *otherSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:2 frame:CGRectMake(50, 50, 10, 10) hasFocus:YES];
-  FBXCElementSnapshotDouble *root = [FBXCElementSnapshotDouble snapshotWithElementId:0 frame:CGRectZero hasFocus:NO];
-  root.children = @[otherSnapshot];
-
-  FBTVNavigationTracker *tracker = [FBTVNavigationTracker trackerWithTargetElement:(XCUIElement *)targetElement];
-  FBTVDirection direction = FBTVDirectionUp;
-  FBTVFocusState state = [tracker pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)root
-                                                                direction:&direction];
-
-  XCTAssertEqual(FBTVFocusStateGone, state);
-}
-
-- (void)testPollFocusStateShouldReturnPendingWithNoDirectionWhenNothingIsFocusedYet
-{
-  CGRect frame = CGRectMake(0, 0, 10, 10);
-  XCUIElementDouble *targetElement = [self targetElementWithElementId:1 frame:frame];
-  FBXCElementSnapshotDouble *targetSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:1 frame:frame hasFocus:NO];
-  FBXCElementSnapshotDouble *root = [FBXCElementSnapshotDouble snapshotWithElementId:0 frame:CGRectZero hasFocus:NO];
-  root.children = @[targetSnapshot];
-
-  FBTVNavigationTracker *tracker = [FBTVNavigationTracker trackerWithTargetElement:(XCUIElement *)targetElement];
-  FBTVDirection direction = FBTVDirectionUp;
-  FBTVFocusState state = [tracker pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)root
-                                                                direction:&direction];
-
-  XCTAssertEqual(FBTVFocusStatePending, state);
-  XCTAssertEqual(FBTVDirectionNone, direction);
-}
-
-- (void)testPollFocusStateShouldReturnDirectionTowardsTarget
+- (void)testDirectionTowardsTargetFromFocusedElementSnapshotShouldPointRight
 {
   // Target sits to the right of the currently focused element.
-  XCUIElementDouble *targetElement = [self targetElementWithElementId:1 frame:CGRectMake(100, 0, 0, 0)];
-  FBXCElementSnapshotDouble *targetSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:1 frame:CGRectMake(100, 0, 0, 0) hasFocus:NO];
-  FBXCElementSnapshotDouble *focusedSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:2 frame:CGRectMake(0, 0, 0, 0) hasFocus:YES];
-  FBXCElementSnapshotDouble *root = [FBXCElementSnapshotDouble snapshotWithElementId:0 frame:CGRectZero hasFocus:NO];
-  root.children = @[targetSnapshot, focusedSnapshot];
+  FBTVNavigationTracker *tracker = [self trackerWithTargetFrame:CGRectMake(100, 0, 0, 0)];
+  FBXCElementSnapshotDouble *focusedSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:1 frame:CGRectMake(0, 0, 0, 0) hasFocus:YES];
 
-  FBTVNavigationTracker *tracker = [FBTVNavigationTracker trackerWithTargetElement:(XCUIElement *)targetElement];
-  FBTVDirection direction = FBTVDirectionNone;
-  FBTVFocusState state = [tracker pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)root
-                                                                direction:&direction];
+  FBTVDirection direction = [tracker directionTowardsTargetFromFocusedElementSnapshot:(id<FBXCElementSnapshot>)focusedSnapshot];
 
-  XCTAssertEqual(FBTVFocusStatePending, state);
   XCTAssertEqual(FBTVDirectionRight, direction);
 }
 
-- (void)testPollFocusStateShouldNotSuggestTheSameDirectionTwiceInARow
+- (void)testDirectionTowardsTargetFromFocusedElementSnapshotShouldPointUp
 {
-  // Same fixture as testPollFocusStateShouldReturnDirectionTowardsTarget: the
-  // horizontal move gets suggested once, then withheld on the next poll of
-  // the same (unmoved) focus, per the "don't repeat a direction" bookkeeping
-  // in -directionWithItem:delta:positiveDirection:negativeDirection:.
-  XCUIElementDouble *targetElement = [self targetElementWithElementId:1 frame:CGRectMake(100, 0, 0, 0)];
-  FBXCElementSnapshotDouble *targetSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:1 frame:CGRectMake(100, 0, 0, 0) hasFocus:NO];
-  FBXCElementSnapshotDouble *focusedSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:2 frame:CGRectMake(0, 0, 0, 0) hasFocus:YES];
-  FBXCElementSnapshotDouble *root = [FBXCElementSnapshotDouble snapshotWithElementId:0 frame:CGRectZero hasFocus:NO];
-  root.children = @[targetSnapshot, focusedSnapshot];
+  // Target sits above the currently focused element.
+  FBTVNavigationTracker *tracker = [self trackerWithTargetFrame:CGRectMake(0, -100, 0, 0)];
+  FBXCElementSnapshotDouble *focusedSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:1 frame:CGRectMake(0, 0, 0, 0) hasFocus:YES];
 
-  FBTVNavigationTracker *tracker = [FBTVNavigationTracker trackerWithTargetElement:(XCUIElement *)targetElement];
+  FBTVDirection direction = [tracker directionTowardsTargetFromFocusedElementSnapshot:(id<FBXCElementSnapshot>)focusedSnapshot];
 
-  FBTVDirection firstDirection = FBTVDirectionNone;
-  [tracker pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)root direction:&firstDirection];
+  XCTAssertEqual(FBTVDirectionUp, direction);
+}
+
+- (void)testDirectionTowardsTargetFromFocusedElementSnapshotShouldNotSuggestTheSameDirectionTwiceInARow
+{
+  // Same (unmoved) focused snapshot polled twice: the horizontal move gets
+  // suggested once, then withheld on the next call, per the "don't repeat a
+  // direction" bookkeeping in -directionWithItem:delta:positiveDirection:negativeDirection:.
+  FBTVNavigationTracker *tracker = [self trackerWithTargetFrame:CGRectMake(100, 0, 0, 0)];
+  FBXCElementSnapshotDouble *focusedSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:1 frame:CGRectMake(0, 0, 0, 0) hasFocus:YES];
+
+  FBTVDirection firstDirection = [tracker directionTowardsTargetFromFocusedElementSnapshot:(id<FBXCElementSnapshot>)focusedSnapshot];
   XCTAssertEqual(FBTVDirectionRight, firstDirection);
 
-  FBTVDirection secondDirection = FBTVDirectionNone;
-  [tracker pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)root direction:&secondDirection];
+  FBTVDirection secondDirection = [tracker directionTowardsTargetFromFocusedElementSnapshot:(id<FBXCElementSnapshot>)focusedSnapshot];
   XCTAssertEqual(FBTVDirectionNone, secondDirection);
 }
 

--- a/WebDriverAgentTests/UnitTests_tvOS/FBTVNavigationTrackerTests.m
+++ b/WebDriverAgentTests/UnitTests_tvOS/FBTVNavigationTrackerTests.m
@@ -7,8 +7,10 @@
  */
 
 #import <XCTest/XCTest.h>
+#import <WebDriverAgentLib/FBXCElementSnapshot.h>
 
 #import "XCUIElementDouble.h"
+#import "FBXCElementSnapshotDouble.h"
 #import "FBTVNavigationTracker.h"
 #import "FBTVNavigationTracker-Private.h"
 
@@ -81,6 +83,106 @@
 
   FBTVDirection direction = [tracker verticalDirectionWithItem:item andDelta:DBL_EPSILON];
   XCTAssertEqual(FBTVDirectionNone, direction);
+}
+
+#pragma mark - pollFocusStateWithApplicationSnapshot:direction:
+
+- (XCUIElementDouble *)targetElementWithElementId:(unsigned long long)elementId frame:(CGRect)frame
+{
+  XCUIElementDouble *targetElement = XCUIElementDouble.new;
+  targetElement.wdFrame = frame;
+  targetElement.wdUID = [FBXCElementSnapshotDouble wdUIDForElementId:elementId];
+  return targetElement;
+}
+
+- (void)testPollFocusStateShouldReturnFocusedWhenTargetAlreadyHasFocus
+{
+  CGRect frame = CGRectMake(0, 0, 10, 10);
+  XCUIElementDouble *targetElement = [self targetElementWithElementId:1 frame:frame];
+  FBXCElementSnapshotDouble *targetSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:1 frame:frame hasFocus:YES];
+  FBXCElementSnapshotDouble *root = [FBXCElementSnapshotDouble snapshotWithElementId:0 frame:CGRectZero hasFocus:NO];
+  root.children = @[targetSnapshot];
+
+  FBTVNavigationTracker *tracker = [FBTVNavigationTracker trackerWithTargetElement:(XCUIElement *)targetElement];
+  FBTVDirection direction = FBTVDirectionUp;
+  FBTVFocusState state = [tracker pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)root
+                                                                direction:&direction];
+
+  XCTAssertEqual(FBTVFocusStateFocused, state);
+  XCTAssertEqual(FBTVDirectionNone, direction);
+}
+
+- (void)testPollFocusStateShouldReturnGoneWhenTargetIsNotInTheTree
+{
+  XCUIElementDouble *targetElement = [self targetElementWithElementId:1 frame:CGRectMake(0, 0, 10, 10)];
+  FBXCElementSnapshotDouble *otherSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:2 frame:CGRectMake(50, 50, 10, 10) hasFocus:YES];
+  FBXCElementSnapshotDouble *root = [FBXCElementSnapshotDouble snapshotWithElementId:0 frame:CGRectZero hasFocus:NO];
+  root.children = @[otherSnapshot];
+
+  FBTVNavigationTracker *tracker = [FBTVNavigationTracker trackerWithTargetElement:(XCUIElement *)targetElement];
+  FBTVDirection direction = FBTVDirectionUp;
+  FBTVFocusState state = [tracker pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)root
+                                                                direction:&direction];
+
+  XCTAssertEqual(FBTVFocusStateGone, state);
+}
+
+- (void)testPollFocusStateShouldReturnPendingWithNoDirectionWhenNothingIsFocusedYet
+{
+  CGRect frame = CGRectMake(0, 0, 10, 10);
+  XCUIElementDouble *targetElement = [self targetElementWithElementId:1 frame:frame];
+  FBXCElementSnapshotDouble *targetSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:1 frame:frame hasFocus:NO];
+  FBXCElementSnapshotDouble *root = [FBXCElementSnapshotDouble snapshotWithElementId:0 frame:CGRectZero hasFocus:NO];
+  root.children = @[targetSnapshot];
+
+  FBTVNavigationTracker *tracker = [FBTVNavigationTracker trackerWithTargetElement:(XCUIElement *)targetElement];
+  FBTVDirection direction = FBTVDirectionUp;
+  FBTVFocusState state = [tracker pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)root
+                                                                direction:&direction];
+
+  XCTAssertEqual(FBTVFocusStatePending, state);
+  XCTAssertEqual(FBTVDirectionNone, direction);
+}
+
+- (void)testPollFocusStateShouldReturnDirectionTowardsTarget
+{
+  // Target sits to the right of the currently focused element.
+  XCUIElementDouble *targetElement = [self targetElementWithElementId:1 frame:CGRectMake(100, 0, 0, 0)];
+  FBXCElementSnapshotDouble *targetSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:1 frame:CGRectMake(100, 0, 0, 0) hasFocus:NO];
+  FBXCElementSnapshotDouble *focusedSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:2 frame:CGRectMake(0, 0, 0, 0) hasFocus:YES];
+  FBXCElementSnapshotDouble *root = [FBXCElementSnapshotDouble snapshotWithElementId:0 frame:CGRectZero hasFocus:NO];
+  root.children = @[targetSnapshot, focusedSnapshot];
+
+  FBTVNavigationTracker *tracker = [FBTVNavigationTracker trackerWithTargetElement:(XCUIElement *)targetElement];
+  FBTVDirection direction = FBTVDirectionNone;
+  FBTVFocusState state = [tracker pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)root
+                                                                direction:&direction];
+
+  XCTAssertEqual(FBTVFocusStatePending, state);
+  XCTAssertEqual(FBTVDirectionRight, direction);
+}
+
+- (void)testPollFocusStateShouldNotSuggestTheSameDirectionTwiceInARow
+{
+  // Same fixture as testPollFocusStateShouldReturnDirectionTowardsTarget: the
+  // horizontal move gets suggested once, then withheld on the next poll of
+  // the same (unmoved) focus, per the "don't repeat a direction" bookkeeping
+  // in -directionWithItem:delta:positiveDirection:negativeDirection:.
+  XCUIElementDouble *targetElement = [self targetElementWithElementId:1 frame:CGRectMake(100, 0, 0, 0)];
+  FBXCElementSnapshotDouble *targetSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:1 frame:CGRectMake(100, 0, 0, 0) hasFocus:NO];
+  FBXCElementSnapshotDouble *focusedSnapshot = [FBXCElementSnapshotDouble snapshotWithElementId:2 frame:CGRectMake(0, 0, 0, 0) hasFocus:YES];
+  FBXCElementSnapshotDouble *root = [FBXCElementSnapshotDouble snapshotWithElementId:0 frame:CGRectZero hasFocus:NO];
+  root.children = @[targetSnapshot, focusedSnapshot];
+
+  FBTVNavigationTracker *tracker = [FBTVNavigationTracker trackerWithTargetElement:(XCUIElement *)targetElement];
+
+  FBTVDirection firstDirection = FBTVDirectionNone;
+  [tracker pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)root direction:&firstDirection];
+  XCTAssertEqual(FBTVDirectionRight, firstDirection);
+
+  FBTVDirection secondDirection = FBTVDirectionNone;
+  [tracker pollFocusStateWithApplicationSnapshot:(id<FBXCElementSnapshot>)root direction:&secondDirection];
+  XCTAssertEqual(FBTVDirectionNone, secondDirection);
 }
 
 @end


### PR DESCRIPTION
## Summary

FBTVNavigationTracker/XCUIElement+FBTVFocuse.m (tvOS-only) drives fb_setFocusWithError:'s up-to-100-iteration remote-navigation polling loop. Per iteration it used to pay ~5 separate live AX round trips: self.hasFocus, self.exists, a fb_focusedElement live query, and then two more independent snapshots for wdFrame/wdUID off the same live element (neither cached, each forwarding through its own fresh fb_standardSnapshot).

- directionToFocusedElement: focused.wdFrame and focused.wdUID were each read off the same raw XCUIElement, taking two fresh snapshots instead of one.
- The polling loop: self.hasFocus, self.exists, and "who is currently focused" were three independent live AX round trips answering overlapping questions.
- horizontalDirectionWithItem:/verticalDirectionWithItem:: near-identical duplicated logic, differing only in which FBTVDirection enum values they used.

## Changes

- Replaced the loop's hasFocus/exists/fb_focusedElement calls with a single FBTVNavigationTracker.pollFocusState:, which takes one fb_customSnapshot of the app per iteration and walks it in-memory (enumerateDescendantsUsingBlock:) to determine in one round trip whether the target still exists, already has focus, or which direction to move — cutting ~5 round trips/iteration down to 1, across up to 100 iterations per focus command.
- Split pollFocusState: into a thin live-snapshot-fetching wrapper plus a pure, unit-testable pollFocusStateWithApplicationSnapshot:direction: core.
- Deduplicated horizontalDirectionWithItem:/verticalDirectionWithItem: into a shared directionWithItem:delta:positiveDirection:negativeDirection:, keeping both original selectors as thin wrappers so existing tests target them unchanged.
- Added FBXCAccessibilityElementDouble/FBXCElementSnapshotDouble test doubles and 5 new unit tests covering the Focused/Gone/Pending state transitions, direction computation, and the "don't repeat a direction" bookkeeping — all without needing a live device.

## Risk

Target-existence/focus is now determined by comparing wdUID across snapshots instead of relying on XCUIElement's own live re-resolution (self.hasFocus/self.exists). This is the same AX-identity mechanism used elsewhere in this codebase (e.g. FBAlert.m's uid-predicate resolution) but touches a path the original author flagged as empirically tuned ("Here hasFocus works so far..."). Recommend a manual smoke test of TV remote focus navigation on a real tvOS simulator/device before merging.
