### PR TITLE
fix: Use wdaRemotePort instead of wdaLocalPort for preinstalled WDA USE_PORT

### DIFF
--- a/lib/wda-strategies.ts
+++ b/lib/wda-strategies.ts
@@ -317,7 +317,7 @@ async function quitXcodebuild(ctx: WdaStartupStrategyContext): Promise<void> {
 
 function createPreinstalledWdaEnvironment(ctx: WdaStartupStrategyContext): WdaLaunchEnvironment {
   const xctestEnv: WdaLaunchEnvironment = {
-    USE_PORT: ctx.wdaLocalPort || WDA_AGENT_PORT,
+    USE_PORT: ctx.wdaRemotePort || WDA_AGENT_PORT,
     WDA_PRODUCT_BUNDLE_IDENTIFIER: ctx.bundleIdForXctest,
   };
   if (ctx.mjpegServerPort) {

--- a/test/unit/webdriveragent.spec.ts
+++ b/test/unit/webdriveragent.spec.ts
@@ -496,6 +496,34 @@ describe('WebDriverAgent', function () {
         });
       });
 
+      it('should use wdaRemotePort rather than wdaLocalPort for the device USE_PORT', async function () {
+        const launchPreinstalled = sandbox.stub().resolves();
+        const terminate = sandbox.stub().resolves();
+        const agent = new WebDriverAgent({
+          ...fakeConstructorArgs,
+          device: {udid: 'real-device-udid'},
+          realDevice: true,
+          usePreinstalledWDA: true,
+          wdaLocalPort: 9100,
+          wdaRemotePort: 8100,
+          updatedWDABundleId: 'io.appium.wda',
+          hostOps: {
+            realDevicePreinstalled: {
+              launchPreinstalled,
+              terminate,
+            },
+          },
+        });
+        sandbox.stub(agent as any, 'getStatus').resolves({build: 'data'});
+
+        await agent.launch('sessionId');
+        sinon.assert.calledOnce(launchPreinstalled);
+        assert.deepStrictEqual(launchPreinstalled.firstCall.args[0].env, {
+          USE_PORT: 8100,
+          WDA_PRODUCT_BUNDLE_IDENTIFIER: 'io.appium.wda.xctrunner',
+        });
+      });
+
       it('should require injected host ops for real-device preinstalled launch', async function () {
         const agent = new WebDriverAgent({
           ...fakeConstructorArgs,


### PR DESCRIPTION
The usePreinstalledWDA launch path set the device listen port (USE_PORT) from wdaLocalPort, while xcodebuild and xctestrun paths correctly use wdaRemotePort. This caused WDA to listen on the wrong port whenever wdaLocalPort and wdaRemotePort differed.

Fixes #1205