### PR TITLE
fix: Mark FBConfiguration alert selector and response attribute params as nullable

### DIFF
--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -27,8 +27,8 @@ extern NSString *const FBSnapshotMaxDepthKey;
 + (BOOL)shouldTerminateApp;
 
 /*! If shouldUseCompactResponses == NO, is the comma-separated list of fields to return with each element. Defaults to "type,label". */
-+ (void)setElementResponseAttributes:(NSString *)value;
-+ (NSString *)elementResponseAttributes;
++ (void)setElementResponseAttributes:(nullable NSString *)value;
++ (nullable NSString *)elementResponseAttributes;
 
 /*! Disables remote query evaluation making Xcode 9.x tests behave same as Xcode 8.x test */
 + (void)disableRemoteQueryEvaluation;
@@ -291,16 +291,16 @@ typedef NS_ENUM(NSInteger, FBConfigurationKeyboardPreference) {
  warning into the log.
  Example: ** /XCUIElementTypeButton[`label CONTAINS[c] 'accept'`]
  */
-+ (void)setAcceptAlertButtonSelector:(NSString *)classChainSelector;
-+ (NSString *)acceptAlertButtonSelector;
-+ (void)setDismissAlertButtonSelector:(NSString *)classChainSelector;
-+ (NSString *)dismissAlertButtonSelector;
++ (void)setAcceptAlertButtonSelector:(nullable NSString *)classChainSelector;
++ (nullable NSString *)acceptAlertButtonSelector;
++ (void)setDismissAlertButtonSelector:(nullable NSString *)classChainSelector;
++ (nullable NSString *)dismissAlertButtonSelector;
 
 /**
  Sets class chain selector to apply for an automated alert click
  */
-+ (void)setAutoClickAlertSelector:(NSString *)classChainSelector;
-+ (NSString *)autoClickAlertSelector;
++ (void)setAutoClickAlertSelector:(nullable NSString *)classChainSelector;
++ (nullable NSString *)autoClickAlertSelector;
 
 /**
  * Whether to use HIDEvent for text clear.

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -221,12 +221,12 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
   return FBShouldTerminateApp;
 }
 
-+ (void)setElementResponseAttributes:(NSString *)value
++ (void)setElementResponseAttributes:(nullable NSString *)value
 {
   FBElementResponseAttributes = value;
 }
 
-+ (NSString *)elementResponseAttributes
++ (nullable NSString *)elementResponseAttributes
 {
   return FBElementResponseAttributes;
 }
@@ -429,32 +429,32 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
   return FBShouldBoundElementsByIndex;
 }
 
-+ (void)setAcceptAlertButtonSelector:(NSString *)classChainSelector
++ (void)setAcceptAlertButtonSelector:(nullable NSString *)classChainSelector
 {
   FBAcceptAlertButtonSelector = classChainSelector;
 }
 
-+ (NSString *)acceptAlertButtonSelector
++ (nullable NSString *)acceptAlertButtonSelector
 {
   return FBAcceptAlertButtonSelector;
 }
 
-+ (void)setDismissAlertButtonSelector:(NSString *)classChainSelector
++ (void)setDismissAlertButtonSelector:(nullable NSString *)classChainSelector
 {
   FBDismissAlertButtonSelector = classChainSelector;
 }
 
-+ (NSString *)dismissAlertButtonSelector
++ (nullable NSString *)dismissAlertButtonSelector
 {
   return FBDismissAlertButtonSelector;
 }
 
-+ (void)setAutoClickAlertSelector:(NSString *)classChainSelector
++ (void)setAutoClickAlertSelector:(nullable NSString *)classChainSelector
 {
   FBAutoClickAlertSelector = classChainSelector;
 }
 
-+ (NSString *)autoClickAlertSelector
++ (nullable NSString *)autoClickAlertSelector
 {
   return FBAutoClickAlertSelector;
 }


### PR DESCRIPTION
setElementResponseAttributes:, setAcceptAlertButtonSelector:/setDismissAlertButtonSelector:, and setAutoClickAlertSelector: (plus their getters) were implicitly nonnull under NS_ASSUME_NONNULL_BEGIN, contradicting documented and actual support for passing nil/empty string to reset to default behaviour.

Ref: https://github.com/appium/WebDriverAgent/issues/1189