### PR TITLE
feat: Add WatchOS support

### DIFF
--- a/.github/workflows/wda-tests.yml
+++ b/.github/workflows/wda-tests.yml
@@ -12,12 +12,16 @@ env:
   MIN_PLATFORM_VERSION: "17.5"
   MIN_TV_PLATFORM_VERSION: "17.5"
   MIN_TV_DEVICE_NAME: "Apple TV 4K (3rd generation)"
+  MIN_WATCH_PLATFORM_VERSION: "10.5"
+  MIN_WATCH_DEVICE_NAME: "Apple Watch Series 9 (45mm)"
   MIN_IPHONE_DEVICE_NAME: "iPhone 15 Plus"
   MIN_IPAD_DEVICE_NAME: "iPad Air 13-inch (M2)"
   MAX_VM_IMAGE: xcode-27
   MAX_XCODE_VERSION: "27.0-beta"
   MAX_PLATFORM_VERSION: "27.0"
   MAX_TV_PLATFORM_VERSION: "27.0"
+  MAX_WATCH_PLATFORM_VERSION: "27.0"
+  MAX_WATCH_DEVICE_NAME: "Apple Watch Series 10 (46mm)"
   MAX_IPHONE_DEVICE_NAME: "iPhone 17"
   MAX_TV_DEVICE_NAME: "Apple TV 4K (3rd generation)"
   MAX_IPAD_DEVICE_NAME: "iPad Air 11-inch (M2)"
@@ -36,10 +40,14 @@ jobs:
             {"name": "Generic_iOS_Build_Min_Xcode", "vm_image": "${{ env.MIN_VM_IMAGE }}", "xcode_version": "${{ env.MIN_XCODE_VERSION }}", "action": "build", "target": "runner", "sdk": "sim", "dest": "generic", "code_sign": "no"},
             {"name": "Generic_tvOS_Build_Max_Xcode", "vm_image": "${{ env.MAX_VM_IMAGE }}", "xcode_version": "${{ env.MAX_XCODE_VERSION }}", "action": "build", "target": "tv_runner", "sdk": "tv_sim", "dest": "tv_generic", "code_sign": "no"},
             {"name": "Generic_tvOS_Build_Min_Xcode", "vm_image": "${{ env.MIN_VM_IMAGE }}", "xcode_version": "${{ env.MIN_XCODE_VERSION }}", "action": "build", "target": "tv_runner", "sdk": "tv_sim", "dest": "tv_generic", "code_sign": "no"},
+            {"name": "Generic_watchOS_Build_Max_Xcode", "vm_image": "${{ env.MAX_VM_IMAGE }}", "xcode_version": "${{ env.MAX_XCODE_VERSION }}", "action": "build", "target": "watch_runner", "sdk": "watch_sim", "dest": "watch_generic", "code_sign": "no"},
+            {"name": "Generic_watchOS_Build_Min_Xcode", "vm_image": "${{ env.MIN_VM_IMAGE }}", "xcode_version": "${{ env.MIN_XCODE_VERSION }}", "action": "build", "target": "watch_runner", "sdk": "watch_sim", "dest": "watch_generic", "code_sign": "no"},
             {"name": "iOS_Build_Max_Xcode", "vm_image": "${{ env.MAX_VM_IMAGE }}", "xcode_version": "${{ env.MAX_XCODE_VERSION }}", "action": "build", "target": "runner", "sdk": "sim", "iphone_model": "${{ env.MAX_IPHONE_DEVICE_NAME }}", "ipad_model": "${{ env.MAX_IPAD_DEVICE_NAME }}", "ios_version": "${{ env.MAX_PLATFORM_VERSION }}"},
             {"name": "iOS_Build_Min_Xcode", "vm_image": "${{ env.MIN_VM_IMAGE }}", "xcode_version": "${{ env.MIN_XCODE_VERSION }}", "action": "build", "target": "runner", "sdk": "sim", "iphone_model": "${{ env.MIN_IPHONE_DEVICE_NAME }}", "ipad_model": "${{ env.MIN_IPAD_DEVICE_NAME }}", "ios_version": "${{ env.MIN_PLATFORM_VERSION }}"},
             {"name": "tvOS_Build_Max_Xcode", "vm_image": "${{ env.MAX_VM_IMAGE }}", "xcode_version": "${{ env.MAX_XCODE_VERSION }}", "action": "build", "target": "tv_runner", "sdk": "tv_sim", "tv_model": "${{ env.MAX_TV_DEVICE_NAME }}", "tv_version": "${{ env.MAX_TV_PLATFORM_VERSION }}"},
-            {"name": "tvOS_Build_Min_Xcode", "vm_image": "${{ env.MIN_VM_IMAGE }}", "xcode_version": "${{ env.MIN_XCODE_VERSION }}", "action": "build", "target": "tv_runner", "sdk": "tv_sim", "dest": "tv", "tv_model": "${{ env.MIN_TV_DEVICE_NAME }}", "tv_version": "${{ env.MIN_TV_PLATFORM_VERSION }}"}
+            {"name": "tvOS_Build_Min_Xcode", "vm_image": "${{ env.MIN_VM_IMAGE }}", "xcode_version": "${{ env.MIN_XCODE_VERSION }}", "action": "build", "target": "tv_runner", "sdk": "tv_sim", "dest": "tv", "tv_model": "${{ env.MIN_TV_DEVICE_NAME }}", "tv_version": "${{ env.MIN_TV_PLATFORM_VERSION }}"},
+            {"name": "watchOS_Build_Max_Xcode", "vm_image": "${{ env.MAX_VM_IMAGE }}", "xcode_version": "${{ env.MAX_XCODE_VERSION }}", "action": "build", "target": "watch_runner", "sdk": "watch_sim", "dest": "watch", "watch_model": "${{ env.MAX_WATCH_DEVICE_NAME }}", "watch_version": "${{ env.MAX_WATCH_PLATFORM_VERSION }}"},
+            {"name": "watchOS_Build_Min_Xcode", "vm_image": "${{ env.MIN_VM_IMAGE }}", "xcode_version": "${{ env.MIN_XCODE_VERSION }}", "action": "build", "target": "watch_runner", "sdk": "watch_sim", "dest": "watch", "watch_model": "${{ env.MIN_WATCH_DEVICE_NAME }}", "watch_version": "${{ env.MIN_WATCH_PLATFORM_VERSION }}"}
           ]
           MATRIX_JSON
           echo "matrix=$(cat matrix.json)" >> $GITHUB_OUTPUT
@@ -60,7 +68,11 @@ jobs:
             {"name": "tvOS_Lib_Analyze_Max_Xcode", "vm_image": "${{ env.MAX_VM_IMAGE }}", "xcode_version": "${{ env.MAX_XCODE_VERSION }}", "target": "tv_lib", "sdk": "tv_sim", "tv_model": "${{ env.MAX_TV_DEVICE_NAME }}", "tv_version": "${{ env.MAX_TV_PLATFORM_VERSION }}"},
             {"name": "tvOS_Lib_Analyze_Min_Xcode", "vm_image": "${{ env.MIN_VM_IMAGE }}", "xcode_version": "${{ env.MIN_XCODE_VERSION }}", "target": "tv_lib", "sdk": "tv_sim", "tv_model": "${{ env.MIN_TV_DEVICE_NAME }}", "tv_version": "${{ env.MIN_TV_PLATFORM_VERSION }}"},
             {"name": "tvOS_Runner_Analyze_Max_Xcode", "vm_image": "${{ env.MAX_VM_IMAGE }}", "xcode_version": "${{ env.MAX_XCODE_VERSION }}", "target": "tv_runner", "sdk": "tv_sim", "tv_model": "${{ env.MAX_TV_DEVICE_NAME }}", "tv_version": "${{ env.MAX_TV_PLATFORM_VERSION }}"},
-            {"name": "tvOS_Runner_Analyze_Min_Xcode", "vm_image": "${{ env.MIN_VM_IMAGE }}", "xcode_version": "${{ env.MIN_XCODE_VERSION }}", "target": "tv_runner", "sdk": "tv_sim", "tv_model": "${{ env.MIN_TV_DEVICE_NAME }}", "tv_version": "${{ env.MIN_TV_PLATFORM_VERSION }}"}
+            {"name": "tvOS_Runner_Analyze_Min_Xcode", "vm_image": "${{ env.MIN_VM_IMAGE }}", "xcode_version": "${{ env.MIN_XCODE_VERSION }}", "target": "tv_runner", "sdk": "tv_sim", "tv_model": "${{ env.MIN_TV_DEVICE_NAME }}", "tv_version": "${{ env.MIN_TV_PLATFORM_VERSION }}"},
+            {"name": "watchOS_Lib_Analyze_Max_Xcode", "vm_image": "${{ env.MAX_VM_IMAGE }}", "xcode_version": "${{ env.MAX_XCODE_VERSION }}", "target": "watch_lib", "sdk": "watch_sim", "watch_model": "${{ env.MAX_WATCH_DEVICE_NAME }}", "watch_version": "${{ env.MAX_WATCH_PLATFORM_VERSION }}"},
+            {"name": "watchOS_Lib_Analyze_Min_Xcode", "vm_image": "${{ env.MIN_VM_IMAGE }}", "xcode_version": "${{ env.MIN_XCODE_VERSION }}", "target": "watch_lib", "sdk": "watch_sim", "watch_model": "${{ env.MIN_WATCH_DEVICE_NAME }}", "watch_version": "${{ env.MIN_WATCH_PLATFORM_VERSION }}"},
+            {"name": "watchOS_Runner_Analyze_Max_Xcode", "vm_image": "${{ env.MAX_VM_IMAGE }}", "xcode_version": "${{ env.MAX_XCODE_VERSION }}", "target": "watch_runner", "sdk": "watch_sim", "watch_model": "${{ env.MAX_WATCH_DEVICE_NAME }}", "watch_version": "${{ env.MAX_WATCH_PLATFORM_VERSION }}"},
+            {"name": "watchOS_Runner_Analyze_Min_Xcode", "vm_image": "${{ env.MIN_VM_IMAGE }}", "xcode_version": "${{ env.MIN_XCODE_VERSION }}", "target": "watch_runner", "sdk": "watch_sim", "watch_model": "${{ env.MIN_WATCH_DEVICE_NAME }}", "watch_version": "${{ env.MIN_WATCH_PLATFORM_VERSION }}"}
           ]
           MATRIX_JSON
           echo "matrix=$(cat matrix.json)" >> $GITHUB_OUTPUT
@@ -131,6 +143,8 @@ jobs:
           IOS_VERSION: ${{ matrix.config.ios_version }}
           TV_MODEL: ${{ matrix.config.tv_model }}
           TV_VERSION: ${{ matrix.config.tv_version }}
+          WATCH_MODEL: ${{ matrix.config.watch_model }}
+          WATCH_VERSION: ${{ matrix.config.watch_version }}
 
   analyze:
     needs: analyze_matrix
@@ -156,6 +170,8 @@ jobs:
           IOS_VERSION: ${{ matrix.config.ios_version }}
           TV_MODEL: ${{ matrix.config.tv_model }}
           TV_VERSION: ${{ matrix.config.tv_version }}
+          WATCH_MODEL: ${{ matrix.config.watch_model }}
+          WATCH_VERSION: ${{ matrix.config.watch_version }}
 
   unit_test:
     needs: unit_test_matrix

--- a/PrivateHeaders/XCTest/XCSynthesizedEventRecord.h
+++ b/PrivateHeaders/XCTest/XCSynthesizedEventRecord.h
@@ -17,7 +17,7 @@
 @property (readonly) NSArray *eventPaths;
 @property (readonly, copy) NSString *name;
 @property (readonly) double maximumOffset;
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 @property (readonly) UIInterfaceOrientation interfaceOrientation;
 #endif
 @property long long targetProcessID;
@@ -34,13 +34,13 @@
 
 /* instance methods */
 - (_Bool)synthesizeWithError:(id *)error;
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 - (id)initWithName:(id)name displayID:(unsigned long long)id interfaceOrientation:(long long)orientation;
 - (void)unsetInterfaceOrientation;
 #endif
 - (id)initWithName:(id)name;
 - (id)initWithName:(id)name displayID:(unsigned long long)id;
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 - (id)initWithName:(id)name interfaceOrientation:(long long)orientation;
 #endif
 - (id)initWithCoder:(id)coder;

--- a/PrivateHeaders/XCTest/XCUIApplication.h
+++ b/PrivateHeaders/XCTest/XCUIApplication.h
@@ -44,7 +44,7 @@
 @property (readonly) _Bool hasAutomationSession;
 @property _Bool idleAnimationWaitEnabled;
 @property (readonly) _Bool fauxCollectionViewCellsEnabled;
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 @property (readonly, nonatomic) UIInterfaceOrientation interfaceOrientation;
 #endif
 @property (nonatomic) unsigned long long crashBehavior;

--- a/PrivateHeaders/XCTest/XCUIElement.h
+++ b/PrivateHeaders/XCTest/XCUIElement.h
@@ -32,7 +32,7 @@
 @property (readonly, copy) XCUIElement *elementBoundByAccessibilityElement;
 @property _Bool safeQueryResolutionEnabled;
 @property (readonly) long long displayID;
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 @property (readonly, nonatomic) UIInterfaceOrientation interfaceOrientation;
 #endif
 @property (readonly) _Bool hasBannerNotificationIsStickyAttribute;

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -17,6 +17,8 @@ function define_xc_macros() {
     "runner" ) XC_TARGET="WebDriverAgentRunner";;
     "tv_lib" ) XC_TARGET="WebDriverAgentLib_tvOS";;
     "tv_runner" ) XC_TARGET="WebDriverAgentRunner_tvOS";;
+    "watch_lib" ) XC_TARGET="WebDriverAgentLib_watchOS";;
+    "watch_runner" ) XC_TARGET="WebDriverAgentRunner_watchOS";;
     *) echo "Unknown TARGET"; exit 1 ;;
   esac
 
@@ -24,8 +26,10 @@ function define_xc_macros() {
     "iphone" ) XC_DESTINATION="platform=iOS Simulator,name=`echo $IPHONE_MODEL | tr -d "'"`,OS=$IOS_VERSION";;
     "ipad" ) XC_DESTINATION="platform=iOS Simulator,name=`echo $IPAD_MODEL | tr -d "'"`,OS=$IOS_VERSION";;
     "tv" ) XC_DESTINATION="platform=tvOS Simulator,name=`echo $TV_MODEL | tr -d "'"`,OS=$TV_VERSION";;
+    "watch" ) XC_DESTINATION="platform=watchOS Simulator,name=`echo $WATCH_MODEL | tr -d "'"`,OS=$WATCH_VERSION";;
     "generic" ) XC_DESTINATION="generic/platform=iOS";;
     "tv_generic" ) XC_DESTINATION="generic/platform=tvOS" XC_MACROS="${XC_MACROS} ARCHS=arm64";; # tvOS only supports arm64
+    "watch_generic" ) XC_DESTINATION="generic/platform=watchOS" XC_MACROS="${XC_MACROS} ARCHS=arm64";; # watchOS only supports arm64
   esac
 
   case "$ACTION" in
@@ -43,6 +47,8 @@ function define_xc_macros() {
     "device" ) XC_SDK="iphoneos";;
     "tv_sim" ) XC_SDK="appletvsimulator";;
     "tv_device" ) XC_SDK="appletvos";;
+    "watch_sim" ) XC_SDK="watchsimulator";;
+    "watch_device" ) XC_SDK="watchos";;
     *) echo "Unknown SDK"; exit 1 ;;
   esac
 

--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -7,26 +7,55 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		005B327C702EF47820887884 /* FBErrorBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = EE3A18601CDE618F00DE4205 /* FBErrorBuilder.h */; };
+		00ABDDC324B060006EA182F7 /* FBScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = 715AFAC01FFA29180053896D /* FBScreen.m */; };
+		01A6F9758F11F6EF5B495D97 /* XCTPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CA02992F03AE1E134F2CAF5 /* XCTPromise.h */; };
 		01AC2C121519821EC6D2ED6B /* XCTMacCatalystStatusProviding-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 42D2B5A0C490D9698C2A87A9 /* XCTMacCatalystStatusProviding-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		02032DB6E25DC5D0DEDD6184 /* XCUIElement+FBUID.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B49EC61ED1A58100D51AD6 /* XCUIElement+FBUID.m */; };
+		023273B7E5BA69B20CE01D2B /* XCTRunnerIDESession.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACF01E3B77D600A02D78 /* XCTRunnerIDESession.h */; };
 		025456CB4E76A4A4AFD07143 /* XCTRunnerDaemonSessionUIAutomationDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B8A163261EFA440E42CA6AC1 /* XCTRunnerDaemonSessionUIAutomationDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		02BFEE1B0BF7B6532A9D1BFD /* XCUIApplicationPlatformServicesProviderDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FB001C1E84011C0096E5D8 /* XCUIApplicationPlatformServicesProviderDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		031C89D75DD7FB7912ED0BA2 /* FBLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9B76A41CF7A43900275851 /* FBLogger.m */; };
 		047BE50FA0C6C01545FB1863 /* XCTWaiterWait.h in Headers */ = {isa = PBXBuildFile; fileRef = 8566F4674B2CF640A678C952 /* XCTWaiterWait.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		051607BF516A7720E8508CAD /* NSFastEnumeration-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 58156929D12ADE7DFE10116F /* NSFastEnumeration-Protocol.h */; };
+		0585257599F49BABFD835DED /* XCTMessagingRole_SiriAutomation-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = FCD1815F2BF21CA0936B04E1 /* XCTMessagingRole_SiriAutomation-Protocol.h */; };
 		059D8E55BE9C5231DA354B0B /* XCTMessagingRole_TelemetrySending-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BA6647ADE7B44F13513065A /* XCTMessagingRole_TelemetrySending-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		05AD9DFEC97A6E9BDF798CDF /* XCUIAlertMonitoring-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DB5797DE5A0B4E7EE3D166F7 /* XCUIAlertMonitoring-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		05F8A3B33BCFAFFA75CD81CA /* FBScreenRecordingContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BB58F42B96531900CB9BFE /* FBScreenRecordingContainer.h */; };
+		062A682A90296DB8AA3B959E /* XCUIDevice+FBVoiceOver.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0002 /* XCUIDevice+FBVoiceOver.m */; };
 		06E45CFFA4E41D77902DA67A /* XCTMeasureOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = B3FDA51EB36F03592BF48762 /* XCTMeasureOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06FF73DCB07047C42DBFB16A /* AXSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 6496A5D8230D6EB30087F8CB /* AXSettings.h */; };
+		07CD6433C98FC4A86E2BC7E3 /* WDAAppLifecycleIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1B9A793C9EFB7853C1AA13 /* WDAAppLifecycleIntegrationTests.swift */; };
 		07D0D478F000C48B33956E9A /* XCTRunnerDaemonSessionUIAutomationDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B8A163261EFA440E42CA6AC1 /* XCTRunnerDaemonSessionUIAutomationDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		080C5B8955F9D1A3DB7C5B81 /* XCUIApplicationOpenRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AEAD1CF473F6AD60333E9FF /* XCUIApplicationOpenRequest.h */; };
 		0936AE3F017DB42A03BF7751 /* XCTTestIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 831F292661C60B68B557F14D /* XCTTestIdentifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0960A9291C94E38AD5F868D6 /* XCTWaiterManager-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = CC227321769E70CDF7C2D38F /* XCTWaiterManager-Protocol.h */; };
 		09C9A6DCF11987546931BE57 /* XCUIResetAuthorizationStatusOfProtectedResourcesInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A0B17F41E4461BBD09A2962 /* XCUIResetAuthorizationStatusOfProtectedResourcesInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		09D97BD46764FD8149747723 /* XCUIElement+FBResolve.h in Headers */ = {isa = PBXBuildFile; fileRef = 71D3B3D3267FC7260076473D /* XCUIElement+FBResolve.h */; };
+		09E27E0455701764DDB8C747 /* XCUIAccessibilityInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = D47DD8BF27FE639742EA2E3E /* XCUIAccessibilityInterface-Protocol.h */; };
+		0B2D769FCCF7C5EEB3BA2404 /* XCUIApplicationPlatformServicesProviderDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FB001C1E84011C0096E5D8 /* XCUIApplicationPlatformServicesProviderDelegate-Protocol.h */; };
 		0B51B2F12BB356C47986D6F9 /* XCTTagSelection.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2092D85A7C691F157B1971 /* XCTTagSelection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0C120FA673A94DB66CB0E6B0 /* XCUIElement+FBCustomActions.m in Sources */ = {isa = PBXBuildFile; fileRef = F59CD6D32EF16E5E00F91287 /* XCUIElement+FBCustomActions.m */; };
 		0C76F63F9267E31C670675B0 /* XCTMessagingRole_TestReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 13AAB3B43FB533B0E9C3F40D /* XCTMessagingRole_TestReporting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0CD32F774B0F7460E218D576 /* XCTMessagingRole_UIAutomationRunnerEventReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 4951F55904679A17CDFEC186 /* XCTMessagingRole_UIAutomationRunnerEventReporting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0CE8AA4C3A10E2375925DE96 /* FBTVNavigationTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 641EE70D2240CE4800173FCB /* FBTVNavigationTracker.m */; };
 		0D0C43A58560AC8C4E368E4A /* XCTMessagingRole_ProtectedResourceAuthorization-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = CCCBEAE654102DBB1C8C22CD /* XCTMessagingRole_ProtectedResourceAuthorization-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0D789050D49FABC6B4DD88EB /* XCTest.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACCF1E3B77D600A02D78 /* XCTest.h */; };
 		0E0413382DF1E15100AF007C /* XCUIElement+FBMinMax.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0413372DF1E15100AF007C /* XCUIElement+FBMinMax.m */; };
 		0E0413392DF1E15100AF007C /* XCUIElement+FBMinMax.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0413372DF1E15100AF007C /* XCUIElement+FBMinMax.m */; };
 		0E04133B2DF1E15900AF007C /* XCUIElement+FBMinMax.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E04133A2DF1E15900AF007C /* XCUIElement+FBMinMax.h */; };
 		0E04133C2DF1E15900AF007C /* XCUIElement+FBMinMax.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E04133A2DF1E15900AF007C /* XCUIElement+FBMinMax.h */; };
+		0E7CAA2FA6570D0C1EADFE4A /* XCTMessagingRole_MemoryTesting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 13D863EAE7F6F8B7E42D99B9 /* XCTMessagingRole_MemoryTesting-Protocol.h */; };
 		0EFF39CC188B42E85D258F5A /* XCUIIssueDiagnosticsProviding-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 55B3452AB887CADB7AD757A4 /* XCUIIssueDiagnosticsProviding-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0F282CAB2A025ECA9EAB18B3 /* HTTPResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DC8F249131D40060D7EB /* HTTPResponse.h */; };
+		10878F7DCE410B73C3F8CCF1 /* FBRouteRequest-Private.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7861CAEDF0C008C271F /* FBRouteRequest-Private.h */; };
+		109F8F2F96E674EB1464EF3B /* FBTVNavigationTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 641EE70A2240CE2D00173FCB /* FBTVNavigationTracker.h */; };
+		10EC41A2ECCD2E865EEE7AB0 /* XCUIElement+FBClassChain.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A7EAF31E20516B001DA4F2 /* XCUIElement+FBClassChain.h */; };
+		1175C43DC358BA16E23F8449 /* XCTCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = DB5400B170F08C71779CCD0E /* XCTCapabilities.h */; };
+		1182F5754C6B30F1E1C86EE7 /* XCUIApplication+FBUIInterruptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 716C9DFF27315EFF005AD475 /* XCUIApplication+FBUIInterruptions.m */; };
 		11B77103CCE2F4A4FA79A77B /* XCTMessagingRole_ScreenRecording-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = F0D85EFE3ACAC48EEE0F8348 /* XCTMessagingRole_ScreenRecording-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		11BF078FAB71B172572A4A10 /* XCTMessagingRole_ForcePressureSupportQuerying-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = AA2351C66A4616534FB81AE4 /* XCTMessagingRole_ForcePressureSupportQuerying-Protocol.h */; };
+		1224FFB1A0EAF2EBABE5A872 /* FBCapabilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 714EAA0C2673FDFE005C5B47 /* FBCapabilities.m */; };
 		1293AD05FC8083D9D3050328 /* XCTestCaseUIAutomationDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 49D8AC825D239A4A1D834F62 /* XCTestCaseUIAutomationDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1357E296233D05240054BDB8 /* XCUIHitPointResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 1357E295233D05240054BDB8 /* XCUIHitPointResult.h */; };
 		1357E297233D05240054BDB8 /* XCUIHitPointResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 1357E295233D05240054BDB8 /* XCUIHitPointResult.h */; };
@@ -54,70 +83,195 @@
 		13DE7A5C287CA444003243C6 /* FBXCElementSnapshotWrapper+Helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 13DE7A59287CA444003243C6 /* FBXCElementSnapshotWrapper+Helpers.h */; };
 		13DE7A5D287CA444003243C6 /* FBXCElementSnapshotWrapper+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 13DE7A5A287CA444003243C6 /* FBXCElementSnapshotWrapper+Helpers.m */; };
 		13DE7A5E287CA444003243C6 /* FBXCElementSnapshotWrapper+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 13DE7A5A287CA444003243C6 /* FBXCElementSnapshotWrapper+Helpers.m */; };
+		13EEC9A220F1C0F1A76A5D4E /* XCUIRemoteSiriInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 7183E8C2B556594311CB8898 /* XCUIRemoteSiriInterface-Protocol.h */; };
 		13FFF2F2287DBEE600E561E4 /* XCElementSnapshotDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = 13FFF2F1287DBEE600E561E4 /* XCElementSnapshotDouble.m */; };
 		140BE8ACECBDB1B06FF531E1 /* XCTSignpostListener-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F9351F7A43851CA5DFF47CD /* XCTSignpostListener-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		145BED6221BAAC51AD8BDFCE /* XCUIApplicationRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 75438FC693C39052C82C27DB /* XCUIApplicationRegistry.h */; };
+		14F77B365BF733160FF366A2 /* FBElementCommands.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7561CAEDF0C008C271F /* FBElementCommands.h */; };
+		150276DDADD9963F29465D57 /* FBNotificationsHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 719DCF132601EAFB000E765F /* FBNotificationsHelper.h */; };
 		153F9DE7ABF551A58C1F38B0 /* XCTReportingSessionConfiguration-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = E859E58C7C717CB6CD2A80BE /* XCTReportingSessionConfiguration-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		15B3FA3EB08B06C9FE888A82 /* XCTRunnerDaemonSession.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACEF1E3B77D600A02D78 /* XCTRunnerDaemonSession.h */; };
 		15FD99037DE115FB57C1A1F2 /* XCUIRemoteSiriInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 7183E8C2B556594311CB8898 /* XCUIRemoteSiriInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		168FCC9CDC7728709037351F /* NSString+FBVisualLength.m in Sources */ = {isa = PBXBuildFile; fileRef = EE0D1F601EBCDCF7006A3123 /* NSString+FBVisualLength.m */; };
+		16E809B6BFDF7CBD862A7B48 /* TIPreferencesController.h in Headers */ = {isa = PBXBuildFile; fileRef = 648C10AE22AAAE4000B81B9A /* TIPreferencesController.h */; };
+		170C47F533B00D1D870D9957 /* FBResponsePayload.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7821CAEDF0C008C271F /* FBResponsePayload.h */; };
 		17847B7E3336DD878EC33908 /* XCTMessagingRole_BundleRequesting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = C928E94CBC13E262D818C28E /* XCTMessagingRole_BundleRequesting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		18E3569349630AA1C465C6E7 /* FBKeyboard.m in Sources */ = {isa = PBXBuildFile; fileRef = EE3A18651CDE734B00DE4205 /* FBKeyboard.m */; };
+		18F6B2130FD815A1B20F05CF /* FBScreenRecordingRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BB58E72B96328700CB9BFE /* FBScreenRecordingRequest.m */; };
 		18FDF2A8A86ED3286CD819DF /* XCUIPlatformApplicationServicesProviding-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BA71BCF1FDA482419CA8596 /* XCUIPlatformApplicationServicesProviding-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		192CACF49EC3825BA6D2EF4F /* XCTestPrivateSymbols.m in Sources */ = {isa = PBXBuildFile; fileRef = EE6B64FC1D0F86EF00E85F5D /* XCTestPrivateSymbols.m */; };
 		1A1EA47F655C5EC77B5DC1DF /* XCTScreenCapturePolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = FDB15E393EA0850C004D26B2 /* XCTScreenCapturePolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1AECD74FEBA8DA2054D5424F /* XCUISystem.h in Headers */ = {isa = PBXBuildFile; fileRef = DE39D4384E531299FAA143F7 /* XCUISystem.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1C03F3BCBB6B5E5D55CFE2C1 /* FBProtocolHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 71B155DD23080CA600646AFB /* FBProtocolHelpers.h */; };
+		1C159E8E35E0823278141DC2 /* FBXPath-Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 712A0C861DA3E55D007D02E5 /* FBXPath-Private.h */; };
+		1CA8A47F9D6B967D99FC0896 /* XCTestExpectationDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACD91E3B77D600A02D78 /* XCTestExpectationDelegate-Protocol.h */; };
 		1CDBA5F3409E37EF663C38EE /* XCUIEventRecording-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B38AC76FAF9275974F272DE9 /* XCUIEventRecording-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1D0120AD346A99834385FBAB /* NSFastEnumeration-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 58156929D12ADE7DFE10116F /* NSFastEnumeration-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D0C64A6600E2D1BBAFC2D62 /* XCSynthesizedEventRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACC91E3B77D600A02D78 /* XCSynthesizedEventRecord.h */; };
 		1DFC6477940D11BBAD68D59F /* _XCTestObservationInternal-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F8E4FAAC62765A3405F90D6 /* _XCTestObservationInternal-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1E668A3BF614D719AE5B4450 /* XCTMessagingRole_UIAutomationRunnerEventReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 4951F55904679A17CDFEC186 /* XCTMessagingRole_UIAutomationRunnerEventReporting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1E6EBAA448D2632F362FFAA7 /* FBKeyboard.h in Headers */ = {isa = PBXBuildFile; fileRef = EE3A18641CDE734B00DE4205 /* FBKeyboard.h */; };
+		1EBB250E6F79EBCBA11FCE9E /* FBW3CActionsSynthesizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7140974A1FAE1B51008FB2C5 /* FBW3CActionsSynthesizer.m */; };
+		1F545FFB67878CBAF4D6E6A0 /* FBLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9B76A31CF7A43900275851 /* FBLogger.h */; };
+		1F9DD4891B8B19D8E13066E9 /* FBXCElementSnapshot.m in Sources */ = {isa = PBXBuildFile; fileRef = 13DE7A4E287C46BB003243C6 /* FBXCElementSnapshot.m */; };
+		1FA2AA058DF5AEAC2212EAF8 /* WDAFindIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCED63DFD03326F6351165FE /* WDAFindIntegrationTests.swift */; };
 		203561B6C2B8456509B60AD7 /* XCTScreenCapturePolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = FDB15E393EA0850C004D26B2 /* XCTScreenCapturePolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		205E75731851D363B53A61DE /* UITestingUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7FD1CAEE048008C271F /* UITestingUITests.m */; };
+		208F3FB46E41B0A1C87B8800 /* FBScreenshot.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C9EAAB25E8415A00470CD8 /* FBScreenshot.m */; };
 		2238B4FC5C7DCD4B4215444D /* XCTMessagingRole_ProtectedResourceAuthorization-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = CCCBEAE654102DBB1C8C22CD /* XCTMessagingRole_ProtectedResourceAuthorization-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		229F9F5B85C1255447495847 /* XCUIApplicationAutomationSessionProviding-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 603D97F0F9A5B9D4E6442BF2 /* XCUIApplicationAutomationSessionProviding-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		22A6AD29DB4A497BC03C2B67 /* XCTIssue+FBPatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A5C67129A4F39600421C37 /* XCTIssue+FBPatcher.h */; };
 		22D9C8C0CDA32D1F307A345E /* XCTMessagingRole_DebugLogging-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 471DF7EE3C63C3069FB9D40D /* XCTMessagingRole_DebugLogging-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2441D42EAC1D00FBB870B129 /* LRUCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 71414ED22670A1ED003A8C5D /* LRUCache.m */; };
+		2454D9F21CF469B983946C79 /* FBXCElementSnapshotWrapper+Helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 13DE7A59287CA444003243C6 /* FBXCElementSnapshotWrapper+Helpers.h */; };
+		24ACBA685BA25B69FB1591F2 /* FBAlertsMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 719CD8F72126C78F00C7D0C2 /* FBAlertsMonitor.m */; };
 		24BB9F6DBFBCEB5839984180 /* XCTElementSnapshotProvider-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8B17452E38AA1AE03AE251 /* XCTElementSnapshotProvider-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2591714E3B2C31C6DF08CBAB /* XCUIRemoteDeviceRunner-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = F2034DFA5DEC7D26F32590EF /* XCUIRemoteDeviceRunner-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2596817CFC1D72E8558555DF /* FBExceptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 71F5BE4D252F14EB00EE9EBA /* FBExceptions.h */; };
 		2673EB1D621B1FE2248B5038 /* XCTMessagingRole_TestReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 13AAB3B43FB533B0E9C3F40D /* XCTMessagingRole_TestReporting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		268CBDE31376AF96DDDD4BD0 /* FBBaseActionsSynthesizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 714097411FAE1B0B008FB2C5 /* FBBaseActionsSynthesizer.h */; };
+		2692E435B9F56451C018F8EA /* XCTestConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACD31E3B77D600A02D78 /* XCTestConfiguration.h */; };
+		26E40B29FBB439AB7CDB7B16 /* FBScreenRecordingContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BB58F52B96531900CB9BFE /* FBScreenRecordingContainer.m */; };
 		26E854C28CA7B6C4CDBF5DE3 /* _XCTMessaging_VoidProtocol-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 059F291E7D13B17580B4AD43 /* _XCTMessaging_VoidProtocol-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2709D2F140C1FF8A8426C42C /* XCTMessagingChannel_RunnerToIDE-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 100F37231BF17CA9BB91DF16 /* XCTMessagingChannel_RunnerToIDE-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		27D0F4516BBBD53AAC9EF7A6 /* XCUIElement+FBTVFocuse.m in Sources */ = {isa = PBXBuildFile; fileRef = 641EE7072240CDEB00173FCB /* XCUIElement+FBTVFocuse.m */; };
 		28104BC8093DBFAB035820FA /* XCTMetricDiagnosticHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = E46239748EC4A6BFBC13F28B /* XCTMetricDiagnosticHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2892ACD1F2CC2B0AF4FC22EA /* XCUIIssueDiagnosticsProviding-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 55B3452AB887CADB7AD757A4 /* XCUIIssueDiagnosticsProviding-Protocol.h */; };
+		28B292C9A3654A81B765EB37 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD1ABD1093739852B52C472B /* Foundation.framework */; };
+		293BD2162964EEC2A3BA6B57 /* HTTPResponseProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DCA224913C210060D7EB /* HTTPResponseProxy.h */; };
+		2B39D11DD29FD3816F8AAC7C /* XCUIKnobControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C78201A2212BEA77979F4FF /* XCUIKnobControl.h */; };
 		2B9D1292546083ACA2E34DB4 /* XCTCapabilitiesProviding-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B069904A4086E12556F1FAB /* XCTCapabilitiesProviding-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2BBEC31A5B1401C28C14899E /* XCTExpectedFailureContextManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AF0584AD9B6D0A57012C978 /* XCTExpectedFailureContextManager.h */; };
 		2C0D6BA4BD20262B836CEDA3 /* XCTRunnerAutomationSession-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 01AF8E73DD47455B4854E470 /* XCTRunnerAutomationSession-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2C3893641ACA0AAFCC8DEB98 /* XCTPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CA02992F03AE1E134F2CAF5 /* XCTPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2C6A45AFEC6B04782EE8E0B0 /* XCUIElement+FBForceTouch.m in Sources */ = {isa = PBXBuildFile; fileRef = EE8DDD7C20C5733B004D4925 /* XCUIElement+FBForceTouch.m */; };
+		2C6A876B29ECA17D6A5BCEED /* HTTPConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DC89249131D30060D7EB /* HTTPConnection.h */; };
+		2CDFA27001529A43B560F3A1 /* WDAScreenshotAndSourceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F677B5B7737E7E1F321C20 /* WDAScreenshotAndSourceIntegrationTests.swift */; };
+		2D6B818DC921A4631A496432 /* FBCommandStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7761CAEDF0C008C271F /* FBCommandStatus.h */; };
+		2EB7B0D78CEB3388711C7A8B /* FBErrorBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = EE3A18611CDE618F00DE4205 /* FBErrorBuilder.m */; };
 		2F56E0614B3A533F388B6B51 /* XCTRemoteSignpostListenerProxy-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E47AA1A44A4A3C6EDCB6804 /* XCTRemoteSignpostListenerProxy-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2F75D210958556EFE6DEBB53 /* _XCTMessaging_VoidProtocol-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 059F291E7D13B17580B4AD43 /* _XCTMessaging_VoidProtocol-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FBE7F1C0491F85B70CF49D9 /* XCUIDevice+FBHealthCheck.h in Headers */ = {isa = PBXBuildFile; fileRef = EEDFE11F1D9C06F800E6FFE5 /* XCUIDevice+FBHealthCheck.h */; };
 		2FFA926EEC1E220816E7146D /* XCTMessagingRole_SelfDiagnosisIssueReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 74AA57E9A81B1B0515CB587F /* XCTMessagingRole_SelfDiagnosisIssueReporting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		300465664BD787F72A66A990 /* XCUIDeviceAutomationModeInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CF2F53B94CC13C628FC7760 /* XCUIDeviceAutomationModeInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3033E8E33134E8E57C446A8A /* XCUIDeviceEventAndStateInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 003AAAB9CB5FB38E45E05F6F /* XCUIDeviceEventAndStateInterface-Protocol.h */; };
+		311644887124D98DDF7E0C22 /* XCTHarnessEventReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CBAA574F7786985E01D0B6F /* XCTHarnessEventReporting-Protocol.h */; };
 		315A15012518CB8700A3A064 /* TouchableView.m in Sources */ = {isa = PBXBuildFile; fileRef = 315A15002518CB8700A3A064 /* TouchableView.m */; };
 		315A15072518CC2800A3A064 /* TouchSpotView.m in Sources */ = {isa = PBXBuildFile; fileRef = 315A15062518CC2800A3A064 /* TouchSpotView.m */; };
 		315A150A2518D6F400A3A064 /* TouchViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 315A15092518D6F400A3A064 /* TouchViewController.m */; };
 		317B37A91569F67DE9B2EACD /* XCTMessagingRole_SignpostRequesting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E2F683D8A6C6EAAEC8B080A /* XCTMessagingRole_SignpostRequesting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32889DF6C27E6F1A6EA13749 /* XCTMessagingRole_AttachmentFutureResultStatusUpdating-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 10FBCE8B3A419B970DB7A5CE /* XCTMessagingRole_AttachmentFutureResultStatusUpdating-Protocol.h */; };
 		328BB10FEA4029E1464BA7B6 /* XCTMessagingRole_TelemetrySending-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BA6647ADE7B44F13513065A /* XCTMessagingRole_TelemetrySending-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		33114F7BD00543F50F3BA4C8 /* XCTMessagingRole_SystemConfiguration-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EA24F4BE52B2520874E09BEF /* XCTMessagingRole_SystemConfiguration-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3400BE6CBA163DC9A58D60E6 /* XCUIApplicationProcessTracker-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3238E68F292452D8234153F1 /* XCUIApplicationProcessTracker-Protocol.h */; };
+		3414F451472B235F637F46BC /* DDNumber.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DC7D249131B00060D7EB /* DDNumber.h */; };
 		348B7FFB742C26599E44DB67 /* XCTMessagingRole_ProcessMonitoring-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B43D656732067585371ADD31 /* XCTMessagingRole_ProcessMonitoring-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34A32D91F0C8B6A31A9E8F9A /* FBSettingsHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 71F3E7D725417FF400E0C22C /* FBSettingsHandler.m */; };
+		34AB13EFF1F673084C910195 /* GCDAsyncSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 718226C72587443600661B83 /* GCDAsyncSocket.h */; };
+		34E3403E0FE0E93C74E8FB2D /* XCTScreenCapturePolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = FDB15E393EA0850C004D26B2 /* XCTScreenCapturePolicy.h */; };
 		35C087E005C82F9642F8A76C /* XCUIDeviceDelayedAttachmentTransferSupportInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C19CEEEC9858A106061D1F8 /* XCUIDeviceDelayedAttachmentTransferSupportInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		36635A59A5AEDDEFC2FC01E3 /* XCUIXcodeApplicationManaging-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 30ABCB5051B826025F77E360 /* XCUIXcodeApplicationManaging-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3663B9177361DA1B4255D8F1 /* NSString+FBXMLSafeString.m in Sources */ = {isa = PBXBuildFile; fileRef = 716E0BCD1E917E810087A825 /* NSString+FBXMLSafeString.m */; };
+		36C5DA6C013EAAFC575B4A2B /* XCUIScreenDataSource-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 711CD03325ED1106001C01D2 /* XCUIScreenDataSource-Protocol.h */; };
+		394E98CB498DB59F0FF21198 /* XCTestCaseRun.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACD11E3B77D600A02D78 /* XCTestCaseRun.h */; };
+		3A671125031D05D33D1BAA20 /* FBCustomCommands.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7521CAEDF0C008C271F /* FBCustomCommands.h */; };
 		3A8D076DCDB0BDD00C57305C /* XCUIRemoteSiriInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 7183E8C2B556594311CB8898 /* XCUIRemoteSiriInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3CF3155292597766001E17D9 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72519967DBAAC567B40AA1A2 /* ContentView.swift */; };
 		3D39B383A140D6907C1FD590 /* XCTAttachmentManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D80202DC5D679EF37896431 /* XCTAttachmentManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3E199AC580C5DA4B070DD01A /* FBSessionCommands.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7601CAEDF0C008C271F /* FBSessionCommands.h */; };
+		3E27F8D796D65C35BA6405C9 /* XCDebugLogDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACB91E3B77D600A02D78 /* XCDebugLogDelegate-Protocol.h */; };
 		3E52826A2F3E44C94AF5ADBF /* XCTMetricDiagnosticHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = E46239748EC4A6BFBC13F28B /* XCTMetricDiagnosticHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3E73A3A978AB5ECBF68EE1F1 /* XCTReportingSessionTestContainer-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = D5D58975822CD58C8FEF7FEB /* XCTReportingSessionTestContainer-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3E78B1C01DDDD27CDCD78B14 /* XCUIResetAuthorizationStatusOfProtectedResourcesInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A0B17F41E4461BBD09A2962 /* XCUIResetAuthorizationStatusOfProtectedResourcesInterface-Protocol.h */; };
+		3EC5404A04E5A61B8144E834 /* FBCommandHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7751CAEDF0C008C271F /* FBCommandHandler.h */; };
 		3EE6EE34505AC0D6A861F3A6 /* XCTRuntimeDiagnosticsPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = AD0DDEAB427BA845375C7384 /* XCTRuntimeDiagnosticsPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F213A7FAB64730F66D3F0A6 /* XCTReportingSession.h in Headers */ = {isa = PBXBuildFile; fileRef = CB69A2606052D5979C5A436F /* XCTReportingSession.h */; };
+		3FB977871FD8786CA90EB3E2 /* FBSessionCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7611CAEDF0C008C271F /* FBSessionCommands.m */; };
+		3FBA39A4D511311DB7C779F4 /* FBProtocolHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B155DE23080CA600646AFB /* FBProtocolHelpers.m */; };
+		3FEF512914A962C5E30579FC /* RouteResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = ED271671803AAF7188E828CF /* RouteResponse.m */; };
+		40955058B413422AABBB21E7 /* XCUIAlertMonitoring-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DB5797DE5A0B4E7EE3D166F7 /* XCUIAlertMonitoring-Protocol.h */; };
+		409BDFE1D64246E9248CD392 /* XCTMessagingChannel_RunnerToDaemon-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = A2793FE9DE63C687BB6E2D37 /* XCTMessagingChannel_RunnerToDaemon-Protocol.h */; };
 		40CF9CA5CE21FC96F1AFF761 /* XCUIApplicationOpenRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AEAD1CF473F6AD60333E9FF /* XCUIApplicationOpenRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4107851005EC0868D0240FC5 /* XCTIssue+FBPatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 71A5C67229A4F39600421C37 /* XCTIssue+FBPatcher.m */; };
+		41662E3D3159E906AA872A0B /* WebDriverAgentLib.h in Headers */ = {isa = PBXBuildFile; fileRef = EE158B5E1CBD47A000A3E3F0 /* WebDriverAgentLib.h */; };
+		4292F2484A46457054541ADD /* FBPasteboard.m in Sources */ = {isa = PBXBuildFile; fileRef = 71930C4120662E1F00D3AFEC /* FBPasteboard.m */; };
+		42A92793513CA29B39B72721 /* XCUIElement+FBSwiping.h in Headers */ = {isa = PBXBuildFile; fileRef = 71F5BE21252E576C00EE9EBA /* XCUIElement+FBSwiping.h */; };
 		431476F175B158C8E009AF69 /* XCTMessagingRole_AttachmentFutureResultStatusUpdating-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 10FBCE8B3A419B970DB7A5CE /* XCTMessagingRole_AttachmentFutureResultStatusUpdating-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		43AFED121DDF428411F72F83 /* FBXMLGenerationOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 714D88CB2733FB970074A925 /* FBXMLGenerationOptions.m */; };
+		43BC9FE4BF5C19F6F6569177 /* FBRouteRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7871CAEDF0C008C271F /* FBRouteRequest.h */; };
+		43EBA0D0D54EB99815CE63B6 /* XCUIElement+FBWebDriverAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = EEE376471D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.h */; };
+		444F211126EAF77FB2B1DB42 /* FBXCElementSnapshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 13DE7A4D287C46BB003243C6 /* FBXCElementSnapshot.h */; };
 		445523B6024EAE485C37C931 /* XCTRuntimeIssueDetectionPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = B98A9F937EF98D6359FCCC7A /* XCTRuntimeIssueDetectionPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		44A9308980F99E72907DD327 /* NSPredicate+FBFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 71A224E41DE2F56600844D55 /* NSPredicate+FBFormat.m */; };
+		44D4667EC1743A6368395EF2 /* XCTestCaseDiscoveryUIAutomationDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = E29888B75A756D1CCD21604C /* XCTestCaseDiscoveryUIAutomationDelegate-Protocol.h */; };
+		45033CF6BD35C16E34BF76CC /* FBScreenRecordingPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BB58E02B9631F100CB9BFE /* FBScreenRecordingPromise.m */; };
 		45857453287A5CCEEFDCEE02 /* XCUIRemoteAccessibilityInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DD2F42015E89D253EA57F63 /* XCUIRemoteAccessibilityInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		45C57D95F5661023AD97D831 /* FBAlertsMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 719CD8F62126C78F00C7D0C2 /* FBAlertsMonitor.h */; };
+		462DA317CCA9DBE4F249516B /* FBAlert.h in Headers */ = {isa = PBXBuildFile; fileRef = AD6C26921CF2379700F8B5FF /* FBAlert.h */; };
+		46AEB32485B508AF1D9B8CE2 /* XCUIApplication+FBTouchAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BD20711F86116100B36EC2 /* XCUIApplication+FBTouchAction.h */; };
+		46C54343FB83AD3AFC6CFCD4 /* FBTCPSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 715557D2211DBCE700613B26 /* FBTCPSocket.m */; };
+		47462913F617EA89DC379A62 /* LRUCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 71414ED02670A1ED003A8C5D /* LRUCache.h */; };
+		476E44716A4A3A22F95EC51A /* XCUIElement+FBUID.h in Headers */ = {isa = PBXBuildFile; fileRef = 71B49EC51ED1A58100D51AD6 /* XCUIElement+FBUID.h */; };
+		478195F824879438605B6E7D /* FBWebServer.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB78C1CAEDF0C008C271F /* FBWebServer.h */; };
+		4819BEAC415E02570C0FA074 /* FBXCElementSnapshotWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 13DE7A54287CA1EC003243C6 /* FBXCElementSnapshotWrapper.m */; };
+		486CFEAEDCA554C63F4214B3 /* FBXCodeCompatibility.m in Sources */ = {isa = PBXBuildFile; fileRef = EE5A24411F136C8D0078B1D9 /* FBXCodeCompatibility.m */; };
+		486F5AEF3C385922994476CD /* XCUIElement+FBCaching.m in Sources */ = {isa = PBXBuildFile; fileRef = 71D04DC725356C43008A052C /* XCUIElement+FBCaching.m */; };
+		488C4CBD86EBFA2AB5396917 /* XCUIElement+FBUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = EEE3763F1D59F81400ED88DD /* XCUIElement+FBUtilities.h */; };
 		491B4CDEC26699164481DFC0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 722E62C63348A451A351524B /* Foundation.framework */; };
+		49963069375202B1974BB426 /* FBExceptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 71F5BE4E252F14EB00EE9EBA /* FBExceptions.m */; };
+		4A00898E99B59366E552239B /* XCTMessagingRole_ScreenRecording-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = F0D85EFE3ACAC48EEE0F8348 /* XCTMessagingRole_ScreenRecording-Protocol.h */; };
+		4A811492530FE8908E4A0A35 /* XCUIApplicationManaging-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 00834B3220005AD5A5ABEF7C /* XCUIApplicationManaging-Protocol.h */; };
+		4ACFAA7C5F1F80A7B695D23A /* FBExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = EEC088E71CB56DA400B65968 /* FBExceptionHandler.m */; };
+		4BE25B66DBA18E7722B9D82A /* XCTWaiterWait.h in Headers */ = {isa = PBXBuildFile; fileRef = 8566F4674B2CF640A678C952 /* XCTWaiterWait.h */; };
+		4C28862FC86A33692E6EF94D /* XCTElementSnapshotAttributeDataSource-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 38E3FC945B8BF6F6AFD73EE7 /* XCTElementSnapshotAttributeDataSource-Protocol.h */; };
+		4C472F2027329ACA65C7D721 /* FBXPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 711084421DA3AA7500F913D6 /* FBXPath.h */; };
+		4D02B1320F9B19FE829D613A /* FBResponseJSONPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7811CAEDF0C008C271F /* FBResponseJSONPayload.m */; };
 		4D11329B023E8B4C4EF348CF /* XCUIApplicationProcessManaging-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C710FE3AB9E9C22BD2A9E84 /* XCUIApplicationProcessManaging-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4D80F932D0CD80C99950DA4F /* NSExpression+FBFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 71555A3B1DEC460A007D4A8B /* NSExpression+FBFormat.h */; };
+		4E54092E98444C98C9887D44 /* XCPointerEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACC21E3B77D600A02D78 /* XCPointerEvent.h */; };
+		4E8E83C42F2E2A2A5A62F3E3 /* FBResponseJSONPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7801CAEDF0C008C271F /* FBResponseJSONPayload.h */; };
+		4EEB442BA8D43BD20A94BB68 /* XCUIDevice+FBHealthCheck.m in Sources */ = {isa = PBXBuildFile; fileRef = EEDFE1201D9C06F800E6FFE5 /* XCUIDevice+FBHealthCheck.m */; };
+		4EEFC2F7BDC3CA343F73E71A /* FBTouchActionCommands.h in Headers */ = {isa = PBXBuildFile; fileRef = 71241D791FAE3D2500B9559F /* FBTouchActionCommands.h */; };
+		515A0862F9234F6069E7F49F /* XCTTestIdentifierSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E079E00FE148476F94BC42F /* XCTTestIdentifierSet.h */; };
+		51FFE79AF3A5FADFFAB287BC /* FBDebugCommands.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7541CAEDF0C008C271F /* FBDebugCommands.h */; };
 		5264691C82CAED776872EB9E /* XCTRunnerIDESessionDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A5EC96F8F1C3888B9E24FAA /* XCTRunnerIDESessionDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		528747420DE2B33940204B98 /* XCTMemoryCheckerDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EEB78C32D7E6DD6E4EBCD26 /* XCTMemoryCheckerDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		52EDA2654EA1B8E6FB842FB3 /* XCTMessagingRole_SignpostRequesting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E2F683D8A6C6EAAEC8B080A /* XCTMessagingRole_SignpostRequesting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		53069B2F807E140CB310AE67 /* FBXPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 711084431DA3AA7500F913D6 /* FBXPath.m */; };
+		53E0F0F38E7847065810FF41 /* XCUIElement+FBTyping.m in Sources */ = {isa = PBXBuildFile; fileRef = AD76723C1D6B7CC000610457 /* XCUIElement+FBTyping.m */; };
+		544D6545052EA800D3E4BA81 /* FBReflectionUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 716C9DF827315D21005AD475 /* FBReflectionUtils.h */; };
 		5582410FB077944A4DB678F6 /* XCTHarnessEventReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CBAA574F7786985E01D0B6F /* XCTHarnessEventReporting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		560C97EA2B2D60B9111E0BEF /* XCTTagSelection.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2092D85A7C691F157B1971 /* XCTTagSelection.h */; };
+		5787FD65011B3AF632694EEA /* XCUIElement.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACFE1E3B77D600A02D78 /* XCUIElement.h */; };
+		57C72DA18039FED310967F8F /* XCTSourceCodeLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 81BB54ECBFB5B7B680BB5D4F /* XCTSourceCodeLocation.h */; };
+		57EAF450031647694B6491F8 /* FBConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9B76A21CF7A43900275851 /* FBConfiguration.m */; };
+		583AD004FF71CAA305E6DEAF /* XCUIDevice+FBHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = AD6C26971CF2481700F8B5FF /* XCUIDevice+FBHelpers.m */; };
 		587AA46196BC2C46555C8E44 /* XCUIButtonConsole.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E09842154A44874C4E9CA01 /* XCUIButtonConsole.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		588F51093FD2A5597366C282 /* XCUIElementEventTarget-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 0DC62BF635704E9C72AF533E /* XCUIElementEventTarget-Protocol.h */; };
+		5917EF5F1372B2098168EA0D /* GCDAsyncUdpSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 718226C62587443600661B83 /* GCDAsyncUdpSocket.h */; };
 		5967912A40E807CDBE87E4B2 /* XCTReportingSessionIssueReporter-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 525D62A58488A52AA1BFE94A /* XCTReportingSessionIssueReporter-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		59689A4C5FC03AF28D15FAA2 /* XCUIAccessibilityInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = D47DD8BF27FE639742EA2E3E /* XCUIAccessibilityInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		59892BBAB84DFD927C94593F /* _XCTestObservationPrivate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = C840A8703A7C8D48897E158A /* _XCTestObservationPrivate-Protocol.h */; };
+		5A1B8098AE35B82BD379B421 /* XCUIElement+FBForceTouch.h in Headers */ = {isa = PBXBuildFile; fileRef = EE8DDD7D20C5733C004D4925 /* XCUIElement+FBForceTouch.h */; };
 		5AF49CE43E731B433375C5B7 /* ViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F87CD156E93338642EEFD54 /* ViewController.h */; };
 		5B736BB83DEA69D3C5EEC7E1 /* XCTElementSetTransformer-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BA7DD8C206D694B007C7C26 /* XCTElementSetTransformer-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C1E821041979B5FA859B6D0 /* XCUIElement+FBPickerWheel.m in Sources */ = {isa = PBXBuildFile; fileRef = 7136A4781E8918E60024FC3D /* XCUIElement+FBPickerWheel.m */; };
+		5D1959FC0B6EBB249DD86062 /* XCApplicationQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACB71E3B77D600A02D78 /* XCApplicationQuery.h */; };
+		5D2A81B261FEC67033F41101 /* XCUIElementQuery+FBHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 71E75E6B254824230099FC87 /* XCUIElementQuery+FBHelpers.h */; };
+		5D31382835A8EAE37804AC15 /* XCTestObservationCenter.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACE11E3B77D600A02D78 /* XCTestObservationCenter.h */; };
+		5D4AF85139930C5B7D49C258 /* XCUIApplication+FBAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = 719CD8FB2126C88B00C7D0C2 /* XCUIApplication+FBAlert.m */; };
 		5D8922D8CA1104F424884038 /* XCTMessagingRole_ForcePressureSupportQuerying-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = AA2351C66A4616534FB81AE4 /* XCTMessagingRole_ForcePressureSupportQuerying-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DE3B29128FA52F078160D5B /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A87AE5544E9A5CA7C9168DDF /* SceneDelegate.m */; };
+		5E4FAB96AC8BE02A1DDD632C /* XCTReportingSessionIssueReporter-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 525D62A58488A52AA1BFE94A /* XCTReportingSessionIssueReporter-Protocol.h */; };
 		5E6CDEC88D7F31EEDA3B11FC /* XCUIEventRecording-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B38AC76FAF9275974F272DE9 /* XCUIEventRecording-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5E8ECB85C540038310F7827E /* FBTouchIDCommands.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7621CAEDF0C008C271F /* FBTouchIDCommands.h */; };
+		5EAD5B877C99E1086732F175 /* FBTouchIDCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7631CAEDF0C008C271F /* FBTouchIDCommands.m */; };
 		5FB3A9CA82CFF72F6B1FCBA2 /* XCUIElementAttributesPrivate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EF5BE504321321FB9320C43 /* XCUIElementAttributesPrivate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		604A7EDA9D8A9BFCF3B62E5C /* _XCTestObservationInternal-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F8E4FAAC62765A3405F90D6 /* _XCTestObservationInternal-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		60CF6CA8AC7961DCCE402764 /* XCTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACD01E3B77D600A02D78 /* XCTestCase.h */; };
+		60E33E299D4BFCF03FB6CFE2 /* XCTMessagingRole_CapabilityExchange-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 62A682C55077710D1D90ABC3 /* XCTMessagingRole_CapabilityExchange-Protocol.h */; };
 		61200BFA4A2ABBE0A9AF82FD /* XCUIApplicationMonitor-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 100F88CC697C688B7444D5BB /* XCUIApplicationMonitor-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		617AE9B41FB23CCE66769441 /* NSPredicate+FBFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A224E31DE2F56600844D55 /* NSPredicate+FBFormat.h */; };
 		628A0FE5A2838D06641C3433 /* XCTMessagingRole_TestExecution-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 209C65575782ECAA09892D2B /* XCTMessagingRole_TestExecution-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		634BCD9D9DE1705A819B2013 /* XCTHarnessEventReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CBAA574F7786985E01D0B6F /* XCTHarnessEventReporting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6385F4A7220A40760095BBDB /* XCUIApplicationProcessDelay.m in Sources */ = {isa = PBXBuildFile; fileRef = 6385F4A5220A40760095BBDB /* XCUIApplicationProcessDelay.m */; };
@@ -126,6 +280,7 @@
 		63FD950221F9D06100A3E356 /* FBImageProcessorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 631B523421F6174300625362 /* FBImageProcessorTests.m */; };
 		63FD950321F9D06100A3E356 /* FBImageProcessorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 631B523421F6174300625362 /* FBImageProcessorTests.m */; };
 		63FD950421F9D06200A3E356 /* FBImageProcessorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 631B523421F6174300625362 /* FBImageProcessorTests.m */; };
+		63FF0E214F64ABD9F4EA2AD2 /* XCTMemoryCheckerDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EEB78C32D7E6DD6E4EBCD26 /* XCTMemoryCheckerDelegate-Protocol.h */; };
 		641EE3452240C1C800173FCB /* UITestingUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7FD1CAEE048008C271F /* UITestingUITests.m */; };
 		641EE5D72240C5CA00173FCB /* FBScreenshotCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB75F1CAEDF0C008C271F /* FBScreenshotCommands.m */; };
 		641EE5D92240C5CA00173FCB /* XCUIElement+FBPickerWheel.m in Sources */ = {isa = PBXBuildFile; fileRef = 7136A4781E8918E60024FC3D /* XCUIElement+FBPickerWheel.m */; };
@@ -324,15 +479,36 @@
 		64E3502F2AC0B6FE005F3ACB /* NSDictionary+FBUtf8SafeDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 716F0D9F2A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.h */; };
 		653D97915AD965AFFB133093 /* XCTIssueHandling-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = CD4DA0D55FD20614EDA82368 /* XCTIssueHandling-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		66030D36126676CD334588B3 /* XCUIApplicationProcessTracker-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3238E68F292452D8234153F1 /* XCUIApplicationProcessTracker-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6627D7B40D3D915B115D7B1A /* FBSession-Private.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7891CAEDF0C008C271F /* FBSession-Private.h */; };
 		664471C47B921A09884F5C1F /* XCTMessagingRole_EventSynthesis-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E2F8B9A21359AC98424DDE0 /* XCTMessagingRole_EventSynthesis-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		668B1D9AFF85F0538E738675 /* XCUIElementAttributesPrivate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EF5BE504321321FB9320C43 /* XCUIElementAttributesPrivate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		67402F46AAB3DCAB3E40ED27 /* FBUnknownCommands.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7641CAEDF0C008C271F /* FBUnknownCommands.h */; };
+		6786D4B257269918E591AC66 /* FBElementUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 713C6DCD1DDC772A00285B92 /* FBElementUtils.h */; };
+		67ADB25EAE13510B87236F2C /* _XCTMessaging_VoidProtocol-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 059F291E7D13B17580B4AD43 /* _XCTMessaging_VoidProtocol-Protocol.h */; };
 		67AFD75FBCD4BFC5424A0956 /* XCTMessagingRole_ActivityReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EED93C03F27978174C7333C1 /* XCTMessagingRole_ActivityReporting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68BAD7FD955D2732151C355D /* XCUIRemoteAccessibilityInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DD2F42015E89D253EA57F63 /* XCUIRemoteAccessibilityInterface-Protocol.h */; };
 		68CF77BE3F4B659BAFC99AF1 /* XCUIDeviceDelayedAttachmentTransferSupportInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C19CEEEC9858A106061D1F8 /* XCUIDeviceDelayedAttachmentTransferSupportInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		698A247C297C36C7DEBFCD28 /* XCTMessagingRole_TestReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 13AAB3B43FB533B0E9C3F40D /* XCTMessagingRole_TestReporting-Protocol.h */; };
+		69D17671BE6F04D5FE909BD1 /* XCTMessagingRole_BundleRequesting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = C928E94CBC13E262D818C28E /* XCTMessagingRole_BundleRequesting-Protocol.h */; };
+		6A093FDB29E19E1F1F51A6A8 /* FBImageUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 7150348521A6DAD600A0F4BA /* FBImageUtils.h */; };
+		6A1D9B851D58D0A36D6822B7 /* XCTWaiter.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACF41E3B77D600A02D78 /* XCTWaiter.h */; };
+		6A4E39AED8C9C8BEBD960710 /* FBImageProcessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 63CCF91021ECE4C700E94ABD /* FBImageProcessor.h */; };
+		6A594CAA5D54658403A031DC /* XCTRunnerAutomationSession-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 01AF8E73DD47455B4854E470 /* XCTRunnerAutomationSession-Protocol.h */; };
 		6ACEDEB2C16EFA502ED27FC4 /* XCTMeasureOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = B3FDA51EB36F03592BF48762 /* XCTMeasureOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6B3AB44BFFDDF042E4B712C1 /* FBPasteboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 71930C4020662E1F00D3AFEC /* FBPasteboard.h */; };
+		6B4E076881F3C7F369044682 /* FBXCDeviceEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 13DE7A47287C4005003243C6 /* FBXCDeviceEvent.h */; };
 		6B68382176E9918AF3110710 /* XCTMacCatalystStatusProviding-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 42D2B5A0C490D9698C2A87A9 /* XCTMacCatalystStatusProviding-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6B9BDA3FFFD557297E75777F /* XCUIElementAttributesPrivate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EF5BE504321321FB9320C43 /* XCUIElementAttributesPrivate-Protocol.h */; };
+		6BF3F57247F59B81B8BCEE7B /* FBClassChainQueryParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A7EAF71E224648001DA4F2 /* FBClassChainQueryParser.h */; };
 		6CE6B9FF16CEAB475B764A92 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DD3770A67ED561EBE5E443A /* main.m */; };
+		6CF55BBD548172F14D4E3BEE /* FBMjpegServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7155D701211DCEF400166C20 /* FBMjpegServer.h */; };
+		6D311C0CB39981D7211B5576 /* XCUICoordinate.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACFC1E3B77D600A02D78 /* XCUICoordinate.h */; };
+		6D5C61FB04D91A81776E0B06 /* XCTRunnerIDESessionDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A5EC96F8F1C3888B9E24FAA /* XCTRunnerIDESessionDelegate-Protocol.h */; };
 		6E9672EC1A999619AED1EF4D /* XCTSourceCodeContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 530D925D1492C4DF826B46BB /* XCTSourceCodeContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6EA187930FA95A0FB2D0338F /* XCUIElement+FBUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = EEE376401D59F81400ED88DD /* XCUIElement+FBUtilities.m */; };
 		6EC82BD561787BE315AD369A /* XCTMessagingRole_SiriAutomation-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = FCD1815F2BF21CA0936B04E1 /* XCTMessagingRole_SiriAutomation-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6FC8E41707F65D5A432206CC /* FBXCAccessibilityElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 13DE7A41287C2A8D003243C6 /* FBXCAccessibilityElement.h */; };
+		70E21F76098198E19A6E5A5E /* FBXCAXClientProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 7157B28F221DADD2001C348C /* FBXCAXClientProxy.h */; };
 		711084441DA3AA7500F913D6 /* FBXPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 711084421DA3AA7500F913D6 /* FBXPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		711084451DA3AA7500F913D6 /* FBXPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 711084431DA3AA7500F913D6 /* FBXPath.m */; };
 		7119097C2152580600BA3C7E /* XCUIScreen.h in Headers */ = {isa = PBXBuildFile; fileRef = 7119097B2152580600BA3C7E /* XCUIScreen.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -512,6 +688,7 @@
 		71BB58F82B96531900CB9BFE /* FBScreenRecordingContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BB58F52B96531900CB9BFE /* FBScreenRecordingContainer.m */; };
 		71BB58F92B96531900CB9BFE /* FBScreenRecordingContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BB58F52B96531900CB9BFE /* FBScreenRecordingContainer.m */; };
 		71BB58FA2B96531900CB9BFE /* FBScreenRecordingContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BB58F52B96531900CB9BFE /* FBScreenRecordingContainer.m */; };
+		71BB64FB648CB9BBBD25F3E3 /* FBVideoCommands.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BB58ED2B96511800CB9BFE /* FBVideoCommands.h */; };
 		71BD20731F86116100B36EC2 /* XCUIApplication+FBTouchAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BD20711F86116100B36EC2 /* XCUIApplication+FBTouchAction.h */; };
 		71BD20741F86116100B36EC2 /* XCUIApplication+FBTouchAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BD20721F86116100B36EC2 /* XCUIApplication+FBTouchAction.m */; };
 		71C8E55125399A6B008572C1 /* XCUIApplication+FBQuiescence.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C8E54F25399A6B008572C1 /* XCUIApplication+FBQuiescence.h */; };
@@ -522,6 +699,7 @@
 		71C9EAAD25E8415A00470CD8 /* FBScreenshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C9EAAA25E8415A00470CD8 /* FBScreenshot.h */; };
 		71C9EAAE25E8415A00470CD8 /* FBScreenshot.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C9EAAB25E8415A00470CD8 /* FBScreenshot.m */; };
 		71C9EAAF25E8415A00470CD8 /* FBScreenshot.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C9EAAB25E8415A00470CD8 /* FBScreenshot.m */; };
+		71CFF495DEF7670A748F569E /* FBSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 71F3E7D325417FF400E0C22B /* FBSettings.m */; };
 		71D04DC825356C43008A052C /* XCUIElement+FBCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 71D04DC625356C43008A052C /* XCUIElement+FBCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		71D04DC925356C43008A052C /* XCUIElement+FBCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 71D04DC625356C43008A052C /* XCUIElement+FBCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		71D04DCA25356C43008A052C /* XCUIElement+FBCaching.m in Sources */ = {isa = PBXBuildFile; fileRef = 71D04DC725356C43008A052C /* XCUIElement+FBCaching.m */; };
@@ -557,44 +735,137 @@
 		71F5BE52252F14EB00EE9EBA /* FBExceptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 71F5BE4E252F14EB00EE9EBA /* FBExceptions.m */; };
 		727A1A132D139DB3B82808F4 /* XCTFuture.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F044AD574A9837C04F833CB /* XCTFuture.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		72FE28D00A69D335B463C03A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 721E280BFFEFFD40C89277AF /* AppDelegate.m */; };
+		732D07CE799D8B584B4033E8 /* XCTMessagingRole_DebugLogging-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 471DF7EE3C63C3069FB9D40D /* XCTMessagingRole_DebugLogging-Protocol.h */; };
+		734735CAB6A95282CCF098E5 /* XCUIElement+FBFind.m in Sources */ = {isa = PBXBuildFile; fileRef = EEBBD48A1D47746D00656A81 /* XCUIElement+FBFind.m */; };
+		74CF72DC7209A5B04763D0D2 /* XCUIDevice+FBRotation.h in Headers */ = {isa = PBXBuildFile; fileRef = EEE3763D1D59F81400ED88DD /* XCUIDevice+FBRotation.h */; };
 		7517E1E214BC4492019D61F4 /* XCUIApplicationRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 75438FC693C39052C82C27DB /* XCUIApplicationRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		75794142172494266C093A62 /* XCUIElement+FBCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 71D04DC625356C43008A052C /* XCUIElement+FBCaching.h */; };
 		757C820973C6603AB68DE0C9 /* XCTTestIdentifierSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E079E00FE148476F94BC42F /* XCTTestIdentifierSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		75AE290C7AFD434C65E42834 /* XCUILocation.h in Headers */ = {isa = PBXBuildFile; fileRef = A8230FDD93639CE2E9EFE311 /* XCUILocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		75BA34FEE03680F41B5054E1 /* LRUCacheNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 71414ED32670A1ED003A8C5D /* LRUCacheNode.m */; };
 		75C826873B52331693682180 /* XCTIssue.h in Headers */ = {isa = PBXBuildFile; fileRef = ACB055BCA9CCEAB3DECD1A74 /* XCTIssue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		760885DAFDB4A126DBD66649 /* XCUIElement+FBFind.h in Headers */ = {isa = PBXBuildFile; fileRef = EEBBD4891D47746D00656A81 /* XCUIElement+FBFind.h */; };
+		764374A915DAEBCB7EB46C2C /* FBRoute.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7851CAEDF0C008C271F /* FBRoute.m */; };
+		767CB761C99AA6275E08FDB9 /* XCUIHitPointResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 1357E295233D05240054BDB8 /* XCUIHitPointResult.h */; };
 		76DDBF4B5DD942D2BC898FF6 /* XCTMessagingRole_TestExecution-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 209C65575782ECAA09892D2B /* XCTMessagingRole_TestExecution-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7738D42AE84269A6963A5610 /* XCTAggregateSuiteRunStatistics.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AA21CEBA6E92AAC73FB6A48 /* XCTAggregateSuiteRunStatistics.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		77E2A6A9EC406845C5E4D58E /* XCTExpectedFailureContextManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AF0584AD9B6D0A57012C978 /* XCTExpectedFailureContextManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		78649785B81BE48282977C23 /* XCTMessagingRole_SelfDiagnosisIssueReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 74AA57E9A81B1B0515CB587F /* XCTMessagingRole_SelfDiagnosisIssueReporting-Protocol.h */; };
+		792C7A9BC732FD697300346A /* FBElementCache.m in Sources */ = {isa = PBXBuildFile; fileRef = EEC088E41CB56AC000B65968 /* FBElementCache.m */; };
 		797F7D6C82C038B5CC646C3C /* XCUIRemoteAccessibilityInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DD2F42015E89D253EA57F63 /* XCUIRemoteAccessibilityInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79A47D7F50179802052ED774 /* CDStructures.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACA41E3B77D600A02D78 /* CDStructures.h */; };
 		79B8E6488DCC9A24132C3F07 /* XCTMessagingChannel_IDEToRunner-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B3F8E1F3F489A3A94A61ADB /* XCTMessagingChannel_IDEToRunner-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79FD4FC269A91F525A4E1413 /* XCUIElementQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35AD021E3B77D600A02D78 /* XCUIElementQuery.h */; };
+		7A1C1BA4A16ACF436D16338D /* FBAlertViewCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7511CAEDF0C008C271F /* FBAlertViewCommands.m */; };
 		7A2822942A7A435177674385 /* XCTMessagingRole_SiriAutomation-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = FCD1815F2BF21CA0936B04E1 /* XCTMessagingRole_SiriAutomation-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7ADF6DB2192FD499AE0056DE /* FBAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = AD6C26931CF2379700F8B5FF /* FBAlert.m */; };
 		7AF7867A7C01AD420A4B8006 /* XCUIAXNotificationHandling-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EA96C2FEDE73CB5148BA4949 /* XCUIAXNotificationHandling-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7B915C6285B9E84989FCB3D9 /* XCTMessagingRole_ScreenRecording-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = F0D85EFE3ACAC48EEE0F8348 /* XCTMessagingRole_ScreenRecording-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BB6E1590E224BAA09B8BE34 /* NSString+FBXMLSafeString.h in Headers */ = {isa = PBXBuildFile; fileRef = 716E0BCC1E917E810087A825 /* NSString+FBXMLSafeString.h */; };
+		7C29155F72C16DF727A0692C /* XCUIElement+FBClassChain.m in Sources */ = {isa = PBXBuildFile; fileRef = 71A7EAF41E20516B001DA4F2 /* XCUIElement+FBClassChain.m */; };
 		7C9C3C651FB37EC3ED8BC4C1 /* XCTReportingSessionConfiguration-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = E859E58C7C717CB6CD2A80BE /* XCTReportingSessionConfiguration-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7CB113A4CAF4C22E962E2097 /* XCTSourceCodeContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 530D925D1492C4DF826B46BB /* XCTSourceCodeContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7D099F5AD14B24B9FC3FEBF0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD1ABD1093739852B52C472B /* Foundation.framework */; };
 		7D2D0CCEF44A91BDB34F5943 /* XCTRuntimeDiagnosticsPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = AD0DDEAB427BA845375C7384 /* XCTRuntimeDiagnosticsPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7D39CABC61A3F585DEC1E6B1 /* XCUIKnobControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C78201A2212BEA77979F4FF /* XCUIKnobControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7DFFC02E95770F89F5A63A8F /* FBSettingsHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 71F3E7D625417FF400E0C22C /* FBSettingsHandler.h */; };
 		7E8A58D4008272867717EC09 /* XCUIElementEventTarget-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 0DC62BF635704E9C72AF533E /* XCUIElementEventTarget-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7F141C27D97D26043A8C0494 /* XCUIApplicationAutomationSessionProviding-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 603D97F0F9A5B9D4E6442BF2 /* XCUIApplicationAutomationSessionProviding-Protocol.h */; };
+		7F54E7702BAD38194CEDF219 /* XCTElementSnapshotProvider-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8B17452E38AA1AE03AE251 /* XCTElementSnapshotProvider-Protocol.h */; };
 		7FFC01A033E0B6345F89CDDC /* XCUIApplicationOpenRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AEAD1CF473F6AD60333E9FF /* XCUIApplicationOpenRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		808BFE11674748A002FB9617 /* XCTReportingSessionConfiguration-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = E859E58C7C717CB6CD2A80BE /* XCTReportingSessionConfiguration-Protocol.h */; };
+		81231F08969740B0C8C67A30 /* XCUIApplication+FBHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = AD6C269A1CF2494200F8B5FF /* XCUIApplication+FBHelpers.h */; };
 		81879CE5BE319B4108442671 /* XCUIApplicationManaging-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 00834B3220005AD5A5ABEF7C /* XCUIApplicationManaging-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		818F15E49B1CEB1B70C412EB /* XCUISiriService.h in Headers */ = {isa = PBXBuildFile; fileRef = 7076779B6AB29D5AAB5E4D33 /* XCUISiriService.h */; };
 		81A1DA56232415B8FC3329E8 /* XCUIApplicationImplReporter-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 221BC403F42F61DDB1F11DD0 /* XCUIApplicationImplReporter-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81BB152C7704087B3FE6F854 /* XCTSkippedTestContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C32C75CC17179B347DF6F78 /* XCTSkippedTestContext.h */; };
+		81D8C17650E61D67CB43061A /* XCTIssue.h in Headers */ = {isa = PBXBuildFile; fileRef = ACB055BCA9CCEAB3DECD1A74 /* XCTIssue.h */; };
+		83FFBD660C6C7F8D2426E2EE /* XCTestRun.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACE41E3B77D600A02D78 /* XCTestRun.h */; };
 		84198CB51920B55B0AD0F5B4 /* XCTMessagingRole_UIAutomation-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 92182E4007B37665AB8CD88E /* XCTMessagingRole_UIAutomation-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		844C1352549460E759ABCCD3 /* XCTMessagingChannel_RunnerToIDE-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 100F37231BF17CA9BB91DF16 /* XCTMessagingChannel_RunnerToIDE-Protocol.h */; };
+		8468AE1133A7B8E7CBC18172 /* FBXCAccessibilityElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 13DE7A42287C2A8D003243C6 /* FBXCAccessibilityElement.m */; };
+		849F04D9E87C06F04B33FC77 /* FBVideoCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BB58EE2B96511800CB9BFE /* FBVideoCommands.m */; };
+		84ADB5DF7FBD5F44F2A8A538 /* XCUIApplication+FBTouchAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BD20721F86116100B36EC2 /* XCUIApplication+FBTouchAction.m */; };
+		84CDC80038E42E8E92E6629B /* XCTRunnerDaemonSessionUIAutomationDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B8A163261EFA440E42CA6AC1 /* XCTRunnerDaemonSessionUIAutomationDelegate-Protocol.h */; };
+		8514673059ADAF54817A5795 /* FBScreenshotCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB75F1CAEDF0C008C271F /* FBScreenshotCommands.m */; };
+		852D69D1623D81697D700B3C /* XCPointerEventPath.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACC31E3B77D600A02D78 /* XCPointerEventPath.h */; };
+		854FE74E5C23053EE3E2F0F1 /* FBScreenshotCommands.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB75E1CAEDF0C008C271F /* FBScreenshotCommands.h */; };
+		8597F35CEB1617767B63D770 /* FBExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = EEC088E61CB56DA400B65968 /* FBExceptionHandler.h */; };
+		85F4463308BA5153D48F7FAE /* XCTAggregateSuiteRunStatistics.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AA21CEBA6E92AAC73FB6A48 /* XCTAggregateSuiteRunStatistics.h */; };
+		865E31CC987F5FCF3C0BFFC3 /* XCUIXcodeApplicationManaging-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 30ABCB5051B826025F77E360 /* XCUIXcodeApplicationManaging-Protocol.h */; };
+		86FCA9F496D404C54B208E36 /* XCTMetricDiagnosticHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = E46239748EC4A6BFBC13F28B /* XCTMetricDiagnosticHelper.h */; };
+		874C3368FEB1CC31D59E72BE /* XCTRepetitionPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = A1291FF806FE75EDE239FE44 /* XCTRepetitionPolicy.h */; };
+		87D464D881B22C316FB1D822 /* XCTMemoryChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = AFD7929A5F0B45397F0D64CB /* XCTMemoryChecker.h */; };
+		87DA621B823DB8B9D25E5C20 /* XCTTestIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 831F292661C60B68B557F14D /* XCTTestIdentifier.h */; };
+		8836331A94BA37168F60E3C8 /* XCTMeasureOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = B3FDA51EB36F03592BF48762 /* XCTMeasureOptions.h */; };
 		887945F48A8D0BBC21EDBC27 /* XCUISiriService.h in Headers */ = {isa = PBXBuildFile; fileRef = 7076779B6AB29D5AAB5E4D33 /* XCUISiriService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8889A10339D4C6B838DD85EF /* FBUnattachedAppLauncher.m in Sources */ = {isa = PBXBuildFile; fileRef = C8FB547822D4C1FC00B69954 /* FBUnattachedAppLauncher.m */; };
+		88A4B0B30D883EDD1D6A8690 /* XCTReportingSessionTestReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D6B33F48F089C945641DB3F /* XCTReportingSessionTestReporter.h */; };
 		88EE4275BFBD9207CBD84959 /* XCTIssue.h in Headers */ = {isa = PBXBuildFile; fileRef = ACB055BCA9CCEAB3DECD1A74 /* XCTIssue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8934D96BE720E53106DCFA6C /* XCUIElement+FBResolve.m in Sources */ = {isa = PBXBuildFile; fileRef = 71D3B3D4267FC7260076473D /* XCUIElement+FBResolve.m */; };
 		8935209ECEC079F126FBDFAC /* XCTSkippedTestContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C32C75CC17179B347DF6F78 /* XCTSkippedTestContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		894AE4397B5992EF738248AE /* RouteRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DCAA24913C220060D7EB /* RouteRequest.h */; };
 		8A8D9B0342BC43BEB65749B7 /* XCUILocation.h in Headers */ = {isa = PBXBuildFile; fileRef = A8230FDD93639CE2E9EFE311 /* XCUILocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8AAA33A5B1943B667B0DB05E /* FBMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9B76A51CF7A43900275851 /* FBMacros.h */; };
 		8CB293E6451EB1A6D1240BAA /* XCTElementSetTransformer-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BA7DD8C206D694B007C7C26 /* XCTElementSetTransformer-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8D04F8FC7260CDC39C84B0C5 /* FBWebServer.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB78D1CAEDF0C008C271F /* FBWebServer.m */; };
+		8D15C0B98A2D7206CA297A41 /* XCUISystem.h in Headers */ = {isa = PBXBuildFile; fileRef = DE39D4384E531299FAA143F7 /* XCUISystem.h */; };
+		8E58B3CAE34ECF6644F80A9B /* XCUIApplicationMonitor-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 100F88CC697C688B7444D5BB /* XCUIApplicationMonitor-Protocol.h */; };
+		8E654AB7D5B1127F2CB6C540 /* FBRuntimeUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7921CAEDF0C008C271F /* FBRuntimeUtils.m */; };
+		8EA51935E09A89896FB1D463 /* FBW3CActionsSynthesizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 714097491FAE1B51008FB2C5 /* FBW3CActionsSynthesizer.h */; };
 		8F36546FCCCBE918C9088111 /* XCTestCaseDiscoveryUIAutomationDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = E29888B75A756D1CCD21604C /* XCTestCaseDiscoveryUIAutomationDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8FC4331C2C06A3E8B8F490E2 /* FBDebugCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7551CAEDF0C008C271F /* FBDebugCommands.m */; };
+		90107B3BBFBF3B073807D51B /* HTTPLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DC8D249131D30060D7EB /* HTTPLogging.h */; };
+		908767A5CCB6552156CDAFB3 /* XCTAttachmentManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D80202DC5D679EF37896431 /* XCTAttachmentManager.h */; };
 		914D7116A5BF672ACC7F1CE6 /* XCUIInterruptionMonitoring-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 44019CB45CF491B5FDAB8213 /* XCUIInterruptionMonitoring-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		918A48693FF49E932FDFE3AE /* FBElementHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 715A84CD2DD92AD3007134CC /* FBElementHelpers.h */; };
+		91FF05D51401D1F1A88FB0B0 /* FBWatchHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = C1CFF432CCF46627AB7315F9 /* FBWatchHTTPServer.m */; };
+		923B2C779F413A9EB7023AC5 /* XCUIElement+FBVisibleFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 71AE3CF62D38EE8E0039FC36 /* XCUIElement+FBVisibleFrame.m */; };
+		92A632860C8133ADDD5DE5F4 /* LRUCacheNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 71414ED12670A1ED003A8C5D /* LRUCacheNode.h */; };
+		92DC81D2F6E58386AC592482 /* FBXCTestDaemonsProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = EE35AD7A1E3B80C000A02D78 /* FBXCTestDaemonsProxy.m */; };
+		932D338E506BD3EDDABBDEA9 /* XCTNSPredicateExpectationObject-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACEC1E3B77D600A02D78 /* XCTNSPredicateExpectationObject-Protocol.h */; };
+		93B85BB5737C85F650FF772F /* WDATypingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912F32C353FE7C3E7C841405 /* WDATypingIntegrationTests.swift */; };
+		93D5C4C8442EFE91D70780CC /* FBScreen.h in Headers */ = {isa = PBXBuildFile; fileRef = 715AFABF1FFA29180053896D /* FBScreen.h */; };
+		9452D57FE97CB2ECED093B9F /* FBAccessibilityTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = B316351E2DDF0D0B007D9317 /* FBAccessibilityTraits.h */; };
+		9472D6847DFCF79A29E201A1 /* FBFailureProofTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = EE6A89391D0B38640083E92B /* FBFailureProofTestCase.m */; };
 		94D6CDC7620D8C6E67BF2E61 /* XCTMessagingChannel_RunnerToIDE-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 100F37231BF17CA9BB91DF16 /* XCTMessagingChannel_RunnerToIDE-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94F8CA38DB16452CC3A8DCB4 /* _TtC10XCTestCore19XCTReportingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DFEF3D0F3F006AC53F9E525 /* _TtC10XCTestCore19XCTReportingContext.h */; };
+		9551664006A016AA225E7E5F /* XCUIElement+FBIsVisible.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7471CAEDF0C008C271F /* XCUIElement+FBIsVisible.h */; };
+		95A597B8CC694006DDE49999 /* XCUIApplication+FBAlert.h in Headers */ = {isa = PBXBuildFile; fileRef = 719CD8FA2126C88B00C7D0C2 /* XCUIApplication+FBAlert.h */; };
+		95CACF0F523461A0E584B3D9 /* XCTestCaseUIAutomationDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 49D8AC825D239A4A1D834F62 /* XCTestCaseUIAutomationDelegate-Protocol.h */; };
+		9624FBB23087B3E9C5489888 /* FBClassChainQueryParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 71A7EAF81E224648001DA4F2 /* FBClassChainQueryParser.m */; };
+		96F629258D7707B90D3E0456 /* FBResponsePayload.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7831CAEDF0C008C271F /* FBResponsePayload.m */; };
 		9709D6A72EB272D0EB6AD51B /* XCTReportingSession.h in Headers */ = {isa = PBXBuildFile; fileRef = CB69A2606052D5979C5A436F /* XCTReportingSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		97A4C24037304C59C4466337 /* FBXCDeviceEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 13DE7A48287C4005003243C6 /* FBXCDeviceEvent.m */; };
+		97AB752A8043A962100DB4EB /* FBElementCache.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB77B1CAEDF0C008C271F /* FBElementCache.h */; };
+		980947E62D1AC9C4588F21C1 /* XCUIApplication+FBHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = AD6C269B1CF2494200F8B5FF /* XCUIApplication+FBHelpers.m */; };
+		980DFA4D113229070611E023 /* XCTMessagingChannel_IDEToRunner-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B3F8E1F3F489A3A94A61ADB /* XCTMessagingChannel_IDEToRunner-Protocol.h */; };
 		983096F88976030E95E13362 /* XCTWaiterManager-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = CC227321769E70CDF7C2D38F /* XCTWaiterManager-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9891B08BAC7C4A6003B20E80 /* XCUIButtonConsole.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E09842154A44874C4E9CA01 /* XCUIButtonConsole.h */; };
+		995AE9FC06719B08D8971D6A /* XCUIElement+FBAccessibility.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7451CAEDF0C008C271F /* XCUIElement+FBAccessibility.h */; };
+		995DF7C1928C60D7AE02840D /* XCUIApplicationImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACFA1E3B77D600A02D78 /* XCUIApplicationImpl.h */; };
+		99BF9DF6BF6B424859BFCDE9 /* FBElementHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 715A84CE2DD92AD3007134CC /* FBElementHelpers.m */; };
+		9AA0E22033281B4EAA78BC51 /* FBCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 714EAA0B2673FDFE005C5B47 /* FBCapabilities.h */; };
+		9AB06AA2F92978172F499013 /* XCTRuntimeDiagnosticsPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = AD0DDEAB427BA845375C7384 /* XCTRuntimeDiagnosticsPolicy.h */; };
+		9B863AF4DB924A69D173FC7B /* XCAXClient_iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACB81E3B77D600A02D78 /* XCAXClient_iOS.h */; };
 		9BE258E6A383AF8BCB59C475 /* FBTVFocusIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A53731B41356D9B4E723A4D /* FBTVFocusIntegrationTests.m */; };
+		9C26D61DAA53AB413E9E8116 /* XCTestExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACD81E3B77D600A02D78 /* XCTestExpectation.h */; };
+		9C2F91D75A5E54901114CC23 /* XCUIApplication+FBQuiescence.m in Sources */ = {isa = PBXBuildFile; fileRef = 71C8E55025399A6B008572C1 /* XCUIApplication+FBQuiescence.m */; };
+		9C4F46F172F29F9875EADE15 /* XCTMacCatalystStatusProviding-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 42D2B5A0C490D9698C2A87A9 /* XCTMacCatalystStatusProviding-Protocol.h */; };
+		9D0C07E71C632403A35F8BDE /* FBScreenshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C9EAAA25E8415A00470CD8 /* FBScreenshot.h */; };
+		9D1DE17E7327477C24099DC7 /* XCTMessagingRole_UIAutomation-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 92182E4007B37665AB8CD88E /* XCTMessagingRole_UIAutomation-Protocol.h */; };
 		9D5C3F3CA977F4F964542F21 /* XCTRepetitionPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = A1291FF806FE75EDE239FE44 /* XCTRepetitionPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9D806BE84EDEFF2B9BC6F729 /* XCTCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = DB5400B170F08C71779CCD0E /* XCTCapabilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9D87A03130302556CA52D1D2 /* NSDictionary+FBUtf8SafeDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 716F0DA02A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.m */; };
+		9DFDA1423A4651A4DB9FE341 /* FBRuntimeUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7911CAEDF0C008C271F /* FBRuntimeUtils.h */; };
+		9E0FA3A0629DA5A53BDFDDA1 /* XCTMessagingRole_ProtectedResourceAuthorization-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = CCCBEAE654102DBB1C8C22CD /* XCTMessagingRole_ProtectedResourceAuthorization-Protocol.h */; };
+		9E914062BD3388A4F3B8100B /* FBXPathExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B2E0022733FB970074B002 /* FBXPathExtensions.m */; };
 		9E97481489FB2345F690578E /* XCTMessagingRole_HIDEventRecording-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 94D7F0C1E30FBDB5D2583908 /* XCTMessagingRole_HIDEventRecording-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F9218F11A1D06F8DCC8308B /* FBXCElementSnapshotWrapper+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 13DE7A5A287CA444003243C6 /* FBXCElementSnapshotWrapper+Helpers.m */; };
 		A0A7AB48F1A3AEEC70AF92D7 /* XCTMessagingRole_ForcePressureSupportQuerying-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = AA2351C66A4616534FB81AE4 /* XCTMessagingRole_ForcePressureSupportQuerying-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A14687C1A2FC70A2356B7839 /* XCUIApplicationImplReporter-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 221BC403F42F61DDB1F11DD0 /* XCUIApplicationImplReporter-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A14CB090646BCB0B50F213CF /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D7DD32943CAC7838F942ED5 /* ViewController.m */; };
+		A15C224F98CDB418E5727697 /* WDAAlertIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F75AEC6442F32A3C4394AD /* WDAAlertIntegrationTests.swift */; };
 		A1B2C3D41F001A00A1B0004 /* XCUIDevice+FBVoiceOver.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A1B2C3D41F001A00A1B0005 /* XCUIDevice+FBVoiceOver.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0002 /* XCUIDevice+FBVoiceOver.m */; };
 		A1B2C3D41F001A00A1B0006 /* XCUIDevice+FBVoiceOver.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -602,18 +873,37 @@
 		A1B2C3D41F001A00A1B0008 /* FBVoiceOverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0003 /* FBVoiceOverTests.m */; };
 		A1B2C3D4E5F600000000001B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000001A /* Assets.xcassets */; };
 		A1CB92379D590821A4D15953 /* XCUIRemoteDeviceRunner-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = F2034DFA5DEC7D26F32590EF /* XCUIRemoteDeviceRunner-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A1DA19AC32A89FD07350BEA6 /* XCTMessagingRole_TelemetrySending-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BA6647ADE7B44F13513065A /* XCTMessagingRole_TelemetrySending-Protocol.h */; };
+		A2CD45A0D42ADED8220DD2C7 /* XCUIElementQuery+FBHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E75E6C254824230099FC87 /* XCUIElementQuery+FBHelpers.m */; };
 		A2D5B2F38D9CBEF9AEF93568 /* XCTTestSelection.h in Headers */ = {isa = PBXBuildFile; fileRef = 42F7AB68482BA168011C52EA /* XCTTestSelection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A2DF15998691849E3DFF34FF /* XCTPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CA02992F03AE1E134F2CAF5 /* XCTPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A35E3A923D45D0474AE04949 /* XCUIApplicationPlatformServicesProviderDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FB001C1E84011C0096E5D8 /* XCUIApplicationPlatformServicesProviderDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A47A7F9E098C88328DF38A4C /* XCTElementSetTransformer-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BA7DD8C206D694B007C7C26 /* XCTElementSetTransformer-Protocol.h */; };
+		A47F8777C5C8D021B2AC910C /* XCTestDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACD61E3B77D600A02D78 /* XCTestDriver.h */; };
+		A4E298C22E485C133E5356E3 /* XCAXClient_iOS+FBSnapshotReqParams.m in Sources */ = {isa = PBXBuildFile; fileRef = 714E14B729805CAE00375DD7 /* XCAXClient_iOS+FBSnapshotReqParams.m */; };
+		A5005275246FC51C1332B7E5 /* XCUIApplication+FBQuiescence.h in Headers */ = {isa = PBXBuildFile; fileRef = 71C8E54F25399A6B008572C1 /* XCUIApplication+FBQuiescence.h */; };
+		A5353D849D394BC630839E59 /* XCUIElement+FBAccessibility.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7461CAEDF0C008C271F /* XCUIElement+FBAccessibility.m */; };
 		A5B1AF65212923D21E54560E /* XCUIButtonConsole.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E09842154A44874C4E9CA01 /* XCUIButtonConsole.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A648F711A5BECD8BE680AB79 /* WDAElementAttributeIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848B7B14F95EFE16EEC46045 /* WDAElementAttributeIntegrationTests.swift */; };
+		A72A2DF58BC103C624F84907 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 716C9342224D53A1004B8542 /* XCTest.framework */; };
 		A72A8752161D64BDB5290703 /* XCUISystem.h in Headers */ = {isa = PBXBuildFile; fileRef = DE39D4384E531299FAA143F7 /* XCUISystem.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A781B56952349EB47FBF0DAD /* XCTMessagingRole_SystemConfiguration-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EA24F4BE52B2520874E09BEF /* XCTMessagingRole_SystemConfiguration-Protocol.h */; };
+		A7F0DE38C7CB24D31857C7AE /* XCTSourceCodeContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 530D925D1492C4DF826B46BB /* XCTSourceCodeContext.h */; };
+		A8635BD557F97E6C29A0790E /* RoutingHTTPServer.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DCA724913C210060D7EB /* RoutingHTTPServer.h */; };
+		A893F1BC22A6066353FCD515 /* XCUIApplicationProcess+FBQuiescence.m in Sources */ = {isa = PBXBuildFile; fileRef = 71D475C12538F5A8008D9401 /* XCUIApplicationProcess+FBQuiescence.m */; };
+		A8CEAEFC8CC63F94DA0176A9 /* XCUIDevice+FBVoiceOver.h in Headers */ = {isa = PBXBuildFile; fileRef = A1B2C3D41F001A00A1B0001 /* XCUIDevice+FBVoiceOver.h */; };
 		A95AE6DC8C54B7E2C3CB2570 /* XCTMessagingRole_SelfDiagnosisIssueReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 74AA57E9A81B1B0515CB587F /* XCTMessagingRole_SelfDiagnosisIssueReporting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A967F44C38E10C0295AD08FF /* XCTMessagingRole_CapabilityExchange-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 62A682C55077710D1D90ABC3 /* XCTMessagingRole_CapabilityExchange-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A970B1FBC690CBE536636228 /* WebDriverAgentLib_watchOS.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1171249FE5D91AC5D797E5C /* WebDriverAgentLib_watchOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A9BCCC677A46E48D4D2B05A9 /* FBActiveAppDetectionPoint.m in Sources */ = {isa = PBXBuildFile; fileRef = 13815F6E2328D20400CDAB61 /* FBActiveAppDetectionPoint.m */; };
 		AAA213E600F40AB7F43D1015 /* WebDriverAgentLib_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 641EE6F82240C5CA00173FCB /* WebDriverAgentLib_tvOS.framework */; };
 		AABBCCDDEEFF001122334457 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AABBCCDDEEFF001122334456 /* SceneDelegate.m */; };
 		AB126E96C642B235EE02B4F1 /* _XCTestObservationPrivate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = C840A8703A7C8D48897E158A /* _XCTestObservationPrivate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AB8D3BCC12F3A47869D31341 /* XCTMessagingRole_TestExecution-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 209C65575782ECAA09892D2B /* XCTMessagingRole_TestExecution-Protocol.h */; };
+		AC3529AFA966E7202CB3B3B1 /* FBRoute.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7841CAEDF0C008C271F /* FBRoute.h */; };
 		AC8CA9AA80C6ECF4D1405F25 /* XCTMemoryCheckerDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EEB78C32D7E6DD6E4EBCD26 /* XCTMemoryCheckerDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ACA7E8FE7C086A9A6EF7CFDF /* SceneDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F719C2804F6473A9C4D3090 /* SceneDelegate.h */; };
+		ACAC30299CC830793EFFFC31 /* FBBaseActionsSynthesizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7140974D1FAE20EE008FB2C5 /* FBBaseActionsSynthesizer.m */; };
 		AD35D06C1CF1C35500870A75 /* WebDriverAgentLib.framework in Copy frameworks */ = {isa = PBXBuildFile; fileRef = EE158A991CBD452B00A3E3F0 /* WebDriverAgentLib.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AD6C26941CF2379700F8B5FF /* FBAlert.h in Headers */ = {isa = PBXBuildFile; fileRef = AD6C26921CF2379700F8B5FF /* FBAlert.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AD6C26951CF2379700F8B5FF /* FBAlert.m in Sources */ = {isa = PBXBuildFile; fileRef = AD6C26931CF2379700F8B5FF /* FBAlert.m */; };
@@ -621,6 +911,7 @@
 		AD6C26991CF2481700F8B5FF /* XCUIDevice+FBHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = AD6C26971CF2481700F8B5FF /* XCUIDevice+FBHelpers.m */; };
 		AD6C269C1CF2494200F8B5FF /* XCUIApplication+FBHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = AD6C269A1CF2494200F8B5FF /* XCUIApplication+FBHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AD6C269D1CF2494200F8B5FF /* XCUIApplication+FBHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = AD6C269B1CF2494200F8B5FF /* XCUIApplication+FBHelpers.m */; };
+		AD764F10E2F00090AEB802F2 /* XCUIElement+FBIsVisible.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7481CAEDF0C008C271F /* XCUIElement+FBIsVisible.m */; };
 		AD76723D1D6B7CC000610457 /* XCUIElement+FBTyping.h in Headers */ = {isa = PBXBuildFile; fileRef = AD76723B1D6B7CC000610457 /* XCUIElement+FBTyping.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AD76723E1D6B7CC000610457 /* XCUIElement+FBTyping.m in Sources */ = {isa = PBXBuildFile; fileRef = AD76723C1D6B7CC000610457 /* XCUIElement+FBTyping.m */; };
 		AD8D96F21D3C12990061268E /* WebDriverAgentLib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE158A991CBD452B00A3E3F0 /* WebDriverAgentLib.framework */; };
@@ -632,7 +923,10 @@
 		ADEF63AF1D09DEBE0070A7E3 /* FBRuntimeUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ADEF63AE1D09DEBE0070A7E3 /* FBRuntimeUtilsTests.m */; };
 		AEA08D6963D0F969992A56C3 /* XCTMemoryChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = AFD7929A5F0B45397F0D64CB /* XCTMemoryChecker.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AF13E087AA2FF233A495CD0A /* XCUIResetAuthorizationStatusOfProtectedResourcesInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A0B17F41E4461BBD09A2962 /* XCUIResetAuthorizationStatusOfProtectedResourcesInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AF4223DDBCC9EC79D4F9DC0D /* DDRange.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DC7B249131B00060D7EB /* DDRange.h */; };
+		AF4B652A13BCF1C08AD6ECA0 /* XCTSignpostListener-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F9351F7A43851CA5DFF47CD /* XCTSignpostListener-Protocol.h */; };
 		AF718FF9F916429C65A2FD11 /* XCTRuntimeIssueDetectionPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = B98A9F937EF98D6359FCCC7A /* XCTRuntimeIssueDetectionPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B1A18407C6600D9E8ABABD5A /* XCUIApplicationProcessDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 43FCB89739438814F43BCA24 /* XCUIApplicationProcessDelegate-Protocol.h */; };
 		B20597D3E9290B4E9ACB812B /* XCTReportingSessionIssueReporter-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 525D62A58488A52AA1BFE94A /* XCTReportingSessionIssueReporter-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B316351C2DDF0CF5007D9317 /* FBAccessibilityTraits.m in Sources */ = {isa = PBXBuildFile; fileRef = B316351B2DDF0CF5007D9317 /* FBAccessibilityTraits.m */; };
 		B316351D2DDF0CF5007D9317 /* FBAccessibilityTraits.m in Sources */ = {isa = PBXBuildFile; fileRef = B316351B2DDF0CF5007D9317 /* FBAccessibilityTraits.m */; };
@@ -640,28 +934,51 @@
 		B31635202DDF0D0B007D9317 /* FBAccessibilityTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = B316351E2DDF0D0B007D9317 /* FBAccessibilityTraits.h */; };
 		B63FBAF7421417011D724B6F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 722E62C63348A451A351524B /* Foundation.framework */; };
 		B6AB97EF303CCF15017EB07A /* XCUIApplicationProcessDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 43FCB89739438814F43BCA24 /* XCUIApplicationProcessDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B6B73CE709728984EF03361D /* FBFailureProofTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = EE6A89381D0B38640083E92B /* FBFailureProofTestCase.h */; };
+		B70EB4BDC07CE9EC58505E85 /* XCUIElement+FBCustomActions.h in Headers */ = {isa = PBXBuildFile; fileRef = F59CD6D22EF16E5E00F91287 /* XCUIElement+FBCustomActions.h */; };
+		B7509C0E6BE45A7CD4037555 /* FBReflectionUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 716C9DF927315D21005AD475 /* FBReflectionUtils.m */; };
 		B7D20D145132B8DBE1027475 /* XCTElementSnapshotProvider-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8B17452E38AA1AE03AE251 /* XCTElementSnapshotProvider-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B82CC2C629E56223A8C355B9 /* XCUIElement+FBSwiping.m in Sources */ = {isa = PBXBuildFile; fileRef = 71F5BE22252E576C00EE9EBA /* XCUIElement+FBSwiping.m */; };
+		B9FAD6E3F3AB201B59D6F8BD /* XCTestPrivateSymbols.h in Headers */ = {isa = PBXBuildFile; fileRef = EE6B64FB1D0F86EF00E85F5D /* XCTestPrivateSymbols.h */; };
 		BBB48B112970D60C5DBF4A79 /* XCUIElementTypeQueryProvider_Private-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = AF208CBAC82CDFF8B6F88867 /* XCUIElementTypeQueryProvider_Private-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BBBF2A41BA8B763552FCC5BD /* XCTMessagingChannel_RunnerToDaemon-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = A2793FE9DE63C687BB6E2D37 /* XCTMessagingChannel_RunnerToDaemon-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BC1470BF3E54F478DAEDF05D /* FBTCPSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 715557D1211DBCE700613B26 /* FBTCPSocket.h */; };
+		BC91C1F00C54FE2115DE983F /* FBRunLoopSpinner.m in Sources */ = {isa = PBXBuildFile; fileRef = EEE9B4711CD02B88009D2030 /* FBRunLoopSpinner.m */; };
 		BC91E1DAF79A56CFC4A77D6E /* XCTReportingSessionTestReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D6B33F48F089C945641DB3F /* XCTReportingSessionTestReporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BCC63D234BBBA7F8BF8E953D /* XCTRepetitionPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = A1291FF806FE75EDE239FE44 /* XCTRepetitionPolicy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BCC9E02491560712221045CC /* HTTPServer.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DC8B249131D30060D7EB /* HTTPServer.h */; };
+		BD2A5D43881B449E533D5800 /* UIKeyboardImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 648C10AA22AAAD9C00B81B9A /* UIKeyboardImpl.h */; };
+		BD8002B8812AF2CDD76BDF4D /* FBImageUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 7150348621A6DAD600A0F4BA /* FBImageUtils.m */; };
 		BE63FC311D9DD0A98874568B /* XCUIApplicationManaging-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 00834B3220005AD5A5ABEF7C /* XCUIApplicationManaging-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BEA2BBF8D2DB363E141B3BD3 /* XCUIIssueDiagnosticsProviding-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 55B3452AB887CADB7AD757A4 /* XCUIIssueDiagnosticsProviding-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BEA2FA45BED17FE03010FECD /* FBFindElementCommands.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7581CAEDF0C008C271F /* FBFindElementCommands.h */; };
 		BF9B191D841681A571BAFED1 /* _XCTestObservationPrivate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = C840A8703A7C8D48897E158A /* _XCTestObservationPrivate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BFF5D9B9446DD542E5D6017D /* XCTTagSelection.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2092D85A7C691F157B1971 /* XCTTagSelection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C040AE5F2E3B934E8EEAEE0F /* XCUIApplicationProcessDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 43FCB89739438814F43BCA24 /* XCUIApplicationProcessDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C07F140AF96143A0A5CAA2B0 /* XCTestCaseDiscoveryUIAutomationDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = E29888B75A756D1CCD21604C /* XCTestCaseDiscoveryUIAutomationDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C1414C29C836902466C4D6DB /* XCTestCastMethodNamesUIAutomationDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = A80A1C12FA9899367D316E8C /* XCTestCastMethodNamesUIAutomationDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C14FD6933C5E978E7E54F44D /* XCTMessagingRole_BundleRequesting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = C928E94CBC13E262D818C28E /* XCTMessagingRole_BundleRequesting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C154B8CD167DBE068EA74719 /* HTTPMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DC87249131D30060D7EB /* HTTPMessage.h */; };
+		C158CE0AD6EEBEA854454AA2 /* XCUIApplicationProcessManaging-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C710FE3AB9E9C22BD2A9E84 /* XCUIApplicationProcessManaging-Protocol.h */; };
 		C1ACCF2EAF1C402FDF4FEFFD /* XCTMessagingRole_PerformanceMeasurementReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B650ADFEEA2369A10F6C1F1 /* XCTMessagingRole_PerformanceMeasurementReporting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C22CA4AEE1C7395AE82B3BD3 /* XCTMessagingRole_PerformanceMeasurementReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B650ADFEEA2369A10F6C1F1 /* XCTMessagingRole_PerformanceMeasurementReporting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C2D22426DB9FCE6AD84FA16A /* RouteRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 97FFAEF000CE312DEBEA9385 /* RouteRequest.m */; };
+		C2F6BB3D8A49F762E5172768 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7155B419224D5B460042A993 /* libxml2.tbd */; };
+		C309FAE89D050C90496FB87B /* XCTRemoteSignpostListenerProxy-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E47AA1A44A4A3C6EDCB6804 /* XCTRemoteSignpostListenerProxy-Protocol.h */; };
 		C3A3578B56BF260A77EB1ECF /* XCUIAlertMonitoring-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = DB5797DE5A0B4E7EE3D166F7 /* XCUIAlertMonitoring-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C3E6942879518EC529341A25 /* XCTRemoteSignpostListenerProxy-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E47AA1A44A4A3C6EDCB6804 /* XCTRemoteSignpostListenerProxy-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C3F7218DAB6B07E34AFDDF44 /* WatchSpikeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE921136A147FD01D630869 /* WatchSpikeApp.swift */; };
 		C3FAD491D46BA2655FDD5861 /* XCUIDeviceAutomationModeInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CF2F53B94CC13C628FC7760 /* XCUIDeviceAutomationModeInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C47007FD2047EBF580060870 /* XCTMessagingChannel_RunnerToDaemon-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = A2793FE9DE63C687BB6E2D37 /* XCTMessagingChannel_RunnerToDaemon-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C4AECD675B9F43748D8091A3 /* XCTMessagingRole_SignpostRequesting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E2F683D8A6C6EAAEC8B080A /* XCTMessagingRole_SignpostRequesting-Protocol.h */; };
+		C4E500AC8CD81B4FE3A75EAE /* FBMathUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = EE1888391DA661C400307AA8 /* FBMathUtils.m */; };
 		C4FA6AE56892A53972967885 /* XCUIElementTypeQueryProvider_Private-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = AF208CBAC82CDFF8B6F88867 /* XCUIElementTypeQueryProvider_Private-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C5C5311BCBCCE031B27BA46D /* XCUIInterruptionMonitoring-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 44019CB45CF491B5FDAB8213 /* XCUIInterruptionMonitoring-Protocol.h */; };
+		C6ADE8E69FBFD7A0B63ECA06 /* FBCommandStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B155DB230711E900646AFB /* FBCommandStatus.m */; };
 		C6D271F7B0C019C71E4C44FB /* XCTMessagingRole_EventSynthesis-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E2F8B9A21359AC98424DDE0 /* XCTMessagingRole_EventSynthesis-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C6DA9297ADD961C826DD93B6 /* FBSession.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB78B1CAEDF0C008C271F /* FBSession.m */; };
 		C6E2082385DCBBF0D9E5F1DC /* XCTMessagingRole_CapabilityExchange-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 62A682C55077710D1D90ABC3 /* XCTMessagingRole_CapabilityExchange-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C74712EC760C30DF5D261DF0 /* FBElementTypeTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7901CAEDF0C008C271F /* FBElementTypeTransformer.m */; };
 		C7FF31C5247498FC5A1C2BE9 /* XCTIssueHandling-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = CD4DA0D55FD20614EDA82368 /* XCTIssueHandling-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C8350994D5FE05F8BE659171 /* XCTSignpostListener-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F9351F7A43851CA5DFF47CD /* XCTSignpostListener-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C845206222D5E79400EA68CB /* FBUnattachedAppLauncher.h in Headers */ = {isa = PBXBuildFile; fileRef = C8FB547722D4C1FC00B69954 /* FBUnattachedAppLauncher.h */; };
@@ -670,31 +987,73 @@
 		C8FB547422D3949C00B69954 /* LSApplicationWorkspace.h in Headers */ = {isa = PBXBuildFile; fileRef = C8FB547322D3949C00B69954 /* LSApplicationWorkspace.h */; };
 		C8FB547922D4C1FC00B69954 /* FBUnattachedAppLauncher.h in Headers */ = {isa = PBXBuildFile; fileRef = C8FB547722D4C1FC00B69954 /* FBUnattachedAppLauncher.h */; };
 		C8FB547A22D4C1FC00B69954 /* FBUnattachedAppLauncher.m in Sources */ = {isa = PBXBuildFile; fileRef = C8FB547822D4C1FC00B69954 /* FBUnattachedAppLauncher.m */; };
+		C931666B44D9F20B3A1026B0 /* XCAXClient_iOS+FBSnapshotReqParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 714E14B629805CAE00375DD7 /* XCAXClient_iOS+FBSnapshotReqParams.h */; };
 		CA1E428789B0D9CB9C874133 /* XCUIKnobControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C78201A2212BEA77979F4FF /* XCUIKnobControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CAA29EF94D29713540C57528 /* XCUIInterruptionMonitoring-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 44019CB45CF491B5FDAB8213 /* XCUIInterruptionMonitoring-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB1790B793BB813AF80F65DF /* XCUIElement+FBTVFocuse.h in Headers */ = {isa = PBXBuildFile; fileRef = 641EE7042240CDCF00173FCB /* XCUIElement+FBTVFocuse.h */; };
 		CB1BAB30928B638B300B4477 /* FBXCAccessibilityElementDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = 16223B3E144418CC980D160E /* FBXCAccessibilityElementDouble.m */; };
+		CC614CD0E2D7952E9F41C34F /* FBRunLoopSpinner.h in Headers */ = {isa = PBXBuildFile; fileRef = EEE9B4701CD02B88009D2030 /* FBRunLoopSpinner.h */; };
 		CC8FE434CEB79CCB5FB9961A /* XCTMessagingChannel_IDEToRunner-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B3F8E1F3F489A3A94A61ADB /* XCTMessagingChannel_IDEToRunner-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CD8224652860F7BB975C508B /* FBTVNavigationTracker-Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 64B26509228CE4FF002A5025 /* FBTVNavigationTracker-Private.h */; };
+		CDDEBD9F5F6A380C8D32D671 /* XCUIElement+FBTyping.h in Headers */ = {isa = PBXBuildFile; fileRef = AD76723B1D6B7CC000610457 /* XCUIElement+FBTyping.h */; };
+		CE3D815D09AD8E137CC18AA5 /* XCUIElement+FBScrolling.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7491CAEDF0C008C271F /* XCUIElement+FBScrolling.h */; };
 		CE4ACC757D04A9662BC1D2D0 /* XCTMessagingRole_AttachmentFutureResultStatusUpdating-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 10FBCE8B3A419B970DB7A5CE /* XCTMessagingRole_AttachmentFutureResultStatusUpdating-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CE57FBF0D8F391F113DAAB91 /* WebDriverAgentLib_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D1171249FE5D91AC5D797E5C /* WebDriverAgentLib_watchOS.framework */; };
+		CEA3AF02E2BFF31ABB97F6F0 /* WDADeviceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 646D714BC17FE9258CFBDF55 /* WDADeviceIntegrationTests.swift */; };
 		CF063E3902F2FF73D65CAAA9 /* XCUIAXNotificationHandling-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EA96C2FEDE73CB5148BA4949 /* XCUIAXNotificationHandling-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CFB0AFBC9F429B279C95F5BC /* FBAlertViewCommands.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7501CAEDF0C008C271F /* FBAlertViewCommands.h */; };
+		CFDBE0DF5D99CB310C7AFB01 /* XCUIApplicationProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACFB1E3B77D600A02D78 /* XCUIApplicationProcess.h */; };
 		D02E19924A93582C7F4F80AF /* _TtC10XCTestCore19XCTReportingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DFEF3D0F3F006AC53F9E525 /* _TtC10XCTestCore19XCTReportingContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D062CA5914608761FE002799 /* FBXCAXClientProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7157B290221DADD2001C348C /* FBXCAXClientProxy.m */; };
 		D101B194EE49F32110C394FD /* NSFastEnumeration-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 58156929D12ADE7DFE10116F /* NSFastEnumeration-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D1212325FDE77754EE503755 /* FBRouteRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7881CAEDF0C008C271F /* FBRouteRequest.m */; };
+		D142183578036F5FD5B9880B /* XCUIDevice+FBHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = AD6C26961CF2481700F8B5FF /* XCUIDevice+FBHelpers.h */; };
+		D14718959F7D46949859EEE6 /* FBDebugLogDelegateDecorator.m in Sources */ = {isa = PBXBuildFile; fileRef = EE7E27191D06C69F001BEC7B /* FBDebugLogDelegateDecorator.m */; };
+		D1DE06DF54156F744E364B5F /* FBDebugLogDelegateDecorator.h in Headers */ = {isa = PBXBuildFile; fileRef = EE7E27181D06C69F001BEC7B /* FBDebugLogDelegateDecorator.h */; };
+		D203F622C7C0D968F3BD2AAF /* XCUIPlatformApplicationServicesProviding-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BA71BCF1FDA482419CA8596 /* XCUIPlatformApplicationServicesProviding-Protocol.h */; };
+		D209CAD44BCD87BDF8BE30B1 /* libAccessibility.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7155B41A224D5B480042A993 /* libAccessibility.tbd */; };
 		D227087A470351BB2BD58376 /* XCTWaiterWait.h in Headers */ = {isa = PBXBuildFile; fileRef = 8566F4674B2CF640A678C952 /* XCTWaiterWait.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D22F20BC746C639DCDD2F69C /* XCTMessagingRole_ProcessMonitoring-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B43D656732067585371ADD31 /* XCTMessagingRole_ProcessMonitoring-Protocol.h */; };
 		D234E390A449065FA22F28EF /* XCUIAccessibilityInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = D47DD8BF27FE639742EA2E3E /* XCUIAccessibilityInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D27A70EE9F480A3D1CDDB389 /* XCTMessagingRole_PerformanceMeasurementReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B650ADFEEA2369A10F6C1F1 /* XCTMessagingRole_PerformanceMeasurementReporting-Protocol.h */; };
 		D2A463EE081CED34AA988123 /* XCTTestIdentifierSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E079E00FE148476F94BC42F /* XCTTestIdentifierSet.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D2B83B27DAB80FE235285D2F /* FBElement.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7791CAEDF0C008C271F /* FBElement.h */; };
+		D3634A090D755F8993EDD3E5 /* XCUIApplicationImplReporter-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 221BC403F42F61DDB1F11DD0 /* XCUIApplicationImplReporter-Protocol.h */; };
+		D40D635A4ABBC79829A0D590 /* FBElementTypeTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB78F1CAEDF0C008C271F /* FBElementTypeTransformer.h */; };
 		D42BE4D9C5231F13BD465DBD /* XCTWaiterManager-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = CC227321769E70CDF7C2D38F /* XCTWaiterManager-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D43AF1E150975634F3AFF329 /* FBSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 71F3E7D225417FF400E0C22B /* FBSettings.h */; };
+		D501A3AAD35E78A425759794 /* XCTFuture.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F044AD574A9837C04F833CB /* XCTFuture.h */; };
+		D607535858B02C328B9D6E33 /* FBUnknownCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7651CAEDF0C008C271F /* FBUnknownCommands.m */; };
 		D62A8FB1FC7E22F8915C845B /* XCTMessagingRole_ActivityReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EED93C03F27978174C7333C1 /* XCTMessagingRole_ActivityReporting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D66C59BA2D0F80023352664F /* FBScreenRecordingRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BB58E62B96328700CB9BFE /* FBScreenRecordingRequest.h */; };
+		D6B48E8EA65EF8401D794A6B /* FBOrientationCommands.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB75C1CAEDF0C008C271F /* FBOrientationCommands.h */; };
+		D7C384A684F2F0F2CAC2861D /* XCUIElement+FBMinMax.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E04133A2DF1E15900AF007C /* XCUIElement+FBMinMax.h */; };
+		D869B58002B298F70EE06B98 /* XCUIElement+FBMinMax.m in Sources */ = {isa = PBXBuildFile; fileRef = 0E0413372DF1E15100AF007C /* XCUIElement+FBMinMax.m */; };
+		D87509BF0784FDFFD57A2EF5 /* FBNotificationsHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 719DCF142601EAFB000E765F /* FBNotificationsHelper.m */; };
 		D9D6F0D054AF1BDAAFD0E667 /* XCUIXcodeApplicationManaging-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 30ABCB5051B826025F77E360 /* XCUIXcodeApplicationManaging-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9FF15E0009D95996128C5E1 /* WDASessionIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27D14C409E982099568175D1 /* WDASessionIntegrationTests.swift */; };
+		DA26A56D4FE01CA1FAF6F1E7 /* FBOrientationCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB75D1CAEDF0C008C271F /* FBOrientationCommands.m */; };
+		DADC5E6FD3E80449EE5B5841 /* NSString+FBVisualLength.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0D1F5F1EBCDCF7006A3123 /* NSString+FBVisualLength.h */; };
 		DAFD9ED6842CE53DBAF9F8EB /* XCTMessagingRole_DebugLogging-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 471DF7EE3C63C3069FB9D40D /* XCTMessagingRole_DebugLogging-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DBD3777FD8EAD997F04F52A2 /* XCTMessagingRole_ProcessMonitoring-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B43D656732067585371ADD31 /* XCTMessagingRole_ProcessMonitoring-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD44723878134A0A42473299 /* XCUIApplication.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACF91E3B77D600A02D78 /* XCUIApplication.h */; };
+		DE2D708340ED70EBF9244D0F /* NSDictionary+FBUtf8SafeDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 716F0D9F2A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.h */; };
 		DE75F01A64FBC6A58012E6B4 /* FBXCElementSnapshotDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = F46F78706C5157469122F730 /* FBXCElementSnapshotDouble.m */; };
+		DEFE56CC1A4EC88BCCD9BD6D /* WDAWatchHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F28D3CD9DDC2E54DB115316 /* WDAWatchHTTPClient.swift */; };
 		DF0FF8388E4C4CFDD1746BF7 /* XCTRunnerIDESessionDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A5EC96F8F1C3888B9E24FAA /* XCTRunnerIDESessionDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DFB9638AF3480053CA39AB3C /* XCUIElement+FBVisibleFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 71AE3CF52D38EE8E0039FC36 /* XCUIElement+FBVisibleFrame.h */; };
 		DFC01347FC6A5308D5C6765D /* XCTMessagingRole_MemoryTesting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 13D863EAE7F6F8B7E42D99B9 /* XCTMessagingRole_MemoryTesting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E046D4602540FA7272DCBCB4 /* XCUIElement+FBWebDriverAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = EEE376481D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.m */; };
+		E101F1B19A8079EAD8457C0C /* WDAWatchIntegrationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24BD02A29E3B2EB1D57FDD29 /* WDAWatchIntegrationTestCase.swift */; };
 		E19946F12AD25E3EFFD89A36 /* XCTAggregateSuiteRunStatistics.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AA21CEBA6E92AAC73FB6A48 /* XCTAggregateSuiteRunStatistics.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1C6D95706F0F87BE535E332 /* WDAClickIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C878996F07A9B26E66FC4EAC /* WDAClickIntegrationTests.swift */; };
 		E1E21D96BC2347D9AC01269D /* XCUIApplicationProcessTracker-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3238E68F292452D8234153F1 /* XCUIApplicationProcessTracker-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E1F9DBCDED4574CBF53450BE /* XCUIApplicationAutomationSessionProviding-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 603D97F0F9A5B9D4E6442BF2 /* XCUIApplicationAutomationSessionProviding-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E29A0688606C24973775C64D /* XCTTestIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 831F292661C60B68B557F14D /* XCTTestIdentifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E2D4264AE37BE5A1EDEA72AF /* XCTReportingSessionTestContainer-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = D5D58975822CD58C8FEF7FEB /* XCTReportingSessionTestContainer-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E2EEFB9B3D049FB31AF1CFF4 /* XCUISiriService.h in Headers */ = {isa = PBXBuildFile; fileRef = 7076779B6AB29D5AAB5E4D33 /* XCUISiriService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E30D52357A950271BD8EF346 /* XCTReportingSessionTestContainer-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = D5D58975822CD58C8FEF7FEB /* XCTReportingSessionTestContainer-Protocol.h */; };
+		E3653A8F329E8AB4061B0310 /* FBConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9B76A11CF7A43900275851 /* FBConfiguration.h */; };
 		E444DC65249131890060D7EB /* HTTPErrorResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DC59249131880060D7EB /* HTTPErrorResponse.h */; };
 		E444DC67249131890060D7EB /* HTTPDataResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = E444DC5B249131880060D7EB /* HTTPDataResponse.m */; };
 		E444DC6C249131890060D7EB /* HTTPDataResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DC60249131890060D7EB /* HTTPDataResponse.h */; };
@@ -736,16 +1095,32 @@
 		E444DCD224917A5E0060D7EB /* HTTPErrorResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = E444DC61249131890060D7EB /* HTTPErrorResponse.m */; };
 		E444DCD424917A5E0060D7EB /* DDNumber.m in Sources */ = {isa = PBXBuildFile; fileRef = E444DC7F249131B00060D7EB /* DDNumber.m */; };
 		E444DCD624917A5E0060D7EB /* DDRange.m in Sources */ = {isa = PBXBuildFile; fileRef = E444DC7E249131B00060D7EB /* DDRange.m */; };
+		E47C0E7ED1200567EC7DA4FC /* XCUIApplicationProcess+FBQuiescence.h in Headers */ = {isa = PBXBuildFile; fileRef = 71D475C02538F5A8008D9401 /* XCUIApplicationProcess+FBQuiescence.h */; };
+		E4F38E2031A5FB938468C536 /* XCTIssueHandling-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = CD4DA0D55FD20614EDA82368 /* XCTIssueHandling-Protocol.h */; };
 		E571286CBEA891946EED7C70 /* XCTSourceCodeLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 81BB54ECBFB5B7B680BB5D4F /* XCTSourceCodeLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E608A983E2E6A6A1A46A6E91 /* XCUIDeviceAutomationModeInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CF2F53B94CC13C628FC7760 /* XCUIDeviceAutomationModeInterface-Protocol.h */; };
+		E62AED48CAE64088C1E7498B /* XCUIElement+FBPickerWheel.h in Headers */ = {isa = PBXBuildFile; fileRef = 7136A4771E8918E60024FC3D /* XCUIElement+FBPickerWheel.h */; };
+		E6B214145FE46BBFD824FAE7 /* FBMathUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = EE1888381DA661C400307AA8 /* FBMathUtils.h */; };
 		E78F581F8E7530B24AC31A8B /* XCTMessagingRole_UIAutomation-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 92182E4007B37665AB8CD88E /* XCTMessagingRole_UIAutomation-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E7DF976BD298CC4815946781 /* WDAUnknownCommandIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C90E6C9835DC2FDB3CB6501 /* WDAUnknownCommandIntegrationTests.swift */; };
 		E8E894CD81C41AC4467A4F4C /* XCTCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = DB5400B170F08C71779CCD0E /* XCTCapabilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E8E917CF8B3ADB4F24CD0B96 /* _TtC10XCTestCore19XCTReportingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DFEF3D0F3F006AC53F9E525 /* _TtC10XCTestCore19XCTReportingContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E8FE8448E0118775E7C789CC /* FBXMLGenerationOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 714D88CA2733FB970074A925 /* FBXMLGenerationOptions.h */; };
 		E951C9DC61A9C5B886B758C7 /* XCTSourceCodeLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 81BB54ECBFB5B7B680BB5D4F /* XCTSourceCodeLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E95851D7BE5DAF50DAF15382 /* XCTMessagingRole_UIAutomationRunnerEventReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 4951F55904679A17CDFEC186 /* XCTMessagingRole_UIAutomationRunnerEventReporting-Protocol.h */; };
 		E974ABEF5CF3E0EF12867E4B /* XCUIApplicationProcessManaging-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C710FE3AB9E9C22BD2A9E84 /* XCUIApplicationProcessManaging-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E9BF93350E324F63CF400B58 /* XCTSkippedTestContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C32C75CC17179B347DF6F78 /* XCTSkippedTestContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E9D0AEDEF6071D720A134E36 /* XCTestCaseUIAutomationDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 49D8AC825D239A4A1D834F62 /* XCTestCaseUIAutomationDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E9EC95AE6425FDB4048F050F /* XCTTestSelection.h in Headers */ = {isa = PBXBuildFile; fileRef = 42F7AB68482BA168011C52EA /* XCTTestSelection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA02B947C3E2FF3DDF8C66BB /* FBElementUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 713C6DCE1DDC772A00285B92 /* FBElementUtils.m */; };
+		EA230F78EA120ADDB665D4A1 /* XCTCapabilitiesProviding-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B069904A4086E12556F1FAB /* XCTCapabilitiesProviding-Protocol.h */; };
+		EAAF5A671C1E9FF099797CDB /* XCUIDevice+FBRotation.m in Sources */ = {isa = PBXBuildFile; fileRef = EEE3763E1D59F81400ED88DD /* XCUIDevice+FBRotation.m */; };
+		EAC0099EAC9722C516860CB3 /* FBTouchActionCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = 71241D7A1FAE3D2500B9559F /* FBTouchActionCommands.m */; };
 		ECC4ABB5477FBA3D442559B1 /* AppDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 242FCA9DD0E30D748E0A1969 /* AppDelegate.h */; };
+		ED055540E72DDD419F88EEA4 /* XCUIApplicationProcessDelay.m in Sources */ = {isa = PBXBuildFile; fileRef = 6385F4A5220A40760095BBDB /* XCUIApplicationProcessDelay.m */; };
+		ED342D194B20A206864675B2 /* XCUIApplication+FBUIInterruptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 716C9DFE27315EFF005AD475 /* XCUIApplication+FBUIInterruptions.h */; };
+		EDB13FDB5D8220A65560629B /* HTTPErrorResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DC59249131880060D7EB /* HTTPErrorResponse.h */; };
+		EDC993E0858F89F73D8E9DF8 /* FBCustomCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7531CAEDF0C008C271F /* FBCustomCommands.m */; };
 		EDF7C92DC3B9860FC08BE3DC /* XCTFuture.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F044AD574A9837C04F833CB /* XCTFuture.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EE006EAD1EB99B15006900A4 /* FBElementVisibilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EE006EAC1EB99B15006900A4 /* FBElementVisibilityTests.m */; };
 		EE05BAFA1D13003C00A3EB00 /* FBKeyboardTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EE05BAF91D13003C00A3EB00 /* FBKeyboardTests.m */; };
@@ -812,6 +1187,7 @@
 		EE2202131ECC612200A29571 /* FBIntegrationTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = EE1E06D91D1808C2007CF043 /* FBIntegrationTestCase.m */; };
 		EE2202171ECC612200A29571 /* WebDriverAgentLib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE158A991CBD452B00A3E3F0 /* WebDriverAgentLib.framework */; };
 		EE22021E1ECC618900A29571 /* FBTapTest.m in Sources */ = {isa = PBXBuildFile; fileRef = EE26409A1D0EB5E8009BE6B0 /* FBTapTest.m */; };
+		EE22974A8F641FA94DCBCB3E /* HTTPDataResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DC60249131890060D7EB /* HTTPDataResponse.h */; };
 		EE26409D1D0EBA25009BE6B0 /* FBElementAttributeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EE26409C1D0EBA25009BE6B0 /* FBElementAttributeTests.m */; };
 		EE35AD151E3B77D600A02D78 /* CDStructures.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACA41E3B77D600A02D78 /* CDStructures.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EE35AD281E3B77D600A02D78 /* XCApplicationQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACB71E3B77D600A02D78 /* XCApplicationQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -904,27 +1280,59 @@
 		EEE3764A1D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = EEE376481D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.m */; };
 		EEE9B4721CD02B88009D2030 /* FBRunLoopSpinner.h in Headers */ = {isa = PBXBuildFile; fileRef = EEE9B4701CD02B88009D2030 /* FBRunLoopSpinner.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EEE9B4731CD02B88009D2030 /* FBRunLoopSpinner.m in Sources */ = {isa = PBXBuildFile; fileRef = EEE9B4711CD02B88009D2030 /* FBRunLoopSpinner.m */; };
+		EF1FE277EB1903306193C6F0 /* XCUILocation.h in Headers */ = {isa = PBXBuildFile; fileRef = A8230FDD93639CE2E9EFE311 /* XCUILocation.h */; };
+		EF47E4D736053EE07FC03D3D /* FBXCTestDaemonsProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35AD791E3B80C000A02D78 /* FBXCTestDaemonsProxy.h */; };
+		EF76D1EC388A2B9A5AA7F20B /* XCUIScreen.h in Headers */ = {isa = PBXBuildFile; fileRef = 7119097B2152580600BA3C7E /* XCUIScreen.h */; };
+		EF91D95D6C7F476683BB2C70 /* FBImageProcessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 63CCF91121ECE4C700E94ABD /* FBImageProcessor.m */; };
+		EFDC22605B42890EBC4709CE /* XCTMessagingRole_ActivityReporting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EED93C03F27978174C7333C1 /* XCTMessagingRole_ActivityReporting-Protocol.h */; };
+		F01BCAAFC7CDDE89BD087347 /* FBFindElementCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7591CAEDF0C008C271F /* FBFindElementCommands.m */; };
+		F036DAC96136D88F0427B9CB /* XCUIElementTypeQueryProvider_Private-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = AF208CBAC82CDFF8B6F88867 /* XCUIElementTypeQueryProvider_Private-Protocol.h */; };
 		F03F1D8CFEA1D26423192BF0 /* XCTExpectedFailureContextManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AF0584AD9B6D0A57012C978 /* XCTExpectedFailureContextManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F044875736461509BDFC72B9 /* XCTMessagingRole_HIDEventRecording-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 94D7F0C1E30FBDB5D2583908 /* XCTMessagingRole_HIDEventRecording-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F0F7B8DFB14C9DFC86DFFBFD /* RouteResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DCA124913C210060D7EB /* RouteResponse.h */; };
 		F12C29FCEE471095C1FA8A7A /* XCUIDeviceEventAndStateInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 003AAAB9CB5FB38E45E05F6F /* XCUIDeviceEventAndStateInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F12D854E1692CE11249A9762 /* XCTReportingSession.h in Headers */ = {isa = PBXBuildFile; fileRef = CB69A2606052D5979C5A436F /* XCTReportingSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F13426E5482242AFB787BE4A /* FBActiveAppDetectionPoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 13815F6D2328D20400CDAB61 /* FBActiveAppDetectionPoint.h */; };
+		F19C884FA08D896CD83DD1EB /* XCTTestSelection.h in Headers */ = {isa = PBXBuildFile; fileRef = 42F7AB68482BA168011C52EA /* XCTTestSelection.h */; };
+		F1AAE4976535FBAC979A1DF3 /* XCUIRemoteDeviceRunner-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = F2034DFA5DEC7D26F32590EF /* XCUIRemoteDeviceRunner-Protocol.h */; };
+		F1BED88CC398B8B1C180238A /* XCTestCastMethodNamesUIAutomationDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = A80A1C12FA9899367D316E8C /* XCTestCastMethodNamesUIAutomationDelegate-Protocol.h */; };
 		F1C141214BED72E3F7E4C2D6 /* XCTCapabilitiesProviding-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B069904A4086E12556F1FAB /* XCTCapabilitiesProviding-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F21813E3FBD5D4DFDB85922A /* XCUIEventRecording-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = B38AC76FAF9275974F272DE9 /* XCUIEventRecording-Protocol.h */; };
+		F26F431FE78FBABA2139F7F7 /* FBAccessibilityTraits.m in Sources */ = {isa = PBXBuildFile; fileRef = B316351B2DDF0CF5007D9317 /* FBAccessibilityTraits.m */; };
 		F49E5675DB57AA9F67C662E2 /* XCTElementSnapshotAttributeDataSource-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 38E3FC945B8BF6F6AFD73EE7 /* XCTElementSnapshotAttributeDataSource-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4E8FB5A2EB57854EB6A00E9 /* _XCTestObservationInternal-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F8E4FAAC62765A3405F90D6 /* _XCTestObservationInternal-Protocol.h */; };
 		F59CD6D42EF16E5E00F91287 /* XCUIElement+FBCustomActions.h in Headers */ = {isa = PBXBuildFile; fileRef = F59CD6D22EF16E5E00F91287 /* XCUIElement+FBCustomActions.h */; };
 		F59CD6D52EF16E5E00F91287 /* XCUIElement+FBCustomActions.m in Sources */ = {isa = PBXBuildFile; fileRef = F59CD6D32EF16E5E00F91287 /* XCUIElement+FBCustomActions.m */; };
 		F59CD6D62EF16E5E00F91287 /* XCUIElement+FBCustomActions.h in Headers */ = {isa = PBXBuildFile; fileRef = F59CD6D22EF16E5E00F91287 /* XCUIElement+FBCustomActions.h */; };
 		F59CD6D72EF16E5E00F91287 /* XCUIElement+FBCustomActions.m in Sources */ = {isa = PBXBuildFile; fileRef = F59CD6D32EF16E5E00F91287 /* XCUIElement+FBCustomActions.m */; };
 		F59DE3E26459A83A374E5B62 /* XCTReportingSessionTestReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D6B33F48F089C945641DB3F /* XCTReportingSessionTestReporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F63D9EB2A1C26B5DCB989CA3 /* FBElementCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7571CAEDF0C008C271F /* FBElementCommands.m */; };
 		F64EF1C56AE8F27435B2FD09 /* XCUIApplicationRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 75438FC693C39052C82C27DB /* XCUIApplicationRegistry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F7010B261A861C5C63D59273 /* XCTWaiterManagement-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACF71E3B77D600A02D78 /* XCTWaiterManagement-Protocol.h */; };
+		F7829FBAAA05B01157C99C0D /* XCTMessagingRole_UserPresence-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 036CD60C5DFA1644E3D51289 /* XCTMessagingRole_UserPresence-Protocol.h */; };
+		F788D281B204A55EA3CB4A00 /* XCTRuntimeIssueDetectionPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = B98A9F937EF98D6359FCCC7A /* XCTRuntimeIssueDetectionPolicy.h */; };
+		F876324AFD3617FFCFC479C3 /* FBScreenRecordingPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BB58DF2B9631F100CB9BFE /* FBScreenRecordingPromise.h */; };
 		F8AA3C37F248FC3985BAFA23 /* XCTAttachmentManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D80202DC5D679EF37896431 /* XCTAttachmentManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F93EF507E81BB1A6697308CE /* NSExpression+FBFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 71555A3C1DEC460A007D4A8B /* NSExpression+FBFormat.m */; };
 		F9EA3F69A986D8D59A5122DB /* XCUIElementEventTarget-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 0DC62BF635704E9C72AF533E /* XCUIElementEventTarget-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FA2CCA58B4A82D18E0F57C74 /* XCTMemoryChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = AFD7929A5F0B45397F0D64CB /* XCTMemoryChecker.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FAAD39E3C21C0415EE00F703 /* XCTestCastMethodNamesUIAutomationDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = A80A1C12FA9899367D316E8C /* XCTestCastMethodNamesUIAutomationDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FAC85D261CAD26DB5F9D804C /* XCUIPlatformApplicationServicesProviding-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BA71BCF1FDA482419CA8596 /* XCUIPlatformApplicationServicesProviding-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FBAFC553152CE132D6CB98E5 /* XCUIDeviceDelayedAttachmentTransferSupportInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C19CEEEC9858A106061D1F8 /* XCUIDeviceDelayedAttachmentTransferSupportInterface-Protocol.h */; };
 		FBB82323D9D57F069440BF94 /* XCTMessagingRole_SystemConfiguration-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EA24F4BE52B2520874E09BEF /* XCTMessagingRole_SystemConfiguration-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FBDF04E5916B91FCEC0190CB /* Route.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DCA324913C210060D7EB /* Route.h */; };
+		FBF064E4D96CFCD08E1F4EF7 /* XCUIDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = EE35ACFD1E3B77D600A02D78 /* XCUIDevice.h */; };
 		FC607DB5132FEF425237267B /* XCTMessagingRole_MemoryTesting-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 13D863EAE7F6F8B7E42D99B9 /* XCTMessagingRole_MemoryTesting-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FC73EE781D24A598B44C3337 /* XCUIElement+FBScrolling.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB74A1CAEDF0C008C271F /* XCUIElement+FBScrolling.m */; };
+		FD89236D119E129E8CEBDBCD /* XCTMessagingRole_HIDEventRecording-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 94D7F0C1E30FBDB5D2583908 /* XCTMessagingRole_HIDEventRecording-Protocol.h */; };
 		FDCF9A86C0531A1240ADAD4D /* XCTMessagingRole_UserPresence-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 036CD60C5DFA1644E3D51289 /* XCTMessagingRole_UserPresence-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FDD8D03066D7654072A51ABF /* FBUnattachedAppLauncher.h in Headers */ = {isa = PBXBuildFile; fileRef = C8FB547722D4C1FC00B69954 /* FBUnattachedAppLauncher.h */; };
+		FDEB571007C83EC56F365EB3 /* XCTMessagingRole_EventSynthesis-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E2F8B9A21359AC98424DDE0 /* XCTMessagingRole_EventSynthesis-Protocol.h */; };
+		FEB143DBE613795D4F8693B4 /* FBSession.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB78A1CAEDF0C008C271F /* FBSession.h */; };
 		FEC3A97A4929115A192F947A /* XCUIDeviceEventAndStateInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 003AAAB9CB5FB38E45E05F6F /* XCUIDeviceEventAndStateInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FEC52AE4F35AD38D3AC2659F /* RoutingConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = E444DCA524913C210060D7EB /* RoutingConnection.h */; };
+		FFA7672B731B57AB9283DD40 /* FBXCElementSnapshotWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 13DE7A53287CA1EC003243C6 /* FBXCElementSnapshotWrapper.h */; };
+		FFD70914E6D8CE5D4FED4B69 /* XCUIAXNotificationHandling-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EA96C2FEDE73CB5148BA4949 /* XCUIAXNotificationHandling-Protocol.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -941,6 +1349,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 641EE5D52240C5CA00173FCB;
 			remoteInfo = WebDriverAgentLib_tvOS;
+		};
+		844B4A2ED5B8EE2FDD98DAD6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 91F9DAE11B99DBC2001349B2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 95186DE2383671DFA81D7FCB;
+			remoteInfo = WebDriverAgentLib_watchOS;
 		};
 		87B9178994EC282C279A8242 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -962,6 +1377,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 641EE5D52240C5CA00173FCB;
 			remoteInfo = WebDriverAgentLib_tvOS;
+		};
+		D564026BFC4C47F0187BD64C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 91F9DAE11B99DBC2001349B2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9D6B02D8FC050BAF7159284F;
+			remoteInfo = IntegrationApp_watchOS;
 		};
 		EE158B5B1CBD462500A3E3F0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1015,6 +1437,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		3265D8138FA0376B6226B963 /* Copy frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				A970B1FBC690CBE536636228 /* WebDriverAgentLib_watchOS.framework in CopyFiles */,
+			);
+			name = "Copy frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		641EE3472240C1EF00173FCB /* Copy frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1049,6 +1482,7 @@
 		0E0413372DF1E15100AF007C /* XCUIElement+FBMinMax.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIElement+FBMinMax.m"; sourceTree = "<group>"; };
 		0E04133A2DF1E15900AF007C /* XCUIElement+FBMinMax.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIElement+FBMinMax.h"; sourceTree = "<group>"; };
 		0F044AD574A9837C04F833CB /* XCTFuture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTFuture.h; sourceTree = "<group>"; };
+		0F28D3CD9DDC2E54DB115316 /* WDAWatchHTTPClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WDAWatchHTTPClient.swift; sourceTree = "<group>"; };
 		0F719C2804F6473A9C4D3090 /* SceneDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
 		0F8E4FAAC62765A3405F90D6 /* _XCTestObservationInternal-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "_XCTestObservationInternal-Protocol.h"; sourceTree = "<group>"; };
 		100F37231BF17CA9BB91DF16 /* XCTMessagingChannel_RunnerToIDE-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingChannel_RunnerToIDE-Protocol.h"; sourceTree = "<group>"; };
@@ -1077,6 +1511,10 @@
 		209C65575782ECAA09892D2B /* XCTMessagingRole_TestExecution-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_TestExecution-Protocol.h"; sourceTree = "<group>"; };
 		221BC403F42F61DDB1F11DD0 /* XCUIApplicationImplReporter-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCUIApplicationImplReporter-Protocol.h"; sourceTree = "<group>"; };
 		242FCA9DD0E30D748E0A1969 /* AppDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		24BD02A29E3B2EB1D57FDD29 /* WDAWatchIntegrationTestCase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WDAWatchIntegrationTestCase.swift; sourceTree = "<group>"; };
+		27D14C409E982099568175D1 /* WDASessionIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WDASessionIntegrationTests.swift; sourceTree = "<group>"; };
+		28F75AEC6442F32A3C4394AD /* WDAAlertIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WDAAlertIntegrationTests.swift; sourceTree = "<group>"; };
+		2B2328F1BEDB7C3DFBC22E9A /* IntegrationTests_watchOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IntegrationTests_watchOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B650ADFEEA2369A10F6C1F1 /* XCTMessagingRole_PerformanceMeasurementReporting-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_PerformanceMeasurementReporting-Protocol.h"; sourceTree = "<group>"; };
 		2BA6647ADE7B44F13513065A /* XCTMessagingRole_TelemetrySending-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_TelemetrySending-Protocol.h"; sourceTree = "<group>"; };
 		2CA02992F03AE1E134F2CAF5 /* XCTPromise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTPromise.h; sourceTree = "<group>"; };
@@ -1092,11 +1530,13 @@
 		315A15082518D6F400A3A064 /* TouchViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TouchViewController.h; sourceTree = "<group>"; };
 		315A15092518D6F400A3A064 /* TouchViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TouchViewController.m; sourceTree = "<group>"; };
 		3238E68F292452D8234153F1 /* XCUIApplicationProcessTracker-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCUIApplicationProcessTracker-Protocol.h"; sourceTree = "<group>"; };
+		341B5F150DED296FF38FB5F7 /* FBWatchHTTPServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = FBWatchHTTPServer.h; sourceTree = "<group>"; };
 		38E3FC945B8BF6F6AFD73EE7 /* XCTElementSnapshotAttributeDataSource-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTElementSnapshotAttributeDataSource-Protocol.h"; sourceTree = "<group>"; };
 		3A53731B41356D9B4E723A4D /* FBTVFocusIntegrationTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = FBTVFocusIntegrationTests.m; sourceTree = "<group>"; };
 		3B3F8E1F3F489A3A94A61ADB /* XCTMessagingChannel_IDEToRunner-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingChannel_IDEToRunner-Protocol.h"; sourceTree = "<group>"; };
 		3BA71BCF1FDA482419CA8596 /* XCUIPlatformApplicationServicesProviding-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCUIPlatformApplicationServicesProviding-Protocol.h"; sourceTree = "<group>"; };
 		3C710FE3AB9E9C22BD2A9E84 /* XCUIApplicationProcessManaging-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCUIApplicationProcessManaging-Protocol.h"; sourceTree = "<group>"; };
+		3C90E6C9835DC2FDB3CB6501 /* WDAUnknownCommandIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WDAUnknownCommandIntegrationTests.swift; sourceTree = "<group>"; };
 		3DD2F42015E89D253EA57F63 /* XCUIRemoteAccessibilityInterface-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCUIRemoteAccessibilityInterface-Protocol.h"; sourceTree = "<group>"; };
 		42D2B5A0C490D9698C2A87A9 /* XCTMacCatalystStatusProviding-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMacCatalystStatusProviding-Protocol.h"; sourceTree = "<group>"; };
 		42F7AB68482BA168011C52EA /* XCTTestSelection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTTestSelection.h; sourceTree = "<group>"; };
@@ -1113,6 +1553,7 @@
 		530D925D1492C4DF826B46BB /* XCTSourceCodeContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTSourceCodeContext.h; sourceTree = "<group>"; };
 		55B3452AB887CADB7AD757A4 /* XCUIIssueDiagnosticsProviding-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCUIIssueDiagnosticsProviding-Protocol.h"; sourceTree = "<group>"; };
 		58156929D12ADE7DFE10116F /* NSFastEnumeration-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSFastEnumeration-Protocol.h"; sourceTree = "<group>"; };
+		5B56DD7542C71ECB1C6E2439 /* WebDriverAgentLib_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WebDriverAgentLib_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CF2F53B94CC13C628FC7760 /* XCUIDeviceAutomationModeInterface-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCUIDeviceAutomationModeInterface-Protocol.h"; sourceTree = "<group>"; };
 		5D7DD32943CAC7838F942ED5 /* ViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
 		603D97F0F9A5B9D4E6442BF2 /* XCUIApplicationAutomationSessionProviding-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCUIApplicationAutomationSessionProviding-Protocol.h"; sourceTree = "<group>"; };
@@ -1130,6 +1571,7 @@
 		641EE70A2240CE2D00173FCB /* FBTVNavigationTracker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBTVNavigationTracker.h; sourceTree = "<group>"; };
 		641EE70D2240CE4800173FCB /* FBTVNavigationTracker.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBTVNavigationTracker.m; sourceTree = "<group>"; };
 		644D9CCD230E1F1A00C90459 /* FBConfigurationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBConfigurationTests.m; sourceTree = "<group>"; };
+		646D714BC17FE9258CFBDF55 /* WDADeviceIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WDADeviceIntegrationTests.swift; sourceTree = "<group>"; };
 		648C10AA22AAAD9C00B81B9A /* UIKeyboardImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIKeyboardImpl.h; sourceTree = "<group>"; };
 		648C10AE22AAAE4000B81B9A /* TIPreferencesController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TIPreferencesController.h; sourceTree = "<group>"; };
 		6496A5D8230D6EB30087F8CB /* AXSettings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AXSettings.h; sourceTree = "<group>"; };
@@ -1291,25 +1733,32 @@
 		71F5BE4E252F14EB00EE9EBA /* FBExceptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBExceptions.m; sourceTree = "<group>"; };
 		721E280BFFEFFD40C89277AF /* AppDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		722E62C63348A451A351524B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		72519967DBAAC567B40AA1A2 /* ContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		74AA57E9A81B1B0515CB587F /* XCTMessagingRole_SelfDiagnosisIssueReporting-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_SelfDiagnosisIssueReporting-Protocol.h"; sourceTree = "<group>"; };
 		75438FC693C39052C82C27DB /* XCUIApplicationRegistry.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCUIApplicationRegistry.h; sourceTree = "<group>"; };
+		758FC0D745C185A2C28BEDA1 /* IntegrationApp_watchOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IntegrationApp_watchOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		75F677B5B7737E7E1F321C20 /* WDAScreenshotAndSourceIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WDAScreenshotAndSourceIntegrationTests.swift; sourceTree = "<group>"; };
 		7AA21CEBA6E92AAC73FB6A48 /* XCTAggregateSuiteRunStatistics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTAggregateSuiteRunStatistics.h; sourceTree = "<group>"; };
 		7CBAA574F7786985E01D0B6F /* XCTHarnessEventReporting-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTHarnessEventReporting-Protocol.h"; sourceTree = "<group>"; };
 		7E079E00FE148476F94BC42F /* XCTTestIdentifierSet.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTTestIdentifierSet.h; sourceTree = "<group>"; };
 		7F87CD156E93338642EEFD54 /* ViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
 		81BB54ECBFB5B7B680BB5D4F /* XCTSourceCodeLocation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTSourceCodeLocation.h; sourceTree = "<group>"; };
 		831F292661C60B68B557F14D /* XCTTestIdentifier.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTTestIdentifier.h; sourceTree = "<group>"; };
+		848B7B14F95EFE16EEC46045 /* WDAElementAttributeIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WDAElementAttributeIntegrationTests.swift; sourceTree = "<group>"; };
 		8535171B1B3194840B8B4FCF /* FBXCElementSnapshotDouble.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBXCElementSnapshotDouble.h; sourceTree = "<group>"; };
 		8566F4674B2CF640A678C952 /* XCTWaiterWait.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTWaiterWait.h; sourceTree = "<group>"; };
 		8A5EC96F8F1C3888B9E24FAA /* XCTRunnerIDESessionDelegate-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTRunnerIDESessionDelegate-Protocol.h"; sourceTree = "<group>"; };
+		8B03F8C09D809131DE7792A7 /* WebDriverAgentRunner_watchOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WebDriverAgentRunner_watchOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B069904A4086E12556F1FAB /* XCTCapabilitiesProviding-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTCapabilitiesProviding-Protocol.h"; sourceTree = "<group>"; };
 		8C32C75CC17179B347DF6F78 /* XCTSkippedTestContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTSkippedTestContext.h; sourceTree = "<group>"; };
 		8E2092D85A7C691F157B1971 /* XCTTagSelection.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTTagSelection.h; sourceTree = "<group>"; };
 		8E47AA1A44A4A3C6EDCB6804 /* XCTRemoteSignpostListenerProxy-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTRemoteSignpostListenerProxy-Protocol.h"; sourceTree = "<group>"; };
 		8EEB78C32D7E6DD6E4EBCD26 /* XCTMemoryCheckerDelegate-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMemoryCheckerDelegate-Protocol.h"; sourceTree = "<group>"; };
 		8EF5BE504321321FB9320C43 /* XCUIElementAttributesPrivate-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCUIElementAttributesPrivate-Protocol.h"; sourceTree = "<group>"; };
+		912F32C353FE7C3E7C841405 /* WDATypingIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WDATypingIntegrationTests.swift; sourceTree = "<group>"; };
 		92182E4007B37665AB8CD88E /* XCTMessagingRole_UIAutomation-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_UIAutomation-Protocol.h"; sourceTree = "<group>"; };
 		94D7F0C1E30FBDB5D2583908 /* XCTMessagingRole_HIDEventRecording-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_HIDEventRecording-Protocol.h"; sourceTree = "<group>"; };
+		97FFAEF000CE312DEBEA9385 /* RouteRequest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RouteRequest.m; sourceTree = "<group>"; };
 		9A0B17F41E4461BBD09A2962 /* XCUIResetAuthorizationStatusOfProtectedResourcesInterface-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCUIResetAuthorizationStatusOfProtectedResourcesInterface-Protocol.h"; sourceTree = "<group>"; };
 		9AF0584AD9B6D0A57012C978 /* XCTExpectedFailureContextManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTExpectedFailureContextManager.h; sourceTree = "<group>"; };
 		9DD3770A67ED561EBE5E443A /* main.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -1325,6 +1774,7 @@
 		AA2351C66A4616534FB81AE4 /* XCTMessagingRole_ForcePressureSupportQuerying-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_ForcePressureSupportQuerying-Protocol.h"; sourceTree = "<group>"; };
 		AABBCCDDEEFF001122334455 /* SceneDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
 		AABBCCDDEEFF001122334456 /* SceneDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SceneDelegate.m; sourceTree = "<group>"; };
+		AAE921136A147FD01D630869 /* WatchSpikeApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WatchSpikeApp.swift; sourceTree = "<group>"; };
 		ACA330765D30E21E3EEB163D /* IntegrationTests_tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IntegrationTests_tvOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		ACB055BCA9CCEAB3DECD1A74 /* XCTIssue.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTIssue.h; sourceTree = "<group>"; };
 		AD0DDEAB427BA845375C7384 /* XCTRuntimeDiagnosticsPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTRuntimeDiagnosticsPolicy.h; sourceTree = "<group>"; };
@@ -1351,9 +1801,14 @@
 		B38AC76FAF9275974F272DE9 /* XCUIEventRecording-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCUIEventRecording-Protocol.h"; sourceTree = "<group>"; };
 		B3FDA51EB36F03592BF48762 /* XCTMeasureOptions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTMeasureOptions.h; sourceTree = "<group>"; };
 		B43D656732067585371ADD31 /* XCTMessagingRole_ProcessMonitoring-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_ProcessMonitoring-Protocol.h"; sourceTree = "<group>"; };
+		B6F479A809ED48C9D0604659 /* RouteRequest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RouteRequest.h; sourceTree = "<group>"; };
 		B8A163261EFA440E42CA6AC1 /* XCTRunnerDaemonSessionUIAutomationDelegate-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTRunnerDaemonSessionUIAutomationDelegate-Protocol.h"; sourceTree = "<group>"; };
 		B98A9F937EF98D6359FCCC7A /* XCTRuntimeIssueDetectionPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTRuntimeIssueDetectionPolicy.h; sourceTree = "<group>"; };
+		BCED63DFD03326F6351165FE /* WDAFindIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WDAFindIntegrationTests.swift; sourceTree = "<group>"; };
+		C1CFF432CCF46627AB7315F9 /* FBWatchHTTPServer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = FBWatchHTTPServer.m; sourceTree = "<group>"; };
+		C31A91BD7553670CBF19500F /* RouteResponse.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = RouteResponse.h; sourceTree = "<group>"; };
 		C840A8703A7C8D48897E158A /* _XCTestObservationPrivate-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "_XCTestObservationPrivate-Protocol.h"; sourceTree = "<group>"; };
+		C878996F07A9B26E66FC4EAC /* WDAClickIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WDAClickIntegrationTests.swift; sourceTree = "<group>"; };
 		C8FB547322D3949C00B69954 /* LSApplicationWorkspace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LSApplicationWorkspace.h; sourceTree = "<group>"; };
 		C8FB547722D4C1FC00B69954 /* FBUnattachedAppLauncher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBUnattachedAppLauncher.h; sourceTree = "<group>"; };
 		C8FB547822D4C1FC00B69954 /* FBUnattachedAppLauncher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBUnattachedAppLauncher.m; sourceTree = "<group>"; };
@@ -1362,10 +1817,13 @@
 		CC227321769E70CDF7C2D38F /* XCTWaiterManager-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTWaiterManager-Protocol.h"; sourceTree = "<group>"; };
 		CCCBEAE654102DBB1C8C22CD /* XCTMessagingRole_ProtectedResourceAuthorization-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_ProtectedResourceAuthorization-Protocol.h"; sourceTree = "<group>"; };
 		CD4DA0D55FD20614EDA82368 /* XCTIssueHandling-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTIssueHandling-Protocol.h"; sourceTree = "<group>"; };
+		CFE8F33794194FA3EB790C46 /* WebDriverAgentRunner_watchOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WebDriverAgentRunner_watchOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D1171249FE5D91AC5D797E5C /* WebDriverAgentLib_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WebDriverAgentLib_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D47DD8BF27FE639742EA2E3E /* XCUIAccessibilityInterface-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCUIAccessibilityInterface-Protocol.h"; sourceTree = "<group>"; };
 		D5D58975822CD58C8FEF7FEB /* XCTReportingSessionTestContainer-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTReportingSessionTestContainer-Protocol.h"; sourceTree = "<group>"; };
 		DB5400B170F08C71779CCD0E /* XCTCapabilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTCapabilities.h; sourceTree = "<group>"; };
 		DB5797DE5A0B4E7EE3D166F7 /* XCUIAlertMonitoring-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCUIAlertMonitoring-Protocol.h"; sourceTree = "<group>"; };
+		DD1ABD1093739852B52C472B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS11.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		DE39D4384E531299FAA143F7 /* XCUISystem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCUISystem.h; sourceTree = "<group>"; };
 		E005FEDAF49DCFA9FB77BEF3 /* IntegrationApp_tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IntegrationApp_tvOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E29888B75A756D1CCD21604C /* XCTestCaseDiscoveryUIAutomationDelegate-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTestCaseDiscoveryUIAutomationDelegate-Protocol.h"; sourceTree = "<group>"; };
@@ -1402,7 +1860,9 @@
 		E859E58C7C717CB6CD2A80BE /* XCTReportingSessionConfiguration-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTReportingSessionConfiguration-Protocol.h"; sourceTree = "<group>"; };
 		EA24F4BE52B2520874E09BEF /* XCTMessagingRole_SystemConfiguration-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_SystemConfiguration-Protocol.h"; sourceTree = "<group>"; };
 		EA96C2FEDE73CB5148BA4949 /* XCUIAXNotificationHandling-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCUIAXNotificationHandling-Protocol.h"; sourceTree = "<group>"; };
+		EB1B9A793C9EFB7853C1AA13 /* WDAAppLifecycleIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WDAAppLifecycleIntegrationTests.swift; sourceTree = "<group>"; };
 		EC8B17452E38AA1AE03AE251 /* XCTElementSnapshotProvider-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTElementSnapshotProvider-Protocol.h"; sourceTree = "<group>"; };
+		ED271671803AAF7188E828CF /* RouteResponse.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = RouteResponse.m; sourceTree = "<group>"; };
 		EE006EAC1EB99B15006900A4 /* FBElementVisibilityTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBElementVisibilityTests.m; sourceTree = "<group>"; };
 		EE006EB21EBA1C7B006900A4 /* XCElementSnapshotHitPointTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCElementSnapshotHitPointTests.m; sourceTree = "<group>"; };
 		EE05BAF91D13003C00A3EB00 /* FBKeyboardTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBKeyboardTests.m; sourceTree = "<group>"; };
@@ -1587,6 +2047,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		01F5E52F4145DB1989253A10 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CE57FBF0D8F391F113DAAB91 /* WebDriverAgentLib_watchOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		266808779F8E38E2C3280720 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1601,6 +2069,16 @@
 			files = (
 				B63FBAF7421417011D724B6F /* Foundation.framework in Frameworks */,
 				AAA213E600F40AB7F43D1015 /* WebDriverAgentLib_tvOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57D58DEF6D8CF9A5E59668A1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A72A2DF58BC103C624F84907 /* XCTest.framework in Frameworks */,
+				C2F6BB3D8A49F762E5172768 /* libxml2.tbd in Frameworks */,
+				D209CAD44BCD87BDF8BE30B1 /* libAccessibility.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1627,6 +2105,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				64B264FE228C50E0002A5025 /* WebDriverAgentLib_tvOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AC5FB93FB859D9BE381F039D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				28B292C9A3654A81B765EB37 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ECA2D9FDA872B089E60C5289 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7D099F5AD14B24B9FC3FEBF0 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1695,6 +2189,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		12A83FB6068CC1266BBDBE2C /* WatchOS */ = {
+			isa = PBXGroup;
+			children = (
+				97FFAEF000CE312DEBEA9385 /* RouteRequest.m */,
+				ED271671803AAF7188E828CF /* RouteResponse.m */,
+				C1CFF432CCF46627AB7315F9 /* FBWatchHTTPServer.m */,
+				B6F479A809ED48C9D0604659 /* RouteRequest.h */,
+				C31A91BD7553670CBF19500F /* RouteResponse.h */,
+				341B5F150DED296FF38FB5F7 /* FBWatchHTTPServer.h */,
+			);
+			path = WatchOS;
+			sourceTree = "<group>";
+		};
 		498495C81BB2E6FA009CC848 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -1750,6 +2257,14 @@
 			path = Doubles;
 			sourceTree = "<group>";
 		};
+		6DE8597334C21E3C441188F2 /* watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				DD1ABD1093739852B52C472B /* Foundation.framework */,
+			);
+			name = watchOS;
+			sourceTree = "<group>";
+		};
 		71414ECF2670A1ED003A8C5D /* LRUCache */ = {
 			isa = PBXGroup;
 			children = (
@@ -1801,7 +2316,6 @@
 				3A53731B41356D9B4E723A4D /* FBTVFocusIntegrationTests.m */,
 				FF8E3B470FC9639D5F18E2EA /* Info.plist */,
 			);
-			name = IntegrationTests_tvOS;
 			path = IntegrationTests_tvOS;
 			sourceTree = "<group>";
 		};
@@ -1839,6 +2353,12 @@
 				64B264F9228C50E0002A5025 /* UnitTests_tvOS.xctest */,
 				E005FEDAF49DCFA9FB77BEF3 /* IntegrationApp_tvOS.app */,
 				ACA330765D30E21E3EEB163D /* IntegrationTests_tvOS.xctest */,
+				758FC0D745C185A2C28BEDA1 /* IntegrationApp_watchOS.app */,
+				2B2328F1BEDB7C3DFBC22E9A /* IntegrationTests_watchOS.xctest */,
+				5B56DD7542C71ECB1C6E2439 /* WebDriverAgentLib_watchOS.framework */,
+				CFE8F33794194FA3EB790C46 /* WebDriverAgentRunner_watchOS.xctest */,
+				D1171249FE5D91AC5D797E5C /* WebDriverAgentLib_watchOS.framework */,
+				8B03F8C09D809131DE7792A7 /* WebDriverAgentRunner_watchOS.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1881,6 +2401,7 @@
 			children = (
 				716C9341224D5369004B8542 /* iOS */,
 				716C9340224D5358004B8542 /* tvOS */,
+				6DE8597334C21E3C441188F2 /* watchOS */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1891,6 +2412,15 @@
 				C8FB547322D3949C00B69954 /* LSApplicationWorkspace.h */,
 			);
 			path = MobileCoreServices;
+			sourceTree = "<group>";
+		};
+		D4A96F28DB0685D9C93CD05D /* IntegrationApp_watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				AAE921136A147FD01D630869 /* WatchSpikeApp.swift */,
+				72519967DBAAC567B40AA1A2 /* ContentView.swift */,
+			);
+			path = IntegrationApp_watchOS;
 			sourceTree = "<group>";
 		};
 		E444DC4A24912EC40060D7EB /* Vendor */ = {
@@ -1959,6 +2489,25 @@
 				E444DCA824913C220060D7EB /* RoutingHTTPServer.m */,
 			);
 			name = RoutingHTTPServer;
+			sourceTree = "<group>";
+		};
+		E94EE979A7D7C50FDC1EFE7D /* IntegrationTests_watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				0F28D3CD9DDC2E54DB115316 /* WDAWatchHTTPClient.swift */,
+				24BD02A29E3B2EB1D57FDD29 /* WDAWatchIntegrationTestCase.swift */,
+				27D14C409E982099568175D1 /* WDASessionIntegrationTests.swift */,
+				BCED63DFD03326F6351165FE /* WDAFindIntegrationTests.swift */,
+				848B7B14F95EFE16EEC46045 /* WDAElementAttributeIntegrationTests.swift */,
+				C878996F07A9B26E66FC4EAC /* WDAClickIntegrationTests.swift */,
+				912F32C353FE7C3E7C841405 /* WDATypingIntegrationTests.swift */,
+				75F677B5B7737E7E1F321C20 /* WDAScreenshotAndSourceIntegrationTests.swift */,
+				EB1B9A793C9EFB7853C1AA13 /* WDAAppLifecycleIntegrationTests.swift */,
+				646D714BC17FE9258CFBDF55 /* WDADeviceIntegrationTests.swift */,
+				28F75AEC6442F32A3C4394AD /* WDAAlertIntegrationTests.swift */,
+				3C90E6C9835DC2FDB3CB6501 /* WDAUnknownCommandIntegrationTests.swift */,
+			);
+			path = IntegrationTests_watchOS;
 			sourceTree = "<group>";
 		};
 		EE9AB73E1CAEDF0C008C271F /* Categories */ = {
@@ -2130,6 +2679,7 @@
 				13DE7A4E287C46BB003243C6 /* FBXCElementSnapshot.m */,
 				13DE7A53287CA1EC003243C6 /* FBXCElementSnapshotWrapper.h */,
 				13DE7A54287CA1EC003243C6 /* FBXCElementSnapshotWrapper.m */,
+				12A83FB6068CC1266BBDBE2C /* WatchOS */,
 			);
 			name = Routing;
 			path = WebDriverAgentLib/Routing;
@@ -2242,6 +2792,8 @@
 				EE9B76561CF7987300275851 /* UnitTests */,
 				F47AAEACC427354CDC7C935F /* IntegrationApp_tvOS */,
 				89DE54DD1FA69115F5538E11 /* IntegrationTests_tvOS */,
+				D4A96F28DB0685D9C93CD05D /* IntegrationApp_watchOS */,
+				E94EE979A7D7C50FDC1EFE7D /* IntegrationTests_watchOS */,
 			);
 			path = WebDriverAgentTests;
 			sourceTree = "<group>";
@@ -2565,7 +3117,6 @@
 				0F719C2804F6473A9C4D3090 /* SceneDelegate.h */,
 				A87AE5544E9A5CA7C9168DDF /* SceneDelegate.m */,
 			);
-			name = IntegrationApp_tvOS;
 			path = IntegrationApp_tvOS;
 			sourceTree = "<group>";
 		};
@@ -2881,6 +3432,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7027B1C595ACC71B793FB79D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		86CF98D7198B272C0DA00216 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -2916,6 +3474,287 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C430CD860EB75059257BA4EC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				43EBA0D0D54EB99815CE63B6 /* XCUIElement+FBWebDriverAttributes.h in Headers */,
+				C154B8CD167DBE068EA74719 /* HTTPMessage.h in Headers */,
+				93D5C4C8442EFE91D70780CC /* FBScreen.h in Headers */,
+				B9FAD6E3F3AB201B59D6F8BD /* XCTestPrivateSymbols.h in Headers */,
+				CDDEBD9F5F6A380C8D32D671 /* XCUIElement+FBTyping.h in Headers */,
+				FBDF04E5916B91FCEC0190CB /* Route.h in Headers */,
+				488C4CBD86EBFA2AB5396917 /* XCUIElement+FBUtilities.h in Headers */,
+				CE3D815D09AD8E137CC18AA5 /* XCUIElement+FBScrolling.h in Headers */,
+				767CB761C99AA6275E08FDB9 /* XCUIHitPointResult.h in Headers */,
+				544D6545052EA800D3E4BA81 /* FBReflectionUtils.h in Headers */,
+				852D69D1623D81697D700B3C /* XCPointerEventPath.h in Headers */,
+				43BC9FE4BF5C19F6F6569177 /* FBRouteRequest.h in Headers */,
+				BD2A5D43881B449E533D5800 /* UIKeyboardImpl.h in Headers */,
+				34AB13EFF1F673084C910195 /* GCDAsyncSocket.h in Headers */,
+				444F211126EAF77FB2B1DB42 /* FBXCElementSnapshot.h in Headers */,
+				FFA7672B731B57AB9283DD40 /* FBXCElementSnapshotWrapper.h in Headers */,
+				D43AF1E150975634F3AFF329 /* FBSettings.h in Headers */,
+				7DFFC02E95770F89F5A63A8F /* FBSettingsHandler.h in Headers */,
+				0D789050D49FABC6B4DD88EB /* XCTest.h in Headers */,
+				45C57D95F5661023AD97D831 /* FBAlertsMonitor.h in Headers */,
+				FEB143DBE613795D4F8693B4 /* FBSession.h in Headers */,
+				4EEFC2F7BDC3CA343F73E71A /* FBTouchActionCommands.h in Headers */,
+				5E8ECB85C540038310F7827E /* FBTouchIDCommands.h in Headers */,
+				E8FE8448E0118775E7C789CC /* FBXMLGenerationOptions.h in Headers */,
+				DD44723878134A0A42473299 /* XCUIApplication.h in Headers */,
+				3A671125031D05D33D1BAA20 /* FBCustomCommands.h in Headers */,
+				D6B48E8EA65EF8401D794A6B /* FBOrientationCommands.h in Headers */,
+				EF76D1EC388A2B9A5AA7F20B /* XCUIScreen.h in Headers */,
+				023273B7E5BA69B20CE01D2B /* XCTRunnerIDESession.h in Headers */,
+				10878F7DCE410B73C3F8CCF1 /* FBRouteRequest-Private.h in Headers */,
+				E47C0E7ED1200567EC7DA4FC /* XCUIApplicationProcess+FBQuiescence.h in Headers */,
+				5D1959FC0B6EBB249DD86062 /* XCApplicationQuery.h in Headers */,
+				15B3FA3EB08B06C9FE888A82 /* XCTRunnerDaemonSession.h in Headers */,
+				C931666B44D9F20B3A1026B0 /* XCAXClient_iOS+FBSnapshotReqParams.h in Headers */,
+				CD8224652860F7BB975C508B /* FBTVNavigationTracker-Private.h in Headers */,
+				2454D9F21CF469B983946C79 /* FBXCElementSnapshotWrapper+Helpers.h in Headers */,
+				D66C59BA2D0F80023352664F /* FBScreenRecordingRequest.h in Headers */,
+				932D338E506BD3EDDABBDEA9 /* XCTNSPredicateExpectationObject-Protocol.h in Headers */,
+				41662E3D3159E906AA872A0B /* WebDriverAgentLib.h in Headers */,
+				BEA2FA45BED17FE03010FECD /* FBFindElementCommands.h in Headers */,
+				83FFBD660C6C7F8D2426E2EE /* XCTestRun.h in Headers */,
+				478195F824879438605B6E7D /* FBWebServer.h in Headers */,
+				854FE74E5C23053EE3E2F0F1 /* FBScreenshotCommands.h in Headers */,
+				DADC5E6FD3E80449EE5B5841 /* NSString+FBVisualLength.h in Headers */,
+				EF47E4D736053EE07FC03D3D /* FBXCTestDaemonsProxy.h in Headers */,
+				9551664006A016AA225E7E5F /* XCUIElement+FBIsVisible.h in Headers */,
+				170C47F533B00D1D870D9957 /* FBResponsePayload.h in Headers */,
+				F876324AFD3617FFCFC479C3 /* FBScreenRecordingPromise.h in Headers */,
+				67402F46AAB3DCAB3E40ED27 /* FBUnknownCommands.h in Headers */,
+				CB1790B793BB813AF80F65DF /* XCUIElement+FBTVFocuse.h in Headers */,
+				2C6A876B29ECA17D6A5BCEED /* HTTPConnection.h in Headers */,
+				617AE9B41FB23CCE66769441 /* NSPredicate+FBFormat.h in Headers */,
+				60CF6CA8AC7961DCCE402764 /* XCTestCase.h in Headers */,
+				995DF7C1928C60D7AE02840D /* XCUIApplicationImpl.h in Headers */,
+				92A632860C8133ADDD5DE5F4 /* LRUCacheNode.h in Headers */,
+				F13426E5482242AFB787BE4A /* FBActiveAppDetectionPoint.h in Headers */,
+				4D80F932D0CD80C99950DA4F /* NSExpression+FBFormat.h in Headers */,
+				95A597B8CC694006DDE49999 /* XCUIApplication+FBAlert.h in Headers */,
+				ED342D194B20A206864675B2 /* XCUIApplication+FBUIInterruptions.h in Headers */,
+				BCC9E02491560712221045CC /* HTTPServer.h in Headers */,
+				E6B214145FE46BBFD824FAE7 /* FBMathUtils.h in Headers */,
+				6786D4B257269918E591AC66 /* FBElementUtils.h in Headers */,
+				51FFE79AF3A5FADFFAB287BC /* FBDebugCommands.h in Headers */,
+				6D311C0CB39981D7211B5576 /* XCUICoordinate.h in Headers */,
+				918A48693FF49E932FDFE3AE /* FBElementHelpers.h in Headers */,
+				5D31382835A8EAE37804AC15 /* XCTestObservationCenter.h in Headers */,
+				995AE9FC06719B08D8971D6A /* XCUIElement+FBAccessibility.h in Headers */,
+				D7C384A684F2F0F2CAC2861D /* XCUIElement+FBMinMax.h in Headers */,
+				06FF73DCB07047C42DBFB16A /* AXSettings.h in Headers */,
+				394E98CB498DB59F0FF21198 /* XCTestCaseRun.h in Headers */,
+				22A6AD29DB4A497BC03C2B67 /* XCTIssue+FBPatcher.h in Headers */,
+				2692E435B9F56451C018F8EA /* XCTestConfiguration.h in Headers */,
+				9C26D61DAA53AB413E9E8116 /* XCTestExpectation.h in Headers */,
+				D40D635A4ABBC79829A0D590 /* FBElementTypeTransformer.h in Headers */,
+				70E21F76098198E19A6E5A5E /* FBXCAXClientProxy.h in Headers */,
+				97AB752A8043A962100DB4EB /* FBElementCache.h in Headers */,
+				F0F7B8DFB14C9DFC86DFFBFD /* RouteResponse.h in Headers */,
+				10EC41A2ECCD2E865EEE7AB0 /* XCUIElement+FBClassChain.h in Headers */,
+				6FC8E41707F65D5A432206CC /* FBXCAccessibilityElement.h in Headers */,
+				4E8E83C42F2E2A2A5A62F3E3 /* FBResponseJSONPayload.h in Headers */,
+				894AE4397B5992EF738248AE /* RouteRequest.h in Headers */,
+				D2B83B27DAB80FE235285D2F /* FBElement.h in Headers */,
+				8597F35CEB1617767B63D770 /* FBExceptionHandler.h in Headers */,
+				FEC52AE4F35AD38D3AC2659F /* RoutingConnection.h in Headers */,
+				AC3529AFA966E7202CB3B3B1 /* FBRoute.h in Headers */,
+				A47F8777C5C8D021B2AC910C /* XCTestDriver.h in Headers */,
+				1D0C64A6600E2D1BBAFC2D62 /* XCSynthesizedEventRecord.h in Headers */,
+				0F282CAB2A025ECA9EAB18B3 /* HTTPResponse.h in Headers */,
+				4C472F2027329ACA65C7D721 /* FBXPath.h in Headers */,
+				5A1B8098AE35B82BD379B421 /* XCUIElement+FBForceTouch.h in Headers */,
+				9DFDA1423A4651A4DB9FE341 /* FBRuntimeUtils.h in Headers */,
+				2596817CFC1D72E8558555DF /* FBExceptions.h in Headers */,
+				E62AED48CAE64088C1E7498B /* XCUIElement+FBPickerWheel.h in Headers */,
+				14F77B365BF733160FF366A2 /* FBElementCommands.h in Headers */,
+				BC1470BF3E54F478DAEDF05D /* FBTCPSocket.h in Headers */,
+				476E44716A4A3A22F95EC51A /* XCUIElement+FBUID.h in Headers */,
+				FBF064E4D96CFCD08E1F4EF7 /* XCUIDevice.h in Headers */,
+				A8635BD557F97E6C29A0790E /* RoutingHTTPServer.h in Headers */,
+				46AEB32485B508AF1D9B8CE2 /* XCUIApplication+FBTouchAction.h in Headers */,
+				3EC5404A04E5A61B8144E834 /* FBCommandHandler.h in Headers */,
+				3E199AC580C5DA4B070DD01A /* FBSessionCommands.h in Headers */,
+				109F8F2F96E674EB1464EF3B /* FBTVNavigationTracker.h in Headers */,
+				DFB9638AF3480053CA39AB3C /* XCUIElement+FBVisibleFrame.h in Headers */,
+				6A4E39AED8C9C8BEBD960710 /* FBImageProcessor.h in Headers */,
+				6627D7B40D3D915B115D7B1A /* FBSession-Private.h in Headers */,
+				7BB6E1590E224BAA09B8BE34 /* NSString+FBXMLSafeString.h in Headers */,
+				9452D57FE97CB2ECED093B9F /* FBAccessibilityTraits.h in Headers */,
+				DE2D708340ED70EBF9244D0F /* NSDictionary+FBUtf8SafeDictionary.h in Headers */,
+				2D6B818DC921A4631A496432 /* FBCommandStatus.h in Headers */,
+				293BD2162964EEC2A3BA6B57 /* HTTPResponseProxy.h in Headers */,
+				90107B3BBFBF3B073807D51B /* HTTPLogging.h in Headers */,
+				CFB0AFBC9F429B279C95F5BC /* FBAlertViewCommands.h in Headers */,
+				6A1D9B851D58D0A36D6822B7 /* XCTWaiter.h in Headers */,
+				F7010B261A861C5C63D59273 /* XCTWaiterManagement-Protocol.h in Headers */,
+				9D0C07E71C632403A35F8BDE /* FBScreenshot.h in Headers */,
+				9B863AF4DB924A69D173FC7B /* XCAXClient_iOS.h in Headers */,
+				16E809B6BFDF7CBD862A7B48 /* TIPreferencesController.h in Headers */,
+				42A92793513CA29B39B72721 /* XCUIElement+FBSwiping.h in Headers */,
+				268CBDE31376AF96DDDD4BD0 /* FBBaseActionsSynthesizer.h in Headers */,
+				EDB13FDB5D8220A65560629B /* HTTPErrorResponse.h in Headers */,
+				462DA317CCA9DBE4F249516B /* FBAlert.h in Headers */,
+				79FD4FC269A91F525A4E1413 /* XCUIElementQuery.h in Headers */,
+				71BB64FB648CB9BBBD25F3E3 /* FBVideoCommands.h in Headers */,
+				4E54092E98444C98C9887D44 /* XCPointerEvent.h in Headers */,
+				1C03F3BCBB6B5E5D55CFE2C1 /* FBProtocolHelpers.h in Headers */,
+				CC614CD0E2D7952E9F41C34F /* FBRunLoopSpinner.h in Headers */,
+				005B327C702EF47820887884 /* FBErrorBuilder.h in Headers */,
+				6B4E076881F3C7F369044682 /* FBXCDeviceEvent.h in Headers */,
+				1E6EBAA448D2632F362FFAA7 /* FBKeyboard.h in Headers */,
+				5D2A81B261FEC67033F41101 /* XCUIElementQuery+FBHelpers.h in Headers */,
+				81231F08969740B0C8C67A30 /* XCUIApplication+FBHelpers.h in Headers */,
+				9AA0E22033281B4EAA78BC51 /* FBCapabilities.h in Headers */,
+				D142183578036F5FD5B9880B /* XCUIDevice+FBHelpers.h in Headers */,
+				09D97BD46764FD8149747723 /* XCUIElement+FBResolve.h in Headers */,
+				6BF3F57247F59B81B8BCEE7B /* FBClassChainQueryParser.h in Headers */,
+				8AAA33A5B1943B667B0DB05E /* FBMacros.h in Headers */,
+				1CA8A47F9D6B967D99FC0896 /* XCTestExpectationDelegate-Protocol.h in Headers */,
+				3414F451472B235F637F46BC /* DDNumber.h in Headers */,
+				74CF72DC7209A5B04763D0D2 /* XCUIDevice+FBRotation.h in Headers */,
+				A8CEAEFC8CC63F94DA0176A9 /* XCUIDevice+FBVoiceOver.h in Headers */,
+				150276DDADD9963F29465D57 /* FBNotificationsHelper.h in Headers */,
+				47462913F617EA89DC379A62 /* LRUCache.h in Headers */,
+				E3653A8F329E8AB4061B0310 /* FBConfiguration.h in Headers */,
+				FDD8D03066D7654072A51ABF /* FBUnattachedAppLauncher.h in Headers */,
+				3E27F8D796D65C35BA6405C9 /* XCDebugLogDelegate-Protocol.h in Headers */,
+				6A093FDB29E19E1F1F51A6A8 /* FBImageUtils.h in Headers */,
+				1F545FFB67878CBAF4D6E6A0 /* FBLogger.h in Headers */,
+				05F8A3B33BCFAFFA75CD81CA /* FBScreenRecordingContainer.h in Headers */,
+				5787FD65011B3AF632694EEA /* XCUIElement.h in Headers */,
+				5917EF5F1372B2098168EA0D /* GCDAsyncUdpSocket.h in Headers */,
+				6B3AB44BFFDDF042E4B712C1 /* FBPasteboard.h in Headers */,
+				36C5DA6C013EAAFC575B4A2B /* XCUIScreenDataSource-Protocol.h in Headers */,
+				D1DE06DF54156F744E364B5F /* FBDebugLogDelegateDecorator.h in Headers */,
+				2FBE7F1C0491F85B70CF49D9 /* XCUIDevice+FBHealthCheck.h in Headers */,
+				6CF55BBD548172F14D4E3BEE /* FBMjpegServer.h in Headers */,
+				CFDBE0DF5D99CB310C7AFB01 /* XCUIApplicationProcess.h in Headers */,
+				8EA51935E09A89896FB1D463 /* FBW3CActionsSynthesizer.h in Headers */,
+				79A47D7F50179802052ED774 /* CDStructures.h in Headers */,
+				AF4223DDBCC9EC79D4F9DC0D /* DDRange.h in Headers */,
+				B70EB4BDC07CE9EC58505E85 /* XCUIElement+FBCustomActions.h in Headers */,
+				EE22974A8F641FA94DCBCB3E /* HTTPDataResponse.h in Headers */,
+				760885DAFDB4A126DBD66649 /* XCUIElement+FBFind.h in Headers */,
+				B6B73CE709728984EF03361D /* FBFailureProofTestCase.h in Headers */,
+				1C159E8E35E0823278141DC2 /* FBXPath-Private.h in Headers */,
+				75794142172494266C093A62 /* XCUIElement+FBCaching.h in Headers */,
+				A5005275246FC51C1332B7E5 /* XCUIApplication+FBQuiescence.h in Headers */,
+				051607BF516A7720E8508CAD /* NSFastEnumeration-Protocol.h in Headers */,
+				85F4463308BA5153D48F7FAE /* XCTAggregateSuiteRunStatistics.h in Headers */,
+				908767A5CCB6552156CDAFB3 /* XCTAttachmentManager.h in Headers */,
+				1175C43DC358BA16E23F8449 /* XCTCapabilities.h in Headers */,
+				EA230F78EA120ADDB665D4A1 /* XCTCapabilitiesProviding-Protocol.h in Headers */,
+				4C28862FC86A33692E6EF94D /* XCTElementSnapshotAttributeDataSource-Protocol.h in Headers */,
+				7F54E7702BAD38194CEDF219 /* XCTElementSnapshotProvider-Protocol.h in Headers */,
+				2BBEC31A5B1401C28C14899E /* XCTExpectedFailureContextManager.h in Headers */,
+				D501A3AAD35E78A425759794 /* XCTFuture.h in Headers */,
+				311644887124D98DDF7E0C22 /* XCTHarnessEventReporting-Protocol.h in Headers */,
+				81D8C17650E61D67CB43061A /* XCTIssue.h in Headers */,
+				E4F38E2031A5FB938468C536 /* XCTIssueHandling-Protocol.h in Headers */,
+				9C4F46F172F29F9875EADE15 /* XCTMacCatalystStatusProviding-Protocol.h in Headers */,
+				8836331A94BA37168F60E3C8 /* XCTMeasureOptions.h in Headers */,
+				87D464D881B22C316FB1D822 /* XCTMemoryChecker.h in Headers */,
+				63FF0E214F64ABD9F4EA2AD2 /* XCTMemoryCheckerDelegate-Protocol.h in Headers */,
+				980DFA4D113229070611E023 /* XCTMessagingChannel_IDEToRunner-Protocol.h in Headers */,
+				409BDFE1D64246E9248CD392 /* XCTMessagingChannel_RunnerToDaemon-Protocol.h in Headers */,
+				844C1352549460E759ABCCD3 /* XCTMessagingChannel_RunnerToIDE-Protocol.h in Headers */,
+				EFDC22605B42890EBC4709CE /* XCTMessagingRole_ActivityReporting-Protocol.h in Headers */,
+				32889DF6C27E6F1A6EA13749 /* XCTMessagingRole_AttachmentFutureResultStatusUpdating-Protocol.h in Headers */,
+				69D17671BE6F04D5FE909BD1 /* XCTMessagingRole_BundleRequesting-Protocol.h in Headers */,
+				60E33E299D4BFCF03FB6CFE2 /* XCTMessagingRole_CapabilityExchange-Protocol.h in Headers */,
+				732D07CE799D8B584B4033E8 /* XCTMessagingRole_DebugLogging-Protocol.h in Headers */,
+				FDEB571007C83EC56F365EB3 /* XCTMessagingRole_EventSynthesis-Protocol.h in Headers */,
+				11BF078FAB71B172572A4A10 /* XCTMessagingRole_ForcePressureSupportQuerying-Protocol.h in Headers */,
+				FD89236D119E129E8CEBDBCD /* XCTMessagingRole_HIDEventRecording-Protocol.h in Headers */,
+				0E7CAA2FA6570D0C1EADFE4A /* XCTMessagingRole_MemoryTesting-Protocol.h in Headers */,
+				D27A70EE9F480A3D1CDDB389 /* XCTMessagingRole_PerformanceMeasurementReporting-Protocol.h in Headers */,
+				D22F20BC746C639DCDD2F69C /* XCTMessagingRole_ProcessMonitoring-Protocol.h in Headers */,
+				9E0FA3A0629DA5A53BDFDDA1 /* XCTMessagingRole_ProtectedResourceAuthorization-Protocol.h in Headers */,
+				4A00898E99B59366E552239B /* XCTMessagingRole_ScreenRecording-Protocol.h in Headers */,
+				78649785B81BE48282977C23 /* XCTMessagingRole_SelfDiagnosisIssueReporting-Protocol.h in Headers */,
+				C4AECD675B9F43748D8091A3 /* XCTMessagingRole_SignpostRequesting-Protocol.h in Headers */,
+				0585257599F49BABFD835DED /* XCTMessagingRole_SiriAutomation-Protocol.h in Headers */,
+				A781B56952349EB47FBF0DAD /* XCTMessagingRole_SystemConfiguration-Protocol.h in Headers */,
+				A1DA19AC32A89FD07350BEA6 /* XCTMessagingRole_TelemetrySending-Protocol.h in Headers */,
+				AB8D3BCC12F3A47869D31341 /* XCTMessagingRole_TestExecution-Protocol.h in Headers */,
+				698A247C297C36C7DEBFCD28 /* XCTMessagingRole_TestReporting-Protocol.h in Headers */,
+				9D1DE17E7327477C24099DC7 /* XCTMessagingRole_UIAutomation-Protocol.h in Headers */,
+				E95851D7BE5DAF50DAF15382 /* XCTMessagingRole_UIAutomationRunnerEventReporting-Protocol.h in Headers */,
+				F7829FBAAA05B01157C99C0D /* XCTMessagingRole_UserPresence-Protocol.h in Headers */,
+				86FCA9F496D404C54B208E36 /* XCTMetricDiagnosticHelper.h in Headers */,
+				01A6F9758F11F6EF5B495D97 /* XCTPromise.h in Headers */,
+				C309FAE89D050C90496FB87B /* XCTRemoteSignpostListenerProxy-Protocol.h in Headers */,
+				874C3368FEB1CC31D59E72BE /* XCTRepetitionPolicy.h in Headers */,
+				3F213A7FAB64730F66D3F0A6 /* XCTReportingSession.h in Headers */,
+				808BFE11674748A002FB9617 /* XCTReportingSessionConfiguration-Protocol.h in Headers */,
+				5E4FAB96AC8BE02A1DDD632C /* XCTReportingSessionIssueReporter-Protocol.h in Headers */,
+				E30D52357A950271BD8EF346 /* XCTReportingSessionTestContainer-Protocol.h in Headers */,
+				88A4B0B30D883EDD1D6A8690 /* XCTReportingSessionTestReporter.h in Headers */,
+				6A594CAA5D54658403A031DC /* XCTRunnerAutomationSession-Protocol.h in Headers */,
+				84CDC80038E42E8E92E6629B /* XCTRunnerDaemonSessionUIAutomationDelegate-Protocol.h in Headers */,
+				6D5C61FB04D91A81776E0B06 /* XCTRunnerIDESessionDelegate-Protocol.h in Headers */,
+				9AB06AA2F92978172F499013 /* XCTRuntimeDiagnosticsPolicy.h in Headers */,
+				F788D281B204A55EA3CB4A00 /* XCTRuntimeIssueDetectionPolicy.h in Headers */,
+				34E3403E0FE0E93C74E8FB2D /* XCTScreenCapturePolicy.h in Headers */,
+				AF4B652A13BCF1C08AD6ECA0 /* XCTSignpostListener-Protocol.h in Headers */,
+				81BB152C7704087B3FE6F854 /* XCTSkippedTestContext.h in Headers */,
+				A7F0DE38C7CB24D31857C7AE /* XCTSourceCodeContext.h in Headers */,
+				57C72DA18039FED310967F8F /* XCTSourceCodeLocation.h in Headers */,
+				560C97EA2B2D60B9111E0BEF /* XCTTagSelection.h in Headers */,
+				87DA621B823DB8B9D25E5C20 /* XCTTestIdentifier.h in Headers */,
+				515A0862F9234F6069E7F49F /* XCTTestIdentifierSet.h in Headers */,
+				F19C884FA08D896CD83DD1EB /* XCTTestSelection.h in Headers */,
+				0960A9291C94E38AD5F868D6 /* XCTWaiterManager-Protocol.h in Headers */,
+				4BE25B66DBA18E7722B9D82A /* XCTWaiterWait.h in Headers */,
+				44D4667EC1743A6368395EF2 /* XCTestCaseDiscoveryUIAutomationDelegate-Protocol.h in Headers */,
+				95CACF0F523461A0E584B3D9 /* XCTestCaseUIAutomationDelegate-Protocol.h in Headers */,
+				F1BED88CC398B8B1C180238A /* XCTestCastMethodNamesUIAutomationDelegate-Protocol.h in Headers */,
+				FFD70914E6D8CE5D4FED4B69 /* XCUIAXNotificationHandling-Protocol.h in Headers */,
+				09E27E0455701764DDB8C747 /* XCUIAccessibilityInterface-Protocol.h in Headers */,
+				40955058B413422AABBB21E7 /* XCUIAlertMonitoring-Protocol.h in Headers */,
+				7F141C27D97D26043A8C0494 /* XCUIApplicationAutomationSessionProviding-Protocol.h in Headers */,
+				D3634A090D755F8993EDD3E5 /* XCUIApplicationImplReporter-Protocol.h in Headers */,
+				4A811492530FE8908E4A0A35 /* XCUIApplicationManaging-Protocol.h in Headers */,
+				8E58B3CAE34ECF6644F80A9B /* XCUIApplicationMonitor-Protocol.h in Headers */,
+				080C5B8955F9D1A3DB7C5B81 /* XCUIApplicationOpenRequest.h in Headers */,
+				0B2D769FCCF7C5EEB3BA2404 /* XCUIApplicationPlatformServicesProviderDelegate-Protocol.h in Headers */,
+				B1A18407C6600D9E8ABABD5A /* XCUIApplicationProcessDelegate-Protocol.h in Headers */,
+				C158CE0AD6EEBEA854454AA2 /* XCUIApplicationProcessManaging-Protocol.h in Headers */,
+				3400BE6CBA163DC9A58D60E6 /* XCUIApplicationProcessTracker-Protocol.h in Headers */,
+				145BED6221BAAC51AD8BDFCE /* XCUIApplicationRegistry.h in Headers */,
+				9891B08BAC7C4A6003B20E80 /* XCUIButtonConsole.h in Headers */,
+				E608A983E2E6A6A1A46A6E91 /* XCUIDeviceAutomationModeInterface-Protocol.h in Headers */,
+				FBAFC553152CE132D6CB98E5 /* XCUIDeviceDelayedAttachmentTransferSupportInterface-Protocol.h in Headers */,
+				3033E8E33134E8E57C446A8A /* XCUIDeviceEventAndStateInterface-Protocol.h in Headers */,
+				6B9BDA3FFFD557297E75777F /* XCUIElementAttributesPrivate-Protocol.h in Headers */,
+				588F51093FD2A5597366C282 /* XCUIElementEventTarget-Protocol.h in Headers */,
+				F036DAC96136D88F0427B9CB /* XCUIElementTypeQueryProvider_Private-Protocol.h in Headers */,
+				F21813E3FBD5D4DFDB85922A /* XCUIEventRecording-Protocol.h in Headers */,
+				C5C5311BCBCCE031B27BA46D /* XCUIInterruptionMonitoring-Protocol.h in Headers */,
+				2892ACD1F2CC2B0AF4FC22EA /* XCUIIssueDiagnosticsProviding-Protocol.h in Headers */,
+				2B39D11DD29FD3816F8AAC7C /* XCUIKnobControl.h in Headers */,
+				EF1FE277EB1903306193C6F0 /* XCUILocation.h in Headers */,
+				D203F622C7C0D968F3BD2AAF /* XCUIPlatformApplicationServicesProviding-Protocol.h in Headers */,
+				68BAD7FD955D2732151C355D /* XCUIRemoteAccessibilityInterface-Protocol.h in Headers */,
+				F1AAE4976535FBAC979A1DF3 /* XCUIRemoteDeviceRunner-Protocol.h in Headers */,
+				13EEC9A220F1C0F1A76A5D4E /* XCUIRemoteSiriInterface-Protocol.h in Headers */,
+				3E78B1C01DDDD27CDCD78B14 /* XCUIResetAuthorizationStatusOfProtectedResourcesInterface-Protocol.h in Headers */,
+				818F15E49B1CEB1B70C412EB /* XCUISiriService.h in Headers */,
+				8D15C0B98A2D7206CA297A41 /* XCUISystem.h in Headers */,
+				865E31CC987F5FCF3C0BFFC3 /* XCUIXcodeApplicationManaging-Protocol.h in Headers */,
+				94F8CA38DB16452CC3A8DCB4 /* _TtC10XCTestCore19XCTReportingContext.h in Headers */,
+				67ADB25EAE13510B87236F2C /* _XCTMessaging_VoidProtocol-Protocol.h in Headers */,
+				F4E8FB5A2EB57854EB6A00E9 /* _XCTestObservationInternal-Protocol.h in Headers */,
+				59892BBAB84DFD927C94593F /* _XCTestObservationPrivate-Protocol.h in Headers */,
+				A47A7F9E098C88328DF38A4C /* XCTElementSetTransformer-Protocol.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3213,6 +4052,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		4632809915F58C9095914E85 /* IntegrationTests_watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9DA322A56A2DFF03F3E5CDEA /* Build configuration list for PBXNativeTarget "IntegrationTests_watchOS" */;
+			buildPhases = (
+				A17BAB1FBE5B3A5B0AB97661 /* Sources */,
+				ECA2D9FDA872B089E60C5289 /* Frameworks */,
+				7A0971F542104119F22CD36E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DC55141E0512D9D0ADE54987 /* PBXTargetDependency */,
+			);
+			name = IntegrationTests_watchOS;
+			productName = IntegrationTests_watchOS;
+			productReference = 2B2328F1BEDB7C3DFBC22E9A /* IntegrationTests_watchOS.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		641EE2D92240BBE300173FCB /* WebDriverAgentRunner_tvOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 641EE2DF2240BBE300173FCB /* Build configuration list for PBXNativeTarget "WebDriverAgentRunner_tvOS" */;
@@ -3287,6 +4144,61 @@
 			productName = IntegrationApp_tvOS;
 			productReference = E005FEDAF49DCFA9FB77BEF3 /* IntegrationApp_tvOS.app */;
 			productType = "com.apple.product-type.application";
+		};
+		95186DE2383671DFA81D7FCB /* WebDriverAgentLib_watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F80B35927AACA48FC55D05B5 /* Build configuration list for PBXNativeTarget "WebDriverAgentLib_watchOS" */;
+			buildPhases = (
+				ED98D7B74F8738C8481E77C1 /* Sources */,
+				57D58DEF6D8CF9A5E59668A1 /* Frameworks */,
+				C430CD860EB75059257BA4EC /* Headers */,
+				360A0A377FD9AB69C7F73ED7 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = WebDriverAgentLib_watchOS;
+			productName = WebDriverAgentLib_watchOS;
+			productReference = D1171249FE5D91AC5D797E5C /* WebDriverAgentLib_watchOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		9D6B02D8FC050BAF7159284F /* IntegrationApp_watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 619E0BD15EC6EE4A0DAC898E /* Build configuration list for PBXNativeTarget "IntegrationApp_watchOS" */;
+			buildPhases = (
+				65E7135AEFFC608F4D1D3B3F /* Sources */,
+				AC5FB93FB859D9BE381F039D /* Frameworks */,
+				319F2FD68F8B493C2DE39447 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = IntegrationApp_watchOS;
+			productName = IntegrationApp_watchOS;
+			productReference = 758FC0D745C185A2C28BEDA1 /* IntegrationApp_watchOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+		C0A58256FB8AD3E976C8F8D2 /* WebDriverAgentRunner_watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9D026747C8BF1F48AC40AE3F /* Build configuration list for PBXNativeTarget "WebDriverAgentRunner_watchOS" */;
+			buildPhases = (
+				2F7FB01E696A3A27F55D6E2C /* Sources */,
+				01F5E52F4145DB1989253A10 /* Frameworks */,
+				B8DDEF2CF5E0E5582F1359E9 /* Resources */,
+				3265D8138FA0376B6226B963 /* Copy frameworks */,
+				7027B1C595ACC71B793FB79D /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				744765485E7F3242FC04CE26 /* PBXTargetDependency */,
+			);
+			name = WebDriverAgentRunner_watchOS;
+			productName = WebDriverAgentRunner_watchOS;
+			productReference = 8B03F8C09D809131DE7792A7 /* WebDriverAgentRunner_watchOS.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 		DE52ACA4B43F527189E374EE /* IntegrationTests_tvOS */ = {
 			isa = PBXNativeTarget;
@@ -3503,8 +4415,10 @@
 			targets = (
 				EE158A981CBD452B00A3E3F0 /* WebDriverAgentLib */,
 				641EE5D52240C5CA00173FCB /* WebDriverAgentLib_tvOS */,
+				95186DE2383671DFA81D7FCB /* WebDriverAgentLib_watchOS */,
 				EEF988291C486603005CA669 /* WebDriverAgentRunner */,
 				641EE2D92240BBE300173FCB /* WebDriverAgentRunner_tvOS */,
+				C0A58256FB8AD3E976C8F8D2 /* WebDriverAgentRunner_watchOS */,
 				EE836C011C0F118600D87246 /* UnitTests */,
 				64B264F8228C50E0002A5025 /* UnitTests_tvOS */,
 				EE9B75EB1CF7956C00275851 /* IntegrationTests_1 */,
@@ -3513,11 +4427,27 @@
 				EE9B75D31CF7956C00275851 /* IntegrationApp */,
 				7C3BE5A1B1A6022529590D15 /* IntegrationApp_tvOS */,
 				DE52ACA4B43F527189E374EE /* IntegrationTests_tvOS */,
+				9D6B02D8FC050BAF7159284F /* IntegrationApp_watchOS */,
+				4632809915F58C9095914E85 /* IntegrationTests_watchOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		319F2FD68F8B493C2DE39447 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		360A0A377FD9AB69C7F73ED7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		641EE2D82240BBE300173FCB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3539,7 +4469,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7A0971F542104119F22CD36E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		96D4839EA1C7D7555DF56450 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B8DDEF2CF5E0E5582F1359E9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3612,6 +4556,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				9BE258E6A383AF8BCB59C475 /* FBTVFocusIntegrationTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2F7FB01E696A3A27F55D6E2C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				205E75731851D363B53A61DE /* UITestingUITests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3763,6 +4715,153 @@
 				64B26504228C5299002A5025 /* FBTVNavigationTrackerTests.m in Sources */,
 				CB1BAB30928B638B300B4477 /* FBXCAccessibilityElementDouble.m in Sources */,
 				DE75F01A64FBC6A58012E6B4 /* FBXCElementSnapshotDouble.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65E7135AEFFC608F4D1D3B3F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C3F7218DAB6B07E34AFDDF44 /* WatchSpikeApp.swift in Sources */,
+				3CF3155292597766001E17D9 /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A17BAB1FBE5B3A5B0AB97661 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DEFE56CC1A4EC88BCCD9BD6D /* WDAWatchHTTPClient.swift in Sources */,
+				E101F1B19A8079EAD8457C0C /* WDAWatchIntegrationTestCase.swift in Sources */,
+				D9FF15E0009D95996128C5E1 /* WDASessionIntegrationTests.swift in Sources */,
+				1FA2AA058DF5AEAC2212EAF8 /* WDAFindIntegrationTests.swift in Sources */,
+				A648F711A5BECD8BE680AB79 /* WDAElementAttributeIntegrationTests.swift in Sources */,
+				E1C6D95706F0F87BE535E332 /* WDAClickIntegrationTests.swift in Sources */,
+				93B85BB5737C85F650FF772F /* WDATypingIntegrationTests.swift in Sources */,
+				2CDFA27001529A43B560F3A1 /* WDAScreenshotAndSourceIntegrationTests.swift in Sources */,
+				07CD6433C98FC4A86E2BC7E3 /* WDAAppLifecycleIntegrationTests.swift in Sources */,
+				CEA3AF02E2BFF31ABB97F6F0 /* WDADeviceIntegrationTests.swift in Sources */,
+				A15C224F98CDB418E5727697 /* WDAAlertIntegrationTests.swift in Sources */,
+				E7DF976BD298CC4815946781 /* WDAUnknownCommandIntegrationTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ED98D7B74F8738C8481E77C1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0C120FA673A94DB66CB0E6B0 /* XCUIElement+FBCustomActions.m in Sources */,
+				9D87A03130302556CA52D1D2 /* NSDictionary+FBUtf8SafeDictionary.m in Sources */,
+				8934D96BE720E53106DCFA6C /* XCUIElement+FBResolve.m in Sources */,
+				1F9DD4891B8B19D8E13066E9 /* FBXCElementSnapshot.m in Sources */,
+				2441D42EAC1D00FBB870B129 /* LRUCache.m in Sources */,
+				8514673059ADAF54817A5795 /* FBScreenshotCommands.m in Sources */,
+				71CFF495DEF7670A748F569E /* FBSettings.m in Sources */,
+				34A32D91F0C8B6A31A9E8F9A /* FBSettingsHandler.m in Sources */,
+				5C1E821041979B5FA859B6D0 /* XCUIElement+FBPickerWheel.m in Sources */,
+				ED055540E72DDD419F88EEA4 /* XCUIApplicationProcessDelay.m in Sources */,
+				53069B2F807E140CB310AE67 /* FBXPath.m in Sources */,
+				9E914062BD3388A4F3B8100B /* FBXPathExtensions.m in Sources */,
+				9C2F91D75A5E54901114CC23 /* XCUIApplication+FBQuiescence.m in Sources */,
+				5D4AF85139930C5B7D49C258 /* XCUIApplication+FBAlert.m in Sources */,
+				0CE8AA4C3A10E2375925DE96 /* FBTVNavigationTracker.m in Sources */,
+				18F6B2130FD815A1B20F05CF /* FBScreenRecordingRequest.m in Sources */,
+				43AFED121DDF428411F72F83 /* FBXMLGenerationOptions.m in Sources */,
+				84ADB5DF7FBD5F44F2A8A538 /* XCUIApplication+FBTouchAction.m in Sources */,
+				A4E298C22E485C133E5356E3 /* XCAXClient_iOS+FBSnapshotReqParams.m in Sources */,
+				8D04F8FC7260CDC39C84B0C5 /* FBWebServer.m in Sources */,
+				2EB7B0D78CEB3388711C7A8B /* FBErrorBuilder.m in Sources */,
+				208F3FB46E41B0A1C87B8800 /* FBScreenshot.m in Sources */,
+				7C29155F72C16DF727A0692C /* XCUIElement+FBClassChain.m in Sources */,
+				97A4C24037304C59C4466337 /* FBXCDeviceEvent.m in Sources */,
+				F93EF507E81BB1A6697308CE /* NSExpression+FBFormat.m in Sources */,
+				980947E62D1AC9C4588F21C1 /* XCUIApplication+FBHelpers.m in Sources */,
+				18E3569349630AA1C465C6E7 /* FBKeyboard.m in Sources */,
+				EA02B947C3E2FF3DDF8C66BB /* FBElementUtils.m in Sources */,
+				1EBB250E6F79EBCBA11FCE9E /* FBW3CActionsSynthesizer.m in Sources */,
+				9472D6847DFCF79A29E201A1 /* FBFailureProofTestCase.m in Sources */,
+				AD764F10E2F00090AEB802F2 /* XCUIElement+FBIsVisible.m in Sources */,
+				49963069375202B1974BB426 /* FBExceptions.m in Sources */,
+				734735CAB6A95282CCF098E5 /* XCUIElement+FBFind.m in Sources */,
+				96F629258D7707B90D3E0456 /* FBResponsePayload.m in Sources */,
+				8889A10339D4C6B838DD85EF /* FBUnattachedAppLauncher.m in Sources */,
+				764374A915DAEBCB7EB46C2C /* FBRoute.m in Sources */,
+				168FCC9CDC7728709037351F /* NSString+FBVisualLength.m in Sources */,
+				BC91C1F00C54FE2115DE983F /* FBRunLoopSpinner.m in Sources */,
+				24ACBA685BA25B69FB1591F2 /* FBAlertsMonitor.m in Sources */,
+				9624FBB23087B3E9C5489888 /* FBClassChainQueryParser.m in Sources */,
+				44A9308980F99E72907DD327 /* NSPredicate+FBFormat.m in Sources */,
+				3FBA39A4D511311DB7C779F4 /* FBProtocolHelpers.m in Sources */,
+				EAAF5A671C1E9FF099797CDB /* XCUIDevice+FBRotation.m in Sources */,
+				062A682A90296DB8AA3B959E /* XCUIDevice+FBVoiceOver.m in Sources */,
+				A9BCCC677A46E48D4D2B05A9 /* FBActiveAppDetectionPoint.m in Sources */,
+				A893F1BC22A6066353FCD515 /* XCUIApplicationProcess+FBQuiescence.m in Sources */,
+				02032DB6E25DC5D0DEDD6184 /* XCUIElement+FBUID.m in Sources */,
+				D1212325FDE77754EE503755 /* FBRouteRequest.m in Sources */,
+				4D02B1320F9B19FE829D613A /* FBResponseJSONPayload.m in Sources */,
+				4EEB442BA8D43BD20A94BB68 /* XCUIDevice+FBHealthCheck.m in Sources */,
+				ACAC30299CC830793EFFFC31 /* FBBaseActionsSynthesizer.m in Sources */,
+				8468AE1133A7B8E7CBC18172 /* FBXCAccessibilityElement.m in Sources */,
+				E046D4602540FA7272DCBCB4 /* XCUIElement+FBWebDriverAttributes.m in Sources */,
+				2C6A45AFEC6B04782EE8E0B0 /* XCUIElement+FBForceTouch.m in Sources */,
+				1182F5754C6B30F1E1C86EE7 /* XCUIApplication+FBUIInterruptions.m in Sources */,
+				EAC0099EAC9722C516860CB3 /* FBTouchActionCommands.m in Sources */,
+				D87509BF0784FDFFD57A2EF5 /* FBNotificationsHelper.m in Sources */,
+				1224FFB1A0EAF2EBABE5A872 /* FBCapabilities.m in Sources */,
+				EF91D95D6C7F476683BB2C70 /* FBImageProcessor.m in Sources */,
+				5EAD5B877C99E1086732F175 /* FBTouchIDCommands.m in Sources */,
+				8FC4331C2C06A3E8B8F490E2 /* FBDebugCommands.m in Sources */,
+				3663B9177361DA1B4255D8F1 /* NSString+FBXMLSafeString.m in Sources */,
+				D607535858B02C328B9D6E33 /* FBUnknownCommands.m in Sources */,
+				DA26A56D4FE01CA1FAF6F1E7 /* FBOrientationCommands.m in Sources */,
+				27D0F4516BBBD53AAC9EF7A6 /* XCUIElement+FBTVFocuse.m in Sources */,
+				8E654AB7D5B1127F2CB6C540 /* FBRuntimeUtils.m in Sources */,
+				6EA187930FA95A0FB2D0338F /* XCUIElement+FBUtilities.m in Sources */,
+				031C89D75DD7FB7912ED0BA2 /* FBLogger.m in Sources */,
+				F26F431FE78FBABA2139F7F7 /* FBAccessibilityTraits.m in Sources */,
+				EDC993E0858F89F73D8E9DF8 /* FBCustomCommands.m in Sources */,
+				45033CF6BD35C16E34BF76CC /* FBScreenRecordingPromise.m in Sources */,
+				583AD004FF71CAA305E6DEAF /* XCUIDevice+FBHelpers.m in Sources */,
+				192CACF49EC3825BA6D2EF4F /* XCTestPrivateSymbols.m in Sources */,
+				53E0F0F38E7847065810FF41 /* XCUIElement+FBTyping.m in Sources */,
+				A5353D849D394BC630839E59 /* XCUIElement+FBAccessibility.m in Sources */,
+				BD8002B8812AF2CDD76BDF4D /* FBImageUtils.m in Sources */,
+				923B2C779F413A9EB7023AC5 /* XCUIElement+FBVisibleFrame.m in Sources */,
+				99BF9DF6BF6B424859BFCDE9 /* FBElementHelpers.m in Sources */,
+				C6DA9297ADD961C826DD93B6 /* FBSession.m in Sources */,
+				F01BCAAFC7CDDE89BD087347 /* FBFindElementCommands.m in Sources */,
+				4107851005EC0868D0240FC5 /* XCTIssue+FBPatcher.m in Sources */,
+				D14718959F7D46949859EEE6 /* FBDebugLogDelegateDecorator.m in Sources */,
+				7A1C1BA4A16ACF436D16338D /* FBAlertViewCommands.m in Sources */,
+				75BA34FEE03680F41B5054E1 /* LRUCacheNode.m in Sources */,
+				26E40B29FBB439AB7CDB7B16 /* FBScreenRecordingContainer.m in Sources */,
+				FC73EE781D24A598B44C3337 /* XCUIElement+FBScrolling.m in Sources */,
+				3FB977871FD8786CA90EB3E2 /* FBSessionCommands.m in Sources */,
+				D869B58002B298F70EE06B98 /* XCUIElement+FBMinMax.m in Sources */,
+				57EAF450031647694B6491F8 /* FBConfiguration.m in Sources */,
+				792C7A9BC732FD697300346A /* FBElementCache.m in Sources */,
+				B82CC2C629E56223A8C355B9 /* XCUIElement+FBSwiping.m in Sources */,
+				4292F2484A46457054541ADD /* FBPasteboard.m in Sources */,
+				7ADF6DB2192FD499AE0056DE /* FBAlert.m in Sources */,
+				C6ADE8E69FBFD7A0B63ECA06 /* FBCommandStatus.m in Sources */,
+				B7509C0E6BE45A7CD4037555 /* FBReflectionUtils.m in Sources */,
+				F63D9EB2A1C26B5DCB989CA3 /* FBElementCommands.m in Sources */,
+				4ACFAA7C5F1F80A7B695D23A /* FBExceptionHandler.m in Sources */,
+				849F04D9E87C06F04B33FC77 /* FBVideoCommands.m in Sources */,
+				486CFEAEDCA554C63F4214B3 /* FBXCodeCompatibility.m in Sources */,
+				A2CD45A0D42ADED8220DD2C7 /* XCUIElementQuery+FBHelpers.m in Sources */,
+				C74712EC760C30DF5D261DF0 /* FBElementTypeTransformer.m in Sources */,
+				9F9218F11A1D06F8DCC8308B /* FBXCElementSnapshotWrapper+Helpers.m in Sources */,
+				00ABDDC324B060006EA182F7 /* FBScreen.m in Sources */,
+				486F5AEF3C385922994476CD /* XCUIElement+FBCaching.m in Sources */,
+				92DC81D2F6E58386AC592482 /* FBXCTestDaemonsProxy.m in Sources */,
+				4819BEAC415E02570C0FA074 /* FBXCElementSnapshotWrapper.m in Sources */,
+				C4E500AC8CD81B4FE3A75EAE /* FBMathUtils.m in Sources */,
+				D062CA5914608761FE002799 /* FBXCAXClientProxy.m in Sources */,
+				46C54343FB83AD3AFC6CFCD4 /* FBTCPSocket.m in Sources */,
+				C2D22426DB9FCE6AD84FA16A /* RouteRequest.m in Sources */,
+				3FEF512914A962C5E30579FC /* RouteResponse.m in Sources */,
+				91FF05D51401D1F1A88FB0B0 /* FBWatchHTTPServer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4049,6 +5148,12 @@
 			target = 7C3BE5A1B1A6022529590D15 /* IntegrationApp_tvOS */;
 			targetProxy = 87B9178994EC282C279A8242 /* PBXContainerItemProxy */;
 		};
+		744765485E7F3242FC04CE26 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = WebDriverAgentLib_watchOS;
+			target = 95186DE2383671DFA81D7FCB /* WebDriverAgentLib_watchOS */;
+			targetProxy = 844B4A2ED5B8EE2FDD98DAD6 /* PBXContainerItemProxy */;
+		};
 		8BD208527AC761DA8EEE05C8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = WebDriverAgentLib_tvOS;
@@ -4059,6 +5164,12 @@
 			isa = PBXTargetDependency;
 			target = EE158A981CBD452B00A3E3F0 /* WebDriverAgentLib */;
 			targetProxy = AD8D96F01D3C12960061268E /* PBXContainerItemProxy */;
+		};
+		DC55141E0512D9D0ADE54987 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = IntegrationApp_watchOS;
+			target = 9D6B02D8FC050BAF7159284F /* IntegrationApp_watchOS */;
+			targetProxy = D564026BFC4C47F0187BD64C /* PBXContainerItemProxy */;
 		};
 		EE158B5C1CBD462500A3E3F0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4109,6 +5220,76 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		12BC722A112C4D54D64F1A9B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_STATIC_ANALYZER_MODE = deep;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = NO;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(PLATFORM_DIR)/Developer/Library/PrivateFrameworks",
+				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
+				INFOPLIST_FILE = WebDriverAgentLib/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					/System/Developer/Library/Frameworks,
+					/System/Developer/Library/PrivateFrameworks,
+					/Developer/Library/PrivateFrameworks,
+					/Developer/Library/Frameworks,
+				);
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.WebDriverAgentLib;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Weverything",
+					"-Wno-objc-missing-property-synthesis",
+					"-Wno-unused-macros",
+					"-Wno-disabled-macro-expansion",
+					"-Wno-gnu-statement-expression",
+					"-Wno-language-extension-token",
+					"-Wno-overriding-method-mismatch",
+					"-Wno-missing-variable-declarations",
+					"-Rno-module-build",
+					"-Wno-auto-import",
+					"-Wno-objc-interface-ivars",
+					"-Wno-documentation-unknown-command",
+					"-Wno-reserved-id-macro",
+					"-Wno-unused-parameter",
+					"-Wno-gnu-conditional-omitted-operand",
+					"-Wno-explicit-ownership-type",
+					"-Wno-date-time",
+					"-Wno-cast-align",
+					"-Wno-cstring-format-directive",
+					"-Wno-double-promotion",
+					"-Wno-partial-availability",
+					"-Wno-objc-messaging-id",
+					"-Wno-direct-ivar-access",
+					"-Wno-cast-qual",
+					"-Wno-declaration-after-statement",
+				);
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
+			};
+			name = Release;
+		};
 		57F43A3AA96962919E073C6F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 717C0D862518ED7000CAA6EC /* TVOSTestSettings.xcconfig */;
@@ -4577,6 +5758,112 @@
 			};
 			name = Release;
 		};
+		98904BB9FB61E1406D4E2754 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.wda.IntegrationTests.watchOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				TEST_TARGET_NAME = IntegrationApp_watchOS;
+				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
+			};
+			name = Release;
+		};
+		9AD9FD0D35FBBD5C87BC6F5B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_STATIC_ANALYZER_MODE = deep;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = NO;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(PLATFORM_DIR)/Developer/Library/PrivateFrameworks",
+				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
+				INFOPLIST_FILE = WebDriverAgentLib/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					/System/Developer/Library/Frameworks,
+					/System/Developer/Library/PrivateFrameworks,
+					/Developer/Library/PrivateFrameworks,
+					/Developer/Library/Frameworks,
+				);
+				OTHER_LDFLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.WebDriverAgentLib;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Weverything",
+					"-Wno-objc-missing-property-synthesis",
+					"-Wno-unused-macros",
+					"-Wno-disabled-macro-expansion",
+					"-Wno-gnu-statement-expression",
+					"-Wno-language-extension-token",
+					"-Wno-overriding-method-mismatch",
+					"-Wno-missing-variable-declarations",
+					"-Rno-module-build",
+					"-Wno-auto-import",
+					"-Wno-objc-interface-ivars",
+					"-Wno-documentation-unknown-command",
+					"-Wno-reserved-id-macro",
+					"-Wno-unused-parameter",
+					"-Wno-gnu-conditional-omitted-operand",
+					"-Wno-explicit-ownership-type",
+					"-Wno-date-time",
+					"-Wno-cast-align",
+					"-Wno-cstring-format-directive",
+					"-Wno-double-promotion",
+					"-Wno-partial-availability",
+					"-Wno-objc-messaging-id",
+					"-Wno-direct-ivar-access",
+					"-Wno-cast-qual",
+					"-Wno-declaration-after-statement",
+				);
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
+			};
+			name = Debug;
+		};
+		B0D268367AB2F8170E7246E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_WKWatchOnly = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.wda.IntegrationApp.watchOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
+			};
+			name = Debug;
+		};
 		B1F1F562B7EDB36C8E6BF55E /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 717C0D862518ED7000CAA6EC /* TVOSTestSettings.xcconfig */;
@@ -4595,6 +5882,28 @@
 				TARGETED_DEVICE_FAMILY = 3;
 				TEST_TARGET_NAME = IntegrationApp_tvOS;
 				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		B92D70B8C0772B7FB1EDD397 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_WKWatchOnly = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.wda.IntegrationApp.watchOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Release;
 		};
@@ -4618,6 +5927,66 @@
 			};
 			name = Release;
 		};
+		CBB9412B2F081EE453A8D639 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = WebDriverAgentRunner/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					/System/Developer/Library/Frameworks,
+					/System/Developer/Library/PrivateFrameworks,
+					/Developer/Library/PrivateFrameworks,
+					/Developer/Library/Frameworks,
+				);
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.WebDriverAgentRunner;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				TARGETED_DEVICE_FAMILY = 4;
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Weverything",
+					"-Wno-objc-missing-property-synthesis",
+					"-Wno-unused-macros",
+					"-Wno-disabled-macro-expansion",
+					"-Wno-gnu-statement-expression",
+					"-Wno-language-extension-token",
+					"-Wno-overriding-method-mismatch",
+					"-Wno-missing-variable-declarations",
+					"-Rno-module-build",
+					"-Wno-auto-import",
+					"-Wno-objc-interface-ivars",
+					"-Wno-documentation-unknown-command",
+					"-Wno-reserved-id-macro",
+					"-Wno-unused-parameter",
+					"-Wno-gnu-conditional-omitted-operand",
+					"-Wno-explicit-ownership-type",
+					"-Wno-date-time",
+					"-Wno-cast-align",
+					"-Wno-cstring-format-directive",
+					"-Wno-double-promotion",
+					"-Wno-partial-availability",
+					"-Wno-cast-qual",
+				);
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
+			};
+			name = Release;
+		};
 		D086EA231A06418467927B2C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 717C0D862518ED7000CAA6EC /* TVOSTestSettings.xcconfig */;
@@ -4634,6 +6003,21 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = Debug;
+		};
+		ED63FDC4EBEFE82B7D106218 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.wda.IntegrationTests.watchOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				TEST_TARGET_NAME = IntegrationApp_watchOS;
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
 		};
@@ -5061,6 +6445,66 @@
 			};
 			name = Release;
 		};
+		FCDAC27CD0999E5F422A47B0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = WebDriverAgentRunner/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					/System/Developer/Library/Frameworks,
+					/System/Developer/Library/PrivateFrameworks,
+					/Developer/Library/PrivateFrameworks,
+					/Developer/Library/Frameworks,
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.WebDriverAgentRunner;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				TARGETED_DEVICE_FAMILY = 4;
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Weverything",
+					"-Wno-objc-missing-property-synthesis",
+					"-Wno-unused-macros",
+					"-Wno-disabled-macro-expansion",
+					"-Wno-gnu-statement-expression",
+					"-Wno-language-extension-token",
+					"-Wno-overriding-method-mismatch",
+					"-Wno-missing-variable-declarations",
+					"-Rno-module-build",
+					"-Wno-auto-import",
+					"-Wno-objc-interface-ivars",
+					"-Wno-documentation-unknown-command",
+					"-Wno-reserved-id-macro",
+					"-Wno-unused-parameter",
+					"-Wno-gnu-conditional-omitted-operand",
+					"-Wno-explicit-ownership-type",
+					"-Wno-date-time",
+					"-Wno-cast-align",
+					"-Wno-cstring-format-directive",
+					"-Wno-double-promotion",
+					"-Wno-partial-availability",
+					"-Wno-cast-qual",
+				);
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -5069,6 +6513,15 @@
 			buildConfigurations = (
 				C58783FF0C15CF1BC4BFD426 /* Release */,
 				D086EA231A06418467927B2C /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		619E0BD15EC6EE4A0DAC898E /* Build configuration list for PBXNativeTarget "IntegrationApp_watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B92D70B8C0772B7FB1EDD397 /* Release */,
+				B0D268367AB2F8170E7246E2 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5114,6 +6567,24 @@
 			buildConfigurations = (
 				91F9DB0A1B99DBC2001349B2 /* Debug */,
 				91F9DB0B1B99DBC2001349B2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9D026747C8BF1F48AC40AE3F /* Build configuration list for PBXNativeTarget "WebDriverAgentRunner_watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FCDAC27CD0999E5F422A47B0 /* Debug */,
+				CBB9412B2F081EE453A8D639 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9DA322A56A2DFF03F3E5CDEA /* Build configuration list for PBXNativeTarget "IntegrationTests_watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				98904BB9FB61E1406D4E2754 /* Release */,
+				ED63FDC4EBEFE82B7D106218 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5177,6 +6648,15 @@
 			buildConfigurations = (
 				EEF988321C486604005CA669 /* Debug */,
 				EEF988331C486604005CA669 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F80B35927AACA48FC55D05B5 /* Build configuration list for PBXNativeTarget "WebDriverAgentLib_watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9AD9FD0D35FBBD5C87BC6F5B /* Debug */,
+				12BC722A112C4D54D64F1A9B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/IntegrationApp_watchOS.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/IntegrationApp_watchOS.xcscheme
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9D6B02D8FC050BAF7159284F"
+               BuildableName = "IntegrationApp_watchOS.app"
+               BlueprintName = "IntegrationApp_watchOS"
+               ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9D6B02D8FC050BAF7159284F"
+            BuildableName = "IntegrationApp_watchOS.app"
+            ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9D6B02D8FC050BAF7159284F"
+            BuildableName = "IntegrationApp_watchOS.app"
+            ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/IntegrationTests_watchOS.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/IntegrationTests_watchOS.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4632809915F58C9095914E85"
+               BuildableName = "IntegrationTests_watchOS.xctest"
+               BlueprintName = "IntegrationTests_watchOS"
+               ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4632809915F58C9095914E85"
+               BuildableName = "IntegrationTests_watchOS.xctest"
+               BlueprintName = "IntegrationTests_watchOS"
+               ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4632809915F58C9095914E85"
+            BuildableName = "IntegrationTests_watchOS.xctest"
+            BlueprintName = "IntegrationTests_watchOS"
+            ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4632809915F58C9095914E85"
+            BuildableName = "IntegrationTests_watchOS.xctest"
+            BlueprintName = "IntegrationTests_watchOS"
+            ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentLib_watchOS.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentLib_watchOS.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "95186DE2383671DFA81D7FCB"
+               BuildableName = "WebDriverAgentLib_watchOS.framework"
+               BlueprintName = "WebDriverAgentLib_watchOS"
+               ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "95186DE2383671DFA81D7FCB"
+            BuildableName = "WebDriverAgentLib_watchOS.framework"
+            BlueprintName = "WebDriverAgentLib_watchOS"
+            ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "95186DE2383671DFA81D7FCB"
+            BuildableName = "WebDriverAgentLib_watchOS.framework"
+            BlueprintName = "WebDriverAgentLib_watchOS"
+            ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "95186DE2383671DFA81D7FCB"
+            BuildableName = "WebDriverAgentLib_watchOS.framework"
+            BlueprintName = "WebDriverAgentLib_watchOS"
+            ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner_watchOS.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner_watchOS.xcscheme
@@ -1,28 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2600"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <PostActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Embed app icon into Runner.app"
-               scriptText = "&quot;${SRCROOT}/Scripts/embed-runner-icon.sh&quot;&#10;">
-               <EnvironmentBuildable>
-                  <BuildableReference
-                     BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "EEF988291C486603005CA669"
-                     BuildableName = "WebDriverAgentRunner.xctest"
-                     BlueprintName = "WebDriverAgentRunner"
-                     ReferencedContainer = "container:WebDriverAgent.xcodeproj">
-                  </BuildableReference>
-               </EnvironmentBuildable>
-            </ActionContent>
-         </ExecutionAction>
-      </PostActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -32,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EEF988291C486603005CA669"
-               BuildableName = "WebDriverAgentRunner.xctest"
-               BlueprintName = "WebDriverAgentRunner"
+               BlueprintIdentifier = "C0A58256FB8AD3E976C8F8D2"
+               BuildableName = "WebDriverAgentRunner_watchOS.xctest"
+               BlueprintName = "WebDriverAgentRunner_watchOS"
                ReferencedContainer = "container:WebDriverAgent.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -46,14 +28,23 @@
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "YES"
       systemAttachmentLifetime = "keepNever">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C0A58256FB8AD3E976C8F8D2"
+            BuildableName = "WebDriverAgentRunner_watchOS.xctest"
+            BlueprintName = "WebDriverAgentRunner_watchOS"
+            ReferencedContainer = "container:WebDriverAgent.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EEF988291C486603005CA669"
-               BuildableName = "WebDriverAgentRunner.xctest"
-               BlueprintName = "WebDriverAgentRunner"
+               BlueprintIdentifier = "C0A58256FB8AD3E976C8F8D2"
+               BuildableName = "WebDriverAgentRunner_watchOS.xctest"
+               BlueprintName = "WebDriverAgentRunner_watchOS"
                ReferencedContainer = "container:WebDriverAgent.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -72,9 +63,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EEF988291C486603005CA669"
-            BuildableName = "WebDriverAgentRunner.xctest"
-            BlueprintName = "WebDriverAgentRunner"
+            BlueprintIdentifier = "C0A58256FB8AD3E976C8F8D2"
+            BuildableName = "WebDriverAgentRunner_watchOS.xctest"
+            BlueprintName = "WebDriverAgentRunner_watchOS"
             ReferencedContainer = "container:WebDriverAgent.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -95,13 +86,18 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "MJPEG_SERVER_PORT"
-            value = "$(MJPEG_SERVER_PORT)"
+            key = "WDA_PRODUCT_BUNDLE_IDENTIFIER"
+            value = "$(WDA_PRODUCT_BUNDLE_IDENTIFIER)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "WDA_PRODUCT_BUNDLE_IDENTIFIER"
-            value = "$(WDA_PRODUCT_BUNDLE_IDENTIFIER)"
+            key = "MAX_HTTP_REQUEST_BODY_SIZE"
+            value = "$(MAX_HTTP_REQUEST_BODY_SIZE)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "VERBOSE_LOGGING"
+            value = "$(VERBOSE_LOGGING)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
@@ -115,9 +111,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EEF988291C486603005CA669"
-            BuildableName = "WebDriverAgentRunner.xctest"
-            BlueprintName = "WebDriverAgentRunner"
+            BlueprintIdentifier = "C0A58256FB8AD3E976C8F8D2"
+            BuildableName = "WebDriverAgentRunner_watchOS.xctest"
+            BlueprintName = "WebDriverAgentRunner_watchOS"
             ReferencedContainer = "container:WebDriverAgent.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBAlert.m
@@ -123,7 +123,12 @@ static NSString *const FB_LIMITED_ACCESS_PROMPT_BUNDLE_ID = @"com.apple.Contacts
     }
   }
 
+#if TARGET_OS_WATCH
+  // No popover concept or UIUserInterfaceIdiom on watchOS - treat sheets like phone sheets.
+  BOOL isPhone = YES;
+#else
   BOOL isPhone = [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone;
+#endif
   for (XCUIElement *sheet in sheets) {
     if (isPhone) {
       return sheet;

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -435,6 +435,7 @@ NSDictionary<NSString *, NSString *> *customExclusionAttributesMap(void) {
     }
   }
   
+#if !TARGET_OS_WATCH
   if ([UIDevice.currentDevice userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
     NSPredicate *searchPredicate = [NSPredicate predicateWithFormat:@"elementType IN %@",
                                     @[@(XCUIElementTypeKey), @(XCUIElementTypeButton)]];
@@ -443,6 +444,7 @@ NSDictionary<NSString *, NSString *> *customExclusionAttributesMap(void) {
       [matchedKeys[matchedKeys.count - 1] tap];
     }
   }
+#endif
 #endif
   NSString *errorDescription = @"Did not know how to dismiss the keyboard. Try to dismiss it in the way supported by your application under test.";
   return [[[[FBRunLoopSpinner new]

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBTouchAction.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBTouchAction.m
@@ -18,7 +18,7 @@
 #import "FBXCTestDaemonsProxy.h"
 #import "XCUIElement+FBUtilities.h"
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 
 @implementation XCUIApplication (FBTouchAction)
 

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -68,13 +68,13 @@ NSDictionary<NSString *, NSNumber *> *fb_availableButtonNames(void) {
     buttons[@"volumeup"] = @(XCUIDeviceButtonVolumeUp);     // 2
     buttons[@"volumedown"] = @(XCUIDeviceButtonVolumeDown); // 3
 #endif
-    if (@available(iOS 16.0, *)) {
+    if (@available(iOS 16.0, watchOS 9.0, *)) {
 #if __clang_major__ >= 15 // likely Xcode 15+
       if ([XCUIDevice.sharedDevice hasHardwareButton:XCUIDeviceButtonAction]) {
         buttons[@"action"] = @(XCUIDeviceButtonAction);     // 4
       }
 #endif
-#if (!TARGET_OS_SIMULATOR && __clang_major__ >= 16) // likely Xcode 16+
+#if (!TARGET_OS_SIMULATOR && !TARGET_OS_WATCH && __clang_major__ >= 16) // likely Xcode 16+; camera button does not exist on watchOS
       if ([XCUIDevice.sharedDevice hasHardwareButton:XCUIDeviceButtonCamera]) {
         buttons[@"camera"] = @(XCUIDeviceButtonCamera);
       }
@@ -357,9 +357,9 @@ static bool fb_isLocked;
     return YES;
   }
 
-#if __clang_major__ >= 15 || (__clang_major__ >= 14 && __clang_minor__ >= 0 && __clang_patchlevel__ >= 3)
+#if !TARGET_OS_WATCH && (__clang_major__ >= 15 || (__clang_major__ >= 14 && __clang_minor__ >= 0 && __clang_patchlevel__ >= 3))
   // Xcode 14.3.1 can build these values.
-  // For iOS 17+
+  // For iOS 17+; the `appearance` property does not exist on watchOS
   if ([self respondsToSelector:NSSelectorFromString(@"appearance")]) {
     self.appearance = (XCUIDeviceAppearance) appearance;
     return YES;

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.h
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.h
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 @interface XCUIDevice (FBRotation)
 
 /**

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBRotation.m
@@ -13,7 +13,7 @@
 #import "XCUIApplication+FBHelpers.h"
 #import "XCUIElement+FBUtilities.h"
 
-# if !TARGET_OS_TV
+# if !TARGET_OS_TV && !TARGET_OS_WATCH
 
 @implementation XCUIDevice (FBRotation)
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBPickerWheel.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBPickerWheel.m
@@ -16,7 +16,7 @@
 #import "XCUIElement+FBCaching.h"
 #import "XCUIElement+FBResolve.h"
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 @implementation XCUIElement (FBPickerWheel)
 
 static const NSTimeInterval VALUE_CHANGE_TIMEOUT = 2;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -89,6 +89,10 @@ BOOL FBTypeText(NSString *text, NSUInteger typingSpeed, NSError **error)
 #if !TARGET_OS_TV
   [FBLogger logFmt:@"Trying to tap the \"%@\" element to have it focused", snapshot.fb_description];
   [self tap];
+#if TARGET_OS_WATCH
+  // watchOS presents a full-screen keyboard sheet (a modal transition) - wait for it.
+  [self fb_waitUntilStableWithTimeout:2.0];
+#endif
   // It might take some time to update the UI
   [self fb_standardSnapshot];
 #endif
@@ -130,7 +134,14 @@ BOOL FBTypeText(NSString *text, NSUInteger typingSpeed, NSError **error)
   if (shouldClear && ![self fb_clearTextWithSnapshot:wrapped shouldPrepareForInput:NO error:error]) {
     return NO;
   }
+#if TARGET_OS_WATCH
+  // FBTypeText's low-level key synthesis never reaches watchOS's keyboard; -typeText: is a
+  // partial workaround (keystrokes still don't always land - a known limitation).
+  [self typeText:text];
+  return YES;
+#else
   return FBTypeText(text, frequency, error);
+#endif
 }
 
 - (BOOL)fb_clearTextWithError:(NSError **)error

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -8,6 +8,9 @@
 
 #import "FBCustomCommands.h"
 
+#if TARGET_OS_WATCH
+@import WatchKit;
+#endif
 #import <XCTest/XCUIDevice.h>
 #import <CoreLocation/CoreLocation.h>
 
@@ -52,7 +55,7 @@
     [[FBRoute GET:@"/wda/screen"].withoutSession respondWithTarget:self action:@selector(handleGetScreen:)],
     [[FBRoute GET:@"/wda/activeAppInfo"] respondWithTarget:self action:@selector(handleActiveAppInfo:)],
     [[FBRoute GET:@"/wda/activeAppInfo"].withoutSession respondWithTarget:self action:@selector(handleActiveAppInfo:)],
-#if !TARGET_OS_TV // tvOS does not provide relevant APIs
+#if !TARGET_OS_TV && !TARGET_OS_WATCH // tvOS/watchOS do not provide relevant APIs
     [[FBRoute POST:@"/wda/setPasteboard"] respondWithTarget:self action:@selector(handleSetPasteboard:)],
     [[FBRoute POST:@"/wda/setPasteboard"].withoutSession respondWithTarget:self action:@selector(handleSetPasteboard:)],
     [[FBRoute POST:@"/wda/getPasteboard"] respondWithTarget:self action:@selector(handleGetPasteboard:)],
@@ -72,8 +75,10 @@
     [[FBRoute GET:@"/wda/device/location"] respondWithTarget:self action:@selector(handleGetLocation:)],
     [[FBRoute GET:@"/wda/device/location"].withoutSession respondWithTarget:self action:@selector(handleGetLocation:)],
 #if !TARGET_OS_TV // tvOS does not provide relevant APIs
+#if !TARGET_OS_WATCH
 #if __clang_major__ >= 15
     [[FBRoute POST:@"/wda/element/:uuid/keyboardInput"] respondWithTarget:self action:@selector(handleKeyboardInput:)],
+#endif
 #endif
     [[FBRoute GET:@"/wda/simulatedLocation"] respondWithTarget:self action:@selector(handleGetSimulatedLocation:)],
     [[FBRoute GET:@"/wda/simulatedLocation"].withoutSession respondWithTarget:self action:@selector(handleGetSimulatedLocation:)],
@@ -151,7 +156,7 @@
   XCUIElement *mainStatusBar = app.statusBars.allElementsBoundByIndex.firstObject;
   CGSize statusBarSize = (nil == mainStatusBar) ? CGSizeZero : mainStatusBar.frame.size;
 
-#if TARGET_OS_TV
+#if TARGET_OS_TV || TARGET_OS_WATCH
   CGSize screenSize = app.frame.size;
 #else
   CGSize screenSize = FBAdjustDimensionsForApplication(app.wdFrame.size, app.interfaceOrientation);
@@ -240,7 +245,7 @@
   };
 }
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 + (id<FBResponsePayload>)handleSetPasteboard:(FBRouteRequest *)request
 {
   NSString *contentType = request.arguments[@"contentType"] ?: @"plaintext";
@@ -357,7 +362,9 @@
   [locationManager setDistanceFilter:kCLHeadingFilterNone];
   // Always return the best acurate location data
   [locationManager setDesiredAccuracy:kCLLocationAccuracyBest];
+#if !TARGET_OS_WATCH
   [locationManager setPausesLocationUpdatesAutomatically:NO];
+#endif
   [locationManager startUpdatingLocation];
 
   CLAuthorizationStatus authStatus;
@@ -438,11 +445,17 @@
                                      @{
     @"currentLocale": currentLocale,
     @"timeZone": self.timeZone,
+#if TARGET_OS_WATCH
+    @"name": WKInterfaceDevice.currentDevice.name,
+    @"model": WKInterfaceDevice.currentDevice.model,
+    @"uuid": @"unknown",
+#else
     @"name": UIDevice.currentDevice.name,
     @"model": UIDevice.currentDevice.model,
     @"uuid": [UIDevice.currentDevice.identifierForVendor UUIDString] ?: @"unknown",
     // https://developer.apple.com/documentation/uikit/uiuserinterfaceidiom?language=objc
     @"userInterfaceIdiom": @(UIDevice.currentDevice.userInterfaceIdiom),
+#endif
     @"userInterfaceStyle": self.userInterfaceStyle,
 #if TARGET_OS_SIMULATOR
     @"isSimulator": @(YES),
@@ -473,6 +486,7 @@
   }
 
   static id userInterfaceStyle = nil;
+#if !TARGET_OS_WATCH
   static dispatch_once_t styleOnceToken;
   dispatch_once(&styleOnceToken, ^{
     if ([UITraitCollection respondsToSelector:NSSelectorFromString(@"currentTraitCollection")]) {
@@ -482,6 +496,7 @@
       }
     }
   });
+#endif
 
   if (nil == userInterfaceStyle) {
     return @"unsupported";
@@ -571,7 +586,7 @@
   return FBResponseWithOK();
 }
 
-#if __clang_major__ >= 15
+#if __clang_major__ >= 15 && !TARGET_OS_WATCH
 + (id<FBResponsePayload>)handleKeyboardInput:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -73,7 +73,8 @@
 #if TARGET_OS_TV
     [[FBRoute GET:@"/element/:uuid/attribute/focused"] respondWithTarget:self action:@selector(handleGetFocused:)],
     [[FBRoute POST:@"/wda/element/:uuid/focuse"] respondWithTarget:self action:@selector(handleFocuse:)],
-#else
+#elif !TARGET_OS_WATCH
+    // Gesture synthesis isn't supported on watchOS - only /element/:uuid/click is available.
     [[FBRoute POST:@"/wda/element/:uuid/swipe"] respondWithTarget:self action:@selector(handleSwipe:)],
     [[FBRoute POST:@"/wda/swipe"] respondWithTarget:self action:@selector(handleSwipe:)],
 
@@ -205,7 +206,7 @@
     ? [value componentsJoinedByString:@""]
     : value;
   XCUIElementType elementType = [element elementType];
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
   if (elementType == XCUIElementTypePickerWheel) {
     [element adjustToPickerWheelValue:textToType];
     return FBResponseWithOK();
@@ -239,7 +240,7 @@
 {
   FBElementCache *elementCache = request.session.elementCache;
   XCUIElement *element = [elementCache elementForUUID:(NSString *)request.parameters[@"uuid"] checkStaleness:YES];
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_WATCH
   [element tap];
 #elif TARGET_OS_TV
   NSError *error = nil;
@@ -534,7 +535,7 @@
   XCUIApplication *app = request.session.activeApplication ?: XCUIApplication.fb_activeApplication;
 
   CGRect frame = app.wdFrame;
-#if TARGET_OS_TV
+#if TARGET_OS_TV || TARGET_OS_WATCH
   CGSize screenSize = frame.size;
 #else
   CGSize screenSize = FBAdjustDimensionsForApplication(frame.size, app.interfaceOrientation);
@@ -551,7 +552,7 @@
   XCUIApplication *app = request.session.activeApplication ?: XCUIApplication.fb_activeApplication;
 
   CGRect frame = app.wdFrame;
-#if TARGET_OS_TV
+#if TARGET_OS_TV || TARGET_OS_WATCH
   CGSize screenSize = frame.size;
 #else
   CGSize screenSize = FBAdjustDimensionsForApplication(frame.size, app.interfaceOrientation);

--- a/WebDriverAgentLib/Commands/FBOrientationCommands.m
+++ b/WebDriverAgentLib/Commands/FBOrientationCommands.m
@@ -29,7 +29,7 @@ const struct FBWDOrientationValues FBWDOrientationValues = {
   .portraitUpsideDown = @"UIA_DEVICE_ORIENTATION_PORTRAIT_UPSIDEDOWN",
 };
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 
 @implementation FBOrientationCommands
 

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -8,6 +8,10 @@
 
 #import "FBSessionCommands.h"
 
+#if TARGET_OS_WATCH
+@import WatchKit;
+#endif
+
 #import "FBCapabilities.h"
 #import "FBConfiguration.h"
 #import "FBExceptions.h"
@@ -189,6 +193,16 @@
     [buildInfo setObject:version forKey:@"version"];
   }
 
+#if TARGET_OS_WATCH
+  NSString *osName = @"watchOS";
+  NSString *osVersion = WKInterfaceDevice.currentDevice.systemVersion;
+  NSString *deviceKind = @"watch";
+#else
+  NSString *osName = [[UIDevice currentDevice] systemName];
+  NSString *osVersion = [[UIDevice currentDevice] systemVersion];
+  NSString *deviceKind = [self.class deviceNameByUserInterfaceIdiom:[UIDevice currentDevice].userInterfaceIdiom];
+#endif
+
   return FBResponseWithObject(
     @{
       @"ready" : @YES,
@@ -196,20 +210,20 @@
       @"state" : @"success",
       @"os" :
         @{
-          @"name" : [[UIDevice currentDevice] systemName],
-          @"version" : [[UIDevice currentDevice] systemVersion],
+          @"name" : osName,
+          @"version" : osVersion,
           @"sdkVersion": FBSDKVersion() ?: @"unknown",
           @"testmanagerdVersion": @(FBTestmanagerdVersion()),
         },
       @"ios" :
         @{
-#if TARGET_OS_SIMULATOR
-          @"simulatorVersion" : [[UIDevice currentDevice] systemVersion],
+#if TARGET_OS_SIMULATOR && !TARGET_OS_WATCH
+          @"simulatorVersion" : osVersion,
 #endif
           @"ip" : [XCUIDevice sharedDevice].fb_wifiIPAddress ?: [NSNull null]
         },
       @"build" : buildInfo.copy,
-      @"device": [self.class deviceNameByUserInterfaceIdiom:[UIDevice currentDevice].userInterfaceIdiom]
+      @"device": deviceKind
     }
   );
 }
@@ -431,6 +445,7 @@
   };
 }
 
+#if !TARGET_OS_WATCH
 /*
  Return the device kind as lower case
 */
@@ -447,14 +462,23 @@
   return @"Unknown";
 
 }
+#endif
 
 + (NSDictionary *)currentCapabilities
 {
+#if TARGET_OS_WATCH
+  return
+  @{
+    @"device": @"watch",
+    @"sdkVersion": WKInterfaceDevice.currentDevice.systemVersion
+  };
+#else
   return
   @{
     @"device": [self.class deviceNameByUserInterfaceIdiom:[UIDevice currentDevice].userInterfaceIdiom],
     @"sdkVersion": [[UIDevice currentDevice] systemVersion]
   };
+#endif
 }
 
 +(nullable id<FBResponsePayload>)openDeepLink:(NSString *)initialUrl

--- a/WebDriverAgentLib/Routing/FBTCPSocket.h
+++ b/WebDriverAgentLib/Routing/FBTCPSocket.h
@@ -6,9 +6,55 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// TARGET_OS_WATCH must be defined before the #if below runs, or (on some older Xcode/SDK
+// toolchains) it silently evaluates as undefined/false here despite being true for the rest of
+// the translation unit - which desyncs this file's declarations from FBTCPSocket.m's own
+// #if TARGET_OS_WATCH branch.
+#import <TargetConditionals.h>
+
+#if TARGET_OS_WATCH
+@import Foundation;
+// A textual import, not `@import Network;` - older Xcode/watchOS SDK combinations (verified:
+// Xcode 15.4/watchOS 10.5) fail to expose nw_listener_t/nw_connection_t and friends through the
+// Network module map on watchOS, even though the underlying API has existed since watchOS 5.0.
+#import <Network/Network.h>
+#else
 #import "GCDAsyncSocket.h"
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
+
+#if TARGET_OS_WATCH
+
+// watchOS forbids BSD sockets, so this is backed by Network.framework instead of GCDAsyncSocket -
+// hence a differently-shaped, push-style delegate protocol.
+@protocol FBTCPSocketDelegate <NSObject>
+
+/**
+ The callback which is fired on new TCP client connection
+
+ @param newClient The newly connected client
+ */
+- (void)didClientConnect:(nw_connection_t)newClient;
+
+/**
+ The callback which is fired when the TCP server receives data from a connected client
+
+ @param client The client, which sent the data
+ @param data The received data
+*/
+- (void)client:(nw_connection_t)client didReceiveData:(NSData *)data;
+
+/**
+ The callback which is fired when TCP client disconnects
+
+ @param client The actual disconnected client
+ */
+- (void)didClientDisconnect:(nw_connection_t)client;
+
+@end
+
+#else
 
 @protocol FBTCPSocketDelegate
 
@@ -34,6 +80,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)didClientDisconnect:(GCDAsyncSocket *)client;
 
 @end
+
+#endif
 
 
 @interface FBTCPSocket : NSObject
@@ -64,6 +112,28 @@ NS_ASSUME_NONNULL_BEGIN
  Stops the socket if it is running
  */
 - (void)stop;
+
+#if TARGET_OS_WATCH
+/**
+ Writes data to the given connected client
+
+ @param data The data to send
+ @param client The destination client, as received via -didClientConnect: or -client:didReceiveData:
+ */
+- (void)writeData:(NSData *)data toClient:(nw_connection_t)client;
+
+/**
+ Like -writeData:toClient:, but invokes completion once the send actually goes out. Use this
+ before cancelling the connection - nw_connection_send is async, so cancelling right away can
+ drop the write before it's sent.
+
+ @param data The data to send
+ @param client The destination client
+ @param completion Called once the send attempt finishes
+ */
+- (void)writeData:(NSData *)data toClient:(nw_connection_t)client completion:(nullable void (^)(void))completion;
+#endif
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Routing/FBTCPSocket.m
+++ b/WebDriverAgentLib/Routing/FBTCPSocket.m
@@ -8,6 +8,199 @@
 
 #import "FBTCPSocket.h"
 
+#if TARGET_OS_WATCH
+
+@interface FBTCPSocket()
+@property (readonly, nonatomic) dispatch_queue_t socketQueue;
+@property (nullable, nonatomic) nw_listener_t listener;
+@property (readonly, nonatomic) NSMutableArray<nw_connection_t> *connectedClients;
+@property (readonly, nonatomic) uint16_t port;
+@end
+
+
+@implementation FBTCPSocket
+
+- (instancetype)initWithPort:(uint16_t)port
+{
+  if ((self = [super init])) {
+    _socketQueue = dispatch_queue_create("socketQueue", NULL);
+    _connectedClients = [[NSMutableArray alloc] initWithCapacity:1];
+    _port = port;
+    _delegate = nil;
+  }
+  return self;
+}
+
+- (BOOL)startWithError:(NSError **)error
+{
+  nw_parameters_t parameters = nw_parameters_create_secure_tcp(NW_PARAMETERS_DISABLE_PROTOCOL,
+                                                                NW_PARAMETERS_DEFAULT_CONFIGURATION);
+  NSString *portString = [NSString stringWithFormat:@"%u", (unsigned int)self.port];
+  // portString is always valid UTF8; -UTF8String is just declared nullable in general.
+  const char * _Nonnull portCString = (const char * _Nonnull)portString.UTF8String;
+  nw_listener_t listener = nw_listener_create_with_port(portCString, parameters);
+  if (nil == listener) {
+    if (error) {
+      *error = [NSError errorWithDomain:@"FBTCPSocket"
+                                    code:1
+                                userInfo:@{NSLocalizedDescriptionKey: @"Failed to create the TCP listener"}];
+    }
+    return NO;
+  }
+  self.listener = listener;
+
+  __weak typeof(self) weakSelf = self;
+  nw_listener_set_queue(listener, self.socketQueue);
+  nw_listener_set_new_connection_handler(listener, ^(nw_connection_t connection) {
+    [weakSelf acceptConnection:connection];
+  });
+
+  dispatch_semaphore_t startupSemaphore = dispatch_semaphore_create(0);
+  __block NSError *startupError = nil;
+  nw_listener_set_state_changed_handler(listener, ^(nw_listener_state_t state, nw_error_t nwError) {
+    // if/else, not switch: -Wswitch-enum, -Wswitch-default, and -Wcovered-switch-default can't
+    // all be satisfied by one switch statement at once.
+    if (nw_listener_state_ready == state) {
+      dispatch_semaphore_signal(startupSemaphore);
+    } else if (nw_listener_state_failed == state || nw_listener_state_cancelled == state) {
+      startupError = [NSError errorWithDomain:@"FBTCPSocket"
+                                          code:2
+                                      userInfo:@{NSLocalizedDescriptionKey: (id)(nwError
+                                        ? CFBridgingRelease(nw_error_copy_cf_error(nwError))
+                                        : @"The TCP listener failed to start")}];
+      dispatch_semaphore_signal(startupSemaphore);
+    }
+  });
+  nw_listener_start(listener);
+  BOOL didStartInTime = 0 == dispatch_semaphore_wait(startupSemaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5 * NSEC_PER_SEC)));
+  if (!didStartInTime) {
+    startupError = [NSError errorWithDomain:@"FBTCPSocket"
+                                        code:3
+                                    userInfo:@{NSLocalizedDescriptionKey: @"Timed out while starting the TCP listener"}];
+  }
+  if (nil != startupError) {
+    if (error) {
+      *error = startupError;
+    }
+    self.listener = nil;
+    return NO;
+  }
+  return YES;
+}
+
+- (void)acceptConnection:(nw_connection_t)connection
+{
+  @synchronized (self.connectedClients) {
+    [self.connectedClients addObject:connection];
+  }
+
+  __weak typeof(self) weakSelf = self;
+  nw_connection_set_queue(connection, self.socketQueue);
+  nw_connection_set_state_changed_handler(connection, ^(nw_connection_state_t state, nw_error_t connectionError) {
+    // Same reasoning as the listener state handler above.
+    if (nw_connection_state_ready == state) {
+      __strong typeof(weakSelf) strongSelf = weakSelf;
+      if (nil == strongSelf) {
+        return;
+      }
+      id<FBTCPSocketDelegate> delegate = strongSelf.delegate;
+      if (nil != delegate) {
+        [delegate didClientConnect:connection];
+      }
+      [strongSelf scheduleReceiveForConnection:connection];
+    } else if (nw_connection_state_failed == state || nw_connection_state_cancelled == state) {
+      [weakSelf handleDisconnectForConnection:connection];
+    }
+  });
+  nw_connection_start(connection);
+}
+
+- (void)scheduleReceiveForConnection:(nw_connection_t)connection
+{
+  __weak typeof(self) weakSelf = self;
+  nw_connection_receive(connection, 1, UINT32_MAX, ^(dispatch_data_t  _Nullable content,
+                                                       nw_content_context_t  _Nullable context,
+                                                       bool isComplete,
+                                                       nw_error_t  _Nullable receiveError) {
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    if (nil == strongSelf) {
+      return;
+    }
+    if (nil != content) {
+      dispatch_data_t nonnullContent = (dispatch_data_t _Nonnull)content;
+      __block NSData *data = nil;
+      dispatch_data_apply(nonnullContent, ^bool(dispatch_data_t  _Nonnull region, size_t offset, const void * _Nonnull buffer, size_t size) {
+        NSMutableData *accumulated = [(data ?: [NSData data]) mutableCopy];
+        [accumulated appendBytes:buffer length:size];
+        data = accumulated.copy;
+        return true;
+      });
+      if (data.length > 0) {
+        id<FBTCPSocketDelegate> delegate = strongSelf.delegate;
+        if (nil != delegate) {
+          [delegate client:connection didReceiveData:data];
+        }
+      }
+    }
+    if (nil != receiveError || (isComplete && nil == content)) {
+      [strongSelf handleDisconnectForConnection:connection];
+      return;
+    }
+    [strongSelf scheduleReceiveForConnection:connection];
+  });
+}
+
+- (void)handleDisconnectForConnection:(nw_connection_t)connection
+{
+  BOOL wasConnected;
+  @synchronized (self.connectedClients) {
+    wasConnected = [self.connectedClients containsObject:connection];
+    [self.connectedClients removeObject:connection];
+  }
+  if (wasConnected) {
+    id<FBTCPSocketDelegate> delegate = self.delegate;
+    if (nil != delegate) {
+      [delegate didClientDisconnect:connection];
+    }
+  }
+}
+
+- (void)writeData:(NSData *)data toClient:(nw_connection_t)client
+{
+  [self writeData:data toClient:client completion:nil];
+}
+
+- (void)writeData:(NSData *)data toClient:(nw_connection_t)client completion:(nullable void (^)(void))completion
+{
+  dispatch_data_t dispatchData = dispatch_data_create(data.bytes, data.length, self.socketQueue, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+  nw_connection_send(client, dispatchData, NW_CONNECTION_DEFAULT_STREAM_CONTEXT, false, ^(nw_error_t  _Nullable sendError) {
+    if (completion) {
+      completion();
+    }
+  });
+}
+
+- (void)stop
+{
+  @synchronized (self.connectedClients) {
+    NSArray<nw_connection_t> *clients = self.connectedClients.copy;
+    [self.connectedClients removeAllObjects];
+    for (nw_connection_t client in clients) {
+      nw_connection_cancel(client);
+    }
+  }
+
+  self.delegate = nil;
+  nw_listener_t listener = self.listener;
+  if (nil != listener) {
+    nw_listener_cancel((nw_listener_t _Nonnull)listener);
+    self.listener = nil;
+  }
+}
+
+@end
+
+#else
 
 @interface FBTCPSocket()
 @property (readonly, nonatomic) dispatch_queue_t socketQueue;
@@ -95,3 +288,5 @@
 }
 
 @end
+
+#endif

--- a/WebDriverAgentLib/Routing/FBTCPSocket.m
+++ b/WebDriverAgentLib/Routing/FBTCPSocket.m
@@ -63,11 +63,15 @@
     if (nw_listener_state_ready == state) {
       dispatch_semaphore_signal(startupSemaphore);
     } else if (nw_listener_state_failed == state || nw_listener_state_cancelled == state) {
-      startupError = [NSError errorWithDomain:@"FBTCPSocket"
-                                          code:2
-                                      userInfo:@{NSLocalizedDescriptionKey: (id)(nwError
-                                        ? CFBridgingRelease(nw_error_copy_cf_error(nwError))
-                                        : @"The TCP listener failed to start")}];
+      // NSLocalizedDescriptionKey must be a string, not the underlying NSError itself, or
+      // -[NSError localizedDescription] crashes trying to treat it as one.
+      NSError *underlyingError = nwError ? (NSError *)CFBridgingRelease(nw_error_copy_cf_error(nwError)) : nil;
+      NSMutableDictionary<NSString *, id> *userInfo = [NSMutableDictionary dictionary];
+      userInfo[NSLocalizedDescriptionKey] = underlyingError.localizedDescription ?: @"The TCP listener failed to start";
+      if (underlyingError) {
+        userInfo[NSUnderlyingErrorKey] = underlyingError;
+      }
+      startupError = [NSError errorWithDomain:@"FBTCPSocket" code:2 userInfo:userInfo];
       dispatch_semaphore_signal(startupSemaphore);
     }
   });

--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -8,17 +8,21 @@
 
 #import "FBWebServer.h"
 
+#if TARGET_OS_WATCH
+#import "FBWatchHTTPServer.h"
+#else
 #import "RoutingConnection.h"
 #import "RoutingHTTPServer.h"
+#import "FBMjpegServer.h"
+#import "FBTCPSocket.h"
+#endif
 
 #import "FBCommandHandler.h"
 #import "FBErrorBuilder.h"
 #import "FBExceptionHandler.h"
-#import "FBMjpegServer.h"
 #import "FBRouteRequest.h"
 #import "FBRuntimeUtils.h"
 #import "FBSession.h"
-#import "FBTCPSocket.h"
 #import "FBUnknownCommands.h"
 #import "FBConfiguration.h"
 #import "FBLogger.h"
@@ -28,6 +32,7 @@
 static NSString *const FBServerURLBeginMarker = @"ServerURLHere->";
 static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
 
+#if !TARGET_OS_WATCH
 @interface FBHTTPConnection : RoutingConnection
 @end
 
@@ -45,21 +50,28 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
 }
 
 @end
+#endif
 
 
 @interface FBWebServer ()
 @property (nonatomic, strong) FBExceptionHandler *exceptionHandler;
+#if TARGET_OS_WATCH
+@property (nonatomic, strong) FBWatchHTTPServer *server;
+#else
 @property (nonatomic, strong) RoutingHTTPServer *server;
-@property (atomic, assign) BOOL keepAlive;
 @property (nonatomic, nullable) FBTCPSocket *screenshotsBroadcaster;
 @property (nonatomic, nullable, strong) FBMjpegServer *mjpegServer;
+#endif
+@property (atomic, assign) BOOL keepAlive;
 @end
 
 @implementation FBWebServer
 
 - (void)dealloc
 {
+#if !TARGET_OS_WATCH
   [self stopScreenshotsBroadcaster];
+#endif
 }
 
 + (NSArray<Class<FBCommandHandler>> *)collectCommandHandlerClasses
@@ -84,7 +96,9 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   if (![self startHTTPServer]) {
     return;
   }
+#if !TARGET_OS_WATCH
   [self initScreenshotsBroadcaster];
+#endif
 
   self.keepAlive = YES;
   NSRunLoop *runLoop = [NSRunLoop mainRunLoop];
@@ -94,22 +108,30 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
 
 - (BOOL)startHTTPServer
 {
+#if TARGET_OS_WATCH
+  self.server = [[FBWatchHTTPServer alloc] init];
+#else
   self.server = [[RoutingHTTPServer alloc] init];
+#endif
   [self.server setRouteQueue:dispatch_get_main_queue()];
   [self.server setDefaultHeader:@"Server" value:@"WebDriverAgent/1.0"];
   [self.server setDefaultHeader:@"Access-Control-Allow-Origin" value:@"*"];
   [self.server setDefaultHeader:@"Access-Control-Allow-Headers" value:@"Content-Type, X-Requested-With"];
+#if !TARGET_OS_WATCH
   [self.server setConnectionClass:[FBHTTPConnection self]];
+#endif
 
   [self registerRouteHandlers:[self.class collectCommandHandlerClasses]];
   [self registerServerKeyRouteHandlers];
 
   NSRange serverPortRange = FBConfiguration.sharedInstance.bindingPortRange;
   NSString *bindingIP = FBConfiguration.sharedInstance.bindingIPAddress;
+#if !TARGET_OS_WATCH
   if (bindingIP != nil) {
     [self.server setInterface:bindingIP];
     [FBLogger logFmt:@"Using custom binding IP address: %@", bindingIP];
   }
+#endif
 
   NSError *error;
   BOOL serverStarted = NO;
@@ -141,6 +163,7 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   return YES;
 }
 
+#if !TARGET_OS_WATCH
 - (void)initScreenshotsBroadcaster
 {
   [self readMjpegSettingsFromEnv];
@@ -186,11 +209,14 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
     FBConfiguration.sharedInstance.mjpegServerScreenshotQuality = [screenshotQuality integerValue];
   }
 }
+#endif
 
 - (void)stopServing
 {
   [FBSession.activeSession kill];
+#if !TARGET_OS_WATCH
   [self stopScreenshotsBroadcaster];
+#endif
   if (self.server.isRunning) {
     [self.server stop:NO];
   }
@@ -199,7 +225,11 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   self.keepAlive = NO;
 }
 
+#if TARGET_OS_WATCH
+- (BOOL)attemptToStartServer:(FBWatchHTTPServer *)server onPort:(NSInteger)port withError:(NSError **)error
+#else
 - (BOOL)attemptToStartServer:(RoutingHTTPServer *)server onPort:(NSInteger)port withError:(NSError **)error
+#endif
 {
   server.port = (UInt16)port;
   NSError *innerError = nil;

--- a/WebDriverAgentLib/Routing/WatchOS/FBWatchHTTPServer.h
+++ b/WebDriverAgentLib/Routing/WatchOS/FBWatchHTTPServer.h
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// RoutingHTTPServer/CocoaHTTPServer need BSD sockets (via GCDAsyncSocket), which watchOS
+// forbids - see FBTCPSocket.h/.m. This is a minimal HTTP/1.1 server on top of the watchOS
+// FBTCPSocket, mirroring just enough of RoutingHTTPServer's API for FBWebServer.m to swap
+// servers with a single #if TARGET_OS_WATCH.
+//
+// No chunked encoding, range requests, or pipelining - just request line + headers +
+// Content-Length body, and ":param" path matching like RoutingHTTPServer.m.
+
+@import Foundation;
+
+#import "RouteRequest.h"
+#import "RouteResponse.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FBWatchHTTPServer : NSObject
+
+/*! The port the server is (or will be) listening on */
+@property (nonatomic) uint16_t port;
+
+/*! Whether the server is currently listening for connections */
+@property (nonatomic, readonly) BOOL isRunning;
+
+/**
+ Sets the dispatch queue on which route blocks are invoked. Pass NULL to invoke them
+ synchronously on the socket's own queue.
+ */
+- (void)setRouteQueue:(nullable dispatch_queue_t)queue;
+
+/**
+ Sets a header which is added to every response, unless overridden by the route itself.
+ */
+- (void)setDefaultHeader:(NSString *)field value:(NSString *)value;
+
+/**
+ Registers a route handler for the given HTTP method and path pattern (":param" segments are
+ captured into the request's `params`, matching RoutingHTTPServer's convention).
+ */
+- (void)handleMethod:(NSString *)method
+            withPath:(NSString *)path
+               block:(void (^)(RouteRequest *request, RouteResponse *response))block;
+
+/**
+ Convenience for -handleMethod:@"GET" withPath:path block:block.
+ */
+- (void)get:(NSString *)path withBlock:(void (^)(RouteRequest *request, RouteResponse *response))block;
+
+/**
+ Starts listening on `port`.
+ */
+- (BOOL)start:(NSError **)error;
+
+/**
+ Stops listening and disconnects all clients.
+ */
+- (void)stop:(BOOL)immediately;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Routing/WatchOS/FBWatchHTTPServer.m
+++ b/WebDriverAgentLib/Routing/WatchOS/FBWatchHTTPServer.m
@@ -1,0 +1,376 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "FBWatchHTTPServer.h"
+
+#import "FBConfiguration.h"
+#import "FBTCPSocket.h"
+
+static NSData *FBCRLFCRLFData(void)
+{
+  static NSData *data;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    data = [@"\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding];
+  });
+  return data;
+}
+
+// -dataUsingEncoding:NSUTF8StringEncoding never actually returns nil; this just keeps the cast
+// out of every call site below.
+static NSData * _Nonnull FBUTF8Data(NSString *string)
+{
+  return (NSData * _Nonnull)[string dataUsingEncoding:NSUTF8StringEncoding];
+}
+
+@interface FBWatchHTTPRoute : NSObject
+@property (nonatomic, copy) NSString *verb;
+@property (nonatomic, strong) NSRegularExpression *regex;
+@property (nonatomic, copy, nullable) NSArray<NSString *> *keys;
+@property (nonatomic, copy) void (^block)(RouteRequest *request, RouteResponse *response);
+@end
+
+@implementation FBWatchHTTPRoute
+@end
+
+
+@interface FBWatchHTTPServer () <FBTCPSocketDelegate>
+
+@property (nonatomic, nullable, strong) FBTCPSocket *socket;
+@property (nonatomic, strong) NSMutableArray<FBWatchHTTPRoute *> *routes;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSString *> *defaultHeaders;
+@property (nonatomic, nullable) dispatch_queue_t routeQueue;
+// nw_connection_t isn't NSCopying, so it can't be an NSDictionary key - use NSMapTable instead.
+@property (nonatomic, strong) NSMapTable<id, NSMutableData *> *connectionBuffers;
+
+@end
+
+@implementation FBWatchHTTPServer
+
+- (instancetype)init
+{
+  if ((self = [super init])) {
+    _routes = [NSMutableArray array];
+    _defaultHeaders = [NSMutableDictionary dictionary];
+    _connectionBuffers = [NSMapTable mapTableWithKeyOptions:(NSPointerFunctionsOptions)(NSMapTableObjectPointerPersonality | NSMapTableStrongMemory)
+                                                 valueOptions:(NSPointerFunctionsOptions)NSMapTableStrongMemory];
+  }
+  return self;
+}
+
+- (void)setRouteQueue:(nullable dispatch_queue_t)queue
+{
+  _routeQueue = queue;
+}
+
+- (void)setDefaultHeader:(NSString *)field value:(NSString *)value
+{
+  self.defaultHeaders[field] = value;
+}
+
+#pragma mark - Route registration
+
+- (FBWatchHTTPRoute *)compiledRouteWithPath:(NSString *)path
+{
+  FBWatchHTTPRoute *route = [FBWatchHTTPRoute new];
+  NSMutableArray<NSString *> *keys = [NSMutableArray array];
+
+  // Escape regex-significant characters before substituting :param placeholders, like
+  // RoutingHTTPServer.m does.
+  NSRegularExpression *escapeRegex = [NSRegularExpression regularExpressionWithPattern:@"[.+()]"
+                                                                                options:(NSRegularExpressionOptions)0
+                                                                                  error:nil];
+  NSString *escapedPath = [escapeRegex stringByReplacingMatchesInString:path
+                                                                  options:(NSMatchingOptions)0
+                                                                    range:NSMakeRange(0, path.length)
+                                                             withTemplate:@"\\\\$0"];
+
+  NSRegularExpression *paramRegex = [NSRegularExpression regularExpressionWithPattern:@"(:(\\w+)|\\*)"
+                                                                               options:(NSRegularExpressionOptions)0
+                                                                                 error:nil];
+  NSMutableString *regexPath = [NSMutableString stringWithString:escapedPath];
+  __block NSInteger diff = 0;
+  [paramRegex enumerateMatchesInString:escapedPath
+                                options:(NSMatchingOptions)0
+                                  range:NSMakeRange(0, escapedPath.length)
+                             usingBlock:^(NSTextCheckingResult * _Nullable result, NSMatchingFlags flags, BOOL * _Nonnull stop) {
+    NSRange replacementRange = NSMakeRange(diff + result.range.location, result.range.length);
+    NSString *capturedString = [escapedPath substringWithRange:result.range];
+    NSString *replacementString;
+    if ([capturedString isEqualToString:@"*"]) {
+      [keys addObject:@"wildcards"];
+      replacementString = @"(.*?)";
+    } else {
+      NSString *keyString = [escapedPath substringWithRange:[result rangeAtIndex:2]];
+      [keys addObject:keyString];
+      replacementString = @"([^/]+)";
+    }
+    [regexPath replaceCharactersInRange:replacementRange withString:replacementString];
+    diff += replacementString.length - result.range.length;
+  }];
+
+  NSString *anchoredPattern = [NSString stringWithFormat:@"^%@$", regexPath];
+  route.regex = [NSRegularExpression regularExpressionWithPattern:anchoredPattern
+                                                            options:NSRegularExpressionCaseInsensitive
+                                                              error:nil];
+  route.keys = keys.count > 0 ? keys.copy : nil;
+  return route;
+}
+
+- (void)handleMethod:(NSString *)method
+            withPath:(NSString *)path
+               block:(void (^)(RouteRequest *request, RouteResponse *response))block
+{
+  FBWatchHTTPRoute *route = [self compiledRouteWithPath:path];
+  route.verb = method.uppercaseString;
+  route.block = block;
+  [self.routes addObject:route];
+}
+
+- (void)get:(NSString *)path withBlock:(void (^)(RouteRequest *request, RouteResponse *response))block
+{
+  [self handleMethod:@"GET" withPath:path block:block];
+}
+
+#pragma mark - Lifecycle
+
+- (BOOL)start:(NSError **)error
+{
+  FBTCPSocket *socket = [[FBTCPSocket alloc] initWithPort:self.port];
+  socket.delegate = self;
+  if (![socket startWithError:error]) {
+    return NO;
+  }
+  self.socket = socket;
+  _isRunning = YES;
+  return YES;
+}
+
+- (void)stop:(BOOL)immediately
+{
+  [self.socket stop];
+  self.socket = nil;
+  @synchronized (self.connectionBuffers) {
+    [self.connectionBuffers removeAllObjects];
+  }
+  _isRunning = NO;
+}
+
+#pragma mark - FBTCPSocketDelegate
+
+- (void)didClientConnect:(nw_connection_t)newClient
+{
+  @synchronized (self.connectionBuffers) {
+    [self.connectionBuffers setObject:[NSMutableData data] forKey:newClient];
+  }
+}
+
+- (void)didClientDisconnect:(nw_connection_t)client
+{
+  @synchronized (self.connectionBuffers) {
+    [self.connectionBuffers removeObjectForKey:client];
+  }
+}
+
+- (void)client:(nw_connection_t)client didReceiveData:(NSData *)data
+{
+  NSMutableData *buffer;
+  @synchronized (self.connectionBuffers) {
+    buffer = [self.connectionBuffers objectForKey:client];
+    if (nil == buffer) {
+      return;
+    }
+    [buffer appendData:data];
+  }
+  [self processBufferForClient:client];
+}
+
+#pragma mark - HTTP parsing
+
+- (void)processBufferForClient:(nw_connection_t)client
+{
+  while (YES) {
+    NSMutableData *buffer;
+    @synchronized (self.connectionBuffers) {
+      buffer = [self.connectionBuffers objectForKey:client];
+    }
+    if (nil == buffer) {
+      return;
+    }
+
+    NSRange headerEndRange = [buffer rangeOfData:FBCRLFCRLFData() options:(NSDataSearchOptions)0 range:NSMakeRange(0, buffer.length)];
+    if (NSNotFound == headerEndRange.location) {
+      return;
+    }
+
+    NSData *headerData = [buffer subdataWithRange:NSMakeRange(0, headerEndRange.location)];
+    NSString *headerString = [[NSString alloc] initWithData:headerData encoding:NSUTF8StringEncoding];
+    NSArray<NSString *> *lines = [headerString componentsSeparatedByString:@"\r\n"];
+    if (lines.count < 1) {
+      [self closeClient:client];
+      return;
+    }
+
+    NSArray<NSString *> *requestLineParts = [lines.firstObject componentsSeparatedByString:@" "];
+    if (requestLineParts.count < 2) {
+      [self closeClient:client];
+      return;
+    }
+    NSString *method = requestLineParts[0].uppercaseString;
+    NSString *pathAndQuery = requestLineParts[1];
+
+    NSMutableDictionary<NSString *, NSString *> *requestHeaders = [NSMutableDictionary dictionary];
+    for (NSUInteger i = 1; i < lines.count; i++) {
+      NSString *line = lines[i];
+      NSRange colonRange = [line rangeOfString:@":"];
+      if (NSNotFound == colonRange.location) {
+        continue;
+      }
+      NSString *name = [line substringToIndex:colonRange.location];
+      NSString *value = [[line substringFromIndex:colonRange.location + 1]
+                          stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+      requestHeaders[name.lowercaseString] = value;
+    }
+
+    NSUInteger contentLength = (NSUInteger)requestHeaders[@"content-length"].integerValue;
+    if (contentLength > FBConfiguration.sharedInstance.httpRequestBodySizeLimit) {
+      // Mirrors FBHTTPConnection's maxRequestBodySize enforcement on iOS/tvOS. Closes the
+      // connection after responding, since the rest of the oversized body is still incoming.
+      RouteResponse *tooLarge = [RouteResponse new];
+      tooLarge.statusCode = kHTTPStatusCodeRequestEntityTooLarge;
+      [tooLarge respondWithString:@"Request Entity Too Large"];
+      [self writeResponse:tooLarge toClient:client thenCloseConnection:YES];
+      return;
+    }
+    NSUInteger bodyStart = headerEndRange.location + headerEndRange.length;
+    NSUInteger totalRequestLength = bodyStart + contentLength;
+    if (buffer.length < totalRequestLength) {
+      // Wait for the rest of the body to arrive.
+      return;
+    }
+
+    NSData *body = contentLength > 0 ? [buffer subdataWithRange:NSMakeRange(bodyStart, contentLength)] : [NSData data];
+
+    @synchronized (self.connectionBuffers) {
+      [buffer replaceBytesInRange:NSMakeRange(0, totalRequestLength) withBytes:NULL length:0];
+    }
+
+    [self dispatchMethod:method pathAndQuery:pathAndQuery body:body client:client];
+  }
+}
+
+- (void)dispatchMethod:(NSString *)method pathAndQuery:(NSString *)pathAndQuery body:(NSData *)body client:(nw_connection_t)client
+{
+  NSURLComponents *requestTarget = [NSURLComponents componentsWithString:pathAndQuery];
+  NSString *path = requestTarget.path ?: pathAndQuery;
+
+  for (FBWatchHTTPRoute *route in self.routes) {
+    if (![route.verb isEqualToString:method]) {
+      continue;
+    }
+    NSTextCheckingResult *result = [route.regex firstMatchInString:path options:(NSMatchingOptions)0 range:NSMakeRange(0, path.length)];
+    if (nil == result) {
+      continue;
+    }
+
+    NSMutableDictionary<NSString *, NSString *> *params = [NSMutableDictionary dictionary];
+    for (NSURLQueryItem *queryItem in requestTarget.queryItems) {
+      params[queryItem.name] = queryItem.value ?: @"";
+    }
+    if (route.keys.count > 0 && result.numberOfRanges == route.keys.count + 1) {
+      NSUInteger index = 1;
+      for (NSString *key in route.keys) {
+        params[key] = [path substringWithRange:[result rangeAtIndex:index]];
+        index++;
+      }
+    }
+
+    NSURL *url = [NSURL URLWithString:path] ?: [NSURL URLWithString:@"/"];
+    RouteRequest *request = [[RouteRequest alloc] initWithURL:url params:params.copy body:body];
+    RouteResponse *response = [RouteResponse new];
+    [self.defaultHeaders enumerateKeysAndObjectsUsingBlock:^(NSString *field, NSString *value, BOOL *stop) {
+      [response setHeader:field value:value];
+    }];
+
+    void (^invoke)(void) = ^{
+      route.block(request, response);
+      [self writeResponse:response toClient:client];
+    };
+    dispatch_queue_t routeQueue = self.routeQueue;
+    if (routeQueue) {
+      dispatch_async((dispatch_queue_t _Nonnull)routeQueue, invoke);
+    } else {
+      invoke();
+    }
+    return;
+  }
+
+  RouteResponse *notFound = [RouteResponse new];
+  notFound.statusCode = kHTTPStatusCodeNotFound;
+  [notFound respondWithString:@"Not Found"];
+  [self writeResponse:notFound toClient:client];
+}
+
+- (void)writeResponse:(RouteResponse *)response toClient:(nw_connection_t)client
+{
+  [self writeResponse:response toClient:client thenCloseConnection:NO];
+}
+
+- (void)writeResponse:(RouteResponse *)response toClient:(nw_connection_t)client thenCloseConnection:(BOOL)shouldClose
+{
+  NSMutableData *payload = [NSMutableData data];
+  NSString *statusLine = [NSString stringWithFormat:@"HTTP/1.1 %ld %@\r\n",
+                           (long)response.statusCode, [self reasonPhraseForStatusCode:response.statusCode]];
+  [payload appendData:FBUTF8Data(statusLine)];
+
+  NSData *body = response.responseData ?: [NSData data];
+  NSMutableDictionary<NSString *, NSString *> *headers = response.headers.mutableCopy;
+  if (nil == headers[@"Content-Length"]) {
+    headers[@"Content-Length"] = [NSString stringWithFormat:@"%lu", (unsigned long)body.length];
+  }
+  [headers enumerateKeysAndObjectsUsingBlock:^(NSString *field, NSString *value, BOOL *stop) {
+    NSString *headerLine = [NSString stringWithFormat:@"%@: %@\r\n", field, value];
+    [payload appendData:FBUTF8Data(headerLine)];
+  }];
+  [payload appendData:FBUTF8Data(@"\r\n")];
+  [payload appendData:body];
+
+  if (shouldClose) {
+    __weak typeof(self) weakSelf = self;
+    [self.socket writeData:payload toClient:client completion:^{
+      [weakSelf closeClient:client];
+    }];
+  } else {
+    [self.socket writeData:payload toClient:client];
+  }
+}
+
+- (void)closeClient:(nw_connection_t)client
+{
+  @synchronized (self.connectionBuffers) {
+    [self.connectionBuffers removeObjectForKey:client];
+  }
+  nw_connection_cancel(client);
+}
+
+- (NSString *)reasonPhraseForStatusCode:(HTTPStatusCode)statusCode
+{
+  // if/else, not switch, to avoid having to list all ~90 HTTPStatusCode cases for -Wswitch-enum.
+  if (kHTTPStatusCodeOK == statusCode) {
+    return @"OK";
+  } else if (kHTTPStatusCodeBadRequest == statusCode) {
+    return @"Bad Request";
+  } else if (kHTTPStatusCodeNotFound == statusCode) {
+    return @"Not Found";
+  } else if (kHTTPStatusCodeInternalServerError == statusCode) {
+    return @"Internal Server Error";
+  }
+  return @"Status";
+}
+
+@end

--- a/WebDriverAgentLib/Routing/WatchOS/RouteRequest.h
+++ b/WebDriverAgentLib/Routing/WatchOS/RouteRequest.h
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Minimal, watchOS-only stand-in for Vendor/RoutingHTTPServer/RouteRequest.h, which is not
+// available on watchOS because RoutingHTTPServer/CocoaHTTPServer/CocoaAsyncSocket cannot be
+// built there (see FBWatchHTTPServer.h). Exposes just the surface FBWebServer's route blocks
+// and FBRoute.decorateRequest: read.
+
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RouteRequest : NSObject
+
+@property (nonatomic, copy, readonly) NSURL *url;
+@property (nonatomic, copy, readonly) NSDictionary<NSString *, NSString *> *params;
+@property (nonatomic, copy, readonly) NSData *body;
+
+- (instancetype)initWithURL:(NSURL *)url
+                      params:(NSDictionary<NSString *, NSString *> *)params
+                        body:(NSData *)body;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Routing/WatchOS/RouteRequest.m
+++ b/WebDriverAgentLib/Routing/WatchOS/RouteRequest.m
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RouteRequest.h"
+
+@implementation RouteRequest
+
+- (instancetype)initWithURL:(NSURL *)url
+                      params:(NSDictionary<NSString *, NSString *> *)params
+                        body:(NSData *)body
+{
+  if ((self = [super init])) {
+    _url = url.copy;
+    _params = params.copy;
+    _body = body.copy;
+  }
+  return self;
+}
+
+@end

--- a/WebDriverAgentLib/Routing/WatchOS/RouteResponse.h
+++ b/WebDriverAgentLib/Routing/WatchOS/RouteResponse.h
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Minimal, watchOS-only stand-in for Vendor/RoutingHTTPServer/RouteResponse.h, reproducing just
+// what FBRoute.m/FBResponseJSONPayload.m call on it. See FBWatchHTTPServer.h.
+
+@import Foundation;
+#import <WebDriverAgentLib/FBHTTPStatusCodes.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RouteResponse : NSObject
+
+@property (nonatomic) HTTPStatusCode statusCode;
+@property (nonatomic, copy, readonly) NSDictionary<NSString *, NSString *> *headers;
+@property (nonatomic, copy, readonly, nullable) NSData *responseData;
+
+- (void)setHeader:(NSString *)field value:(NSString *)value;
+- (void)respondWithString:(NSString *)string;
+- (void)respondWithString:(NSString *)string encoding:(NSStringEncoding)encoding;
+- (void)respondWithData:(NSData *)data;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Routing/WatchOS/RouteResponse.m
+++ b/WebDriverAgentLib/Routing/WatchOS/RouteResponse.m
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RouteResponse.h"
+
+@interface RouteResponse ()
+@property (nonatomic, copy) NSMutableDictionary<NSString *, NSString *> *mutableHeaders;
+@end
+
+@implementation RouteResponse
+
+- (instancetype)init
+{
+  if ((self = [super init])) {
+    _statusCode = kHTTPStatusCodeOK;
+    _mutableHeaders = [NSMutableDictionary dictionary];
+  }
+  return self;
+}
+
+- (NSDictionary<NSString *, NSString *> *)headers
+{
+  return self.mutableHeaders.copy;
+}
+
+- (void)setHeader:(NSString *)field value:(NSString *)value
+{
+  self.mutableHeaders[field] = value;
+}
+
+- (void)respondWithData:(NSData *)data
+{
+  _responseData = data.copy;
+  if (nil == self.mutableHeaders[@"Content-Length"]) {
+    self.mutableHeaders[@"Content-Length"] = [NSString stringWithFormat:@"%lu", (unsigned long)data.length];
+  }
+}
+
+- (void)respondWithString:(NSString *)string
+{
+  [self respondWithString:string encoding:NSUTF8StringEncoding];
+}
+
+- (void)respondWithString:(NSString *)string encoding:(NSStringEncoding)encoding
+{
+  [self respondWithData:[string dataUsingEncoding:encoding] ?: [NSData data]];
+}
+
+@end

--- a/WebDriverAgentLib/Utilities/FBActiveAppDetectionPoint.m
+++ b/WebDriverAgentLib/Utilities/FBActiveAppDetectionPoint.m
@@ -8,6 +8,10 @@
 
 #import "FBActiveAppDetectionPoint.h"
 
+#if TARGET_OS_WATCH
+@import WatchKit;
+#endif
+
 #import "FBErrorBuilder.h"
 #import "FBLogger.h"
 #import "FBXCTestDaemonsProxy.h"
@@ -17,7 +21,11 @@
 
 - (instancetype)init {
   if ((self = [super init])) {
+#if TARGET_OS_WATCH
+    CGSize screenSize = WKInterfaceDevice.currentDevice.screenBounds.size;
+#else
     CGSize screenSize = [UIScreen mainScreen].bounds.size;
+#endif
     // Consider the element, which is located close to the top left corner of the screen the on-screen one.
     CGFloat pointDistance = MIN(screenSize.width, screenSize.height) * (CGFloat) 0.2;
     _coordinates = CGPointMake(pointDistance, pointDistance);

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.h
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.h
@@ -14,7 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 @interface FBBaseActionItem : NSObject
 
 /*! Raw JSON representation of the corresponding action item */

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
@@ -21,7 +21,7 @@
 #import "XCSynthesizedEventRecord.h"
 #import "XCUIElement+FBUtilities.h"
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 @implementation FBBaseActionItem
 
 + (NSString *)actionName

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -262,7 +262,7 @@ typedef NS_ENUM(NSInteger, FBConfigurationKeyboardPreference) {
  */
 @property (atomic, assign) BOOL useClearTextShortcut;
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 /**
  Set the screenshot orientation for iOS
 

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -37,7 +37,7 @@ static NSString *const axSettingsClassName = @"AXSettings";
 @interface FBConfiguration ()
 
 @property (atomic, strong) NSNumber *maxTypingFrequencyOverride;
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 @property (atomic, assign) UIInterfaceOrientation screenshotOrientationStorage;
 #endif
 
@@ -292,7 +292,7 @@ static NSString *const axSettingsClassName = @"AXSettings";
   return [FBGetCustomParameterForElementSnapshot(FBSnapshotMaxChildrenKey) intValue];
 }
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 - (BOOL)setScreenshotOrientation:(NSString *)orientation error:(NSError **)error
 {
   // Only UIInterfaceOrientationUnknown is over iOS 8. Others are over iOS 2.
@@ -359,7 +359,7 @@ static NSString *const axSettingsClassName = @"AXSettings";
   FBSetCustomParameterForElementSnapshot(FBSnapshotMaxChildrenKey, @INT_MAX);
   self.useClearTextShortcut = YES;
   self.limitXpathContextScope = YES;
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
   self.screenshotOrientationStorage = UIInterfaceOrientationUnknown;
 #endif
 }

--- a/WebDriverAgentLib/Utilities/FBImageProcessor.m
+++ b/WebDriverAgentLib/Utilities/FBImageProcessor.m
@@ -109,8 +109,12 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
                               desiredOrientation:(nullable NSNumber *)orientation
 {
   scalingFactor = MAX(FBMinScalingFactor, MIN(FBMaxScalingFactor, scalingFactor));
-  BOOL usesScaling = scalingFactor > 0.0 && scalingFactor < FBMaxScalingFactor;
   @autoreleasepool {
+#if TARGET_OS_WATCH
+    // UIGraphicsImageRenderer is unavailable and the watch screen doesn't rotate, so skip both.
+    return [uti conformsToType:UTTypePNG] ? FBToPngData(imageData) : FBToJpegData(imageData, compressionQuality);
+#else
+    BOOL usesScaling = scalingFactor > 0.0 && scalingFactor < FBMaxScalingFactor;
     if (!usesScaling && !fixOrientation) {
       return [uti conformsToType:UTTypePNG] ? FBToPngData(imageData) : FBToJpegData(imageData, compressionQuality);
     }
@@ -157,6 +161,7 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
                                          actions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
         [uiImage drawInRect:CGRectMake(0, 0, scaledSize.width, scaledSize.height)];
       }];
+#endif
   }
 }
 
@@ -167,7 +172,7 @@ const CGFloat FBMaxCompressionQuality = 1.0f;
                                    error:(NSError **)error
 {
   NSNumber *orientation = nil;
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
   if (FBConfiguration.sharedInstance.screenshotOrientation == UIInterfaceOrientationPortrait) {
     orientation = @(UIImageOrientationUp);
   } else if (FBConfiguration.sharedInstance.screenshotOrientation == UIInterfaceOrientationPortraitUpsideDown) {

--- a/WebDriverAgentLib/Utilities/FBMacros.h
+++ b/WebDriverAgentLib/Utilities/FBMacros.h
@@ -42,12 +42,21 @@
   typeof(arg) arg = wda_weak_##arg \
   _Pragma("clang diagnostic pop")
 
+/*! Current OS version as a dotted string, e.g. "17.4". UIDevice.systemVersion is unavailable on
+    watchOS, so this is sourced from NSProcessInfo, which works identically on every platform. */
+NS_INLINE NSString *FBSystemVersion(void) {
+  NSOperatingSystemVersion v = NSProcessInfo.processInfo.operatingSystemVersion;
+  return 0 == v.patchVersion
+    ? [NSString stringWithFormat:@"%ld.%ld", (long)v.majorVersion, (long)v.minorVersion]
+    : [NSString stringWithFormat:@"%ld.%ld.%ld", (long)v.majorVersion, (long)v.minorVersion, (long)v.patchVersion];
+}
+
 /*! Returns YES if current system version satisfies the given codition */
-#define SYSTEM_VERSION_EQUAL_TO(v)                  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedSame)
-#define SYSTEM_VERSION_GREATER_THAN(v)              ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedDescending)
-#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
-#define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
-#define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)     ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedDescending)
+#define SYSTEM_VERSION_EQUAL_TO(v)                  ([FBSystemVersion() compare:v options:NSNumericSearch] == NSOrderedSame)
+#define SYSTEM_VERSION_GREATER_THAN(v)              ([FBSystemVersion() compare:v options:NSNumericSearch] == NSOrderedDescending)
+#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([FBSystemVersion() compare:v options:NSNumericSearch] != NSOrderedAscending)
+#define SYSTEM_VERSION_LESS_THAN(v)                 ([FBSystemVersion() compare:v options:NSNumericSearch] == NSOrderedAscending)
+#define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)     ([FBSystemVersion() compare:v options:NSNumericSearch] != NSOrderedDescending)
 
 /*! Converts the given number of milliseconds into seconds */
 #define FBMillisToSeconds(ms) ((ms) / 1000.0)

--- a/WebDriverAgentLib/Utilities/FBMathUtils.h
+++ b/WebDriverAgentLib/Utilities/FBMathUtils.h
@@ -30,7 +30,7 @@ BOOL FBSizeFuzzyEqualToSize(CGSize size1, CGSize size2, CGFloat threshold);
 /*! Returns whether rect are equal within given threshold */
 BOOL FBRectFuzzyEqualToRect(CGRect rect1, CGRect rect2, CGFloat threshold);
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 /*! Inverts size if necessary to match current screen orientation */
 CGSize FBAdjustDimensionsForApplication(CGSize actualSize, UIInterfaceOrientation orientation);
 #endif

--- a/WebDriverAgentLib/Utilities/FBMathUtils.m
+++ b/WebDriverAgentLib/Utilities/FBMathUtils.m
@@ -44,7 +44,7 @@ BOOL FBRectFuzzyEqualToRect(CGRect rect1, CGRect rect2, CGFloat threshold)
   FBSizeFuzzyEqualToSize(rect1.size, rect2.size, threshold);
 }
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 
 CGSize FBAdjustDimensionsForApplication(CGSize actualSize, UIInterfaceOrientation orientation)
 {

--- a/WebDriverAgentLib/Utilities/FBPasteboard.h
+++ b/WebDriverAgentLib/Utilities/FBPasteboard.h
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 @interface FBPasteboard : NSObject
 
 /**

--- a/WebDriverAgentLib/Utilities/FBPasteboard.m
+++ b/WebDriverAgentLib/Utilities/FBPasteboard.m
@@ -20,7 +20,7 @@
 // Must not be less than FB_MONTORING_INTERVAL in FBAlertsMonitor
 #define ALERT_CHECK_INTERVAL_SEC 2
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 @implementation FBPasteboard
 
 + (BOOL)setData:(NSData *)data forType:(NSString *)type error:(NSError **)error

--- a/WebDriverAgentLib/Utilities/FBSettingsHandler.m
+++ b/WebDriverAgentLib/Utilities/FBSettingsHandler.m
@@ -186,7 +186,7 @@ static NSSet<NSString *> *FBNilClearableSettingKeys(void)
       FBConfiguration.sharedInstance.limitXpathContextScope = [value boolValue];
       return nil;
     };
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
     map[FB_SETTING_SCREENSHOT_ORIENTATION] = ^FBCommandStatus *(FBSession *session, id value) {
       NSError *error;
       if (![FBConfiguration.sharedInstance setScreenshotOrientation:(NSString *)value error:&error]) {
@@ -303,7 +303,7 @@ static NSSet<NSString *> *FBNilClearableSettingKeys(void)
     map[FB_SETTING_LIMIT_XPATH_CONTEXT_SCOPE] = ^id(FBSession *session) {
       return @(FBConfiguration.sharedInstance.limitXpathContextScope);
     };
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
     map[FB_SETTING_SCREENSHOT_ORIENTATION] = ^id(FBSession *session) {
       return FBConfiguration.sharedInstance.humanReadableScreenshotOrientation;
     };

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -63,7 +63,7 @@ static NSString *const FB_KEY_PARAMETERS = @"parameters";
 static NSString *const FB_KEY_ACTIONS = @"actions";
 
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
 @interface FBW3CGestureItem : FBBaseGestureItem
 
 @property (nullable, readonly, nonatomic) FBBaseGestureItem *previousItem;

--- a/WebDriverAgentTests/IntegrationApp_watchOS/ContentView.swift
+++ b/WebDriverAgentTests/IntegrationApp_watchOS/ContentView.swift
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import SwiftUI
+
+struct ContentView: View {
+  @State private var resultText = "Idle"
+  @State private var typedText = ""
+
+  var body: some View {
+    // ScrollView keeps content reachable - WDA's test-launch path shifts the scene down
+    // vs. a plain launch, which can push a plain VStack off-screen.
+    ScrollView {
+      VStack(spacing: 8) {
+        Text(resultText)
+          .accessibilityIdentifier("resultLabel")
+        Button("Tap Me") {
+          resultText = "Tapped"
+        }
+        .accessibilityIdentifier("tapMeButton")
+        TextField("Type here", text: $typedText)
+          .accessibilityIdentifier("typingField")
+      }
+    }
+  }
+}

--- a/WebDriverAgentTests/IntegrationApp_watchOS/WatchSpikeApp.swift
+++ b/WebDriverAgentTests/IntegrationApp_watchOS/WatchSpikeApp.swift
@@ -6,14 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import "FBBaseActionsSynthesizer.h"
+import SwiftUI
 
-NS_ASSUME_NONNULL_BEGIN
-
-#if !TARGET_OS_TV && !TARGET_OS_WATCH
-@interface FBW3CActionsSynthesizer : FBBaseActionsSynthesizer
-
-@end
-#endif
-
-NS_ASSUME_NONNULL_END
+@main
+struct WatchSpikeApp: App {
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+    }
+  }
+}

--- a/WebDriverAgentTests/IntegrationTests_watchOS/WDAAlertIntegrationTests.swift
+++ b/WebDriverAgentTests/IntegrationTests_watchOS/WDAAlertIntegrationTests.swift
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import XCTest
+
+/// Covers FBAlertViewCommands' error path - IntegrationApp_watchOS never presents a real alert,
+/// so this only exercises the "no alert open" error, not the success path.
+final class WDAAlertIntegrationTests: WDAWatchIntegrationTestCase {
+  func testAlertTextWithNoAlertPresentReturnsAnError() throws {
+    let response = try client.get("/session/\(sessionId!)/alert/text")
+    XCTAssertNotEqual(response.statusCode, 200)
+  }
+
+  func testAlertButtonsWithNoAlertPresentReturnsAnError() throws {
+    let response = try client.get("/session/\(sessionId!)/wda/alert/buttons")
+    XCTAssertNotEqual(response.statusCode, 200)
+  }
+}

--- a/WebDriverAgentTests/IntegrationTests_watchOS/WDAAppLifecycleIntegrationTests.swift
+++ b/WebDriverAgentTests/IntegrationTests_watchOS/WDAAppLifecycleIntegrationTests.swift
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import XCTest
+
+/// Covers the app lifecycle routes (launch/activate/terminate/state/list). Unlike
+/// /wda/homescreen or /wda/lock, these only ever target IntegrationApp_watchOS, so they're
+/// safe to run repeatedly without disrupting shared simulator state.
+final class WDAAppLifecycleIntegrationTests: WDAWatchIntegrationTestCase {
+  // XCUIApplicationState raw values: NotRunning = 1, RunningForeground = 4.
+  private static let notRunningState = 1
+  private static let runningForegroundState = 4
+
+  func testAppsListIncludesTheAppUnderTest() throws {
+    let response = try client.get("/session/\(sessionId!)/wda/apps/list")
+    XCTAssertEqual(response.statusCode, 200)
+    guard let apps = response.value as? [[String: Any]] else {
+      return XCTFail("Expected an array of active apps: \(String(describing: response.json))")
+    }
+    XCTAssertTrue(apps.contains { $0["bundleId"] as? String == Self.integrationAppBundleId })
+  }
+
+  func testTerminateThenRelaunchLifecycle() throws {
+    let bundleId = Self.integrationAppBundleId
+
+    let terminateResponse = try client.post("/session/\(sessionId!)/wda/apps/terminate", body: ["bundleId": bundleId])
+    XCTAssertEqual(terminateResponse.statusCode, 200)
+    XCTAssertEqual(terminateResponse.value as? Bool, true)
+
+    let stateAfterTerminate = try client.post("/session/\(sessionId!)/wda/apps/state", body: ["bundleId": bundleId])
+    XCTAssertEqual(stateAfterTerminate.value as? Int, Self.notRunningState)
+
+    let launchResponse = try client.post("/session/\(sessionId!)/wda/apps/launch", body: ["bundleId": bundleId])
+    XCTAssertEqual(launchResponse.statusCode, 200)
+    Thread.sleep(forTimeInterval: 1)
+
+    let stateAfterLaunch = try client.post("/session/\(sessionId!)/wda/apps/state", body: ["bundleId": bundleId])
+    XCTAssertEqual(stateAfterLaunch.value as? Int, Self.runningForegroundState)
+
+    // The app relaunched fresh, so its accessibility tree should be back too.
+    XCTAssertNoThrow(try findElement(byAccessibilityId: "tapMeButton"))
+  }
+
+  func testActivateBringsTheAppToTheForeground() throws {
+    let bundleId = Self.integrationAppBundleId
+    let activateResponse = try client.post("/session/\(sessionId!)/wda/apps/activate", body: ["bundleId": bundleId])
+    XCTAssertEqual(activateResponse.statusCode, 200)
+
+    let stateResponse = try client.post("/session/\(sessionId!)/wda/apps/state", body: ["bundleId": bundleId])
+    XCTAssertEqual(stateResponse.value as? Int, Self.runningForegroundState)
+  }
+}

--- a/WebDriverAgentTests/IntegrationTests_watchOS/WDAClickIntegrationTests.swift
+++ b/WebDriverAgentTests/IntegrationTests_watchOS/WDAClickIntegrationTests.swift
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import XCTest
+
+/// Covers /element/:uuid/click - the only tap-like interaction registered on watchOS
+/// (gesture synthesis routes aren't).
+final class WDAClickIntegrationTests: WDAWatchIntegrationTestCase {
+  func testClickingButtonUpdatesTheResultLabel() throws {
+    let labelId = try findElement(byAccessibilityId: "resultLabel")
+    XCTAssertEqual(try attributeValue(labelId, "label"), "Idle")
+
+    let buttonId = try findElement(byAccessibilityId: "tapMeButton")
+    let clickResponse = try client.post("/session/\(sessionId!)/element/\(buttonId)/click")
+    XCTAssertEqual(clickResponse.statusCode, 200)
+
+    // Re-find: element UUIDs aren't stable across snapshots, and the label just changed.
+    let updatedLabelId = try findElement(byAccessibilityId: "resultLabel")
+    XCTAssertEqual(try attributeValue(updatedLabelId, "label"), "Tapped")
+  }
+
+  func testClickingAnElementThatDoesNotExistReturnsAnError() throws {
+    let response = try client.post("/session/\(sessionId!)/element/00000000-0000-0000-0000-000000000000/click")
+    XCTAssertNotEqual(response.statusCode, 200)
+  }
+}

--- a/WebDriverAgentTests/IntegrationTests_watchOS/WDADeviceIntegrationTests.swift
+++ b/WebDriverAgentTests/IntegrationTests_watchOS/WDADeviceIntegrationTests.swift
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import XCTest
+
+/// Covers device-info and location routes. These only read device state or set a simulated
+/// GPS fix, so unlike /wda/lock or /wda/voiceOver/enable, they won't disrupt later tests.
+final class WDADeviceIntegrationTests: WDAWatchIntegrationTestCase {
+  func testDeviceInfo() throws {
+    let response = try client.get("/session/\(sessionId!)/wda/device/info")
+    XCTAssertEqual(response.statusCode, 200)
+    XCTAssertFalse((response.valueDict?["name"] as? String ?? "").isEmpty)
+    XCTAssertFalse((response.valueDict?["model"] as? String ?? "").isEmpty)
+  }
+
+  func testActiveAppInfo() throws {
+    let response = try client.get("/session/\(sessionId!)/wda/activeAppInfo")
+    XCTAssertEqual(response.statusCode, 200)
+    XCTAssertEqual(response.valueDict?["bundleId"] as? String, Self.integrationAppBundleId)
+    XCTAssertGreaterThan(response.valueDict?["pid"] as? Int ?? 0, 0)
+  }
+
+  func testDeviceLocation() throws {
+    let response = try client.get("/session/\(sessionId!)/wda/device/location")
+    XCTAssertEqual(response.statusCode, 200)
+    XCTAssertNotNil(response.valueDict?["latitude"])
+    XCTAssertNotNil(response.valueDict?["authorizationStatus"])
+  }
+
+  func testSimulatedLocationRoundTrip() throws {
+    let setResponse = try client.post("/session/\(sessionId!)/wda/simulatedLocation", body: [
+      "latitude": 37.3230,
+      "longitude": -122.0322,
+    ])
+    XCTAssertEqual(setResponse.statusCode, 200)
+
+    let getResponse = try client.get("/session/\(sessionId!)/wda/simulatedLocation")
+    XCTAssertEqual(getResponse.statusCode, 200)
+    XCTAssertEqual(getResponse.valueDict?["latitude"] as? Double ?? 0, 37.3230, accuracy: 0.001)
+    XCTAssertEqual(getResponse.valueDict?["longitude"] as? Double ?? 0, -122.0322, accuracy: 0.001)
+
+    let clearResponse = try client.delete("/session/\(sessionId!)/wda/simulatedLocation")
+    XCTAssertEqual(clearResponse.statusCode, 200)
+  }
+}

--- a/WebDriverAgentTests/IntegrationTests_watchOS/WDAElementAttributeIntegrationTests.swift
+++ b/WebDriverAgentTests/IntegrationTests_watchOS/WDAElementAttributeIntegrationTests.swift
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import XCTest
+
+/// Covers FBElementCommands' read-only element/window attribute routes.
+final class WDAElementAttributeIntegrationTests: WDAWatchIntegrationTestCase {
+  func testWindowSizeAndRect() throws {
+    let sizeResponse = try client.get("/session/\(sessionId!)/window/size")
+    XCTAssertEqual(sizeResponse.statusCode, 200)
+    XCTAssertGreaterThan(sizeResponse.valueDict?["width"] as? Double ?? 0, 0)
+    XCTAssertGreaterThan(sizeResponse.valueDict?["height"] as? Double ?? 0, 0)
+
+    let rectResponse = try client.get("/session/\(sessionId!)/window/rect")
+    XCTAssertEqual(rectResponse.statusCode, 200)
+    XCTAssertGreaterThan(rectResponse.valueDict?["width"] as? Double ?? 0, 0)
+  }
+
+  func testButtonAttributes() throws {
+    let buttonId = try findElement(byAccessibilityId: "tapMeButton")
+
+    let enabledResponse = try client.get("/session/\(sessionId!)/element/\(buttonId)/enabled")
+    XCTAssertEqual(enabledResponse.value as? Bool, true)
+
+    let displayedResponse = try client.get("/session/\(sessionId!)/element/\(buttonId)/displayed")
+    XCTAssertEqual(displayedResponse.value as? Bool, true)
+
+    let rectResponse = try client.get("/session/\(sessionId!)/element/\(buttonId)/rect")
+    XCTAssertEqual(rectResponse.statusCode, 200)
+    XCTAssertGreaterThan(rectResponse.valueDict?["width"] as? Double ?? 0, 0)
+
+    let nameResponse = try client.get("/session/\(sessionId!)/element/\(buttonId)/name")
+    XCTAssertEqual(nameResponse.valueString, "XCUIElementTypeButton")
+
+    let labelResponse = try client.get("/session/\(sessionId!)/element/\(buttonId)/attribute/label")
+    XCTAssertEqual(labelResponse.valueString, "Tap Me")
+
+    let accessibleResponse = try client.get("/session/\(sessionId!)/wda/element/\(buttonId)/accessible")
+    XCTAssertEqual(accessibleResponse.statusCode, 200)
+  }
+
+  func testResultLabelTextAndSelectedState() throws {
+    let labelId = try findElement(byAccessibilityId: "resultLabel")
+
+    let textResponse = try client.get("/session/\(sessionId!)/element/\(labelId)/text")
+    XCTAssertEqual(textResponse.valueString, "Idle")
+
+    let selectedResponse = try client.get("/session/\(sessionId!)/element/\(labelId)/selected")
+    XCTAssertEqual(selectedResponse.statusCode, 200)
+    XCTAssertEqual(selectedResponse.value as? Bool, false)
+  }
+}

--- a/WebDriverAgentTests/IntegrationTests_watchOS/WDAFindIntegrationTests.swift
+++ b/WebDriverAgentTests/IntegrationTests_watchOS/WDAFindIntegrationTests.swift
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import XCTest
+
+/// Covers FBFindElementCommands: find/sub-find/active-element, not-found errors, and every
+/// locator strategy (accessibility id/name/id, class name, class chain, xpath, predicate
+/// string, link text). getVisibleCells is skipped - no table/collection view to test it against.
+final class WDAFindIntegrationTests: WDAWatchIntegrationTestCase {
+  func testFindElementByAccessibilityId() throws {
+    let elementId = try findElement(byAccessibilityId: "tapMeButton")
+    XCTAssertFalse(elementId.isEmpty)
+  }
+
+  func testFindElementByNameAndIdAliases() throws {
+    // "name" and "id" are aliases for "accessibility id".
+    for using in ["name", "id"] {
+      let response = try client.post("/session/\(sessionId!)/element", body: [
+        "using": using,
+        "value": "tapMeButton",
+      ])
+      XCTAssertEqual(response.statusCode, 200, "using: \(using)")
+      XCTAssertNotNil(response.valueDict?["ELEMENT"], "using: \(using)")
+    }
+  }
+
+  func testFindElementByPredicateString() throws {
+    let response = try client.post("/session/\(sessionId!)/element", body: [
+      "using": "predicate string",
+      "value": "label == \"Tap Me\"",
+    ])
+    XCTAssertEqual(response.statusCode, 200)
+    XCTAssertNotNil(response.valueDict?["ELEMENT"])
+  }
+
+  func testFindElementsByClassChain() throws {
+    let response = try client.post("/session/\(sessionId!)/elements", body: [
+      "using": "class chain",
+      "value": "**/XCUIElementTypeButton",
+    ])
+    XCTAssertEqual(response.statusCode, 200)
+    XCTAssertGreaterThanOrEqual((response.value as? [[String: Any]])?.count ?? 0, 1)
+  }
+
+  func testFindElementByXPath() throws {
+    let response = try client.post("/session/\(sessionId!)/element", body: [
+      "using": "xpath",
+      "value": "//XCUIElementTypeButton[@name=\"tapMeButton\"]",
+    ])
+    XCTAssertEqual(response.statusCode, 200)
+    XCTAssertNotNil(response.valueDict?["ELEMENT"])
+  }
+
+  func testFindElementByLinkTextAndPartialLinkText() throws {
+    // WDA matches (partial) link text against `name`, not an actual hyperlink search.
+    for using in ["link text", "partial link text"] {
+      let value = using == "link text" ? "tapMeButton" : "tapMe"
+      let response = try client.post("/session/\(sessionId!)/element", body: [
+        "using": using,
+        "value": value,
+      ])
+      XCTAssertEqual(response.statusCode, 200, "using: \(using)")
+      XCTAssertNotNil(response.valueDict?["ELEMENT"], "using: \(using)")
+    }
+  }
+
+  func testFindElementThatDoesNotExistReturnsAnError() throws {
+    let response = try client.post("/session/\(sessionId!)/element", body: [
+      "using": "accessibility id",
+      "value": "thisElementDoesNotExist",
+    ])
+    XCTAssertNotEqual(response.statusCode, 200)
+  }
+
+  func testFindElements() throws {
+    let response = try client.post("/session/\(sessionId!)/elements", body: [
+      "using": "class name",
+      "value": "XCUIElementTypeButton",
+    ])
+    XCTAssertEqual(response.statusCode, 200)
+    guard let elements = response.value as? [[String: Any]] else {
+      return XCTFail("Expected an array of elements: \(String(describing: response.json))")
+    }
+    XCTAssertGreaterThanOrEqual(elements.count, 1)
+  }
+
+  func testFindSubElementAndSubElements() throws {
+    let windowResponse = try client.post("/session/\(sessionId!)/element", body: [
+      "using": "class name",
+      "value": "XCUIElementTypeWindow",
+    ])
+    guard let windowId = windowResponse.valueDict?["ELEMENT"] as? String else {
+      return XCTFail("Could not find the root window element")
+    }
+
+    let subElementResponse = try client.post("/session/\(sessionId!)/element/\(windowId)/element", body: [
+      "using": "accessibility id",
+      "value": "tapMeButton",
+    ])
+    XCTAssertEqual(subElementResponse.statusCode, 200)
+    XCTAssertNotNil(subElementResponse.valueDict?["ELEMENT"])
+
+    let subElementsResponse = try client.post("/session/\(sessionId!)/element/\(windowId)/elements", body: [
+      "using": "class name",
+      "value": "XCUIElementTypeButton",
+    ])
+    XCTAssertEqual(subElementsResponse.statusCode, 200)
+    XCTAssertGreaterThanOrEqual((subElementsResponse.value as? [[String: Any]])?.count ?? 0, 1)
+  }
+
+  func testActiveElementResolvesToTheFocusedTextField() throws {
+    let fieldId = try findElement(byAccessibilityId: "typingField")
+    try client.post("/session/\(sessionId!)/element/\(fieldId)/click")
+    // Give the keyboard-sheet transition a moment to finish before checking focus.
+    Thread.sleep(forTimeInterval: 1)
+
+    let response = try client.get("/session/\(sessionId!)/element/active")
+    XCTAssertEqual(response.statusCode, 200)
+    XCTAssertNotNil(response.valueDict?["ELEMENT"])
+  }
+}

--- a/WebDriverAgentTests/IntegrationTests_watchOS/WDAScreenshotAndSourceIntegrationTests.swift
+++ b/WebDriverAgentTests/IntegrationTests_watchOS/WDAScreenshotAndSourceIntegrationTests.swift
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import XCTest
+
+/// Covers device/element screenshots and /source, /wda/accessibleSource.
+final class WDAScreenshotAndSourceIntegrationTests: WDAWatchIntegrationTestCase {
+  private static let pngMagicBytes: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+
+  private func assertLooksLikeAPNG(_ base64String: String?, file: StaticString = #filePath, line: UInt = #line) {
+    guard let base64String = base64String, let data = Data(base64Encoded: base64String) else {
+      return XCTFail("Response value was not base64 data", file: file, line: line)
+    }
+    XCTAssertGreaterThan(data.count, Self.pngMagicBytes.count, file: file, line: line)
+    XCTAssertEqual(Array(data.prefix(Self.pngMagicBytes.count)), Self.pngMagicBytes, "response was not a PNG", file: file, line: line)
+  }
+
+  func testDeviceScreenshot() throws {
+    let response = try client.get("/session/\(sessionId!)/screenshot")
+    XCTAssertEqual(response.statusCode, 200)
+    assertLooksLikeAPNG(response.valueString)
+  }
+
+  func testElementScreenshot() throws {
+    let buttonId = try findElement(byAccessibilityId: "tapMeButton")
+    let response = try client.get("/session/\(sessionId!)/element/\(buttonId)/screenshot")
+    XCTAssertEqual(response.statusCode, 200)
+    assertLooksLikeAPNG(response.valueString)
+  }
+
+  func testPageSourceContainsTheKnownElements() throws {
+    let response = try client.get("/session/\(sessionId!)/source?format=xml")
+    XCTAssertEqual(response.statusCode, 200)
+    guard let xml = response.valueString else {
+      return XCTFail("No XML source returned")
+    }
+    XCTAssertTrue(xml.contains("tapMeButton"))
+    XCTAssertTrue(xml.contains("resultLabel"))
+    XCTAssertTrue(xml.contains("typingField"))
+  }
+
+  func testAccessibleSource() throws {
+    let response = try client.get("/session/\(sessionId!)/wda/accessibleSource")
+    XCTAssertEqual(response.statusCode, 200)
+    XCTAssertNotNil(response.value)
+  }
+}

--- a/WebDriverAgentTests/IntegrationTests_watchOS/WDASessionIntegrationTests.swift
+++ b/WebDriverAgentTests/IntegrationTests_watchOS/WDASessionIntegrationTests.swift
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import XCTest
+
+/// Covers FBSessionCommands. Manages its own session lifecycle per test, since that's what's
+/// under test here, rather than using WDAWatchIntegrationTestCase.
+final class WDASessionIntegrationTests: XCTestCase {
+  let client = WDAWatchHTTPClient()
+
+  override func setUp() {
+    super.setUp()
+    continueAfterFailure = false
+  }
+
+  func testStatusIsReadyWithoutASession() throws {
+    let response = try client.get("/status")
+    XCTAssertEqual(response.statusCode, 200)
+    XCTAssertEqual(response.valueDict?["ready"] as? Bool, true)
+    XCTAssertEqual(response.valueDict?["state"] as? String, "success")
+  }
+
+  func testHealthCheck() throws {
+    let response = try client.get("/wda/healthcheck")
+    XCTAssertEqual(response.statusCode, 200)
+  }
+
+  func testCreateGetActiveAndDeleteSessionLifecycle() throws {
+    let createResponse = try client.post("/session", body: [
+      "capabilities": ["alwaysMatch": ["bundleId": WDAWatchIntegrationTestCase.integrationAppBundleId]]
+    ])
+    XCTAssertEqual(createResponse.statusCode, 200)
+    guard let sessionId = createResponse.valueDict?["sessionId"] as? String else {
+      return XCTFail("No sessionId in create-session response: \(String(describing: createResponse.json))")
+    }
+    XCTAssertFalse(sessionId.isEmpty)
+
+    let activeResponse = try client.get("/session/\(sessionId)")
+    XCTAssertEqual(activeResponse.statusCode, 200)
+    XCTAssertEqual(activeResponse.valueDict?["sessionId"] as? String, sessionId)
+
+    let deleteResponse = try client.delete("/session/\(sessionId)")
+    XCTAssertEqual(deleteResponse.statusCode, 200)
+  }
+
+  func testTimeoutsAndAppiumSettingsRoundTrip() throws {
+    let createResponse = try client.post("/session", body: [
+      "capabilities": ["alwaysMatch": ["bundleId": WDAWatchIntegrationTestCase.integrationAppBundleId]]
+    ])
+    guard let sessionId = createResponse.valueDict?["sessionId"] as? String else {
+      return XCTFail("No sessionId in create-session response")
+    }
+    defer { _ = try? client.delete("/session/\(sessionId)") }
+
+    let timeoutsResponse = try client.post("/session/\(sessionId)/timeouts", body: ["implicit": 500])
+    XCTAssertEqual(timeoutsResponse.statusCode, 200)
+
+    let getSettingsResponse = try client.get("/session/\(sessionId)/appium/settings")
+    XCTAssertEqual(getSettingsResponse.statusCode, 200)
+    XCTAssertNotNil(getSettingsResponse.valueDict)
+
+    let setSettingsResponse = try client.post("/session/\(sessionId)/appium/settings", body: [
+      "settings": ["shouldUseCompactResponses": false]
+    ])
+    XCTAssertEqual(setSettingsResponse.statusCode, 200)
+  }
+}

--- a/WebDriverAgentTests/IntegrationTests_watchOS/WDATypingIntegrationTests.swift
+++ b/WebDriverAgentTests/IntegrationTests_watchOS/WDATypingIntegrationTests.swift
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import XCTest
+
+/// Covers /element/:uuid/value, /element/:uuid/clear, and /wda/keyboard/dismiss.
+///
+/// KNOWN LIMITATION (see XCUIElement+FBTyping.m): the keyboard opens and the field gets focus,
+/// but no keystrokes land. Wrapped in XCTExpectFailure so this re-verifies itself and starts
+/// failing loudly the moment it starts working, instead of silently staying stale.
+final class WDATypingIntegrationTests: WDAWatchIntegrationTestCase {
+  func testSetValueOpensTheKeyboardAndAttemptsToTypeIntoTheField() throws {
+    let fieldId = try findElement(byAccessibilityId: "typingField")
+    XCTAssertEqual(try attributeValue(fieldId, "value"), "Type here", "expected the untouched placeholder")
+
+    let setValueResponse = try client.post("/session/\(sessionId!)/element/\(fieldId)/value", body: [
+      "value": ["h", "i"]
+    ])
+    XCTAssertEqual(setValueResponse.statusCode, 200, "the route itself should not error even though typing doesn't land")
+
+    XCTExpectFailure("watchOS keystroke delivery into the on-screen keyboard is a known unresolved limitation") {
+      let value = try? attributeValue(fieldId, "value")
+      XCTAssertEqual(value, "hi")
+    }
+
+    // Back out so later tests start clean.
+    if let cancelId = try? findElement(byAccessibilityId: "Cancel") {
+      _ = try? client.post("/session/\(sessionId!)/element/\(cancelId)/click")
+    }
+  }
+
+  func testClearingAnAlreadyEmptyFieldSucceeds() throws {
+    // Clearing an empty field short-circuits, so this works despite the typing limitation.
+    let fieldId = try findElement(byAccessibilityId: "typingField")
+    let clearResponse = try client.post("/session/\(sessionId!)/element/\(fieldId)/clear")
+    XCTAssertEqual(clearResponse.statusCode, 200)
+  }
+
+  func testDismissKeyboardRouteRespondsWithoutCrashingTheServer() throws {
+    // Only asserts the route round-trips cleanly, not that dismissal actually happens.
+    let fieldId = try findElement(byAccessibilityId: "typingField")
+    try client.post("/session/\(sessionId!)/element/\(fieldId)/click")
+    Thread.sleep(forTimeInterval: 1)
+
+    _ = try client.post("/session/\(sessionId!)/wda/keyboard/dismiss")
+
+    // Back out regardless of whether dismiss actually closed the sheet.
+    if let cancelId = try? findElement(byAccessibilityId: "Cancel") {
+      _ = try? client.post("/session/\(sessionId!)/element/\(cancelId)/click")
+    }
+  }
+}

--- a/WebDriverAgentTests/IntegrationTests_watchOS/WDAUnknownCommandIntegrationTests.swift
+++ b/WebDriverAgentTests/IntegrationTests_watchOS/WDAUnknownCommandIntegrationTests.swift
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import XCTest
+
+/// Covers the catch-all 404 routes and the OPTIONS ping route - neither needs a session.
+final class WDAUnknownCommandIntegrationTests: XCTestCase {
+  let client = WDAWatchHTTPClient()
+
+  func testUnknownRouteReturnsAnError() throws {
+    let response = try client.get("/this/route/does/not/exist")
+    XCTAssertNotEqual(response.statusCode, 200)
+  }
+
+  func testPing() throws {
+    let response = try client.send("OPTIONS", "/anything")
+    XCTAssertEqual(response.statusCode, 200)
+  }
+}

--- a/WebDriverAgentTests/IntegrationTests_watchOS/WDAWatchHTTPClient.swift
+++ b/WebDriverAgentTests/IntegrationTests_watchOS/WDAWatchHTTPClient.swift
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Foundation
+
+/// Minimal synchronous JSON/HTTP client for driving the real WebDriverAgentRunner_watchOS
+/// server, the same way a real client (Appium, curl) would. Requires the server to already be
+/// running - see Scripts/watchos-http-integration-test.sh.
+struct WDAWatchHTTPClient {
+  struct Response {
+    let statusCode: Int
+    let json: [String: Any]?
+
+    var value: Any? { json?["value"] }
+    var valueDict: [String: Any]? { value as? [String: Any] }
+    var valueString: String? { value as? String }
+  }
+
+  enum ClientError: Error, CustomStringConvertible {
+    case requestFailed(String)
+
+    var description: String {
+      switch self {
+      case .requestFailed(let message): return message
+      }
+    }
+  }
+
+  let baseURL: URL
+
+  init() {
+    let host = ProcessInfo.processInfo.environment["WDA_TEST_HOST"] ?? "127.0.0.1"
+    let port = ProcessInfo.processInfo.environment["WDA_TEST_PORT"] ?? "8100"
+    self.baseURL = URL(string: "http://\(host):\(port)")!
+  }
+
+  /// Splits path/query before resolving against baseURL - appendingPathComponent would
+  /// percent-encode a literal "?" instead of treating it as a query delimiter.
+  private func url(for path: String) -> URL {
+    let parts = path.split(separator: "?", maxSplits: 1)
+    var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!
+    components.path = components.path + parts[0]
+    if parts.count > 1 {
+      components.percentEncodedQuery = String(parts[1])
+    }
+    return components.url!
+  }
+
+  @discardableResult
+  func send(_ method: String, _ path: String, body: [String: Any]? = nil, timeout: TimeInterval = 20) throws -> Response {
+    var request = URLRequest(url: url(for: path))
+    request.httpMethod = method
+    request.timeoutInterval = timeout
+    if let body = body {
+      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+      request.httpBody = try JSONSerialization.data(withJSONObject: body)
+    }
+
+    let semaphore = DispatchSemaphore(value: 0)
+    var resultData: Data?
+    var resultResponse: URLResponse?
+    var resultError: Error?
+
+    URLSession.shared.dataTask(with: request) { data, response, error in
+      resultData = data
+      resultResponse = response
+      resultError = error
+      semaphore.signal()
+    }.resume()
+
+    if semaphore.wait(timeout: .now() + timeout + 5) == .timedOut {
+      throw ClientError.requestFailed("Request to \(method) \(path) timed out")
+    }
+    if let resultError = resultError {
+      throw ClientError.requestFailed("Request to \(method) \(path) failed: \(resultError)")
+    }
+    guard let httpResponse = resultResponse as? HTTPURLResponse else {
+      throw ClientError.requestFailed("Request to \(method) \(path) returned no HTTP response")
+    }
+    var json: [String: Any]?
+    if let resultData = resultData, !resultData.isEmpty {
+      json = try? JSONSerialization.jsonObject(with: resultData) as? [String: Any]
+    }
+    return Response(statusCode: httpResponse.statusCode, json: json)
+  }
+
+  func get(_ path: String) throws -> Response { try send("GET", path) }
+  func post(_ path: String, body: [String: Any] = [:]) throws -> Response { try send("POST", path, body: body) }
+  func delete(_ path: String) throws -> Response { try send("DELETE", path) }
+}

--- a/WebDriverAgentTests/IntegrationTests_watchOS/WDAWatchHTTPClient.swift
+++ b/WebDriverAgentTests/IntegrationTests_watchOS/WDAWatchHTTPClient.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// Minimal synchronous JSON/HTTP client for driving the real WebDriverAgentRunner_watchOS
 /// server, the same way a real client (Appium, curl) would. Requires the server to already be
-/// running - see Scripts/watchos-http-integration-test.sh.
+/// running, e.g. via `xcodebuild test -scheme WebDriverAgentRunner_watchOS`.
 struct WDAWatchHTTPClient {
   struct Response {
     let statusCode: Int

--- a/WebDriverAgentTests/IntegrationTests_watchOS/WDAWatchIntegrationTestCase.swift
+++ b/WebDriverAgentTests/IntegrationTests_watchOS/WDAWatchIntegrationTestCase.swift
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import XCTest
+
+/// Creates a fresh WDA session against IntegrationApp_watchOS per test, so each starts clean.
+class WDAWatchIntegrationTestCase: XCTestCase {
+  static let integrationAppBundleId = ProcessInfo.processInfo.environment["WDA_TEST_BUNDLE_ID"]
+    ?? "com.facebook.wda.IntegrationApp.watchOS"
+
+  let client = WDAWatchHTTPClient()
+  var sessionId: String!
+
+  override func setUp() {
+    super.setUp()
+    continueAfterFailure = false
+    do {
+      let response = try client.post("/session", body: [
+        "capabilities": ["alwaysMatch": ["bundleId": Self.integrationAppBundleId]]
+      ])
+      guard response.statusCode == 200, let sessionId = response.valueDict?["sessionId"] as? String else {
+        XCTFail("Failed to create session: \(String(describing: response.json))")
+        return
+      }
+      self.sessionId = sessionId
+    } catch {
+      XCTFail("Failed to create session: \(error)")
+    }
+  }
+
+  override func tearDown() {
+    if let sessionId = sessionId {
+      _ = try? client.delete("/session/\(sessionId)")
+    }
+    super.tearDown()
+  }
+
+  /// Finds an element by accessibility id and returns its WDA element UUID.
+  @discardableResult
+  func findElement(byAccessibilityId accessibilityId: String, file: StaticString = #filePath, line: UInt = #line) throws -> String {
+    let response = try client.post("/session/\(sessionId!)/element", body: [
+      "using": "accessibility id",
+      "value": accessibilityId,
+    ])
+    guard response.statusCode == 200, let elementId = response.valueDict?["ELEMENT"] as? String else {
+      XCTFail("Could not find element '\(accessibilityId)': \(String(describing: response.json))", file: file, line: line)
+      throw WDAWatchHTTPClient.ClientError.requestFailed("element not found")
+    }
+    return elementId
+  }
+
+  func attributeValue(_ elementId: String, _ name: String) throws -> String? {
+    let response = try client.get("/session/\(sessionId!)/element/\(elementId)/attribute/\(name)")
+    return response.valueString
+  }
+}


### PR DESCRIPTION
## Summary

Adds a working watchOS port of WebDriverAgent (#4829): `WebDriverAgentLib_watchOS` and `WebDriverAgentRunner_watchOS` build, run, and serve the real WebDriver HTTP API against a watchOS Simulator target — verified end to end, not just compiled.

- `find`, `click`, `screenshot`, `source`, session lifecycle, app lifecycle, device info/location, and all locator strategies (accessibility id, class name, class chain, xpath, predicate string, link text) work correctly over HTTP against the real server, the same way Appium would drive it.
- `type` has a known, documented limitation: the on-screen keyboard opens and the field gets focus, but neither low-level key synthesis nor the public `-typeText:` API delivers keystrokes into it in this environment. Covered by a test wrapped in `XCTExpectFailure` so it starts failing loudly (as a signal to revisit) the moment it starts working, instead of silently staying stale.
- CI builds and statically analyzes the new watchOS targets, mirroring the existing tvOS matrix.

## Why watchOS needs its own port, not just new `#if` branches

- **No BSD sockets.** watchOS forbids them entirely, so `RoutingHTTPServer`/`CocoaHTTPServer`/`CocoaAsyncSocket` (all GCDAsyncSocket-based) can't be built there. `FBTCPSocket` gained a full `TARGET_OS_WATCH` implementation on `Network.framework`'s C API (`nw_listener_t`/`nw_connection_t`) instead.
- **No RoutingHTTPServer.** A new minimal HTTP/1.1 server (`FBWatchHTTPServer`, plus `RouteRequest`/`RouteResponse` stand-ins) sits on top of the new socket layer, reproducing just enough of RoutingHTTPServer's surface that `FBWebServer.m` only needs a single `#if TARGET_OS_WATCH` swap of which server class it drives — no changes to route registration, dispatch, or exception handling.
- **A much smaller UI-automation surface.** Gesture synthesis (swipe/pinch/rotate/tap-coordinates/etc.), orientation/rotation, pasteboard, battery info, and MJPEG streaming are either not meaningfully applicable on watchOS or not verified to work there, so those routes are excluded from the watchOS build rather than left to fail unpredictably at runtime.

## Test coverage

`IntegrationTests_watchOS` was rewritten from a single leftover spike file into 10 split test files (32 test methods), organized by feature area like `IntegrationTests_1/2/3`/`IntegrationTests_tvOS` — but unlike those, which call WDA's `fb_*` categories in-process, this suite runs as its own XCTest process and drives the real `WebDriverAgentRunner_watchOS` server purely over HTTP, matching how a real client actually exercises WDA.

Deliberately out of scope for this suite (with rationale in code comments): gesture synthesis, orientation, pasteboard, battery, keyboard input, picker wheel (none registered on watchOS at all); video recording, VoiceOver toggling, Touch ID, Siri, homescreen/lock/pressButton (registered, but either unverified on the Simulator or too disruptive for a repeatable, hermetic suite).

## CI

Added `Generic_watchOS_Build`, `watchOS_Build`, `watchOS_Lib_Analyze`, and `watchOS_Runner_Analyze` to the build/analyze matrix in `wda-tests.yml`, at both MIN and MAX Xcode — the same shape as the existing tvOS entries. `Scripts/build.sh` gained matching `watch_lib`/`watch_runner`/`watch`/`watch_generic`/`watch_sim`/`watch_device` cases. No unit/integration test job was added yet — that's future work, see below.

## Real device status

Per feedback from @Dan-Maor testing on real hardware (see [comment](https://github.com/appium/WebDriverAgent/pull/1209#issuecomment-3195587871)):

- A framework-embed bug (`WebDriverAgentLib_watchOS.framework` was copied into `Resources/` instead of `Frameworks/` inside the `.xctest` bundle) has been fixed — this was causing the runner to crash on launch on a real device.
- With that fixed, the HTTP server still doesn't work on a real Apple Watch: connections never complete (`nw_connection_get_flow_id_on_nw_queue failed` repeating in the log). Per Apple's own guidance ([TN3135](https://developer.apple.com/documentation/technotes/tn3135-low-level-networking-on-watchos)), low-level networking via `Network.framework` is permitted on the Simulator but restricted to a narrow set of approved use cases on real watchOS hardware — general-purpose TCP servers aren't one of them. This is a platform restriction, not a WDA bug, and there is currently no known workaround.
- **watchOS Simulator is the only supported target for now.** Real-device support is blocked on Apple's networking restrictions and is tracked as a follow-up, not solved in this PR.

## Known limitations / follow-ups (not in scope for this PR)

- **Typing doesn't work** (see above) — needs further investigation, possibly lower-level HID key injection.
- **Real hardware doesn't work** for the reasons above — Simulator only for now.
- **No CI test job yet** for `IntegrationTests_watchOS` (build + static analysis only for now).
- **No `appium-xcuitest-driver` changes** — this PR is WDA-side only; the driver still needs scheme selection, platform/device detection, and new capabilities to actually launch this from Appium (see the tvOS driver PR, appium/appium-xcuitest-driver#911, as a template).
