### PR TITLE
feat: Convert FBConfiguration to a singleton with native properties

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBTouchAction.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBTouchAction.m
@@ -61,7 +61,7 @@
                                             error:error]) {
     return NO;
   }
-  [self fb_waitUntilStableWithTimeout:FBConfiguration.animationCoolOffTimeout];
+  [self fb_waitUntilStableWithTimeout:FBConfiguration.sharedInstance.animationCoolOffTimeout];
   return YES;
 }
 

--- a/WebDriverAgentLib/Categories/XCUIApplicationProcess+FBQuiescence.m
+++ b/WebDriverAgentLib/Categories/XCUIApplicationProcess+FBQuiescence.m
@@ -22,13 +22,13 @@ static void (*original_waitForQuiescenceIncludingAnimationsIdlePreEvent)(id, SEL
 static void swizzledWaitForQuiescenceIncludingAnimationsIdle(id self, SEL _cmd, BOOL includingAnimations)
 {
   NSString *bundleId = [self bundleID];
-  if (![[self fb_shouldWaitForQuiescence] boolValue] || FBConfiguration.waitForIdleTimeout < DBL_EPSILON) {
+  if (![[self fb_shouldWaitForQuiescence] boolValue] || FBConfiguration.sharedInstance.waitForIdleTimeout < DBL_EPSILON) {
     [FBLogger logFmt:@"Quiescence checks are disabled for %@ application. Making it to believe it is idling",
      bundleId];
     return;
   }
 
-  NSTimeInterval desiredTimeout = FBConfiguration.waitForIdleTimeout;
+  NSTimeInterval desiredTimeout = FBConfiguration.sharedInstance.waitForIdleTimeout;
   NSTimeInterval previousTimeout = _XCTApplicationStateTimeout();
   _XCTSetApplicationStateTimeout(desiredTimeout);
   [FBLogger logFmt:@"Waiting up to %@s until %@ is in idle state (%@ animations)",
@@ -43,13 +43,13 @@ static void swizzledWaitForQuiescenceIncludingAnimationsIdle(id self, SEL _cmd, 
 static void swizzledWaitForQuiescenceIncludingAnimationsIdlePreEvent(id self, SEL _cmd, BOOL includingAnimations, BOOL isPreEvent)
 {
   NSString *bundleId = [self bundleID];
-  if (![[self fb_shouldWaitForQuiescence] boolValue] || FBConfiguration.waitForIdleTimeout < DBL_EPSILON) {
+  if (![[self fb_shouldWaitForQuiescence] boolValue] || FBConfiguration.sharedInstance.waitForIdleTimeout < DBL_EPSILON) {
     [FBLogger logFmt:@"Quiescence checks are disabled for %@ application. Making it to believe it is idling",
      bundleId];
     return;
   }
 
-  NSTimeInterval desiredTimeout = FBConfiguration.waitForIdleTimeout;
+  NSTimeInterval desiredTimeout = FBConfiguration.sharedInstance.waitForIdleTimeout;
   NSTimeInterval previousTimeout = _XCTApplicationStateTimeout();
   _XCTSetApplicationStateTimeout(desiredTimeout);
   [FBLogger logFmt:@"Waiting up to %@s until %@ is in idle state (%@ animations)",

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -174,7 +174,7 @@ static bool fb_isLocked;
 
 - (NSData *)fb_screenshotWithError:(NSError*__autoreleasing*)error
 {
-  return [FBScreenshot takeInOriginalResolutionWithQuality:FBConfiguration.screenshotQuality
+  return [FBScreenshot takeInOriginalResolutionWithQuality:FBConfiguration.sharedInstance.screenshotQuality
                                                      error:error];
 }
 

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.m
@@ -59,7 +59,7 @@ static UIInterfaceOrientation FBInterfaceOrientationFromDeviceOrientation(UIDevi
 {
   // Tapping elements immediately after rotation may fail due to way UIKit is handling touches.
   // We should wait till UI cools off, before continuing
-  [application fb_waitUntilStableWithTimeout:FBConfiguration.animationCoolOffTimeout];
+  [application fb_waitUntilStableWithTimeout:FBConfiguration.sharedInstance.animationCoolOffTimeout];
 
   return application.interfaceOrientation == FBInterfaceOrientationFromDeviceOrientation(orientation);
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -109,7 +109,7 @@
     id<FBXCElementSnapshot> snapshot = matchingSnapshots.firstObject;
     matchingSnapshots = @[snapshot];
   }
-  XCUIElement *scopeRoot = FBConfiguration.limitXpathContextScope ? self : self.application;
+  XCUIElement *scopeRoot = FBConfiguration.sharedInstance.limitXpathContextScope ? self : self.application;
   return [scopeRoot fb_filterDescendantsWithSnapshots:matchingSnapshots
                                          onlyChildren:NO];
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
@@ -198,7 +198,7 @@ const CGFloat FBScrollTouchProportion = 0.75f;
       }
       scrollCount++;
       // Wait for scroll animation
-      [self fb_waitUntilStableWithTimeout:FBConfiguration.animationCoolOffTimeout];
+      [self fb_waitUntilStableWithTimeout:FBConfiguration.sharedInstance.animationCoolOffTimeout];
     }
   }
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTVFocuse.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTVFocuse.m
@@ -24,7 +24,7 @@ int const MAX_ITERATIONS_COUNT = 100;
 
 - (BOOL)fb_setFocusWithError:(NSError**) error
 {
-  [XCUIApplication.fb_activeApplication fb_waitUntilStableWithTimeout:FBConfiguration.animationCoolOffTimeout];
+  [XCUIApplication.fb_activeApplication fb_waitUntilStableWithTimeout:FBConfiguration.sharedInstance.animationCoolOffTimeout];
 
   if (!self.wdEnabled) {
     if (error) {

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -100,7 +100,7 @@ BOOL FBTypeText(NSString *text, NSUInteger typingSpeed, NSError **error)
 {
   return [self fb_typeText:text
                shouldClear:shouldClear
-                 frequency:FBConfiguration.maxTypingFrequency
+                 frequency:FBConfiguration.sharedInstance.maxTypingFrequency
                      error:error];
 }
 
@@ -184,7 +184,7 @@ BOOL FBTypeText(NSString *text, NSUInteger typingSpeed, NSError **error)
       [self fb_prepareForTextInputWithSnapshot:snapshot];
     }
 
-    if (retry == 0 && FBConfiguration.useClearTextShortcut) {
+    if (retry == 0 && FBConfiguration.sharedInstance.useClearTextShortcut) {
       // 1st attempt is via the IOHIDEvent as the fastest operation
       // https://github.com/appium/appium/issues/19389
       [[XCUIDevice sharedDevice] fb_performIOHIDEventWithPage:0x07  // kHIDPage_KeyboardOrKeypad
@@ -194,8 +194,8 @@ BOOL FBTypeText(NSString *text, NSUInteger typingSpeed, NSError **error)
     } else if (retry >= MAX_CLEAR_RETRIES - 1) {
       // Last chance retry. Tripple-tap the field to select its content
       [self tapWithNumberOfTaps:3 numberOfTouches:1];
-      return FBTypeText(backspaceDeleteSequence, FBConfiguration.defaultTypingFrequency, error);
-    } else if (!FBTypeText(backspacesToType, FBConfiguration.defaultTypingFrequency, error)) {
+      return FBTypeText(backspaceDeleteSequence, FBConfiguration.sharedInstance.defaultTypingFrequency, error);
+    } else if (!FBTypeText(backspacesToType, FBConfiguration.sharedInstance.defaultTypingFrequency, error)) {
       // 2nd operation
       return NO;
     }
@@ -215,7 +215,7 @@ BOOL FBTypeText(NSString *text, NSUInteger typingSpeed, NSError **error)
   // kHIDPage_KeyboardOrKeypad did not work for tvOS's search field. (tvOS 17 at least)
   // Tested XCUIElementTypeSearchField and XCUIElementTypeTextView whch were
   // common search field and email/passowrd input in tvOS apps.
-  return FBTypeText(backspacesToType, FBConfiguration.defaultTypingFrequency, error);
+  return FBTypeText(backspacesToType, FBConfiguration.sharedInstance.defaultTypingFrequency, error);
 #endif
 }
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -130,7 +130,7 @@
 
 - (void)fb_waitUntilStable
 {
-  [self fb_waitUntilStableWithTimeout:FBConfiguration.waitForIdleTimeout];
+  [self fb_waitUntilStableWithTimeout:FBConfiguration.sharedInstance.waitForIdleTimeout];
 }
 
 - (void)fb_waitUntilStableWithTimeout:(NSTimeInterval)timeout
@@ -139,9 +139,9 @@
     return;
   }
 
-  NSTimeInterval previousTimeout = FBConfiguration.waitForIdleTimeout;
+  NSTimeInterval previousTimeout = FBConfiguration.sharedInstance.waitForIdleTimeout;
   BOOL previousQuiescence = self.application.fb_shouldWaitForQuiescence;
-  FBConfiguration.waitForIdleTimeout = timeout;
+  FBConfiguration.sharedInstance.waitForIdleTimeout = timeout;
   if (!previousQuiescence) {
     self.application.fb_shouldWaitForQuiescence = YES;
   }
@@ -150,7 +150,7 @@
   if (previousQuiescence != self.application.fb_shouldWaitForQuiescence) {
     self.application.fb_shouldWaitForQuiescence = previousQuiescence;
   }
-  FBConfiguration.waitForIdleTimeout = previousTimeout;
+  FBConfiguration.sharedInstance.waitForIdleTimeout = previousTimeout;
 }
 
 - (void)fb_raiseStaleElementExceptionWithError:(NSError *)error __attribute__((noreturn))

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -37,7 +37,7 @@
     return [self fb_nativeSnapshot];
   }
   // https://github.com/appium/WebDriverAgent/issues/1085
-  if (FBConfiguration.enforceCustomSnapshots) {
+  if (FBConfiguration.sharedInstance.enforceCustomSnapshots) {
     return [self fb_customSnapshot];
   }
   // https://github.com/appium/appium-xcuitest-driver/issues/2552

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -219,7 +219,7 @@
     [element adjustToNormalizedSliderPosition:sliderValue];
     return FBResponseWithOK();
   }
-  NSUInteger frequency = (NSUInteger)[request.arguments[@"frequency"] longLongValue] ?: [FBConfiguration maxTypingFrequency];
+  NSUInteger frequency = (NSUInteger)[request.arguments[@"frequency"] longLongValue] ?: FBConfiguration.sharedInstance.maxTypingFrequency;
   NSError *error = nil;
   // checkStaleness:YES above already took a fresh, verified-live snapshot of
   // `element` and cached it as `lastSnapshot` - reuse it instead of paying
@@ -292,7 +292,7 @@
   if (![element fb_setFocusWithError:&error]) {
     return FBResponseWithStatus([FBCommandStatus invalidElementStateErrorWithMessage:error.description traceback:nil]);
   }
-  return FBResponseWithStatus([FBCommandStatus okWithValue: FBDictionaryResponseWithElement(element, FBConfiguration.shouldUseCompactResponses)]);
+  return FBResponseWithStatus([FBCommandStatus okWithValue: FBDictionaryResponseWithElement(element, FBConfiguration.sharedInstance.shouldUseCompactResponses)]);
 }
 #else
 + (id<FBResponsePayload>)handleDoubleTap:(FBRouteRequest *)request
@@ -520,7 +520,7 @@
 + (id<FBResponsePayload>)handleKeys:(FBRouteRequest *)request
 {
   NSString *textToType = [request.arguments[@"value"] componentsJoinedByString:@""];
-  NSUInteger frequency = [request.arguments[@"frequency"] unsignedIntegerValue] ?: [FBConfiguration maxTypingFrequency];
+  NSUInteger frequency = [request.arguments[@"frequency"] unsignedIntegerValue] ?: FBConfiguration.sharedInstance.maxTypingFrequency;
   NSError *error;
   if (!FBTypeText(textToType, frequency, &error)) {
     return FBResponseWithStatus([FBCommandStatus invalidElementStateErrorWithMessage:error.description

--- a/WebDriverAgentLib/Commands/FBFindElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBFindElementCommands.m
@@ -63,7 +63,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
   if (!element) {
     return FBNoSuchElementErrorResponseForRequest(request);
   }
-  return FBResponseWithCachedElement(element, request.session.elementCache, FBConfiguration.shouldUseCompactResponses);
+  return FBResponseWithCachedElement(element, request.session.elementCache, FBConfiguration.sharedInstance.shouldUseCompactResponses);
 }
 
 + (id<FBResponsePayload>)handleFindElements:(FBRouteRequest *)request
@@ -73,7 +73,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
                                       withValue:request.arguments[@"value"]
                                           under:session.activeApplication
                     shouldReturnAfterFirstMatch:NO];
-  return FBResponseWithCachedElements(elements, request.session.elementCache, FBConfiguration.shouldUseCompactResponses);
+  return FBResponseWithCachedElements(elements, request.session.elementCache, FBConfiguration.sharedInstance.shouldUseCompactResponses);
 }
 
 + (id<FBResponsePayload>)handleFindVisibleCells:(FBRouteRequest *)request
@@ -87,7 +87,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
   }];
   NSArray *cells = [element fb_filterDescendantsWithSnapshots:visibleCellSnapshots
                                                  onlyChildren:NO];
-  return FBResponseWithCachedElements(cells, request.session.elementCache, FBConfiguration.shouldUseCompactResponses);
+  return FBResponseWithCachedElements(cells, request.session.elementCache, FBConfiguration.sharedInstance.shouldUseCompactResponses);
 }
 
 + (id<FBResponsePayload>)handleFindSubElement:(FBRouteRequest *)request
@@ -101,7 +101,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
   if (!foundElement) {
     return FBNoSuchElementErrorResponseForRequest(request);
   }
-  return FBResponseWithCachedElement(foundElement, request.session.elementCache, FBConfiguration.shouldUseCompactResponses);
+  return FBResponseWithCachedElement(foundElement, request.session.elementCache, FBConfiguration.sharedInstance.shouldUseCompactResponses);
 }
 
 + (id<FBResponsePayload>)handleFindSubElements:(FBRouteRequest *)request
@@ -113,7 +113,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
                                            withValue:request.arguments[@"value"]
                                                under:element
                          shouldReturnAfterFirstMatch:NO];
-  return FBResponseWithCachedElements(foundElements, request.session.elementCache, FBConfiguration.shouldUseCompactResponses);
+  return FBResponseWithCachedElements(foundElements, request.session.elementCache, FBConfiguration.sharedInstance.shouldUseCompactResponses);
 }
 
 + (id<FBResponsePayload>)handleGetActiveElement:(FBRouteRequest *)request
@@ -122,7 +122,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
   if (nil == element) {
     return FBNoSuchElementErrorResponseForRequest(request);
   }
-  return FBResponseWithCachedElement(element, request.session.elementCache, FBConfiguration.shouldUseCompactResponses);
+  return FBResponseWithCachedElement(element, request.session.elementCache, FBConfiguration.sharedInstance.shouldUseCompactResponses);
 }
 
 #if TARGET_OS_TV
@@ -131,7 +131,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
   XCUIElement *element = request.session.activeApplication.fb_focusedElement;
   return element == nil
     ? FBNoSuchElementErrorResponseForRequest(request)
-    : FBResponseWithCachedElement(element, request.session.elementCache, FBConfiguration.shouldUseCompactResponses);
+    : FBResponseWithCachedElement(element, request.session.elementCache, FBConfiguration.sharedInstance.shouldUseCompactResponses);
 }
 #endif
 

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -264,29 +264,29 @@
 
 + (void)applyConfigurationFromCapabilities:(NSDictionary<NSString *, id> *)capabilities
 {
-  [FBConfiguration resetSessionSettings];
+  [FBConfiguration.sharedInstance resetSessionSettings];
   if (capabilities[FB_SETTING_USE_COMPACT_RESPONSES]) {
-    [FBConfiguration setShouldUseCompactResponses:[capabilities[FB_SETTING_USE_COMPACT_RESPONSES] boolValue]];
+    FBConfiguration.sharedInstance.shouldUseCompactResponses = [capabilities[FB_SETTING_USE_COMPACT_RESPONSES] boolValue];
   }
   NSString *elementResponseAttributes = capabilities[FB_SETTING_ELEMENT_RESPONSE_ATTRIBUTES];
   if (elementResponseAttributes) {
-    [FBConfiguration setElementResponseAttributes:elementResponseAttributes];
+    FBConfiguration.sharedInstance.elementResponseAttributes = elementResponseAttributes;
   }
   if (capabilities[FB_CAP_MAX_TYPING_FREQUENCY]) {
-    [FBConfiguration setMaxTypingFrequency:[capabilities[FB_CAP_MAX_TYPING_FREQUENCY] unsignedIntegerValue]];
+    FBConfiguration.sharedInstance.maxTypingFrequency = [capabilities[FB_CAP_MAX_TYPING_FREQUENCY] unsignedIntegerValue];
   }
   if (capabilities[FB_CAP_USE_SINGLETON_TEST_MANAGER]) {
-    [FBConfiguration setShouldUseSingletonTestManager:[capabilities[FB_CAP_USE_SINGLETON_TEST_MANAGER] boolValue]];
+    FBConfiguration.sharedInstance.shouldUseSingletonTestManager = [capabilities[FB_CAP_USE_SINGLETON_TEST_MANAGER] boolValue];
   }
   if (capabilities[FB_CAP_DISABLE_AUTOMATIC_SCREENSHOTS]) {
     if ([capabilities[FB_CAP_DISABLE_AUTOMATIC_SCREENSHOTS] boolValue]) {
-      [FBConfiguration disableScreenshots];
+      [FBConfiguration.sharedInstance disableScreenshots];
     } else {
-      [FBConfiguration enableScreenshots];
+      [FBConfiguration.sharedInstance enableScreenshots];
     }
   }
   if (capabilities[FB_CAP_SHOULD_TERMINATE_APP]) {
-    [FBConfiguration setShouldTerminateApp:[capabilities[FB_CAP_SHOULD_TERMINATE_APP] boolValue]];
+    FBConfiguration.sharedInstance.shouldTerminateApp = [capabilities[FB_CAP_SHOULD_TERMINATE_APP] boolValue];
   }
   NSNumber *delay = capabilities[FB_CAP_EVENT_LOOP_IDLE_DELAY_SEC];
   if ([delay doubleValue] > 0.0) {
@@ -295,11 +295,11 @@
     [XCUIApplicationProcessDelay disableEventLoopDelay];
   }
   if (nil != capabilities[FB_SETTING_WAIT_FOR_IDLE_TIMEOUT]) {
-    FBConfiguration.waitForIdleTimeout = [capabilities[FB_SETTING_WAIT_FOR_IDLE_TIMEOUT] doubleValue];
+    FBConfiguration.sharedInstance.waitForIdleTimeout = [capabilities[FB_SETTING_WAIT_FOR_IDLE_TIMEOUT] doubleValue];
   }
   if (nil == capabilities[FB_CAP_FORCE_SIMULATOR_SOFTWARE_KEYBOARD_PRESENCE] ||
       [capabilities[FB_CAP_FORCE_SIMULATOR_SOFTWARE_KEYBOARD_PRESENCE] boolValue]) {
-    [FBConfiguration forceSimulatorSoftwareKeyboardPresence];
+    [FBConfiguration.sharedInstance forceSimulatorSoftwareKeyboardPresence];
   }
 }
 

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -200,7 +200,7 @@
   id<FBXCElementSnapshot> snapshot = dstField.fb_cachedSnapshot ?: [dstField fb_standardSnapshot];
   if (![dstField fb_typeText:text
                   shouldClear:YES
-                    frequency:FBConfiguration.maxTypingFrequency
+                    frequency:FBConfiguration.sharedInstance.maxTypingFrequency
                      snapshot:snapshot
                         error:&error]) {
     [self fb_raiseSetTextFailedExceptionWithReason:error.description];
@@ -236,17 +236,17 @@
   }
 
   XCUIElement *acceptButton = nil;
-  if (FBConfiguration.acceptAlertButtonSelector.length) {
+  if (FBConfiguration.sharedInstance.acceptAlertButtonSelector.length) {
     NSString *errorReason = nil;
     @try {
-      acceptButton = [[alertElement fb_descendantsMatchingClassChain:FBConfiguration.acceptAlertButtonSelector
+      acceptButton = [[alertElement fb_descendantsMatchingClassChain:FBConfiguration.sharedInstance.acceptAlertButtonSelector
                                            shouldReturnAfterFirstMatch:YES] firstObject];
     } @catch (NSException *ex) {
       errorReason = ex.reason;
     }
     if (nil == acceptButton) {
       [FBLogger logFmt:@"Cannot find any match for Accept alert button using the class chain selector '%@'",
-       FBConfiguration.acceptAlertButtonSelector];
+       FBConfiguration.sharedInstance.acceptAlertButtonSelector];
       if (nil != errorReason) {
         [FBLogger logFmt:@"Original error: %@", errorReason];
       }
@@ -293,17 +293,17 @@
   }
 
   XCUIElement *dismissButton = nil;
-  if (FBConfiguration.dismissAlertButtonSelector.length) {
+  if (FBConfiguration.sharedInstance.dismissAlertButtonSelector.length) {
     NSString *errorReason = nil;
     @try {
-      dismissButton = [[alertElement fb_descendantsMatchingClassChain:FBConfiguration.dismissAlertButtonSelector
+      dismissButton = [[alertElement fb_descendantsMatchingClassChain:FBConfiguration.sharedInstance.dismissAlertButtonSelector
                                             shouldReturnAfterFirstMatch:YES] firstObject];
     } @catch (NSException *ex) {
       errorReason = ex.reason;
     }
     if (nil == dismissButton) {
       [FBLogger logFmt:@"Cannot find any match for Dismiss alert button using the class chain selector '%@'",
-       FBConfiguration.dismissAlertButtonSelector];
+       FBConfiguration.sharedInstance.dismissAlertButtonSelector];
       if (nil != errorReason) {
         [FBLogger logFmt:@"Original error: %@", errorReason];
       }

--- a/WebDriverAgentLib/Routing/FBResponsePayload.m
+++ b/WebDriverAgentLib/Routing/FBResponsePayload.m
@@ -120,7 +120,7 @@ inline NSDictionary *FBDictionaryResponseWithElement(XCUIElement *element, BOOL 
 
     NSMutableDictionary *result = compactResult.mutableCopy;
     FBXCElementSnapshotWrapper *wrappedSnapshot = [FBXCElementSnapshotWrapper ensureWrapped:snapshot];
-    NSArray *fields = [FBConfiguration.elementResponseAttributes componentsSeparatedByString:@","];
+    NSArray *fields = [FBConfiguration.sharedInstance.elementResponseAttributes componentsSeparatedByString:@","];
     for (NSString *field in fields) {
       // 'name' here is the w3c-approved identifier for what we mean by 'type'
       if ([field isEqualToString:@"name"] || [field isEqualToString:@"type"]) {

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -52,7 +52,7 @@ NSString *const FB_SAFARI_BUNDLE_ID = @"com.apple.mobilesafari";
 
 - (void)didDetectAlert:(FBAlert *)alert
 {
-  NSString *autoClickAlertSelector = FBConfiguration.autoClickAlertSelector;
+  NSString *autoClickAlertSelector = FBConfiguration.sharedInstance.autoClickAlertSelector;
   if ([autoClickAlertSelector length] > 0) {
     @try {
       [alert clickElementMatchingClassChain:autoClickAlertSelector];
@@ -185,7 +185,7 @@ static FBSession *_activeSession = nil;
   }
 
   if (nil != self.testedApplication
-      && FBConfiguration.shouldTerminateApp
+      && FBConfiguration.sharedInstance.shouldTerminateApp
       && self.testedApplication.running
       && ![self.testedApplication fb_isSameAppAs:XCUIApplication.fb_systemApplication]) {
     @try {
@@ -217,7 +217,7 @@ static FBSession *_activeSession = nil;
                                       // To look for 'criticalAlertSetting' elements https://developer.apple.com/documentation/usernotifications/unnotificationsettings/criticalalertsetting
                                       // See https://github.com/appium/appium/issues/20835
                                       @"NotificationShortLookView"];
-      if ([FBConfiguration shouldRespectSystemAlerts]
+      if (FBConfiguration.sharedInstance.shouldRespectSystemAlerts
           && [[XCUIApplication.fb_systemApplication descendantsMatchingType:XCUIElementTypeAny]
               matchingPredicate:searchPredicate].count > 0) {
         return XCUIApplication.fb_systemApplication;

--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -41,7 +41,7 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
 
 - (UInt64)maxRequestBodySize
 {
-  return FBConfiguration.httpRequestBodySizeLimit;
+  return FBConfiguration.sharedInstance.httpRequestBodySizeLimit;
 }
 
 @end
@@ -104,8 +104,8 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   [self registerRouteHandlers:[self.class collectCommandHandlerClasses]];
   [self registerServerKeyRouteHandlers];
 
-  NSRange serverPortRange = FBConfiguration.bindingPortRange;
-  NSString *bindingIP = FBConfiguration.bindingIPAddress;
+  NSRange serverPortRange = FBConfiguration.sharedInstance.bindingPortRange;
+  NSString *bindingIP = FBConfiguration.sharedInstance.bindingIPAddress;
   if (bindingIP != nil) {
     [self.server setInterface:bindingIP];
     [FBLogger logFmt:@"Using custom binding IP address: %@", bindingIP];
@@ -146,11 +146,11 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   [self readMjpegSettingsFromEnv];
   self.mjpegServer = [[FBMjpegServer alloc] init];
   self.screenshotsBroadcaster = [[FBTCPSocket alloc]
-                                 initWithPort:(uint16_t)FBConfiguration.mjpegServerPort];
+                                 initWithPort:(uint16_t)FBConfiguration.sharedInstance.mjpegServerPort];
   self.screenshotsBroadcaster.delegate = self.mjpegServer;
   NSError *error;
   if (![self.screenshotsBroadcaster startWithError:&error]) {
-    [FBLogger logFmt:@"Cannot init screenshots broadcaster service on port %@. Original error: %@", @(FBConfiguration.mjpegServerPort), error.description];
+    [FBLogger logFmt:@"Cannot init screenshots broadcaster service on port %@. Original error: %@", @(FBConfiguration.sharedInstance.mjpegServerPort), error.description];
     [self.mjpegServer stopStreaming];
     self.mjpegServer = nil;
     self.screenshotsBroadcaster = nil;
@@ -179,11 +179,11 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   NSDictionary *env = NSProcessInfo.processInfo.environment;
   NSString *scalingFactor = [env objectForKey:@"MJPEG_SCALING_FACTOR"];
   if (scalingFactor != nil && [scalingFactor length] > 0) {
-    [FBConfiguration setMjpegScalingFactor:[scalingFactor floatValue]];
+    FBConfiguration.sharedInstance.mjpegScalingFactor = [scalingFactor floatValue];
   }
   NSString *screenshotQuality = [env objectForKey:@"MJPEG_SERVER_SCREENSHOT_QUALITY"];
   if (screenshotQuality != nil && [screenshotQuality length] > 0) {
-    [FBConfiguration setMjpegServerScreenshotQuality:[screenshotQuality integerValue]];
+    FBConfiguration.sharedInstance.mjpegServerScreenshotQuality = [screenshotQuality integerValue];
   }
 }
 

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -27,8 +27,8 @@ extern NSString *const FBSnapshotMaxDepthKey;
 + (BOOL)shouldTerminateApp;
 
 /*! If shouldUseCompactResponses == NO, is the comma-separated list of fields to return with each element. Defaults to "type,label". */
-+ (void)setElementResponseAttributes:(NSString *)value;
-+ (NSString *)elementResponseAttributes;
++ (void)setElementResponseAttributes:(nullable NSString *)value;
++ (nullable NSString *)elementResponseAttributes;
 
 /*! Disables remote query evaluation making Xcode 9.x tests behave same as Xcode 8.x test */
 + (void)disableRemoteQueryEvaluation;
@@ -291,16 +291,16 @@ typedef NS_ENUM(NSInteger, FBConfigurationKeyboardPreference) {
  warning into the log.
  Example: ** /XCUIElementTypeButton[`label CONTAINS[c] 'accept'`]
  */
-+ (void)setAcceptAlertButtonSelector:(NSString *)classChainSelector;
-+ (NSString *)acceptAlertButtonSelector;
-+ (void)setDismissAlertButtonSelector:(NSString *)classChainSelector;
-+ (NSString *)dismissAlertButtonSelector;
++ (void)setAcceptAlertButtonSelector:(nullable NSString *)classChainSelector;
++ (nullable NSString *)acceptAlertButtonSelector;
++ (void)setDismissAlertButtonSelector:(nullable NSString *)classChainSelector;
++ (nullable NSString *)dismissAlertButtonSelector;
 
 /**
  Sets class chain selector to apply for an automated alert click
  */
-+ (void)setAutoClickAlertSelector:(NSString *)classChainSelector;
-+ (NSString *)autoClickAlertSelector;
++ (void)setAutoClickAlertSelector:(nullable NSString *)classChainSelector;
++ (nullable NSString *)autoClickAlertSelector;
 
 /**
  * Whether to use HIDEvent for text clear.

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -14,53 +14,59 @@ extern NSString *const FBSnapshotMaxChildrenKey;
 extern NSString *const FBSnapshotMaxDepthKey;
 
 /**
+Defines keyboard preference enabled status
+*/
+typedef NS_ENUM(NSInteger, FBConfigurationKeyboardPreference) {
+    FBConfigurationKeyboardPreferenceDisabled = 0,
+    FBConfigurationKeyboardPreferenceEnabled = 1,
+    FBConfigurationKeyboardPreferenceNotSupported = 2,
+};
+
+/**
  Accessors for Global Constants.
  */
 @interface FBConfiguration : NSObject
 
+/*! The shared configuration instance */
+@property (class, nonatomic, readonly) FBConfiguration *sharedInstance;
+
 /*! If set to YES will use compact (standards-compliant) & faster responses */
-+ (void)setShouldUseCompactResponses:(BOOL)value;
-+ (BOOL)shouldUseCompactResponses;
+@property (atomic, assign) BOOL shouldUseCompactResponses;
 
 /*! If set to YES (which is the default), the app will be terminated at the end of the session, if a bundleId was specified */
-+ (void)setShouldTerminateApp:(BOOL)value;
-+ (BOOL)shouldTerminateApp;
+@property (atomic, assign) BOOL shouldTerminateApp;
 
 /*! If shouldUseCompactResponses == NO, is the comma-separated list of fields to return with each element. Defaults to "type,label". */
-+ (void)setElementResponseAttributes:(NSString *)value;
-+ (NSString *)elementResponseAttributes;
+@property (atomic, copy) NSString *elementResponseAttributes;
 
 /*! Disables remote query evaluation making Xcode 9.x tests behave same as Xcode 8.x test */
-+ (void)disableRemoteQueryEvaluation;
+- (void)disableRemoteQueryEvaluation;
 
 /*! Enables the extended XCTest debug logging. Useful for developemnt purposes */
-+ (void)enableXcTestDebugLogs;
+- (void)enableXcTestDebugLogs;
 
 /*! Disables attribute key path analysis, which will cause XCTest on Xcode 9.x to ignore some elements */
-+ (void)disableAttributeKeyPathAnalysis;
+- (void)disableAttributeKeyPathAnalysis;
 
 /*! Disables XCTest automated screenshots taking */
-+ (void)disableScreenshots;
+- (void)disableScreenshots;
 /*! Enables XCTest automated screenshots taking */
-+ (void)enableScreenshots;
+- (void)enableScreenshots;
 
 /*! Disables XCTest automated videos taking (iOS 17+) */
-+ (void)disableScreenRecordings;
+- (void)disableScreenRecordings;
 /*! Enables XCTest automated videos taking  (iOS 17+) */
-+ (void)enableScreenRecordings;
+- (void)enableScreenRecordings;
 
-/* The maximum typing frequency for all typing activities */
-+ (void)setMaxTypingFrequency:(NSUInteger)value;
-+ (NSUInteger)maxTypingFrequency;
-+ (NSUInteger)defaultTypingFrequency;
+/*! The maximum typing frequency for all typing activities */
+@property (atomic, assign) NSUInteger maxTypingFrequency;
+@property (atomic, readonly) NSUInteger defaultTypingFrequency;
 
-/* Use singleton test manager proxy */
-+ (void)setShouldUseSingletonTestManager:(BOOL)value;
-+ (BOOL)shouldUseSingletonTestManager;
+/*! Use singleton test manager proxy */
+@property (atomic, assign) BOOL shouldUseSingletonTestManager;
 
-/* Enforces WDA to verify the presense of system alerts while checking for an active app */
-+ (void)setShouldRespectSystemAlerts:(BOOL)value;
-+ (BOOL)shouldRespectSystemAlerts;
+/*! Enforces WDA to verify the presense of system alerts while checking for an active app */
+@property (atomic, assign) BOOL shouldRespectSystemAlerts;
 
 /**
  * Extract switch value from arguments
@@ -78,8 +84,7 @@ extern NSString *const FBSnapshotMaxDepthKey;
  (or lowest quality) while the value 100 represents the least compression (or best
  quality). The default value is 25.
  */
-+ (NSUInteger)mjpegServerScreenshotQuality;
-+ (void)setMjpegServerScreenshotQuality:(NSUInteger)quality;
+@property (atomic, assign) NSUInteger mjpegServerScreenshotQuality;
 
 /**
  Whether to apply orientation fixes to the streamed JPEG images.
@@ -88,24 +93,21 @@ extern NSString *const FBSnapshotMaxDepthKey;
  metadata.
  ! Enablement of this setting may lead to WDA process termination because of an excessive CPU usage.
  */
-+ (BOOL)mjpegShouldFixOrientation;
-+ (void)setMjpegShouldFixOrientation:(BOOL)enabled;
+@property (atomic, assign) BOOL mjpegShouldFixOrientation;
 
 /**
  The framerate at which the background screenshots broadcaster should broadcast
  screenshots in range 1..60. The default value is 10 (Frames Per Second).
  Setting zero value will cause the framerate to be at its maximum possible value.
  */
-+ (NSUInteger)mjpegServerFramerate;
-+ (void)setMjpegServerFramerate:(NSUInteger)framerate;
+@property (atomic, assign) NSUInteger mjpegServerFramerate;
 
 /**
  Whether to limit the XPath scope to descendant items only while performing a lookup
  in an element context. Enabled by default. Being disabled, allows to use XPath locators
  like ".." in order to match parent items of the current context root.
  */
-+ (BOOL)limitXpathContextScope;
-+ (void)setLimitXpathContextScope:(BOOL)enabled;
+@property (atomic, assign) BOOL limitXpathContextScope;
 
 /**
  The quality of display screenshots. The higher quality you set is the bigger screenshot size is.
@@ -113,30 +115,29 @@ extern NSString *const FBSnapshotMaxDepthKey;
  The default quality value is 3 (lossless HEIC).
  See https://developer.apple.com/documentation/xctest/xctimagequality?language=objc
  */
-+ (NSUInteger)screenshotQuality;
-+ (void)setScreenshotQuality:(NSUInteger)quality;
+@property (atomic, assign) NSUInteger screenshotQuality;
 
 /**
  The range of ports that the HTTP Server should attempt to bind on launch
  */
-+ (NSRange)bindingPortRange;
+@property (atomic, readonly) NSRange bindingPortRange;
 
 /**
  The IP address that the HTTP Server should bind to on launch.
  Returns nil if not specified, which causes the server to listen on all interfaces.
  */
-+ (NSString * _Nullable)bindingIPAddress;
+@property (atomic, readonly, nullable) NSString *bindingIPAddress;
 
 /**
  The port number where the background screenshots broadcaster is supposed to run
  */
-+ (NSInteger)mjpegServerPort;
+@property (atomic, readonly) NSInteger mjpegServerPort;
 
 /**
  The maximum allowed HTTP request body size in bytes.
  Defaults to 1GB and can be overridden with the MAX_HTTP_REQUEST_BODY_SIZE environment variable.
  */
-+ (UInt64)httpRequestBodySizeLimit;
+@property (atomic, readonly) UInt64 httpRequestBodySizeLimit;
 
 /**
  The scaling factor for frames of the mjpeg stream. The default (and maximum) value is 100,
@@ -144,172 +145,122 @@ extern NSString *const FBSnapshotMaxDepthKey;
  ! Setting this to a value less than 100, especially together with orientation fixing enabled
  ! may lead to WDA process termination because of an excessive CPU usage.
  */
-+ (double)mjpegScalingFactor;
-+ (void)setMjpegScalingFactor:(double)scalingFactor;
+@property (atomic, assign) double mjpegScalingFactor;
 
 /**
  YES if verbose logging is enabled. NO otherwise.
  */
-+ (BOOL)verboseLoggingEnabled;
+@property (atomic, readonly) BOOL verboseLoggingEnabled;
 
 /**
  Disables automatic handling of XCTest UI interruptions.
  */
-+ (void)disableApplicationUIInterruptionsHandling;
+- (void)disableApplicationUIInterruptionsHandling;
 
 /**
  * Configure keyboards preference to make test running stable
  */
-+ (void)configureDefaultKeyboardPreferences;
+- (void)configureDefaultKeyboardPreferences;
 
 
 /**
  * Turn on softwar keyboard forcefully for simulator.
  */
-+ (void)forceSimulatorSoftwareKeyboardPresence;
-
-/**
-Defines keyboard preference enabled status
-*/
-typedef NS_ENUM(NSInteger, FBConfigurationKeyboardPreference) {
-    FBConfigurationKeyboardPreferenceDisabled = 0,
-    FBConfigurationKeyboardPreferenceEnabled = 1,
-    FBConfigurationKeyboardPreferenceNotSupported = 2,
-};
+- (void)forceSimulatorSoftwareKeyboardPresence;
 
 /**
  * Modify keyboard configuration of 'auto-correction'.
- *
- * @param isEnabled Turn the configuration on if the value is YES
  */
-+ (void)setKeyboardAutocorrection:(BOOL)isEnabled;
-+ (FBConfigurationKeyboardPreference)keyboardAutocorrection;
+@property (atomic, assign) FBConfigurationKeyboardPreference keyboardAutocorrection;
 
 /**
  * Modify keyboard configuration of 'predictive'
- *
- * @param isEnabled Turn the configuration on if the value is YES
  */
-+ (void)setKeyboardPrediction:(BOOL)isEnabled;
-+ (FBConfigurationKeyboardPreference)keyboardPrediction;
+@property (atomic, assign) FBConfigurationKeyboardPreference keyboardPrediction;
 
 /**
- Sets maximum depth for traversing elements tree from parents to children while requesting XCElementSnapshot.
+ Maximum depth for traversing elements tree from parents to children while requesting XCElementSnapshot.
  Used to set maxDepth value in a dictionary provided by XCAXClient_iOS's method defaultParams.
  The original XCAXClient_iOS maxDepth value is set to INT_MAX, which is too big for some queries
  (for example: searching elements inside a WebView).
  Reasonable values are from 15 to 100 (larger numbers make queries slower).
-
- @param maxDepth The number of maximum depth for traversing elements tree
  */
-+ (void)setSnapshotMaxDepth:(int)maxDepth;
+@property (atomic, assign) int snapshotMaxDepth;
 
 /**
-  @return The number of maximum depth for traversing elements tree
- */
-+ (int)snapshotMaxDepth;
-
-/**
- Sets the maximum number of element children to traverse in each snapshot
+ Maximum number of element children to traverse in each snapshot
  while requesting XCElementSnapshot.
  Used to set the `maxChildren` value in a dictionary provided by
  XCAXClient_iOS's `defaultParameters` method.
  The original XCAXClient_iOS `maxChildren` value is `INT_MAX`.
-
- @param maxChildren The number of maximum element children for traversing elements tree
  */
-+ (void)setSnapshotMaxChildren:(int)maxChildren;
-
-/**
-  @return The maximum number of element children for traversing elements tree
- */
-+ (int)snapshotMaxChildren;
+@property (atomic, assign) int snapshotMaxChildren;
 
 /**
  * Whether to use fast search result matching while searching for elements.
  * By default this is disabled due to https://github.com/appium/appium/issues/10101
  * but it still makes sense to enable it for views containing large counts of elements
- *
- * @param enabled Either YES or NO
  */
-+ (void)setUseFirstMatch:(BOOL)enabled;
-+ (BOOL)useFirstMatch;
+@property (atomic, assign) BOOL useFirstMatch;
 
 /**
  * Whether to bound the lookup results by index.
  * By default this is disabled and bounding by accessibility is used.
  * Read https://stackoverflow.com/questions/49307513/meaning-of-allelementsboundbyaccessibilityelement
  * for more details on these two bounding methods.
- *
- * @param enabled Either YES or NO
  */
-+ (void)setBoundElementsByIndex:(BOOL)enabled;
-+ (BOOL)boundElementsByIndex;
+@property (atomic, assign) BOOL boundElementsByIndex;
 
 /**
  * Modify reduce motion configuration in accessibility.
  * It works only for Simulator since Real device has security model which allows chnaging preferences
  * only from settings app.
- *
- * @param isEnabled Turn the configuration on if the value is YES
  */
-+ (void)setReduceMotionEnabled:(BOOL)isEnabled;
-+ (BOOL)reduceMotionEnabled;
+@property (atomic, assign) BOOL reduceMotionEnabled;
 
 /**
- * Set the idling timeout. If the timeout expires then WDA
+ * The idling timeout. If the timeout expires then WDA
  * tries to interact with the application even if it is not idling.
  * Setting it to zero disables idling checks.
  * The default timeout is set to 10 seconds.
- *
- * @param timeout The actual timeout value in float seconds
  */
-+ (void)setWaitForIdleTimeout:(NSTimeInterval)timeout;
-+ (NSTimeInterval)waitForIdleTimeout;
+@property (atomic, assign) NSTimeInterval waitForIdleTimeout;
 
 /**
- * Set the idling timeout for different actions, for example events synthesis, rotation change,
+ * The idling timeout for different actions, for example events synthesis, rotation change,
  * etc. If the timeout expires then WDA tries to interact with the application even if it is not idling.
  * Setting it to zero disables idling checks.
  * The default timeout is set to 2 seconds.
- *
- * @param timeout The actual timeout value in float seconds
  */
-+ (void)setAnimationCoolOffTimeout:(NSTimeInterval)timeout;
-+ (NSTimeInterval)animationCoolOffTimeout;
+@property (atomic, assign) NSTimeInterval animationCoolOffTimeout;
 
 /**
- Sets custom class chain locators for accept/dismiss alert buttons location.
+ Custom class chain locator for accept alert button location.
  This might be useful if the default buttons detection algorithm fails to determine alert buttons properly
  when defaultAlertAction is set.
 
- @param classChainSelector Valid class chain locator, which determines accept/reject button
- on the alert. The search root is the alert element itself.
  Setting this value to nil or an empty string (the default
  value) will enforce WDA to apply the default algorithm for alert buttons location.
  If an invalid/non-parseable locator is set then the lookup will fallback to the default algorithm and print a
  warning into the log.
  Example: ** /XCUIElementTypeButton[`label CONTAINS[c] 'accept'`]
  */
-+ (void)setAcceptAlertButtonSelector:(NSString *)classChainSelector;
-+ (NSString *)acceptAlertButtonSelector;
-+ (void)setDismissAlertButtonSelector:(NSString *)classChainSelector;
-+ (NSString *)dismissAlertButtonSelector;
+@property (atomic, copy) NSString *acceptAlertButtonSelector;
+/**
+ Custom class chain locator for dismiss alert button location. See `acceptAlertButtonSelector` for details.
+ */
+@property (atomic, copy) NSString *dismissAlertButtonSelector;
 
 /**
- Sets class chain selector to apply for an automated alert click
+ Class chain selector to apply for an automated alert click
  */
-+ (void)setAutoClickAlertSelector:(NSString *)classChainSelector;
-+ (NSString *)autoClickAlertSelector;
+@property (atomic, copy) NSString *autoClickAlertSelector;
 
 /**
  * Whether to use HIDEvent for text clear.
  * By default this is enabled and HIDEvent is used for text clear.
- *
- * @param enabled Either YES or NO
  */
-+ (void)setUseClearTextShortcut:(BOOL)enabled;
-+ (BOOL)useClearTextShortcut;
+@property (atomic, assign) BOOL useClearTextShortcut;
 
 #if !TARGET_OS_TV
 /**
@@ -326,35 +277,32 @@ typedef NS_ENUM(NSInteger, FBConfigurationKeyboardPreference) {
  the adjustment automatically. Defaults to "auto".
  @param error If no availale orientation strategy was given, it returns an NSError object that describes the problem.
  */
-+ (BOOL)setScreenshotOrientation:(NSString *)orientation error:(NSError **)error;
+- (BOOL)setScreenshotOrientation:(NSString *)orientation error:(NSError **)error;
 
 /**
 @return The value of UIInterfaceOrientation
 */
-+ (NSInteger)screenshotOrientation;
+@property (atomic, readonly) NSInteger screenshotOrientation;
 
 /**
 @return The orientation as String for human read
 */
-+ (NSString *)humanReadableScreenshotOrientation;
+@property (atomic, readonly) NSString *humanReadableScreenshotOrientation;
 
 #endif
 
 /**
  Resets all session-specific settings to their default values
  */
-+ (void)resetSessionSettings;
+- (void)resetSessionSettings;
 
 /**
  * Whether to calculate `hittable` attribute using native APIs
  * instead of legacy heuristics.
  * This flag improves accuracy, but may affect performance.
  * Disabled by default.
- *
- * @param enabled Either YES or NO
  */
-+ (void)setIncludeHittableInPageSource:(BOOL)enabled;
-+ (BOOL)includeHittableInPageSource;
+@property (atomic, assign) BOOL includeHittableInPageSource;
 
 /**
  * Whether to include `nativeFrame` attribute in the XML page source.
@@ -366,11 +314,8 @@ typedef NS_ENUM(NSInteger, FBConfigurationKeyboardPreference) {
  * and may introduce inconsistencies in size and position calculations.
  *
  * The value is disabled by default to avoid potential performance overhead.
- *
- * @param enabled Either YES or NO
  */
-+ (void)setIncludeNativeFrameInPageSource:(BOOL)enabled;
-+ (BOOL)includeNativeFrameInPageSource;
+@property (atomic, assign) BOOL includeNativeFrameInPageSource;
 
 /**
  * Whether to include the `nativeAccessibilityElement` attribute in the XML page source.
@@ -384,11 +329,8 @@ typedef NS_ENUM(NSInteger, FBConfigurationKeyboardPreference) {
  * accessibility flag alongside the computed `accessible` value.
  *
  * The value is disabled by default to keep the default page source stable.
- *
- * @param enabled Either YES or NO
  */
-+ (void)setIncludeNativeAccessibilityElementInPageSource:(BOOL)enabled;
-+ (BOOL)includeNativeAccessibilityElementInPageSource;
+@property (atomic, assign) BOOL includeNativeAccessibilityElementInPageSource;
 
 /**
  * Whether to include `minValue`/`maxValue` attributes in the page source.
@@ -396,33 +338,24 @@ typedef NS_ENUM(NSInteger, FBConfigurationKeyboardPreference) {
  * value boundaries for elements like sliders or progress indicators.
  * This may affect performance if used on many elements.
  * Disabled by default.
- *
- * @param enabled Either YES or NO
  */
-+ (void)setIncludeMinMaxValueInPageSource:(BOOL)enabled;
-+ (BOOL)includeMinMaxValueInPageSource;
+@property (atomic, assign) BOOL includeMinMaxValueInPageSource;
 
 /**
  * Whether to include `customActions` attribute in the XML page source.
  * Custom actions represent accessibility actions available on UI elements.
  * This may affect performance if used on many elements.
  * Disabled by default.
- *
- * @param enabled Either YES or NO
  */
-+ (void)setIncludeCustomActionsInPageSource:(BOOL)enabled;
-+ (BOOL)includeCustomActionsInPageSource;
+@property (atomic, assign) BOOL includeCustomActionsInPageSource;
 
 /**
  * Whether to enforce the use of custom snapshots instead of standard snapshots.
  * When enabled, fb_customSnapshot is always invoked instead of fb_standardSnapshot
  * for XPath tree building and element attributes fetching.
  * Disabled by default.
- *
- * @param enabled Either YES or NO
  */
-+ (void)setEnforceCustomSnapshots:(BOOL)enabled;
-+ (BOOL)enforceCustomSnapshots;
+@property (atomic, assign) BOOL enforceCustomSnapshots;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -34,101 +34,98 @@ static NSString *const FBKeyboardAutocorrectionKey = @"KeyboardAutocorrection";
 static NSString *const FBKeyboardPredictionKey = @"KeyboardPrediction";
 static NSString *const axSettingsClassName = @"AXSettings";
 
-static BOOL FBShouldUseSingletonTestManager = YES;
-static BOOL FBShouldRespectSystemAlerts = NO;
+@interface FBConfiguration ()
 
-static double FBMjpegScalingFactor = 100.0;
-static BOOL FBMjpegShouldFixOrientation = NO;
-static NSUInteger FBMjpegServerScreenshotQuality = 25;
-static NSUInteger FBMjpegServerFramerate = 10;
-
-// Session-specific settings
-static BOOL FBShouldTerminateApp;
-static NSNumber* FBMaxTypingFrequency;
-static NSUInteger FBScreenshotQuality;
-static BOOL FBShouldUseFirstMatch;
-static BOOL FBShouldBoundElementsByIndex;
-static NSString *FBAcceptAlertButtonSelector;
-static NSString *FBDismissAlertButtonSelector;
-static NSString *FBAutoClickAlertSelector;
-static NSTimeInterval FBWaitForIdleTimeout;
-static NSTimeInterval FBAnimationCoolOffTimeout;
-static BOOL FBShouldUseCompactResponses;
-static NSString *FBElementResponseAttributes;
-static BOOL FBUseClearTextShortcut;
-static BOOL FBLimitXpathContextScope = YES;
+@property (atomic, strong) NSNumber *maxTypingFrequencyOverride;
 #if !TARGET_OS_TV
-static UIInterfaceOrientation FBScreenshotOrientation;
+@property (atomic, assign) UIInterfaceOrientation screenshotOrientationStorage;
 #endif
-static BOOL FBShouldIncludeHittableInPageSource = NO;
-static BOOL FBShouldIncludeNativeFrameInPageSource = NO;
-static BOOL FBShouldIncludeNativeAccessibilityElementInPageSource = NO;
-static BOOL FBShouldIncludeMinMaxValueInPageSource = NO;
-static BOOL FBShouldIncludeCustomActionsInPageSource = NO;
-static BOOL FBShouldEnforceCustomSnapshots = NO;
+
+@end
 
 @implementation FBConfiguration
 
-+ (NSUInteger)defaultTypingFrequency
++ (instancetype)sharedInstance
+{
+  static FBConfiguration *instance;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    instance = [FBConfiguration new];
+  });
+  return instance;
+}
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    // Process-level defaults that are intentionally NOT reset by -resetSessionSettings
+    self.shouldUseSingletonTestManager = YES;
+    self.mjpegScalingFactor = 100.0;
+    self.mjpegServerScreenshotQuality = 25;
+    self.mjpegServerFramerate = 10;
+
+    [self resetSessionSettings];
+  }
+  return self;
+}
+
+- (NSUInteger)defaultTypingFrequency
 {
   NSInteger defaultFreq = [[NSUserDefaults standardUserDefaults]
                            integerForKey:@"com.apple.xctest.iOSMaximumTypingFrequency"];
   return defaultFreq > 0 ? defaultFreq : 60;
 }
 
-+ (void)initialize
-{
-  [FBConfiguration resetSessionSettings];
-}
-
 #pragma mark Public
 
-+ (void)disableRemoteQueryEvaluation
+- (void)disableRemoteQueryEvaluation
 {
   [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"XCTDisableRemoteQueryEvaluation"];
 }
 
-+ (void)disableApplicationUIInterruptionsHandling
+- (void)disableApplicationUIInterruptionsHandling
 {
   [XCUIApplication fb_disableUIInterruptionsHandling];
 }
 
-+ (void)enableXcTestDebugLogs
+- (void)enableXcTestDebugLogs
 {
   ((XCTestConfiguration *)XCTestConfiguration.activeTestConfiguration).emitOSLogs = YES;
   [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"XCTEmitOSLogs"];
 }
 
-+ (void)disableAttributeKeyPathAnalysis
+- (void)disableAttributeKeyPathAnalysis
 {
   [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"XCTDisableAttributeKeyPathAnalysis"];
 }
 
-+ (void)disableScreenshots
+- (void)disableScreenshots
 {
   [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"DisableScreenshots"];
 }
 
-+ (void)enableScreenshots
+- (void)enableScreenshots
 {
   [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"DisableScreenshots"];
 }
 
-+ (void)disableScreenRecordings
+- (void)disableScreenRecordings
 {
   [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"DisableDiagnosticScreenRecordings"];
 }
 
-+ (void)enableScreenRecordings
+- (void)enableScreenRecordings
 {
   [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"DisableDiagnosticScreenRecordings"];
 }
 
-+ (NSRange)bindingPortRange
+- (NSRange)bindingPortRange
 {
   // 'WebDriverAgent --port 8080' can be passed via the arguments to the process
-  if (self.bindingPortRangeFromArguments.location != NSNotFound) {
-    return self.bindingPortRangeFromArguments;
+  NSRange rangeFromArguments = [self.class bindingPortRangeFromArguments];
+  if (rangeFromArguments.location != NSNotFound) {
+    return rangeFromArguments;
   }
 
   // Existence of USE_PORT in the environment implies the port range is managed by the launching process.
@@ -140,7 +137,7 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
   return NSMakeRange(DefaultStartingPort, DefaultPortRange);
 }
 
-+ (NSString *)bindingIPAddress
+- (NSString *)bindingIPAddress
 {
   // Existence of USE_IP in the environment allows specifying which interface to bind to
   if (NSProcessInfo.processInfo.environment[@"USE_IP"] &&
@@ -151,10 +148,11 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
   return nil;
 }
 
-+ (NSInteger)mjpegServerPort
+- (NSInteger)mjpegServerPort
 {
-  if (self.mjpegServerPortFromArguments != NSNotFound) {
-    return self.mjpegServerPortFromArguments;
+  NSUInteger portFromArguments = [self.class mjpegServerPortFromArguments];
+  if (portFromArguments != NSNotFound) {
+    return portFromArguments;
   }
 
   if (NSProcessInfo.processInfo.environment[@"MJPEG_SERVER_PORT"] &&
@@ -165,7 +163,7 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
   return DefaultMjpegServerPort;
 }
 
-+ (UInt64)httpRequestBodySizeLimit
+- (UInt64)httpRequestBodySizeLimit
 {
   NSString *limit = NSProcessInfo.processInfo.environment[@"MAX_HTTP_REQUEST_BODY_SIZE"];
   if (limit.length > 0) {
@@ -178,136 +176,28 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
   return DefaultHttpRequestBodySizeLimit;
 }
 
-+ (double)mjpegScalingFactor
-{
-  return FBMjpegScalingFactor;
-}
-
-+ (void)setMjpegScalingFactor:(double)scalingFactor {
-  FBMjpegScalingFactor = scalingFactor;
-}
-
-+ (BOOL)mjpegShouldFixOrientation
-{
-  return FBMjpegShouldFixOrientation;
-}
-
-+ (void)setMjpegShouldFixOrientation:(BOOL)enabled {
-  FBMjpegShouldFixOrientation = enabled;
-}
-
-+ (BOOL)verboseLoggingEnabled
+- (BOOL)verboseLoggingEnabled
 {
   return [NSProcessInfo.processInfo.environment[@"VERBOSE_LOGGING"] boolValue];
 }
 
-+ (void)setShouldUseCompactResponses:(BOOL)value
+- (NSUInteger)maxTypingFrequency
 {
-  FBShouldUseCompactResponses = value;
-}
-
-+ (BOOL)shouldUseCompactResponses
-{
-  return FBShouldUseCompactResponses;
-}
-
-+ (void)setShouldTerminateApp:(BOOL)value
-{
-  FBShouldTerminateApp = value;
-}
-
-+ (BOOL)shouldTerminateApp
-{
-  return FBShouldTerminateApp;
-}
-
-+ (void)setElementResponseAttributes:(NSString *)value
-{
-  FBElementResponseAttributes = value;
-}
-
-+ (NSString *)elementResponseAttributes
-{
-  return FBElementResponseAttributes;
-}
-
-+ (void)setMaxTypingFrequency:(NSUInteger)value
-{
-  FBMaxTypingFrequency = @(value);
-}
-
-+ (NSUInteger)maxTypingFrequency
-{
-  if (nil == FBMaxTypingFrequency) {
-    return [self defaultTypingFrequency];
+  if (nil == self.maxTypingFrequencyOverride) {
+    return self.defaultTypingFrequency;
   }
-  return FBMaxTypingFrequency.integerValue <= 0
-    ? [self defaultTypingFrequency]
-    : FBMaxTypingFrequency.integerValue;
+  return self.maxTypingFrequencyOverride.integerValue <= 0
+    ? self.defaultTypingFrequency
+    : self.maxTypingFrequencyOverride.integerValue;
 }
 
-+ (void)setShouldUseSingletonTestManager:(BOOL)value
+- (void)setMaxTypingFrequency:(NSUInteger)value
 {
-  FBShouldUseSingletonTestManager = value;
-}
-
-+ (BOOL)shouldUseSingletonTestManager
-{
-  return FBShouldUseSingletonTestManager;
-}
-
-+ (NSUInteger)mjpegServerFramerate
-{
-  return FBMjpegServerFramerate;
-}
-
-+ (void)setMjpegServerFramerate:(NSUInteger)framerate
-{
-  FBMjpegServerFramerate = framerate;
-}
-
-+ (NSUInteger)mjpegServerScreenshotQuality
-{
-  return FBMjpegServerScreenshotQuality;
-}
-
-+ (void)setMjpegServerScreenshotQuality:(NSUInteger)quality
-{
-  FBMjpegServerScreenshotQuality = quality;
-}
-
-+ (NSUInteger)screenshotQuality
-{
-  return FBScreenshotQuality;
-}
-
-+ (void)setScreenshotQuality:(NSUInteger)quality
-{
-  FBScreenshotQuality = quality;
-}
-
-+ (NSTimeInterval)waitForIdleTimeout
-{
-  return FBWaitForIdleTimeout;
-}
-
-+ (void)setWaitForIdleTimeout:(NSTimeInterval)timeout
-{
-  FBWaitForIdleTimeout = timeout;
-}
-
-+ (NSTimeInterval)animationCoolOffTimeout
-{
-  return FBAnimationCoolOffTimeout;
-}
-
-+ (void)setAnimationCoolOffTimeout:(NSTimeInterval)timeout
-{
-  FBAnimationCoolOffTimeout = timeout;
+  self.maxTypingFrequencyOverride = @(value);
 }
 
 // Works for Simulator and Real devices
-+ (void)configureDefaultKeyboardPreferences
+- (void)configureDefaultKeyboardPreferences
 {
   void *handle = dlopen(controllerPrefBundlePath, RTLD_LAZY);
 
@@ -343,7 +233,7 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
   dlclose(handle);
 }
 
-+ (void)forceSimulatorSoftwareKeyboardPresence
+- (void)forceSimulatorSoftwareKeyboardPresence
 {
 #if TARGET_OS_SIMULATOR
   // Force toggle software keyboard on.
@@ -359,141 +249,63 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
 #endif
 }
 
-+ (FBConfigurationKeyboardPreference)keyboardAutocorrection
+- (FBConfigurationKeyboardPreference)keyboardAutocorrection
 {
   return [self keyboardsPreference:FBKeyboardAutocorrectionKey];
 }
 
-+ (void)setKeyboardAutocorrection:(BOOL)isEnabled
+- (void)setKeyboardAutocorrection:(FBConfigurationKeyboardPreference)preference
 {
-  [self configureKeyboardsPreference:isEnabled forPreferenceKey:FBKeyboardAutocorrectionKey];
+  [self configureKeyboardsPreference:(preference == FBConfigurationKeyboardPreferenceEnabled)
+                     forPreferenceKey:FBKeyboardAutocorrectionKey];
 }
 
-+ (FBConfigurationKeyboardPreference)keyboardPrediction
+- (FBConfigurationKeyboardPreference)keyboardPrediction
 {
   return [self keyboardsPreference:FBKeyboardPredictionKey];
 }
 
-+ (void)setKeyboardPrediction:(BOOL)isEnabled
+- (void)setKeyboardPrediction:(FBConfigurationKeyboardPreference)preference
 {
-  [self configureKeyboardsPreference:isEnabled forPreferenceKey:FBKeyboardPredictionKey];
+  [self configureKeyboardsPreference:(preference == FBConfigurationKeyboardPreferenceEnabled)
+                     forPreferenceKey:FBKeyboardPredictionKey];
 }
 
-+ (void)setSnapshotMaxDepth:(int)maxDepth
+- (void)setSnapshotMaxDepth:(int)maxDepth
 {
   FBSetCustomParameterForElementSnapshot(FBSnapshotMaxDepthKey, @(maxDepth));
 }
 
-+ (int)snapshotMaxDepth
+- (int)snapshotMaxDepth
 {
   return [FBGetCustomParameterForElementSnapshot(FBSnapshotMaxDepthKey) intValue];
 }
 
-+ (void)setSnapshotMaxChildren:(int)maxChildren
+- (void)setSnapshotMaxChildren:(int)maxChildren
 {
   FBSetCustomParameterForElementSnapshot(FBSnapshotMaxChildrenKey, @(maxChildren));
 }
 
-+ (int)snapshotMaxChildren
+- (int)snapshotMaxChildren
 {
   return [FBGetCustomParameterForElementSnapshot(FBSnapshotMaxChildrenKey) intValue];
 }
 
-+ (void)setShouldRespectSystemAlerts:(BOOL)value
-{
-  FBShouldRespectSystemAlerts = value;
-}
-
-+ (BOOL)shouldRespectSystemAlerts
-{
-  return FBShouldRespectSystemAlerts;
-}
-
-+ (void)setUseFirstMatch:(BOOL)enabled
-{
-  FBShouldUseFirstMatch = enabled;
-}
-
-+ (BOOL)useFirstMatch
-{
-  return FBShouldUseFirstMatch;
-}
-
-+ (void)setBoundElementsByIndex:(BOOL)enabled
-{
-  FBShouldBoundElementsByIndex = enabled;
-}
-
-+ (BOOL)boundElementsByIndex
-{
-  return FBShouldBoundElementsByIndex;
-}
-
-+ (void)setAcceptAlertButtonSelector:(NSString *)classChainSelector
-{
-  FBAcceptAlertButtonSelector = classChainSelector;
-}
-
-+ (NSString *)acceptAlertButtonSelector
-{
-  return FBAcceptAlertButtonSelector;
-}
-
-+ (void)setDismissAlertButtonSelector:(NSString *)classChainSelector
-{
-  FBDismissAlertButtonSelector = classChainSelector;
-}
-
-+ (NSString *)dismissAlertButtonSelector
-{
-  return FBDismissAlertButtonSelector;
-}
-
-+ (void)setAutoClickAlertSelector:(NSString *)classChainSelector
-{
-  FBAutoClickAlertSelector = classChainSelector;
-}
-
-+ (NSString *)autoClickAlertSelector
-{
-  return FBAutoClickAlertSelector;
-}
-
-+ (void)setUseClearTextShortcut:(BOOL)enabled
-{
-  FBUseClearTextShortcut = enabled;
-}
-
-+ (BOOL)useClearTextShortcut
-{
-  return FBUseClearTextShortcut;
-}
-
-+ (BOOL)limitXpathContextScope
-{
-  return FBLimitXpathContextScope;
-}
-
-+ (void)setLimitXpathContextScope:(BOOL)enabled
-{
-  FBLimitXpathContextScope = enabled;
-}
-
 #if !TARGET_OS_TV
-+ (BOOL)setScreenshotOrientation:(NSString *)orientation error:(NSError **)error
+- (BOOL)setScreenshotOrientation:(NSString *)orientation error:(NSError **)error
 {
   // Only UIInterfaceOrientationUnknown is over iOS 8. Others are over iOS 2.
   // https://developer.apple.com/documentation/uikit/uiinterfaceorientation/uiinterfaceorientationunknown
   if ([orientation.lowercaseString isEqualToString:@"portrait"]) {
-    FBScreenshotOrientation = UIInterfaceOrientationPortrait;
+    self.screenshotOrientationStorage = UIInterfaceOrientationPortrait;
   } else if ([orientation.lowercaseString isEqualToString:@"portraitupsidedown"]) {
-    FBScreenshotOrientation = UIInterfaceOrientationPortraitUpsideDown;
+    self.screenshotOrientationStorage = UIInterfaceOrientationPortraitUpsideDown;
   } else if ([orientation.lowercaseString isEqualToString:@"landscaperight"]) {
-    FBScreenshotOrientation = UIInterfaceOrientationLandscapeRight;
+    self.screenshotOrientationStorage = UIInterfaceOrientationLandscapeRight;
   } else if ([orientation.lowercaseString isEqualToString:@"landscapeleft"]) {
-    FBScreenshotOrientation = UIInterfaceOrientationLandscapeLeft;
+    self.screenshotOrientationStorage = UIInterfaceOrientationLandscapeLeft;
   } else if ([orientation.lowercaseString isEqualToString:@"auto"]) {
-    FBScreenshotOrientation = UIInterfaceOrientationUnknown;
+    self.screenshotOrientationStorage = UIInterfaceOrientationUnknown;
   } else {
     return [[FBErrorBuilder.builder withDescriptionFormat:
              @"The orientation value '%@' is not known. Only the following orientation values are supported: " \
@@ -503,14 +315,14 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
   return YES;
 }
 
-+ (NSInteger)screenshotOrientation
+- (NSInteger)screenshotOrientation
 {
-  return FBScreenshotOrientation;
+  return self.screenshotOrientationStorage;
 }
 
-+ (NSString *)humanReadableScreenshotOrientation
+- (NSString *)humanReadableScreenshotOrientation
 {
-  switch (FBScreenshotOrientation) {
+  switch (self.screenshotOrientationStorage) {
     case UIInterfaceOrientationPortrait:
       return @"portrait";
     case UIInterfaceOrientationPortraitUpsideDown:
@@ -523,36 +335,61 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
       return @"auto";
     default: break;
   }
+  return @"auto";
 }
 #endif
 
-+ (void)resetSessionSettings
+- (void)resetSessionSettings
 {
-  FBShouldTerminateApp = YES;
-  FBShouldUseCompactResponses = YES;
-  FBElementResponseAttributes = @"type,label";
-  FBMaxTypingFrequency = @([self defaultTypingFrequency]);
-  FBScreenshotQuality = 3;
-  FBShouldUseFirstMatch = NO;
-  FBShouldBoundElementsByIndex = NO;
-  FBAcceptAlertButtonSelector = @"";
-  FBDismissAlertButtonSelector = @"";
-  FBAutoClickAlertSelector = @"";
-  FBWaitForIdleTimeout = 10.;
-  FBAnimationCoolOffTimeout = 2.;
+  self.shouldTerminateApp = YES;
+  self.shouldUseCompactResponses = YES;
+  self.elementResponseAttributes = @"type,label";
+  self.maxTypingFrequencyOverride = @(self.defaultTypingFrequency);
+  self.screenshotQuality = 3;
+  self.useFirstMatch = NO;
+  self.boundElementsByIndex = NO;
+  self.acceptAlertButtonSelector = @"";
+  self.dismissAlertButtonSelector = @"";
+  self.autoClickAlertSelector = @"";
+  self.waitForIdleTimeout = 10.;
+  self.animationCoolOffTimeout = 2.;
   // 50 should be enough for the majority of the cases. The performance is acceptable for values up to 100.
   FBSetCustomParameterForElementSnapshot(FBSnapshotMaxDepthKey, @50);
   FBSetCustomParameterForElementSnapshot(FBSnapshotMaxChildrenKey, @INT_MAX);
-  FBUseClearTextShortcut = YES;
-  FBLimitXpathContextScope = YES;
+  self.useClearTextShortcut = YES;
+  self.limitXpathContextScope = YES;
 #if !TARGET_OS_TV
-  FBScreenshotOrientation = UIInterfaceOrientationUnknown;
+  self.screenshotOrientationStorage = UIInterfaceOrientationUnknown;
 #endif
+}
+
+- (void)setReduceMotionEnabled:(BOOL)isEnabled
+{
+  Class settingsClass = NSClassFromString(axSettingsClassName);
+  AXSettings *settings = (AXSettings *)[settingsClass sharedInstance];
+
+  // Below does not work on real devices because of iOS security model
+  //  (lldb) po settings.reduceMotionEnabled = isEnabled
+  //  2019-08-21 22:58:19.776165+0900 WebDriverAgentRunner-Runner[322:13361] [User Defaults] Couldn't write value for key ReduceMotionEnabled in CFPrefsPlistSource<0x28111a700> (Domain: com.apple.Accessibility, User: kCFPreferencesCurrentUser, ByHost: No, Container: (null), Contents Need Refresh: No): setting preferences outside an application's container requires user-preference-write or file-write-data sandbox access
+  if ([settings respondsToSelector:@selector(setReduceMotionEnabled:)]) {
+    [settings setReduceMotionEnabled:isEnabled];
+  }
+}
+
+- (BOOL)reduceMotionEnabled
+{
+  Class settingsClass = NSClassFromString(axSettingsClassName);
+  AXSettings *settings = (AXSettings *)[settingsClass sharedInstance];
+
+  if ([settings respondsToSelector:@selector(reduceMotionEnabled)]) {
+    return settings.reduceMotionEnabled;
+  }
+  return NO;
 }
 
 #pragma mark Private
 
-+ (FBConfigurationKeyboardPreference)keyboardsPreference:(nonnull NSString *)key
+- (FBConfigurationKeyboardPreference)keyboardsPreference:(nonnull NSString *)key
 {
   Class controllerClass = NSClassFromString(controllerClassName);
   TIPreferencesController *controller = [controllerClass sharedPreferencesController];
@@ -578,7 +415,7 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
   @throw [[FBErrorBuilder.builder withDescriptionFormat:@"No available keyboardsPreferenceKey: '%@'", key] build];
 }
 
-+ (void)configureKeyboardsPreference:(BOOL)enable forPreferenceKey:(nonnull NSString *)key
+- (void)configureKeyboardsPreference:(BOOL)enable forPreferenceKey:(nonnull NSString *)key
 {
   void *handle = dlopen(controllerPrefBundlePath, RTLD_LAZY);
   Class controllerClass = NSClassFromString(controllerClassName);
@@ -634,90 +471,6 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
     return NSMakeRange(NSNotFound, 0);
   }
   return NSMakeRange(port, 1);
-}
-
-+ (void)setReduceMotionEnabled:(BOOL)isEnabled
-{
-  Class settingsClass = NSClassFromString(axSettingsClassName);
-  AXSettings *settings = [settingsClass sharedInstance];
-
-  // Below does not work on real devices because of iOS security model
-  //  (lldb) po settings.reduceMotionEnabled = isEnabled
-  //  2019-08-21 22:58:19.776165+0900 WebDriverAgentRunner-Runner[322:13361] [User Defaults] Couldn't write value for key ReduceMotionEnabled in CFPrefsPlistSource<0x28111a700> (Domain: com.apple.Accessibility, User: kCFPreferencesCurrentUser, ByHost: No, Container: (null), Contents Need Refresh: No): setting preferences outside an application's container requires user-preference-write or file-write-data sandbox access
-  if ([settings respondsToSelector:@selector(setReduceMotionEnabled:)]) {
-    [settings setReduceMotionEnabled:isEnabled];
-  }
-}
-
-+ (BOOL)reduceMotionEnabled
-{
-  Class settingsClass = NSClassFromString(axSettingsClassName);
-  AXSettings *settings = [settingsClass sharedInstance];
-
-  if ([settings respondsToSelector:@selector(reduceMotionEnabled)]) {
-    return settings.reduceMotionEnabled;
-  }
-  return NO;
-}
-
-+ (void)setIncludeHittableInPageSource:(BOOL)enabled
-{
-  FBShouldIncludeHittableInPageSource = enabled;
-}
-
-+ (BOOL)includeHittableInPageSource
-{
-  return FBShouldIncludeHittableInPageSource;
-}
-
-+ (void)setIncludeNativeFrameInPageSource:(BOOL)enabled
-{
-  FBShouldIncludeNativeFrameInPageSource = enabled;
-}
-
-+ (BOOL)includeNativeFrameInPageSource
-{
-  return FBShouldIncludeNativeFrameInPageSource;
-}
-
-+ (void)setIncludeNativeAccessibilityElementInPageSource:(BOOL)enabled
-{
-  FBShouldIncludeNativeAccessibilityElementInPageSource = enabled;
-}
-
-+ (BOOL)includeNativeAccessibilityElementInPageSource
-{
-  return FBShouldIncludeNativeAccessibilityElementInPageSource;
-}
-
-+ (void)setIncludeMinMaxValueInPageSource:(BOOL)enabled
-{
-  FBShouldIncludeMinMaxValueInPageSource = enabled;
-}
-
-+ (BOOL)includeMinMaxValueInPageSource
-{
-  return FBShouldIncludeMinMaxValueInPageSource;
-}
-
-+ (void)setIncludeCustomActionsInPageSource:(BOOL)enabled
-{
-  FBShouldIncludeCustomActionsInPageSource = enabled;
-}
-
-+ (BOOL)includeCustomActionsInPageSource
-{
-  return FBShouldIncludeCustomActionsInPageSource;
-}
-
-+ (void)setEnforceCustomSnapshots:(BOOL)enabled
-{
-  FBShouldEnforceCustomSnapshots = enabled;
-}
-
-+ (BOOL)enforceCustomSnapshots
-{
-  return FBShouldEnforceCustomSnapshots;
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -221,12 +221,12 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
   return FBShouldTerminateApp;
 }
 
-+ (void)setElementResponseAttributes:(NSString *)value
++ (void)setElementResponseAttributes:(nullable NSString *)value
 {
   FBElementResponseAttributes = value;
 }
 
-+ (NSString *)elementResponseAttributes
++ (nullable NSString *)elementResponseAttributes
 {
   return FBElementResponseAttributes;
 }
@@ -429,32 +429,32 @@ static BOOL FBShouldEnforceCustomSnapshots = NO;
   return FBShouldBoundElementsByIndex;
 }
 
-+ (void)setAcceptAlertButtonSelector:(NSString *)classChainSelector
++ (void)setAcceptAlertButtonSelector:(nullable NSString *)classChainSelector
 {
   FBAcceptAlertButtonSelector = classChainSelector;
 }
 
-+ (NSString *)acceptAlertButtonSelector
++ (nullable NSString *)acceptAlertButtonSelector
 {
   return FBAcceptAlertButtonSelector;
 }
 
-+ (void)setDismissAlertButtonSelector:(NSString *)classChainSelector
++ (void)setDismissAlertButtonSelector:(nullable NSString *)classChainSelector
 {
   FBDismissAlertButtonSelector = classChainSelector;
 }
 
-+ (NSString *)dismissAlertButtonSelector
++ (nullable NSString *)dismissAlertButtonSelector
 {
   return FBDismissAlertButtonSelector;
 }
 
-+ (void)setAutoClickAlertSelector:(NSString *)classChainSelector
++ (void)setAutoClickAlertSelector:(nullable NSString *)classChainSelector
 {
   FBAutoClickAlertSelector = classChainSelector;
 }
 
-+ (NSString *)autoClickAlertSelector
++ (nullable NSString *)autoClickAlertSelector
 {
   return FBAutoClickAlertSelector;
 }

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -183,12 +183,13 @@ static NSString *const axSettingsClassName = @"AXSettings";
 
 - (NSUInteger)maxTypingFrequency
 {
-  if (nil == self.maxTypingFrequencyOverride) {
+  NSNumber *override = self.maxTypingFrequencyOverride;
+  if (nil == override) {
     return self.defaultTypingFrequency;
   }
-  return self.maxTypingFrequencyOverride.integerValue <= 0
+  return override.integerValue <= 0
     ? self.defaultTypingFrequency
-    : self.maxTypingFrequencyOverride.integerValue;
+    : override.integerValue;
 }
 
 - (void)setMaxTypingFrequency:(NSUInteger)value

--- a/WebDriverAgentLib/Utilities/FBImageProcessor.m
+++ b/WebDriverAgentLib/Utilities/FBImageProcessor.m
@@ -83,14 +83,14 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
         // We do not want this value to be too high because then we get images larger in size than original ones
         // Although, we also don't want to lose too much of the quality on recompression
         CGFloat recompressionQuality = MAX(0.9,
-                                           MIN(FBMaxCompressionQuality, (double)FBConfiguration.mjpegServerScreenshotQuality / 100.0));
+                                           MIN(FBMaxCompressionQuality, (double)FBConfiguration.sharedInstance.mjpegServerScreenshotQuality / 100.0));
         NSData *thumbnailData = [self.class fixedImageDataWithImageData:nextImageData
                                                           scalingFactor:scalingFactor
                                                                     uti:UTTypeJPEG
                                                      compressionQuality:recompressionQuality
         // iOS always returns screenshots in portrait orientation, but puts the real value into the metadata
         // Use it with care. See https://github.com/appium/WebDriverAgent/pull/812
-                                                         fixOrientation:FBConfiguration.mjpegShouldFixOrientation
+                                                         fixOrientation:FBConfiguration.sharedInstance.mjpegShouldFixOrientation
                                                      desiredOrientation:nil];
         NSData *processedImageData = thumbnailData ?: nextImageData;
         for (void (^handler)(NSData *) in handlers) {
@@ -168,13 +168,13 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
 {
   NSNumber *orientation = nil;
 #if !TARGET_OS_TV
-  if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationPortrait) {
+  if (FBConfiguration.sharedInstance.screenshotOrientation == UIInterfaceOrientationPortrait) {
     orientation = @(UIImageOrientationUp);
-  } else if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationPortraitUpsideDown) {
+  } else if (FBConfiguration.sharedInstance.screenshotOrientation == UIInterfaceOrientationPortraitUpsideDown) {
     orientation = @(UIImageOrientationDown);
-  } else if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationLandscapeLeft) {
+  } else if (FBConfiguration.sharedInstance.screenshotOrientation == UIInterfaceOrientationLandscapeLeft) {
     orientation = @(UIImageOrientationRight);
-  } else if (FBConfiguration.screenshotOrientation == UIInterfaceOrientationLandscapeRight) {
+  } else if (FBConfiguration.sharedInstance.screenshotOrientation == UIInterfaceOrientationLandscapeRight) {
     orientation = @(UIImageOrientationLeft);
   }
 #endif

--- a/WebDriverAgentLib/Utilities/FBLogger.m
+++ b/WebDriverAgentLib/Utilities/FBLogger.m
@@ -27,7 +27,7 @@
 
 + (void)verboseLog:(NSString *)message
 {
-  if (!FBConfiguration.verboseLoggingEnabled) {
+  if (!FBConfiguration.sharedInstance.verboseLoggingEnabled) {
     return;
   }
   [self log:message];
@@ -35,7 +35,7 @@
 
 + (void)verboseLogFmt:(NSString *)format, ...
 {
-  if (!FBConfiguration.verboseLoggingEnabled) {
+  if (!FBConfiguration.sharedInstance.verboseLoggingEnabled) {
     return;
   }
   va_list args;

--- a/WebDriverAgentLib/Utilities/FBMjpegServer.m
+++ b/WebDriverAgentLib/Utilities/FBMjpegServer.m
@@ -94,7 +94,7 @@ static NSUInteger FBNormalizedMjpegFramerate(NSUInteger framerate)
   if (!self.isStreaming) {
     return;
   }
-  NSUInteger framerate = FBNormalizedMjpegFramerate(FBConfiguration.mjpegServerFramerate);
+  NSUInteger framerate = FBNormalizedMjpegFramerate(FBConfiguration.sharedInstance.mjpegServerFramerate);
   uint64_t timerInterval = (uint64_t)(1.0 / (double)framerate * NSEC_PER_SEC);
   uint64_t timeStarted = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW);
   @synchronized (self.listeningClients) {
@@ -106,7 +106,7 @@ static NSUInteger FBNormalizedMjpegFramerate(NSUInteger framerate)
 
   NSError *error;
   CGFloat compressionQuality = MAX(FBMinCompressionQuality,
-                                   MIN(FBMaxCompressionQuality, (double)FBConfiguration.mjpegServerScreenshotQuality / 100.0));
+                                   MIN(FBMaxCompressionQuality, (double)FBConfiguration.sharedInstance.mjpegServerScreenshotQuality / 100.0));
   NSData *screenshotData = [FBScreenshot takeInOriginalResolutionWithScreenID:self.mainScreenID
                                                            compressionQuality:compressionQuality
                                                                           uti:UTTypeJPEG
@@ -124,7 +124,7 @@ static NSUInteger FBNormalizedMjpegFramerate(NSUInteger framerate)
 
   self.consecutiveScreenshotFailures = 0;
 
-  CGFloat scalingFactor = FBConfiguration.mjpegScalingFactor / 100.0;
+  CGFloat scalingFactor = FBConfiguration.sharedInstance.mjpegScalingFactor / 100.0;
   __weak typeof(self) weakSelf = self;
   [self.imageProcessor submitImageData:screenshotData
                          scalingFactor:scalingFactor
@@ -154,7 +154,7 @@ static NSUInteger FBNormalizedMjpegFramerate(NSUInteger framerate)
     }
     self.sentFramesCount++;
     self.sentBytesCount += chunk.length * clientCount;
-    NSUInteger framerate = FBNormalizedMjpegFramerate(FBConfiguration.mjpegServerFramerate);
+    NSUInteger framerate = FBNormalizedMjpegFramerate(FBConfiguration.sharedInstance.mjpegServerFramerate);
     if (0 == self.sentFramesCount % framerate) {
       [FBLogger verboseLog:[NSString stringWithFormat:@"MJPEG stats: clients=%@ sentFrames=%@ sentBytes=%@",
                             @(clientCount),

--- a/WebDriverAgentLib/Utilities/FBSettingsHandler.m
+++ b/WebDriverAgentLib/Utilities/FBSettingsHandler.m
@@ -47,63 +47,67 @@ static NSSet<NSString *> *FBNilClearableSettingKeys(void)
   dispatch_once(&onceToken, ^{
     NSMutableDictionary<NSString *, FBSettingApplyBlock> *map = [NSMutableDictionary dictionary];
     map[FB_SETTING_USE_COMPACT_RESPONSES] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setShouldUseCompactResponses:[value boolValue]];
+      FBConfiguration.sharedInstance.shouldUseCompactResponses = [value boolValue];
       return nil;
     };
     map[FB_SETTING_ELEMENT_RESPONSE_ATTRIBUTES] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setElementResponseAttributes:(NSString *)value];
+      FBConfiguration.sharedInstance.elementResponseAttributes = (NSString *)value;
       return nil;
     };
     map[FB_SETTING_MJPEG_SERVER_SCREENSHOT_QUALITY] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setMjpegServerScreenshotQuality:[value unsignedIntegerValue]];
+      FBConfiguration.sharedInstance.mjpegServerScreenshotQuality = [value unsignedIntegerValue];
       return nil;
     };
     map[FB_SETTING_MJPEG_SERVER_FRAMERATE] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setMjpegServerFramerate:[value unsignedIntegerValue]];
+      FBConfiguration.sharedInstance.mjpegServerFramerate = [value unsignedIntegerValue];
       return nil;
     };
     map[FB_SETTING_SCREENSHOT_QUALITY] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setScreenshotQuality:[value unsignedIntegerValue]];
+      FBConfiguration.sharedInstance.screenshotQuality = [value unsignedIntegerValue];
       return nil;
     };
     map[FB_SETTING_MJPEG_SCALING_FACTOR] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setMjpegScalingFactor:[value floatValue]];
+      FBConfiguration.sharedInstance.mjpegScalingFactor = [value floatValue];
       return nil;
     };
     map[FB_SETTING_MJPEG_FIX_ORIENTATION] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setMjpegShouldFixOrientation:[value boolValue]];
+      FBConfiguration.sharedInstance.mjpegShouldFixOrientation = [value boolValue];
       return nil;
     };
     map[FB_SETTING_KEYBOARD_AUTOCORRECTION] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setKeyboardAutocorrection:[value boolValue]];
+      FBConfiguration.sharedInstance.keyboardAutocorrection = [value boolValue]
+        ? FBConfigurationKeyboardPreferenceEnabled
+        : FBConfigurationKeyboardPreferenceDisabled;
       return nil;
     };
     map[FB_SETTING_KEYBOARD_PREDICTION] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setKeyboardPrediction:[value boolValue]];
+      FBConfiguration.sharedInstance.keyboardPrediction = [value boolValue]
+        ? FBConfigurationKeyboardPreferenceEnabled
+        : FBConfigurationKeyboardPreferenceDisabled;
       return nil;
     };
     map[FB_SETTING_RESPECT_SYSTEM_ALERTS] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setShouldRespectSystemAlerts:[value boolValue]];
+      FBConfiguration.sharedInstance.shouldRespectSystemAlerts = [value boolValue];
       return nil;
     };
     map[FB_SETTING_SNAPSHOT_MAX_DEPTH] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setSnapshotMaxDepth:[value intValue]];
+      FBConfiguration.sharedInstance.snapshotMaxDepth = [value intValue];
       return nil;
     };
     map[FB_SETTING_SNAPSHOT_MAX_CHILDREN] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setSnapshotMaxChildren:[value intValue]];
+      FBConfiguration.sharedInstance.snapshotMaxChildren = [value intValue];
       return nil;
     };
     map[FB_SETTING_USE_FIRST_MATCH] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setUseFirstMatch:[value boolValue]];
+      FBConfiguration.sharedInstance.useFirstMatch = [value boolValue];
       return nil;
     };
     map[FB_SETTING_BOUND_ELEMENTS_BY_INDEX] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setBoundElementsByIndex:[value boolValue]];
+      FBConfiguration.sharedInstance.boundElementsByIndex = [value boolValue];
       return nil;
     };
     map[FB_SETTING_REDUCE_MOTION] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setReduceMotionEnabled:[value boolValue]];
+      FBConfiguration.sharedInstance.reduceMotionEnabled = [value boolValue];
       return nil;
     };
     map[FB_SETTING_DEFAULT_ACTIVE_APPLICATION] = ^FBCommandStatus *(FBSession *session, id value) {
@@ -120,22 +124,22 @@ static NSSet<NSString *> *FBNilClearableSettingKeys(void)
       return nil;
     };
     map[FB_SETTING_ACCEPT_ALERT_BUTTON_SELECTOR] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setAcceptAlertButtonSelector:(NSString *)value];
+      FBConfiguration.sharedInstance.acceptAlertButtonSelector = (NSString *)value;
       return nil;
     };
     map[FB_SETTING_DISMISS_ALERT_BUTTON_SELECTOR] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setDismissAlertButtonSelector:(NSString *)value];
+      FBConfiguration.sharedInstance.dismissAlertButtonSelector = (NSString *)value;
       return nil;
     };
     map[FB_SETTING_AUTO_CLICK_ALERT_SELECTOR] = ^FBCommandStatus *(FBSession *session, id value) {
       return [self configureAutoClickAlertWithSelector:(NSString *)value forSession:session];
     };
     map[FB_SETTING_WAIT_FOR_IDLE_TIMEOUT] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setWaitForIdleTimeout:[value doubleValue]];
+      FBConfiguration.sharedInstance.waitForIdleTimeout = [value doubleValue];
       return nil;
     };
     map[FB_SETTING_ANIMATION_COOL_OFF_TIMEOUT] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setAnimationCoolOffTimeout:[value doubleValue]];
+      FBConfiguration.sharedInstance.animationCoolOffTimeout = [value doubleValue];
       return nil;
     };
     map[FB_SETTING_DEFAULT_ALERT_ACTION] = ^FBCommandStatus *(FBSession *session, id value) {
@@ -147,45 +151,45 @@ static NSSet<NSString *> *FBNilClearableSettingKeys(void)
       return nil;
     };
     map[FB_SETTING_MAX_TYPING_FREQUENCY] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setMaxTypingFrequency:[value unsignedIntegerValue]];
+      FBConfiguration.sharedInstance.maxTypingFrequency = [value unsignedIntegerValue];
       return nil;
     };
     map[FB_SETTING_USE_CLEAR_TEXT_SHORTCUT] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setUseClearTextShortcut:[value boolValue]];
+      FBConfiguration.sharedInstance.useClearTextShortcut = [value boolValue];
       return nil;
     };
     map[FB_SETTING_INCLUDE_HITTABLE_IN_PAGE_SOURCE] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setIncludeHittableInPageSource:[value boolValue]];
+      FBConfiguration.sharedInstance.includeHittableInPageSource = [value boolValue];
       return nil;
     };
     map[FB_SETTING_INCLUDE_NATIVE_FRAME_IN_PAGE_SOURCE] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setIncludeNativeFrameInPageSource:[value boolValue]];
+      FBConfiguration.sharedInstance.includeNativeFrameInPageSource = [value boolValue];
       return nil;
     };
     map[FB_SETTING_INCLUDE_NATIVE_ACCESSIBILITY_ELEMENT_IN_PAGE_SOURCE] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setIncludeNativeAccessibilityElementInPageSource:[value boolValue]];
+      FBConfiguration.sharedInstance.includeNativeAccessibilityElementInPageSource = [value boolValue];
       return nil;
     };
     map[FB_SETTING_INCLUDE_MIN_MAX_VALUE_IN_PAGE_SOURCE] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setIncludeMinMaxValueInPageSource:[value boolValue]];
+      FBConfiguration.sharedInstance.includeMinMaxValueInPageSource = [value boolValue];
       return nil;
     };
     map[FB_SETTING_INCLUDE_CUSTOM_ACTIONS_IN_PAGE_SOURCE] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setIncludeCustomActionsInPageSource:[value boolValue]];
+      FBConfiguration.sharedInstance.includeCustomActionsInPageSource = [value boolValue];
       return nil;
     };
     map[FB_SETTING_ENFORCE_CUSTOM_SNAPSHOTS] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setEnforceCustomSnapshots:[value boolValue]];
+      FBConfiguration.sharedInstance.enforceCustomSnapshots = [value boolValue];
       return nil;
     };
     map[FB_SETTING_LIMIT_XPATH_CONTEXT_SCOPE] = ^FBCommandStatus *(FBSession *session, id value) {
-      [FBConfiguration setLimitXpathContextScope:[value boolValue]];
+      FBConfiguration.sharedInstance.limitXpathContextScope = [value boolValue];
       return nil;
     };
 #if !TARGET_OS_TV
     map[FB_SETTING_SCREENSHOT_ORIENTATION] = ^FBCommandStatus *(FBSession *session, id value) {
       NSError *error;
-      if (![FBConfiguration setScreenshotOrientation:(NSString *)value error:&error]) {
+      if (![FBConfiguration.sharedInstance setScreenshotOrientation:(NSString *)value error:&error]) {
         return [FBCommandStatus invalidArgumentErrorWithMessage:error.localizedDescription
                                                       traceback:nil];
       }
@@ -204,52 +208,52 @@ static NSSet<NSString *> *FBNilClearableSettingKeys(void)
   dispatch_once(&onceToken, ^{
     NSMutableDictionary<NSString *, FBSettingGetBlock> *map = [NSMutableDictionary dictionary];
     map[FB_SETTING_USE_COMPACT_RESPONSES] = ^id(FBSession *session) {
-      return @([FBConfiguration shouldUseCompactResponses]);
+      return @(FBConfiguration.sharedInstance.shouldUseCompactResponses);
     };
     map[FB_SETTING_ELEMENT_RESPONSE_ATTRIBUTES] = ^id(FBSession *session) {
-      return [FBConfiguration elementResponseAttributes];
+      return FBConfiguration.sharedInstance.elementResponseAttributes;
     };
     map[FB_SETTING_MJPEG_SERVER_SCREENSHOT_QUALITY] = ^id(FBSession *session) {
-      return @([FBConfiguration mjpegServerScreenshotQuality]);
+      return @(FBConfiguration.sharedInstance.mjpegServerScreenshotQuality);
     };
     map[FB_SETTING_MJPEG_SERVER_FRAMERATE] = ^id(FBSession *session) {
-      return @([FBConfiguration mjpegServerFramerate]);
+      return @(FBConfiguration.sharedInstance.mjpegServerFramerate);
     };
     map[FB_SETTING_MJPEG_SCALING_FACTOR] = ^id(FBSession *session) {
-      return @([FBConfiguration mjpegScalingFactor]);
+      return @(FBConfiguration.sharedInstance.mjpegScalingFactor);
     };
     map[FB_SETTING_MJPEG_FIX_ORIENTATION] = ^id(FBSession *session) {
-      return @([FBConfiguration mjpegShouldFixOrientation]);
+      return @(FBConfiguration.sharedInstance.mjpegShouldFixOrientation);
     };
     map[FB_SETTING_SCREENSHOT_QUALITY] = ^id(FBSession *session) {
-      return @([FBConfiguration screenshotQuality]);
+      return @(FBConfiguration.sharedInstance.screenshotQuality);
     };
     map[FB_SETTING_KEYBOARD_AUTOCORRECTION] = ^id(FBSession *session) {
-      return @([FBConfiguration keyboardAutocorrection]);
+      return @(FBConfiguration.sharedInstance.keyboardAutocorrection);
     };
     map[FB_SETTING_KEYBOARD_PREDICTION] = ^id(FBSession *session) {
-      return @([FBConfiguration keyboardPrediction]);
+      return @(FBConfiguration.sharedInstance.keyboardPrediction);
     };
     map[FB_SETTING_SNAPSHOT_MAX_DEPTH] = ^id(FBSession *session) {
-      return @([FBConfiguration snapshotMaxDepth]);
+      return @(FBConfiguration.sharedInstance.snapshotMaxDepth);
     };
     map[FB_SETTING_SNAPSHOT_MAX_CHILDREN] = ^id(FBSession *session) {
-      return @([FBConfiguration snapshotMaxChildren]);
+      return @(FBConfiguration.sharedInstance.snapshotMaxChildren);
     };
     map[FB_SETTING_USE_FIRST_MATCH] = ^id(FBSession *session) {
-      return @([FBConfiguration useFirstMatch]);
+      return @(FBConfiguration.sharedInstance.useFirstMatch);
     };
     map[FB_SETTING_WAIT_FOR_IDLE_TIMEOUT] = ^id(FBSession *session) {
-      return @([FBConfiguration waitForIdleTimeout]);
+      return @(FBConfiguration.sharedInstance.waitForIdleTimeout);
     };
     map[FB_SETTING_ANIMATION_COOL_OFF_TIMEOUT] = ^id(FBSession *session) {
-      return @([FBConfiguration animationCoolOffTimeout]);
+      return @(FBConfiguration.sharedInstance.animationCoolOffTimeout);
     };
     map[FB_SETTING_BOUND_ELEMENTS_BY_INDEX] = ^id(FBSession *session) {
-      return @([FBConfiguration boundElementsByIndex]);
+      return @(FBConfiguration.sharedInstance.boundElementsByIndex);
     };
     map[FB_SETTING_REDUCE_MOTION] = ^id(FBSession *session) {
-      return @([FBConfiguration reduceMotionEnabled]);
+      return @(FBConfiguration.sharedInstance.reduceMotionEnabled);
     };
     map[FB_SETTING_DEFAULT_ACTIVE_APPLICATION] = ^id(FBSession *session) {
       return session.defaultActiveApplication;
@@ -258,50 +262,50 @@ static NSSet<NSString *> *FBNilClearableSettingKeys(void)
       return FBActiveAppDetectionPoint.sharedInstance.stringCoordinates;
     };
     map[FB_SETTING_ACCEPT_ALERT_BUTTON_SELECTOR] = ^id(FBSession *session) {
-      return FBConfiguration.acceptAlertButtonSelector;
+      return FBConfiguration.sharedInstance.acceptAlertButtonSelector;
     };
     map[FB_SETTING_DISMISS_ALERT_BUTTON_SELECTOR] = ^id(FBSession *session) {
-      return FBConfiguration.dismissAlertButtonSelector;
+      return FBConfiguration.sharedInstance.dismissAlertButtonSelector;
     };
     map[FB_SETTING_AUTO_CLICK_ALERT_SELECTOR] = ^id(FBSession *session) {
-      return FBConfiguration.autoClickAlertSelector;
+      return FBConfiguration.sharedInstance.autoClickAlertSelector;
     };
     map[FB_SETTING_DEFAULT_ALERT_ACTION] = ^id(FBSession *session) {
       return session.defaultAlertAction ?: @"";
     };
     map[FB_SETTING_MAX_TYPING_FREQUENCY] = ^id(FBSession *session) {
-      return @([FBConfiguration maxTypingFrequency]);
+      return @(FBConfiguration.sharedInstance.maxTypingFrequency);
     };
     map[FB_SETTING_RESPECT_SYSTEM_ALERTS] = ^id(FBSession *session) {
-      return @([FBConfiguration shouldRespectSystemAlerts]);
+      return @(FBConfiguration.sharedInstance.shouldRespectSystemAlerts);
     };
     map[FB_SETTING_USE_CLEAR_TEXT_SHORTCUT] = ^id(FBSession *session) {
-      return @([FBConfiguration useClearTextShortcut]);
+      return @(FBConfiguration.sharedInstance.useClearTextShortcut);
     };
     map[FB_SETTING_INCLUDE_HITTABLE_IN_PAGE_SOURCE] = ^id(FBSession *session) {
-      return @([FBConfiguration includeHittableInPageSource]);
+      return @(FBConfiguration.sharedInstance.includeHittableInPageSource);
     };
     map[FB_SETTING_INCLUDE_NATIVE_FRAME_IN_PAGE_SOURCE] = ^id(FBSession *session) {
-      return @([FBConfiguration includeNativeFrameInPageSource]);
+      return @(FBConfiguration.sharedInstance.includeNativeFrameInPageSource);
     };
     map[FB_SETTING_INCLUDE_NATIVE_ACCESSIBILITY_ELEMENT_IN_PAGE_SOURCE] = ^id(FBSession *session) {
-      return @([FBConfiguration includeNativeAccessibilityElementInPageSource]);
+      return @(FBConfiguration.sharedInstance.includeNativeAccessibilityElementInPageSource);
     };
     map[FB_SETTING_INCLUDE_MIN_MAX_VALUE_IN_PAGE_SOURCE] = ^id(FBSession *session) {
-      return @([FBConfiguration includeMinMaxValueInPageSource]);
+      return @(FBConfiguration.sharedInstance.includeMinMaxValueInPageSource);
     };
     map[FB_SETTING_INCLUDE_CUSTOM_ACTIONS_IN_PAGE_SOURCE] = ^id(FBSession *session) {
-      return @([FBConfiguration includeCustomActionsInPageSource]);
+      return @(FBConfiguration.sharedInstance.includeCustomActionsInPageSource);
     };
     map[FB_SETTING_ENFORCE_CUSTOM_SNAPSHOTS] = ^id(FBSession *session) {
-      return @([FBConfiguration enforceCustomSnapshots]);
+      return @(FBConfiguration.sharedInstance.enforceCustomSnapshots);
     };
     map[FB_SETTING_LIMIT_XPATH_CONTEXT_SCOPE] = ^id(FBSession *session) {
-      return @([FBConfiguration limitXpathContextScope]);
+      return @(FBConfiguration.sharedInstance.limitXpathContextScope);
     };
 #if !TARGET_OS_TV
     map[FB_SETTING_SCREENSHOT_ORIENTATION] = ^id(FBSession *session) {
-      return [FBConfiguration humanReadableScreenshotOrientation];
+      return FBConfiguration.sharedInstance.humanReadableScreenshotOrientation;
     };
 #endif
     gettersMap = map.copy;
@@ -344,7 +348,7 @@ static NSSet<NSString *> *FBNilClearableSettingKeys(void)
                                               forSession:(FBSession *)session
 {
   if (0 == [selector length]) {
-    [FBConfiguration setAutoClickAlertSelector:selector];
+    FBConfiguration.sharedInstance.autoClickAlertSelector = selector;
     [session disableAlertsMonitor];
     return [FBCommandStatus ok];
   }
@@ -355,7 +359,7 @@ static NSSet<NSString *> *FBNilClearableSettingKeys(void)
     return [FBCommandStatus invalidSelectorErrorWithMessage:error.localizedDescription
                                                   traceback:nil];
   }
-  [FBConfiguration setAutoClickAlertSelector:selector];
+  FBConfiguration.sharedInstance.autoClickAlertSelector = selector;
   [session enableAlertsMonitor];
   return [FBCommandStatus ok];
 }

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -472,7 +472,7 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   XCPointerEventPath *resultPath = [[XCPointerEventPath alloc] initForTextInput];
   [resultPath typeText:text
               atOffset:offset
-           typingSpeed:FBConfiguration.maxTypingFrequency
+           typingSpeed:FBConfiguration.sharedInstance.maxTypingFrequency
           shouldRedact:YES];
   return @[resultPath];
 }

--- a/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.m
@@ -83,7 +83,7 @@ static void swizzledLaunchApp(id self, SEL _cmd, NSString *path, NSString *bundl
 + (id<XCTMessagingChannel_RunnerToDaemon>)testRunnerProxy
 {
   static id<XCTMessagingChannel_RunnerToDaemon> proxy = nil;
-  if ([FBConfiguration shouldUseSingletonTestManager]) {
+  if (FBConfiguration.sharedInstance.shouldUseSingletonTestManager) {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
       [FBLogger logFmt:@"Using singleton test manager"];

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -37,7 +37,7 @@
 
 - (XCUIElement *)fb_firstMatch
 {
-  if (FBConfiguration.useFirstMatch) {
+  if (FBConfiguration.sharedInstance.useFirstMatch) {
     XCUIElement* match = self.firstMatch;
     return [match exists] ? match : nil;
   }
@@ -46,7 +46,7 @@
 
 - (NSArray<XCUIElement *> *)fb_allMatches
 {
-  return FBConfiguration.boundElementsByIndex
+  return FBConfiguration.sharedInstance.boundElementsByIndex
     ? self.allElementsBoundByIndex
     : self.allElementsBoundByAccessibilityElement;
 }

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -195,7 +195,7 @@ static NSString *const topNodeIndexPath = @"top";
       // If 'includeHittableInPageSource' setting is enabled, then use native snapshots
       // to calculate a more accurate value for the 'hittable' attribute.
       rc = [self xmlRepresentationWithRootElement:[self snapshotWithRoot:root
-                                                        useNative:FBConfiguration.includeHittableInPageSource]
+                                                        useNative:FBConfiguration.sharedInstance.includeHittableInPageSource]
                                            writer:writer
                                      elementStore:nil
                                             query:nil
@@ -252,7 +252,7 @@ static NSString *const topNodeIndexPath = @"top";
     [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterStartDocument. Error code: %d", rc];
   } else {
     [self waitUntilStableWithElement:root];
-    if (FBConfiguration.limitXpathContextScope) {
+    if (FBConfiguration.sharedInstance.limitXpathContextScope) {
       lookupScopeSnapshot = [self snapshotWithRoot:root useNative:useNativeSnapshot];
     } else {
       if ([root isKindOfClass:XCUIElement.class]) {
@@ -404,25 +404,25 @@ static NSString *const topNodeIndexPath = @"top";
   NSMutableSet<Class> *includedAttributes;
   if (nil == query) {
     includedAttributes = [NSMutableSet setWithArray:FBElementAttribute.supportedAttributes];
-    if (!FBConfiguration.includeHittableInPageSource) {
+    if (!FBConfiguration.sharedInstance.includeHittableInPageSource) {
       // The hittable attribute is expensive to calculate for each snapshot item
       // thus we only include it when requested explicitly
       [includedAttributes removeObject:FBHittableAttribute.class];
     }
-    if (!FBConfiguration.includeNativeFrameInPageSource) {
+    if (!FBConfiguration.sharedInstance.includeNativeFrameInPageSource) {
       // Include nativeFrame only when requested
       [includedAttributes removeObject:FBNativeFrameAttribute.class];
     }
-    if (!FBConfiguration.includeNativeAccessibilityElementInPageSource) {
+    if (!FBConfiguration.sharedInstance.includeNativeAccessibilityElementInPageSource) {
       // Include the raw native accessibility flag only when requested
       [includedAttributes removeObject:FBNativeAccessibilityElementAttribute.class];
     }
-    if (!FBConfiguration.includeMinMaxValueInPageSource) {
+    if (!FBConfiguration.sharedInstance.includeMinMaxValueInPageSource) {
       // minValue/maxValue are retrieved from private APIs and may be slow on deep trees
       [includedAttributes removeObject:FBMinValueAttribute.class];
       [includedAttributes removeObject:FBMaxValueAttribute.class];
     }
-    if (!FBConfiguration.includeCustomActionsInPageSource) {
+    if (!FBConfiguration.sharedInstance.includeCustomActionsInPageSource) {
       // customActions are retrieved from accessibility attributes and may be slow on deep trees
       [includedAttributes removeObject:FBCustomActionsAttribute.class];
     }
@@ -620,7 +620,7 @@ static NSString *const topNodeIndexPath = @"top";
     return [(XCUIElement *)root fb_nativeSnapshot];
   }
   // https://github.com/appium/WebDriverAgent/issues/1085
-  return [root isKindOfClass:XCUIApplication.class] && !FBConfiguration.enforceCustomSnapshots
+  return [root isKindOfClass:XCUIApplication.class] && !FBConfiguration.sharedInstance.enforceCustomSnapshots
     ? [(XCUIElement *)root fb_standardSnapshot]
     : [(XCUIElement *)root fb_customSnapshot];
 }
@@ -630,7 +630,7 @@ static NSString *const topNodeIndexPath = @"top";
   if ([root isKindOfClass:XCUIElement.class]) {
     // If the app is not idle state while we retrieve the visiblity state
     // then the snapshot retrieval operation might freeze and time out
-    [[(XCUIElement *)root application] fb_waitUntilStableWithTimeout:FBConfiguration.animationCoolOffTimeout];
+    [[(XCUIElement *)root application] fb_waitUntilStableWithTimeout:FBConfiguration.sharedInstance.animationCoolOffTimeout];
   }
 }
 

--- a/WebDriverAgentRunner/UITestingUITests.m
+++ b/WebDriverAgentRunner/UITestingUITests.m
@@ -22,18 +22,18 @@
 + (void)setUp
 {
   [FBDebugLogDelegateDecorator decorateXCTestLogger];
-  [FBConfiguration disableRemoteQueryEvaluation];
-  [FBConfiguration configureDefaultKeyboardPreferences];
-  [FBConfiguration disableApplicationUIInterruptionsHandling];
+  [FBConfiguration.sharedInstance disableRemoteQueryEvaluation];
+  [FBConfiguration.sharedInstance configureDefaultKeyboardPreferences];
+  [FBConfiguration.sharedInstance disableApplicationUIInterruptionsHandling];
   if (NSProcessInfo.processInfo.environment[@"ENABLE_AUTOMATIC_SCREEN_RECORDINGS"]) {
-    [FBConfiguration enableScreenRecordings];
+    [FBConfiguration.sharedInstance enableScreenRecordings];
   } else {
-    [FBConfiguration disableScreenRecordings];
+    [FBConfiguration.sharedInstance disableScreenRecordings];
   }
   if (NSProcessInfo.processInfo.environment[@"ENABLE_AUTOMATIC_SCREENSHOTS"]) {
-    [FBConfiguration enableScreenshots];
+    [FBConfiguration.sharedInstance enableScreenshots];
   } else {
-    [FBConfiguration disableScreenshots];
+    [FBConfiguration.sharedInstance disableScreenshots];
   }
   [super setUp];
 }

--- a/WebDriverAgentTests/IntegrationTests/FBAlertTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBAlertTests.m
@@ -27,7 +27,7 @@
   [self resetPermissions];
   [self launchApplication];
   [self goToAlertsPage];
-  [FBConfiguration disableApplicationUIInterruptionsHandling];
+  [FBConfiguration.sharedInstance disableApplicationUIInterruptionsHandling];
 }
 
 - (void)resetPermissions
@@ -113,12 +113,12 @@
 - (void)testAcceptingAlertWithCustomLocator
 {
   [self showApplicationAlert];
-  [FBConfiguration setAcceptAlertButtonSelector:@"**/XCUIElementTypeButton[-1]"];
+  FBConfiguration.sharedInstance.acceptAlertButtonSelector = @"**/XCUIElementTypeButton[-1]";
   @try {
     XCTAssertNoThrow([[FBAlert alertWithApplication:self.testedApplication] accept]);
     FBAssertWaitTillBecomesTrue(self.testedApplication.alerts.count == 0);
   } @finally {
-    [FBConfiguration setAcceptAlertButtonSelector:@""];
+    FBConfiguration.sharedInstance.acceptAlertButtonSelector = @"";
   }
 }
 
@@ -132,12 +132,12 @@
 - (void)testDismissingAlertWithCustomLocator
 {
   [self showApplicationAlert];
-  [FBConfiguration setDismissAlertButtonSelector:@"**/XCUIElementTypeButton[-1]"];
+  FBConfiguration.sharedInstance.dismissAlertButtonSelector = @"**/XCUIElementTypeButton[-1]";
   @try {
     XCTAssertNoThrow([[FBAlert alertWithApplication:self.testedApplication] dismiss]);
     FBAssertWaitTillBecomesTrue(self.testedApplication.alerts.count == 0);
   } @finally {
-    [FBConfiguration setDismissAlertButtonSelector:@""];
+    FBConfiguration.sharedInstance.dismissAlertButtonSelector = @"";
   }
 }
 

--- a/WebDriverAgentTests/IntegrationTests/FBConfigurationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBConfigurationTests.m
@@ -26,13 +26,13 @@
 
 - (void)testReduceMotion
 {
-  BOOL defaultReduceMotionEnabled = [FBConfiguration reduceMotionEnabled];
+  BOOL defaultReduceMotionEnabled = FBConfiguration.sharedInstance.reduceMotionEnabled;
 
-  [FBConfiguration setReduceMotionEnabled:YES];
-  XCTAssertTrue([FBConfiguration reduceMotionEnabled]);
+  FBConfiguration.sharedInstance.reduceMotionEnabled = YES;
+  XCTAssertTrue(FBConfiguration.sharedInstance.reduceMotionEnabled);
 
-  [FBConfiguration setReduceMotionEnabled:defaultReduceMotionEnabled];
-  XCTAssertEqual([FBConfiguration reduceMotionEnabled], defaultReduceMotionEnabled);
+  FBConfiguration.sharedInstance.reduceMotionEnabled = defaultReduceMotionEnabled;
+  XCTAssertEqual(FBConfiguration.sharedInstance.reduceMotionEnabled, defaultReduceMotionEnabled);
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.m
+++ b/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.m
@@ -46,13 +46,13 @@ NSArray<NSString *> *const FBMainViewButtonLabels = @[
 - (void)setUp
 {
   // Enable it to get extended XCTest logs printed into the console
-  // [FBConfiguration enableXcTestDebugLogs];
+  // [FBConfiguration.sharedInstance enableXcTestDebugLogs];
   [super setUp];
-  [FBConfiguration disableRemoteQueryEvaluation];
-  [FBConfiguration disableAttributeKeyPathAnalysis];
-  [FBConfiguration configureDefaultKeyboardPreferences];
-  [FBConfiguration disableApplicationUIInterruptionsHandling];
-  [FBConfiguration disableScreenshots];
+  [FBConfiguration.sharedInstance disableRemoteQueryEvaluation];
+  [FBConfiguration.sharedInstance disableAttributeKeyPathAnalysis];
+  [FBConfiguration.sharedInstance configureDefaultKeyboardPreferences];
+  [FBConfiguration.sharedInstance disableApplicationUIInterruptionsHandling];
+  [FBConfiguration.sharedInstance disableScreenshots];
   self.continueAfterFailure = NO;
   self.springboard = XCUIApplication.fb_systemApplication;
   self.testedApplication = [XCUIApplication new];

--- a/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
@@ -139,8 +139,8 @@
 - (void)testFindMatchesWithoutContextScopeLimit
 {
   XCUIElement *button = self.testedApplication.buttons.firstMatch;
-  BOOL previousValue = FBConfiguration.limitXpathContextScope;
-  FBConfiguration.limitXpathContextScope = NO;
+  BOOL previousValue = FBConfiguration.sharedInstance.limitXpathContextScope;
+  FBConfiguration.sharedInstance.limitXpathContextScope = NO;
   @try {
     NSArray *parentSnapshots = [FBXPath matchesWithRootElement:button forQuery:@".."];
     XCTAssertEqual(parentSnapshots.count, 1);
@@ -167,7 +167,7 @@
                           @"XCUIElementTypeButton"
                           );
   } @finally {
-    FBConfiguration.limitXpathContextScope = previousValue;
+    FBConfiguration.sharedInstance.limitXpathContextScope = previousValue;
   }
 }
 

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementAttributesTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementAttributesTests.m
@@ -176,7 +176,7 @@
 
 - (void)testCompactResponseYesWithResponseAttributesSet
 {
-  [FBConfiguration setElementResponseAttributes:@"name,text,enabled"];
+  FBConfiguration.sharedInstance.elementResponseAttributes = @"name,text,enabled";
   XCUIElement *alertsButton = self.testedApplication.buttons[@"Alerts"];
   NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, YES);
   XCTAssertNotNil(fields[@"ELEMENT"]);
@@ -186,7 +186,7 @@
 
 - (void)testCompactResponseNoWithResponseAttributesSet
 {
-  [FBConfiguration setElementResponseAttributes:@"name,text,enabled"];
+  FBConfiguration.sharedInstance.elementResponseAttributes = @"name,text,enabled";
   XCUIElement *alertsButton = self.testedApplication.buttons[@"Alerts"];
   NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, NO);
   XCTAssertNotNil(fields[@"ELEMENT"]);
@@ -199,7 +199,7 @@
 
 - (void)testInvalidAttribute
 {
-  [FBConfiguration setElementResponseAttributes:@"invalid_field,name"];
+  FBConfiguration.sharedInstance.elementResponseAttributes = @"invalid_field,name";
   XCUIElement *alertsButton = self.testedApplication.buttons[@"Alerts"];
   NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, NO);
   XCTAssertNotNil(fields[@"ELEMENT"]);
@@ -210,7 +210,7 @@
 
 - (void)testKnownAttributes
 {
-  [FBConfiguration setElementResponseAttributes:@"name,type,label,text,rect,enabled,displayed,selected"];
+  FBConfiguration.sharedInstance.elementResponseAttributes = @"name,type,label,text,rect,enabled,displayed,selected";
   XCUIElement *alertsButton = self.testedApplication.buttons[@"Alerts"];
   NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, NO);
   XCTAssertNotNil(fields[@"ELEMENT"]);
@@ -228,7 +228,7 @@
 
 - (void)testArbitraryAttributes
 {
-  [FBConfiguration setElementResponseAttributes:@"attribute/name,attribute/value"];
+  FBConfiguration.sharedInstance.elementResponseAttributes = @"attribute/name,attribute/value";
   XCUIElement *alertsButton = self.testedApplication.buttons[@"Alerts"];
   NSDictionary *fields = FBDictionaryResponseWithElement(alertsButton, NO);
   XCTAssertNotNil(fields[@"ELEMENT"]);

--- a/WebDriverAgentTests/UnitTests/FBConfigurationTests.m
+++ b/WebDriverAgentTests/UnitTests/FBConfigurationTests.m
@@ -27,46 +27,46 @@
 
 - (void)testBindingPortDefault
 {
-  XCTAssertTrue(NSEqualRanges([FBConfiguration bindingPortRange], NSMakeRange(8100, 100)));
+  XCTAssertTrue(NSEqualRanges(FBConfiguration.sharedInstance.bindingPortRange, NSMakeRange(8100, 100)));
 }
 
 - (void)testBindingPortEnvironmentOverwrite
 {
   setenv("USE_PORT", "1000", 1);
-  XCTAssertTrue(NSEqualRanges([FBConfiguration bindingPortRange], NSMakeRange(1000, 1)));
+  XCTAssertTrue(NSEqualRanges(FBConfiguration.sharedInstance.bindingPortRange, NSMakeRange(1000, 1)));
 }
 
 - (void)testVerboseLoggingDefault
 {
-  XCTAssertFalse([FBConfiguration verboseLoggingEnabled]);
+  XCTAssertFalse(FBConfiguration.sharedInstance.verboseLoggingEnabled);
 }
 
 - (void)testVerboseLoggingEnvironmentOverwrite
 {
   setenv("VERBOSE_LOGGING", "YES", 1);
-  XCTAssertTrue([FBConfiguration verboseLoggingEnabled]);
+  XCTAssertTrue(FBConfiguration.sharedInstance.verboseLoggingEnabled);
 }
 
 - (void)testBindingIPDefault
 {
-  XCTAssertNil([FBConfiguration bindingIPAddress]);
+  XCTAssertNil(FBConfiguration.sharedInstance.bindingIPAddress);
 }
 
 - (void)testBindingIPEnvironmentOverwrite
 {
   setenv("USE_IP", "192.168.1.100", 1);
-  XCTAssertEqualObjects([FBConfiguration bindingIPAddress], @"192.168.1.100");
+  XCTAssertEqualObjects(FBConfiguration.sharedInstance.bindingIPAddress, @"192.168.1.100");
 }
 
 - (void)testHttpRequestBodySizeLimitDefault
 {
-  XCTAssertEqual([FBConfiguration httpRequestBodySizeLimit], 1024ull * 1024ull * 1024ull);
+  XCTAssertEqual(FBConfiguration.sharedInstance.httpRequestBodySizeLimit, 1024ull * 1024ull * 1024ull);
 }
 
 - (void)testHttpRequestBodySizeLimitEnvironmentOverwrite
 {
   setenv("MAX_HTTP_REQUEST_BODY_SIZE", "1024", 1);
-  XCTAssertEqual([FBConfiguration httpRequestBodySizeLimit], 1024ull);
+  XCTAssertEqual(FBConfiguration.sharedInstance.httpRequestBodySizeLimit, 1024ull);
 }
 
 @end

--- a/WebDriverAgentTests/UnitTests/FBSessionTests.m
+++ b/WebDriverAgentTests/UnitTests/FBSessionTests.m
@@ -24,15 +24,15 @@
 {
   [super setUp];
   self.testedApplication = (id)XCUIApplicationDouble.new;
-  self.shouldTerminateAppValue = FBConfiguration.shouldTerminateApp;
-  [FBConfiguration setShouldTerminateApp:NO];
+  self.shouldTerminateAppValue = FBConfiguration.sharedInstance.shouldTerminateApp;
+  FBConfiguration.sharedInstance.shouldTerminateApp = NO;
   self.session = [FBSession initWithApplication:self.testedApplication];
 }
 
 - (void)tearDown
 {
   [self.session kill];
-  [FBConfiguration setShouldTerminateApp:self.shouldTerminateAppValue];
+  FBConfiguration.sharedInstance.shouldTerminateApp = self.shouldTerminateAppValue;
   [super tearDown];
 }
 


### PR DESCRIPTION
FBConfiguration previously exposed ~30 settings as unsynchronized class-method get/set pairs backed by plain static globals, which allowed a real race between FBMjpegServer's background streaming thread and concurrent settings writes from the main route queue (e.g. via POST /session/:id/appium/settings).

Convert it to a singleton (+sharedInstance) with native atomic @property accessors, which close that race, and migrate all ~150 call sites across the codebase to uniform property dot-syntax (FBConfiguration.sharedInstance.propertyName).