### PR TITLE
fix: add watchOS assets to GitHub release artifacts

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -8,5 +8,7 @@ export default releaseConfig({
     'WebDriverAgentRunner-Build-Sim-x86_64.zip',
     'WebDriverAgentRunner_tvOS-Build-Sim-arm64.zip',
     'WebDriverAgentRunner_tvOS-Build-Sim-x86_64.zip',
+    'WebDriverAgentRunner_watchOS-Build-Sim-arm64.zip',
+    'WebDriverAgentRunner_watchOS-Build-Sim-x86_64.zip',
   ],
 });


### PR DESCRIPTION
Follow-up to #1217, should hopefully fix watchOS-related failures in the XCUITest driver's CI.