### PR TITLE
fix: sign the runner by certificate hash instead of display name

### DIFF
--- a/Scripts/embed-runner-icon.sh
+++ b/Scripts/embed-runner-icon.sh
@@ -36,12 +36,32 @@ if [ ${#ICONS[@]} -eq 0 ]; then
     exit 0
 fi
 
-cp -f "${ICONS[@]}" "$RUNNER_APP/"
+PLIST="$RUNNER_APP/Info.plist"
+
+# Everything below mutates a bundle Xcode already signed, so keep enough state
+# to undo it: a failed re-sign must not leave an uninstallable runner behind.
+PLIST_BACKUP=$(mktemp)
+CERT_DIR=$(mktemp -d)
+trap 'rm -rf "$PLIST_BACKUP" "$CERT_DIR"' EXIT
+cp "$PLIST" "$PLIST_BACKUP"
+ADDED_FILES=()
+
+restore_bundle() {
+    cp -f "$PLIST_BACKUP" "$PLIST"
+    if [ ${#ADDED_FILES[@]} -gt 0 ]; then
+        rm -f "${ADDED_FILES[@]}"
+    fi
+}
+
+for icon in "${ICONS[@]}"; do
+    dest="$RUNNER_APP/$(basename "$icon")"
+    [ -e "$dest" ] || ADDED_FILES+=("$dest")
+    cp -f "$icon" "$dest"
+done
 if [ -f "$XCTEST/Assets.car" ]; then
+    [ -e "$RUNNER_APP/Assets.car" ] || ADDED_FILES+=("$RUNNER_APP/Assets.car")
     cp -f "$XCTEST/Assets.car" "$RUNNER_APP/"
 fi
-
-PLIST="$RUNNER_APP/Info.plist"
 /usr/libexec/PlistBuddy -c "Delete :CFBundleIcons" "$PLIST" 2>/dev/null || true
 /usr/libexec/PlistBuddy -c "Delete :CFBundleIcons~ipad" "$PLIST" 2>/dev/null || true
 
@@ -58,29 +78,40 @@ PLIST="$RUNNER_APP/Info.plist"
 /usr/libexec/PlistBuddy -c "Add :CFBundleIcons~ipad:CFBundlePrimaryIcon:CFBundleIconFiles:0 string AppIcon60x60" "$PLIST"
 /usr/libexec/PlistBuddy -c "Add :CFBundleIcons~ipad:CFBundlePrimaryIcon:CFBundleIconFiles:1 string AppIcon76x76" "$PLIST"
 
-# Re-codesign since we modified the bundle after Xcode signed it.
-# In a scheme post-action context Xcode's CODE_SIGN_* env vars are not exposed,
-# so discover the existing signing identity from the already-signed bundle.
+# Re-codesign since we modified the bundle after Xcode signed it. Scheme
+# post-actions never receive EXPANDED_CODE_SIGN_IDENTITY, so the signer has to
+# be recovered from the already-signed bundle.
 if [ -d "$RUNNER_APP/_CodeSignature" ]; then
     # Capture the signature info once. Piping codesign straight into
     # `awk ... exit` makes awk close the pipe early, killing codesign with
     # SIGPIPE -- which `set -o pipefail` turns into a fatal error. That trips
     # only when an Authority line exists, i.e. on every real-device build.
     SIGN_INFO=$(codesign -dvv "$RUNNER_APP" 2>&1 || true)
-    EXISTING_IDENT="${EXPANDED_CODE_SIGN_IDENTITY:-}"
-    if [ -z "$EXISTING_IDENT" ]; then
-        EXISTING_IDENT=$(awk -F'=' '/^Authority/ {print $2; exit}' <<< "$SIGN_INFO")
-    fi
-    # Simulator builds are ad-hoc signed: there is no Authority line, but the
-    # bundle can still be re-signed ad-hoc with an identity of "-".
-    if [ -z "$EXISTING_IDENT" ] && grep -q '^Signature=adhoc' <<< "$SIGN_INFO"; then
+
+    if grep -q '^Signature=adhoc' <<< "$SIGN_INFO"; then
+        # Simulator builds are ad-hoc signed; re-sign them ad-hoc.
         EXISTING_IDENT="-"
-    fi
-    if [ -n "$EXISTING_IDENT" ]; then
-        codesign --force --sign "$EXISTING_IDENT" \
-                 --preserve-metadata=identifier,entitlements "$RUNNER_APP"
     else
-        echo "warning: bundle is signed but no identity discovered; signature will be invalid"
+        # Identify the signer by leaf-certificate SHA-1, never by Authority
+        # display name: duplicate identities can share a name, and codesign
+        # then rejects the name as ambiguous (Apple TN3161).
+        EXISTING_IDENT=""
+        if codesign -d --extract-certificates="$CERT_DIR/leaf" "$RUNNER_APP" 2>/dev/null \
+                && [ -f "$CERT_DIR/leaf0" ]; then
+            EXISTING_IDENT=$(shasum -a 1 "$CERT_DIR/leaf0" | awk '{print toupper($1)}')
+        fi
+        if [ -z "$EXISTING_IDENT" ]; then
+            EXISTING_IDENT=$(awk -F'=' '/^Authority/ {print $2; exit}' <<< "$SIGN_INFO")
+        fi
+    fi
+
+    if [ -z "$EXISTING_IDENT" ] || ! codesign --force --sign "$EXISTING_IDENT" \
+            --preserve-metadata=identifier,entitlements "$RUNNER_APP"; then
+        # A modified-but-stale-signed bundle fails to install, which would break
+        # the session over a cosmetic icon. Undo instead.
+        restore_bundle
+        echo "warning: could not re-sign $RUNNER_APP; skipped icon embed"
+        exit 0
     fi
 fi
 


### PR DESCRIPTION
Fixes appium/appium#22637

## Problem

`Scripts/embed-runner-icon.sh` runs as a scheme post-action. It copies the compiled
app icon up into `Runner.app`, patches `Info.plist`, then re-signs the bundle because
Xcode has already signed it by that point.

To re-sign it needs an identity, and it took that identity from the `Authority` line
of `codesign -dvv`, which is a display name such as
`Apple Development: Jane Doe (ABCDE12345)`. Display names are not unique. A keychain
that holds two Apple Development certificates for the same person, which happens when
a certificate is recreated instead of revoked, makes `codesign --sign <name>` fail:

```
Apple Development: Jane Doe (ABCDE12345): ambiguous (matches
  "Apple Development: Jane Doe (ABCDE12345)" and
  "Apple Development: Jane Doe (ABCDE12345)" in login.keychain-db)
```

Because `set -euo pipefail` aborts the script at that point, and the `Info.plist`
edits have already been written, the runner is left modified under a stale signature.
The build fails with exit 65, and if anything tries to install the runner the device
rejects it:

```
Failed to verify code signature ... 0xe8008001 (An unknown error has occurred.)
LegacyErrorString = ApplicationVerificationFailed;
```

Apple's [TN3161](https://developer.apple.com/documentation/technotes/tn3161-inside-code-signing-certificates)
says to use the certificate SHA-1 hash exactly when names can collide.

## Root cause detail

The script already tried to avoid the name lookup by preferring
`EXPANDED_CODE_SIGN_IDENTITY`, which Xcode sets to the certificate SHA-1. That branch
never runs. Xcode injects `EXPANDED_*` variables into the CodeSign task inside a build
phase, not into a scheme post-action's environment.

Dumping the environment from inside the post-action shows 1658 exported variables,
including more than 20 `CODE_SIGN*` entries, and zero `EXPANDED_*` entries:

```
CODE_SIGN_IDENTITY=-
CODE_SIGN_STYLE=
CODE_SIGN_CONTEXT_CLASS=XCiPhoneSimulatorCodeSignContext
...
EXPANDED_CODE_SIGN_IDENTITY=[<unset>]
```

So the display name path was taken on every build, and every real device build was
exposed to the ambiguity, not just unusual setups.

## Fix

1. Identify the signer by leaf certificate SHA-1, taken from the signature already on
   the bundle:

   ```sh
   codesign -d --extract-certificates="$CERT_DIR/leaf" "$RUNNER_APP"
   EXISTING_IDENT=$(shasum -a 1 "$CERT_DIR/leaf0" | awk '{print toupper($1)}')
   ```

   That hash is the form `security find-identity` prints and `codesign --sign` accepts,
   and it is unique per certificate. `shasum` of the DER bytes is the SHA-1
   fingerprint, so no `openssl` dependency is added. The `Authority` name stays only as
   a fallback if extraction fails.

2. The ad-hoc check now runs first. Simulator bundles have no certificate to extract,
   and `Signature=adhoc` is a definite signal.

3. Drop the `EXPANDED_CODE_SIGN_IDENTITY` branch, since it cannot fire here.

4. Back up `Info.plist` and record the files copied in, then restore them if re-signing
   fails. Xcode's signature seals the original bytes, so putting them back makes the
   bundle valid again. A signing problem now costs the icon instead of the session.

## Testing

Xcode 26.5, macOS 26.5.1, iPhone (real device), and a keychain deliberately holding two
valid Apple Development certificates with the same display name but different SHA-1
hashes.

Reproduction of the bug, current `master` script:

| Bundle signed by | Result |
| --- | --- |
| certificate 1 | `codesign` reports ambiguous, script exits non-zero, bundle left `invalid Info.plist (plist or signature have been modified)` |
| certificate 2 | same |

With this change:

| Case | Result |
| --- | --- |
| Bundle signed by certificate 1 | exit 0, signature valid, re-signed with certificate 1 |
| Bundle signed by certificate 2 | exit 0, signature valid, re-signed with certificate 2 |
| Real device `build-for-testing` | build succeeded, signature valid, signer chain preserved, runner installed on the device |
| Clean simulator `build-for-testing` | build succeeded, ad-hoc re-sign, signature valid, icon present |
| `codesign --sign` forced to fail | exit 0 with a warning, `Info.plist` byte identical to Xcode's, signature valid, no leftover icon files, temp files cleaned |
| Syntax | `bash -n` under `/bin/bash` 3.2.57, the version the shebang resolves to on macOS |

Note on bash 3.2: `restore_bundle` guards on `${#ADDED_FILES[@]}` before expanding the
array, because bash 3.2 errors on expanding an empty array under `set -u`.

The two direction test matters more than the pass or fail: the script picks the
certificate that actually signed the bundle, rather than whichever the keychain returns
first.

## Notes

- Only `Scripts/embed-runner-icon.sh` changes. No project settings, schemes, team IDs,
  or bundle identifiers.
- The icon post-action arrived in #1138 and first shipped in v13.1.0, so any version
  from v13.1.0 on is affected.
- The failing path only happens on real device builds. Simulator builds are ad-hoc
  signed and take a branch that cannot be ambiguous, which is why CI stayed green.
