### PR TITLE
fix: let /status, /screenshot, and DELETE /session API methods to bypass the dispatch queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,5 @@ Then, you find `WebDriverAgentRunner-Runner-sim-<version>.zip`  for iOS and `Web
 
 [`WebDriverAgent` is BSD-licensed](LICENSE).
 
-## Third Party Sources
-
-WebDriverAgent depends on the following third-party frameworks:
-- [CocoaHTTPServer](https://github.com/robbiehanson/CocoaHTTPServer)
-- [RoutingHTTPServer](https://github.com/mattstevens/RoutingHTTPServer)
-
-These projects haven't been maintained in a while. That's why the source code of these
-projects has been integrated directly in the WebDriverAgent source tree.
-
-You can find the source files and their licenses in the `WebDriverAgentLib/Vendor` directory.
 
 Have fun!

--- a/WebDriverAgentLib/Commands/FBScreenshotCommands.m
+++ b/WebDriverAgentLib/Commands/FBScreenshotCommands.m
@@ -18,8 +18,8 @@
 {
   return
   @[
-    [[FBRoute GET:@"/screenshot"].withoutSession respondWithTarget:self action:@selector(handleGetScreenshot:)],
-    [[FBRoute GET:@"/screenshot"] respondWithTarget:self action:@selector(handleGetScreenshot:)],
+    [[FBRoute GET:@"/screenshot"].withoutSession.standalone respondWithTarget:self action:@selector(handleGetScreenshot:)],
+    [[FBRoute GET:@"/screenshot"].standalone respondWithTarget:self action:@selector(handleGetScreenshot:)],
   ];
 }
 

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -47,8 +47,8 @@
     [[FBRoute POST:@"/wda/apps/state"] respondWithTarget:self action:@selector(handleSessionAppState:)],
     [[FBRoute GET:@"/wda/apps/list"] respondWithTarget:self action:@selector(handleGetActiveAppsList:)],
     [[FBRoute GET:@""] respondWithTarget:self action:@selector(handleGetActiveSession:)],
-    [[FBRoute DELETE:@""] respondWithTarget:self action:@selector(handleDeleteSession:)],
-    [[FBRoute GET:@"/status"].withoutSession respondWithTarget:self action:@selector(handleGetStatus:)],
+    [[FBRoute DELETE:@""].standalone respondWithTarget:self action:@selector(handleDeleteSession:)],
+    [[FBRoute GET:@"/status"].withoutSession.standalone respondWithTarget:self action:@selector(handleGetStatus:)],
 
     // Health check might modify simulator state so it should only be called in-between testing sessions
     [[FBRoute GET:@"/wda/healthcheck"].withoutSession respondWithTarget:self action:@selector(handleGetHealthCheck:)],

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -89,9 +89,7 @@
 
 + (id<FBResponsePayload>)handleCreateSession:(FBRouteRequest *)request
 {
-  if (nil != FBSession.activeSession) {
-    [FBSession.activeSession kill];
-  }
+  [FBSession killActiveSessionAndWaitForTeardown];
 
   NSDictionary<NSString *, id> *capabilities;
   id<FBResponsePayload> errorResponse = [self capabilitiesFromCreateSessionRequest:request

--- a/WebDriverAgentLib/Routing/FBHTTPServer.h
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.h
@@ -72,6 +72,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)get:(NSString *)path withBlock:(void (^)(RouteRequest *request, RouteResponse *response))block;
 
 /**
+ Immediately sends `response` to every non-standalone request currently pending for the given
+ "sessionID" path param - whether still queued on -routeQueue or already executing - instead of
+ leaving their HTTP clients waiting on a session that no longer exists. A request that has already
+ started executing keeps running to completion in the background regardless (GCD gives no way to
+ abort a block once it starts), but its eventual result is discarded rather than ever reaching a
+ client. `response` is written as-is to every pending client, so the caller is expected to supply
+ a fully-populated, protocol-correct error response (e.g. a W3C-shaped JSON body).
+ */
+- (void)abandonPendingRequestsForSessionID:(NSString *)sessionID withResponse:(RouteResponse *)response;
+
+/**
  Starts listening on `port`.
  */
 - (BOOL)start:(NSError **)error;

--- a/WebDriverAgentLib/Routing/FBHTTPServer.h
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.h
@@ -47,10 +47,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Registers a route handler for the given HTTP method and path pattern (":param" segments are
- captured into the request's `params`).
+ captured into the request's `params`). Equivalent to -handleMethod:withPath:standalone:block:
+ with standalone:NO.
  */
 - (void)handleMethod:(NSString *)method
             withPath:(NSString *)path
+               block:(void (^)(RouteRequest *request, RouteResponse *response))block;
+
+/**
+ Registers a route handler that, when `standalone` is YES, bypasses -routeQueue entirely so a
+ handler stuck on that queue can never block it. Concurrent requests to the same method+path are
+ coalesced into a single in-flight execution, whose response is delivered to all of them; anything
+ else runs on its own queue, so distinct standalone endpoints always execute in parallel with each
+ other and with whatever is stuck on -routeQueue.
+ */
+- (void)handleMethod:(NSString *)method
+            withPath:(NSString *)path
+          standalone:(BOOL)standalone
                block:(void (^)(RouteRequest *request, RouteResponse *response))block;
 
 /**

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -88,6 +88,12 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 // Per-client cache of the already-parsed request line + headers while its body is still
 // arriving; nil while a client's next unread bytes start with an unparsed header block.
 @property (nonatomic, strong) NSMapTable<id, FBPendingHTTPRequestHeader *> *pendingRequestHeaders;
+// -processBufferForClient: parses a connection's buffer outside of any lock (cheap, and it can
+// hand off to -dispatchMethod:...). It's only safe to do that unlocked because every call to it -
+// from -client:didReceiveData: and from -writeResponse:toClient:thenCloseConnection: alike - is
+// funneled through this single serial queue, so no two calls (even for different connections) ever
+// run concurrently with each other.
+@property (nonatomic, strong) dispatch_queue_t bufferProcessingQueue;
 // Connections with a request that's been parsed off the buffer but not yet answered. While a
 // connection is in this set, -processBufferForClient: won't start any further pipelined request
 // already sitting in its buffer - that keeps responses on one connection from being written out
@@ -116,6 +122,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
                                                  valueOptions:(NSPointerFunctionsOptions)NSMapTableStrongMemory];
     _pendingRequestHeaders = [NSMapTable mapTableWithKeyOptions:(NSPointerFunctionsOptions)(NSMapTableObjectPointerPersonality | NSMapTableStrongMemory)
                                                     valueOptions:(NSPointerFunctionsOptions)NSMapTableStrongMemory];
+    _bufferProcessingQueue = dispatch_queue_create("com.facebook.wda.http.bufferProcessing", DISPATCH_QUEUE_SERIAL);
     _connectionsAwaitingResponse = [NSMutableSet set];
     _standaloneWaiters = [NSMutableDictionary dictionary];
     _pendingSessionRequests = [NSMutableDictionary dictionary];
@@ -271,7 +278,10 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
     }
     [buffer appendData:data];
   }
-  [self processBufferForClient:client];
+  __weak typeof(self) weakSelf = self;
+  dispatch_async(self.bufferProcessingQueue, ^{
+    [weakSelf processBufferForClient:client];
+  });
 }
 
 #pragma mark - HTTP parsing
@@ -447,7 +457,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
       // -sessionWasKilled:); tracking its own request here would make it abandon itself and write
       // a response twice.
       NSString *trackedSessionID = [route.verb isEqualToString:@"DELETE"] ? nil : sessionID;
-      [self dispatchStandaloneRoute:route request:request response:response client:client method:method path:path sessionID:trackedSessionID];
+      [self dispatchStandaloneRoute:route request:request response:response client:client method:method pathAndQuery:pathAndQuery sessionID:trackedSessionID];
       return;
     }
 
@@ -536,10 +546,13 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
                         response:(RouteResponse *)response
                           client:(nw_connection_t)client
                           method:(NSString *)method
-                            path:(NSString *)path
+                    pathAndQuery:(NSString *)pathAndQuery
                        sessionID:(nullable NSString *)sessionID
 {
-  NSString *key = [NSString stringWithFormat:@"%@ %@", method, path];
+  // Includes the query string, not just the path, so two concurrent requests that would run
+  // route.block with genuinely different `request` objects (e.g. differing query params) are
+  // never coalesced into sharing one response.
+  NSString *key = [NSString stringWithFormat:@"%@ %@", method, pathAndQuery];
   FBPendingRequest *waiter = [[FBPendingRequest alloc] initWithClient:client];
   if (nil != sessionID) {
     [self trackPendingRequest:waiter forSessionID:sessionID];
@@ -620,7 +633,10 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
     @synchronized (self.connectionBuffers) {
       [self.connectionsAwaitingResponse removeObject:client];
     }
-    [self processBufferForClient:client];
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(self.bufferProcessingQueue, ^{
+      [weakSelf processBufferForClient:client];
+    });
   }
 }
 

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -56,6 +56,26 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 @end
 
 
+// Represents one dispatched-but-not-yet-answered request. Uses default (pointer) identity, so two
+// pending requests that happen to share the same underlying connection - e.g. two pipelined
+// requests for the same session - are never conflated into a single tracked entry.
+@interface FBPendingRequest : NSObject
+@property (nonatomic, strong, readonly) nw_connection_t client;
+@end
+
+@implementation FBPendingRequest
+
+- (instancetype)initWithClient:(nw_connection_t)client
+{
+  if ((self = [super init])) {
+    _client = client;
+  }
+  return self;
+}
+
+@end
+
+
 @interface FBHTTPServer () <FBTCPSocketDelegate>
 
 @property (nonatomic, nullable, strong) FBTCPSocket *socket;
@@ -68,13 +88,20 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 // Per-client cache of the already-parsed request line + headers while its body is still
 // arriving; nil while a client's next unread bytes start with an unparsed header block.
 @property (nonatomic, strong) NSMapTable<id, FBPendingHTTPRequestHeader *> *pendingRequestHeaders;
-// Keyed by "METHOD path" - holds connections waiting on an already in-flight standalone request
-// for that same endpoint. Guarded by @synchronized(self.standaloneWaiters).
-@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableArray *> *standaloneWaiters;
-// Keyed by the "sessionID" path param - holds clients with a non-standalone request currently
-// queued on -routeQueue or executing for that session. See -abandonPendingRequestsForSessionID:.
-// Guarded by @synchronized(self.pendingSessionRequests).
-@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableSet *> *pendingSessionRequests;
+// Connections with a request that's been parsed off the buffer but not yet answered. While a
+// connection is in this set, -processBufferForClient: won't start any further pipelined request
+// already sitting in its buffer - that keeps responses on one connection from being written out
+// of order when e.g. a standalone /screenshot and /status are pipelined back to back and finish
+// on independent queues. Guarded by @synchronized(self.connectionBuffers) (same lock as the
+// buffers themselves, so the busy-check and the buffer consume-and-dispatch stay one atomic step).
+@property (nonatomic, strong) NSMutableSet *connectionsAwaitingResponse;
+// Keyed by "METHOD path" - holds requests waiting on an already in-flight standalone request for
+// that same endpoint. Guarded by @synchronized(self.standaloneWaiters).
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableArray<FBPendingRequest *> *> *standaloneWaiters;
+// Keyed by the "sessionID" path param - holds requests currently queued or executing for that
+// session, standalone or not (except DELETE /session itself - see -dispatchMethod:...).
+// See -abandonPendingRequestsForSessionID:. Guarded by @synchronized(self.pendingSessionRequests).
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableSet<FBPendingRequest *> *> *pendingSessionRequests;
 
 @end
 
@@ -89,6 +116,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
                                                  valueOptions:(NSPointerFunctionsOptions)NSMapTableStrongMemory];
     _pendingRequestHeaders = [NSMapTable mapTableWithKeyOptions:(NSPointerFunctionsOptions)(NSMapTableObjectPointerPersonality | NSMapTableStrongMemory)
                                                     valueOptions:(NSPointerFunctionsOptions)NSMapTableStrongMemory];
+    _connectionsAwaitingResponse = [NSMutableSet set];
     _standaloneWaiters = [NSMutableDictionary dictionary];
     _pendingSessionRequests = [NSMutableDictionary dictionary];
   }
@@ -210,6 +238,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
   @synchronized (self.connectionBuffers) {
     [self.connectionBuffers removeAllObjects];
     [self.pendingRequestHeaders removeAllObjects];
+    [self.connectionsAwaitingResponse removeAllObjects];
   }
   _isRunning = NO;
 }
@@ -228,6 +257,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
   @synchronized (self.connectionBuffers) {
     [self.connectionBuffers removeObjectForKey:client];
     [self.pendingRequestHeaders removeObjectForKey:client];
+    [self.connectionsAwaitingResponse removeObject:client];
   }
 }
 
@@ -246,104 +276,109 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 
 #pragma mark - HTTP parsing
 
+// Parses and dispatches at most one request per call. A connection with a request already
+// in flight is left alone - see -connectionsAwaitingResponse - and picks back up, via a fresh
+// call to this method, once that request's response has been written.
 - (void)processBufferForClient:(nw_connection_t)client
 {
-  while (YES) {
-    NSMutableData *buffer;
-    FBPendingHTTPRequestHeader *pending;
-    @synchronized (self.connectionBuffers) {
-      buffer = [self.connectionBuffers objectForKey:client];
-      if (nil == buffer) {
-        return;
-      }
-      pending = [self.pendingRequestHeaders objectForKey:client];
+  NSMutableData *buffer;
+  FBPendingHTTPRequestHeader *pending;
+  @synchronized (self.connectionBuffers) {
+    if ([self.connectionsAwaitingResponse containsObject:client]) {
+      return;
     }
-
-    if (nil == pending) {
-      NSRange headerEndRange = [buffer rangeOfData:FBCRLFCRLFData() options:(NSDataSearchOptions)0 range:NSMakeRange(0, buffer.length)];
-      if (NSNotFound == headerEndRange.location) {
-        // Wait for the rest of the header block to arrive.
-        return;
-      }
-
-      NSData *headerData = [buffer subdataWithRange:NSMakeRange(0, headerEndRange.location)];
-      NSString *headerString = [[NSString alloc] initWithData:headerData encoding:NSUTF8StringEncoding];
-      NSArray<NSString *> *lines = [headerString componentsSeparatedByString:@"\r\n"];
-      if (lines.count < 1) {
-        [self respondBadRequestToClient:client];
-        return;
-      }
-
-      NSArray<NSString *> *requestLineParts = [lines.firstObject componentsSeparatedByString:@" "];
-      if (requestLineParts.count < 2) {
-        [self respondBadRequestToClient:client];
-        return;
-      }
-
-      NSMutableDictionary<NSString *, NSString *> *requestHeaders = [NSMutableDictionary dictionary];
-      for (NSUInteger i = 1; i < lines.count; i++) {
-        NSString *line = lines[i];
-        NSRange colonRange = [line rangeOfString:@":"];
-        if (NSNotFound == colonRange.location) {
-          continue;
-        }
-        NSString *name = [line substringToIndex:colonRange.location];
-        NSString *value = [[line substringFromIndex:colonRange.location + 1]
-                            stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
-        requestHeaders[name.lowercaseString] = value;
-      }
-
-      NSString *transferEncoding = requestHeaders[@"transfer-encoding"];
-      if (transferEncoding.length > 0) {
-        // No transfer decoder is implemented at all, so any encoding (chunked or otherwise -
-        // including a value only introduced by a duplicate header overwriting "chunked" above)
-        // is rejected rather than risking the body being misread as empty and desyncing the rest
-        // of the connection's request stream.
-        RouteResponse *notImplemented = [RouteResponse new];
-        id<FBResponsePayload> notImplementedPayload = FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"Transfer-Encoding is not supported"
-                                                                                                                    traceback:nil]);
-        [notImplementedPayload dispatchWithResponse:notImplemented];
-        [self failClient:client withResponse:notImplemented];
-        return;
-      }
-
-      NSUInteger contentLength = (NSUInteger)requestHeaders[@"content-length"].integerValue;
-      if (contentLength > FBConfiguration.sharedInstance.httpRequestBodySizeLimit) {
-        // Closes the connection after responding, since the rest of the oversized body is still incoming.
-        RouteResponse *tooLarge = [RouteResponse new];
-        id<FBResponsePayload> tooLargePayload = FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"The request body exceeds the configured size limit"
-                                                                                                              traceback:nil]);
-        [tooLargePayload dispatchWithResponse:tooLarge];
-        [self failClient:client withResponse:tooLarge];
-        return;
-      }
-
-      pending = [FBPendingHTTPRequestHeader new];
-      pending.method = requestLineParts[0].uppercaseString;
-      pending.pathAndQuery = requestLineParts[1];
-      pending.bodyStart = headerEndRange.location + headerEndRange.length;
-      pending.contentLength = contentLength;
-      @synchronized (self.connectionBuffers) {
-        [self.pendingRequestHeaders setObject:pending forKey:client];
-      }
+    buffer = [self.connectionBuffers objectForKey:client];
+    if (nil == buffer) {
+      return;
     }
+    pending = [self.pendingRequestHeaders objectForKey:client];
+  }
 
-    NSUInteger totalRequestLength = pending.bodyStart + pending.contentLength;
-    if (buffer.length < totalRequestLength) {
-      // Wait for the rest of the body to arrive - the parsed header stays cached above, so this
-      // doesn't re-scan/re-parse the header block on every subsequently arriving chunk.
+  if (nil == pending) {
+    NSRange headerEndRange = [buffer rangeOfData:FBCRLFCRLFData() options:(NSDataSearchOptions)0 range:NSMakeRange(0, buffer.length)];
+    if (NSNotFound == headerEndRange.location) {
+      // Wait for the rest of the header block to arrive.
       return;
     }
 
-    NSData *body = pending.contentLength > 0 ? [buffer subdataWithRange:NSMakeRange(pending.bodyStart, pending.contentLength)] : [NSData data];
-
-    @synchronized (self.connectionBuffers) {
-      [buffer replaceBytesInRange:NSMakeRange(0, totalRequestLength) withBytes:NULL length:0];
-      [self.pendingRequestHeaders removeObjectForKey:client];
+    NSData *headerData = [buffer subdataWithRange:NSMakeRange(0, headerEndRange.location)];
+    NSString *headerString = [[NSString alloc] initWithData:headerData encoding:NSUTF8StringEncoding];
+    NSArray<NSString *> *lines = [headerString componentsSeparatedByString:@"\r\n"];
+    if (lines.count < 1) {
+      [self respondBadRequestToClient:client];
+      return;
     }
 
-    [self dispatchMethod:pending.method pathAndQuery:pending.pathAndQuery body:body client:client];
+    NSArray<NSString *> *requestLineParts = [lines.firstObject componentsSeparatedByString:@" "];
+    if (requestLineParts.count < 2) {
+      [self respondBadRequestToClient:client];
+      return;
+    }
+
+    NSMutableDictionary<NSString *, NSString *> *requestHeaders = [NSMutableDictionary dictionary];
+    for (NSUInteger i = 1; i < lines.count; i++) {
+      NSString *line = lines[i];
+      NSRange colonRange = [line rangeOfString:@":"];
+      if (NSNotFound == colonRange.location) {
+        continue;
+      }
+      NSString *name = [line substringToIndex:colonRange.location];
+      NSString *value = [[line substringFromIndex:colonRange.location + 1]
+                          stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+      requestHeaders[name.lowercaseString] = value;
+    }
+
+    NSString *transferEncoding = requestHeaders[@"transfer-encoding"];
+    if (transferEncoding.length > 0) {
+      // No transfer decoder is implemented at all, so any encoding (chunked or otherwise -
+      // including a value only introduced by a duplicate header overwriting "chunked" above)
+      // is rejected rather than risking the body being misread as empty and desyncing the rest
+      // of the connection's request stream.
+      RouteResponse *notImplemented = [RouteResponse new];
+      id<FBResponsePayload> notImplementedPayload = FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"Transfer-Encoding is not supported"
+                                                                                                                  traceback:nil]);
+      [notImplementedPayload dispatchWithResponse:notImplemented];
+      [self failClient:client withResponse:notImplemented];
+      return;
+    }
+
+    NSUInteger contentLength = (NSUInteger)requestHeaders[@"content-length"].integerValue;
+    if (contentLength > FBConfiguration.sharedInstance.httpRequestBodySizeLimit) {
+      // Closes the connection after responding, since the rest of the oversized body is still incoming.
+      RouteResponse *tooLarge = [RouteResponse new];
+      id<FBResponsePayload> tooLargePayload = FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"The request body exceeds the configured size limit"
+                                                                                                            traceback:nil]);
+      [tooLargePayload dispatchWithResponse:tooLarge];
+      [self failClient:client withResponse:tooLarge];
+      return;
+    }
+
+    pending = [FBPendingHTTPRequestHeader new];
+    pending.method = requestLineParts[0].uppercaseString;
+    pending.pathAndQuery = requestLineParts[1];
+    pending.bodyStart = headerEndRange.location + headerEndRange.length;
+    pending.contentLength = contentLength;
+    @synchronized (self.connectionBuffers) {
+      [self.pendingRequestHeaders setObject:pending forKey:client];
+    }
   }
+
+  NSUInteger totalRequestLength = pending.bodyStart + pending.contentLength;
+  if (buffer.length < totalRequestLength) {
+    // Wait for the rest of the body to arrive - the parsed header stays cached above, so this
+    // doesn't re-scan/re-parse the header block on every subsequently arriving chunk.
+    return;
+  }
+
+  NSData *body = pending.contentLength > 0 ? [buffer subdataWithRange:NSMakeRange(pending.bodyStart, pending.contentLength)] : [NSData data];
+
+  @synchronized (self.connectionBuffers) {
+    [buffer replaceBytesInRange:NSMakeRange(0, totalRequestLength) withBytes:NULL length:0];
+    [self.pendingRequestHeaders removeObjectForKey:client];
+    [self.connectionsAwaitingResponse addObject:client];
+  }
+
+  [self dispatchMethod:pending.method pathAndQuery:pending.pathAndQuery body:body client:client];
 }
 
 // Removes the client's buffered state and responds with a closing error response. Removing the
@@ -406,40 +441,27 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
     RouteResponse *response = [RouteResponse new];
     [self applyDefaultHeadersToResponse:response];
 
+    NSString *sessionID = params[@"sessionID"];
     if (route.isStandalone) {
-      [self dispatchStandaloneRoute:route request:request response:response client:client method:method path:path];
+      // DELETE /session is what triggers -abandonPendingRequestsForSessionID: (see -kill /
+      // -sessionWasKilled:); tracking its own request here would make it abandon itself and write
+      // a response twice.
+      NSString *trackedSessionID = [route.verb isEqualToString:@"DELETE"] ? nil : sessionID;
+      [self dispatchStandaloneRoute:route request:request response:response client:client method:method path:path sessionID:trackedSessionID];
       return;
     }
 
-    NSString *sessionID = params[@"sessionID"];
+    FBPendingRequest *pendingRequest = nil;
     if (nil != sessionID) {
-      @synchronized (self.pendingSessionRequests) {
-        NSMutableSet *pendingClients = self.pendingSessionRequests[sessionID];
-        if (nil == pendingClients) {
-          pendingClients = [NSMutableSet set];
-          self.pendingSessionRequests[sessionID] = pendingClients;
-        }
-        [pendingClients addObject:client];
-      }
+      pendingRequest = [[FBPendingRequest alloc] initWithClient:client];
+      [self trackPendingRequest:pendingRequest forSessionID:sessionID];
     }
 
     void (^invoke)(void) = ^{
       route.block(request, response);
-      // Whoever removes `client` from pendingSessionRequests first "wins" and gets to respond -
-      // either this normal completion, or -abandonPendingRequestsForSessionID: on another thread.
-      BOOL shouldRespond = YES;
-      if (nil != sessionID) {
-        @synchronized (self.pendingSessionRequests) {
-          NSMutableSet *pendingClients = self.pendingSessionRequests[sessionID];
-          shouldRespond = [pendingClients containsObject:client];
-          if (shouldRespond) {
-            [pendingClients removeObject:client];
-            if (0 == pendingClients.count) {
-              [self.pendingSessionRequests removeObjectForKey:sessionID];
-            }
-          }
-        }
-      }
+      // Whoever untracks `pendingRequest` first "wins" and gets to respond - either this normal
+      // completion, or -abandonPendingRequestsForSessionID: on another thread.
+      BOOL shouldRespond = (nil == pendingRequest) || [self untrackPendingRequest:pendingRequest forSessionID:sessionID];
       if (shouldRespond) {
         [self writeResponse:response toClient:client];
       }
@@ -463,15 +485,47 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 
 #pragma mark - Session-scoped request cancellation
 
+// `pendingRequest` identifies one dispatched request - see FBPendingRequest - so pipelined
+// requests that happen to share a connection are tracked independently of one another.
+- (void)trackPendingRequest:(FBPendingRequest *)pendingRequest forSessionID:(NSString *)sessionID
+{
+  @synchronized (self.pendingSessionRequests) {
+    NSMutableSet<FBPendingRequest *> *pendingRequests = self.pendingSessionRequests[sessionID];
+    if (nil == pendingRequests) {
+      pendingRequests = [NSMutableSet set];
+      self.pendingSessionRequests[sessionID] = pendingRequests;
+    }
+    [pendingRequests addObject:pendingRequest];
+  }
+}
+
+// Returns YES if `pendingRequest` was still tracked (and is now removed) - i.e. this caller won
+// the race to respond to it, as opposed to -abandonPendingRequestsForSessionID: having already
+// claimed it on another thread.
+- (BOOL)untrackPendingRequest:(FBPendingRequest *)pendingRequest forSessionID:(NSString *)sessionID
+{
+  @synchronized (self.pendingSessionRequests) {
+    NSMutableSet<FBPendingRequest *> *pendingRequests = self.pendingSessionRequests[sessionID];
+    BOOL wasPending = [pendingRequests containsObject:pendingRequest];
+    if (wasPending) {
+      [pendingRequests removeObject:pendingRequest];
+      if (0 == pendingRequests.count) {
+        [self.pendingSessionRequests removeObjectForKey:sessionID];
+      }
+    }
+    return wasPending;
+  }
+}
+
 - (void)abandonPendingRequestsForSessionID:(NSString *)sessionID withResponse:(RouteResponse *)response
 {
-  NSSet *clients;
+  NSSet<FBPendingRequest *> *pendingRequests;
   @synchronized (self.pendingSessionRequests) {
-    clients = [self.pendingSessionRequests[sessionID] copy];
+    pendingRequests = [self.pendingSessionRequests[sessionID] copy];
     [self.pendingSessionRequests removeObjectForKey:sessionID];
   }
-  for (nw_connection_t client in clients) {
-    [self writeResponse:response toClient:client];
+  for (FBPendingRequest *pendingRequest in pendingRequests) {
+    [self writeResponse:response toClient:pendingRequest.client];
   }
 }
 
@@ -483,13 +537,19 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
                           client:(nw_connection_t)client
                           method:(NSString *)method
                             path:(NSString *)path
+                       sessionID:(nullable NSString *)sessionID
 {
   NSString *key = [NSString stringWithFormat:@"%@ %@", method, path];
+  FBPendingRequest *waiter = [[FBPendingRequest alloc] initWithClient:client];
+  if (nil != sessionID) {
+    [self trackPendingRequest:waiter forSessionID:sessionID];
+  }
+
   BOOL isInFlight = NO;
   @synchronized (self.standaloneWaiters) {
-    NSMutableArray *waiters = self.standaloneWaiters[key];
+    NSMutableArray<FBPendingRequest *> *waiters = self.standaloneWaiters[key];
     if (nil != waiters) {
-      [waiters addObject:client];
+      [waiters addObject:waiter];
       isInFlight = YES;
     } else {
       self.standaloneWaiters[key] = [NSMutableArray array];
@@ -508,14 +568,18 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
     if (nil == strongSelf) {
       return;
     }
-    NSArray *joinedClients;
+    NSArray<FBPendingRequest *> *joinedWaiters;
     @synchronized (strongSelf.standaloneWaiters) {
-      joinedClients = [strongSelf.standaloneWaiters[key] copy];
+      joinedWaiters = [strongSelf.standaloneWaiters[key] copy];
       [strongSelf.standaloneWaiters removeObjectForKey:key];
     }
-    [strongSelf writeResponse:response toClient:client];
-    for (nw_connection_t joinedClient in joinedClients) {
-      [strongSelf writeResponse:response toClient:joinedClient];
+    for (FBPendingRequest *joinedWaiter in [@[waiter] arrayByAddingObjectsFromArray:joinedWaiters]) {
+      // Whoever untracks a waiter first "wins" and gets to respond - either this normal
+      // completion, or -abandonPendingRequestsForSessionID: on another thread.
+      BOOL shouldRespond = (nil == sessionID) || [strongSelf untrackPendingRequest:joinedWaiter forSessionID:sessionID];
+      if (shouldRespond) {
+        [strongSelf writeResponse:response toClient:joinedWaiter.client];
+      }
     }
   });
 }
@@ -550,7 +614,13 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
       [weakSelf closeClient:client];
     }];
   } else {
+    // Submitted before this connection is allowed to move on to its next pipelined request (see
+    // -processBufferForClient:), so responses can't reach the wire out of order.
     [self.socket writeData:payload toClient:client];
+    @synchronized (self.connectionBuffers) {
+      [self.connectionsAwaitingResponse removeObject:client];
+    }
+    [self processBufferForClient:client];
   }
 }
 
@@ -558,6 +628,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 {
   @synchronized (self.connectionBuffers) {
     [self.connectionBuffers removeObjectForKey:client];
+    [self.connectionsAwaitingResponse removeObject:client];
   }
   nw_connection_cancel(client);
 }

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -71,6 +71,10 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 // Keyed by "METHOD path" - holds connections waiting on an already in-flight standalone request
 // for that same endpoint. Guarded by @synchronized(self.standaloneWaiters).
 @property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableArray *> *standaloneWaiters;
+// Keyed by the "sessionID" path param - holds clients with a non-standalone request currently
+// queued on -routeQueue or executing for that session. See -abandonPendingRequestsForSessionID:.
+// Guarded by @synchronized(self.pendingSessionRequests).
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableSet *> *pendingSessionRequests;
 
 @end
 
@@ -86,6 +90,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
     _pendingRequestHeaders = [NSMapTable mapTableWithKeyOptions:(NSPointerFunctionsOptions)(NSMapTableObjectPointerPersonality | NSMapTableStrongMemory)
                                                     valueOptions:(NSPointerFunctionsOptions)NSMapTableStrongMemory];
     _standaloneWaiters = [NSMutableDictionary dictionary];
+    _pendingSessionRequests = [NSMutableDictionary dictionary];
   }
   return self;
 }
@@ -406,9 +411,38 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
       return;
     }
 
+    NSString *sessionID = params[@"sessionID"];
+    if (nil != sessionID) {
+      @synchronized (self.pendingSessionRequests) {
+        NSMutableSet *pendingClients = self.pendingSessionRequests[sessionID];
+        if (nil == pendingClients) {
+          pendingClients = [NSMutableSet set];
+          self.pendingSessionRequests[sessionID] = pendingClients;
+        }
+        [pendingClients addObject:client];
+      }
+    }
+
     void (^invoke)(void) = ^{
       route.block(request, response);
-      [self writeResponse:response toClient:client];
+      // Whoever removes `client` from pendingSessionRequests first "wins" and gets to respond -
+      // either this normal completion, or -abandonPendingRequestsForSessionID: on another thread.
+      BOOL shouldRespond = YES;
+      if (nil != sessionID) {
+        @synchronized (self.pendingSessionRequests) {
+          NSMutableSet *pendingClients = self.pendingSessionRequests[sessionID];
+          shouldRespond = [pendingClients containsObject:client];
+          if (shouldRespond) {
+            [pendingClients removeObject:client];
+            if (0 == pendingClients.count) {
+              [self.pendingSessionRequests removeObjectForKey:sessionID];
+            }
+          }
+        }
+      }
+      if (shouldRespond) {
+        [self writeResponse:response toClient:client];
+      }
     };
     dispatch_queue_t routeQueue = self.routeQueue;
     if (routeQueue) {
@@ -425,6 +459,20 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
   [FBResponseWithStatus(status) dispatchWithResponse:notFound];
   [self applyDefaultHeadersToResponse:notFound];
   [self writeResponse:notFound toClient:client];
+}
+
+#pragma mark - Session-scoped request cancellation
+
+- (void)abandonPendingRequestsForSessionID:(NSString *)sessionID withResponse:(RouteResponse *)response
+{
+  NSSet *clients;
+  @synchronized (self.pendingSessionRequests) {
+    clients = [self.pendingSessionRequests[sessionID] copy];
+    [self.pendingSessionRequests removeObjectForKey:sessionID];
+  }
+  for (nw_connection_t client in clients) {
+    [self writeResponse:response toClient:client];
+  }
 }
 
 #pragma mark - Standalone route dispatch

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -56,9 +56,8 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 @end
 
 
-// Represents one dispatched-but-not-yet-answered request. Uses default (pointer) identity, so two
-// pending requests that happen to share the same underlying connection - e.g. two pipelined
-// requests for the same session - are never conflated into a single tracked entry.
+// One dispatched-but-not-yet-answered request. Default (pointer) identity, so two pipelined
+// requests sharing a connection are never conflated into a single tracked entry.
 @interface FBPendingRequest : NSObject
 @property (nonatomic, strong, readonly) nw_connection_t client;
 @end
@@ -88,25 +87,20 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 // Per-client cache of the already-parsed request line + headers while its body is still
 // arriving; nil while a client's next unread bytes start with an unparsed header block.
 @property (nonatomic, strong) NSMapTable<id, FBPendingHTTPRequestHeader *> *pendingRequestHeaders;
-// -processBufferForClient: parses a connection's buffer outside of any lock (cheap, and it can
-// hand off to -dispatchMethod:...). It's only safe to do that unlocked because every call to it -
-// from -client:didReceiveData: and from -writeResponse:toClient:thenCloseConnection: alike - is
-// funneled through this single serial queue, so no two calls (even for different connections) ever
-// run concurrently with each other.
+// -processBufferForClient: parses a connection's buffer unlocked; safe only because every caller
+// (-client:didReceiveData: and -writeResponse:toClient:thenCloseConnection:) funnels through this
+// one serial queue, so no two calls ever run concurrently.
 @property (nonatomic, strong) dispatch_queue_t bufferProcessingQueue;
-// Connections with a request that's been parsed off the buffer but not yet answered. While a
-// connection is in this set, -processBufferForClient: won't start any further pipelined request
-// already sitting in its buffer - that keeps responses on one connection from being written out
-// of order when e.g. a standalone /screenshot and /status are pipelined back to back and finish
-// on independent queues. Guarded by @synchronized(self.connectionBuffers) (same lock as the
-// buffers themselves, so the busy-check and the buffer consume-and-dispatch stay one atomic step).
+// Connections with a request parsed off the buffer but not yet answered. Blocks
+// -processBufferForClient: from starting the next pipelined request, so responses on one
+// connection can't be written out of order. Guarded by @synchronized(self.connectionBuffers).
 @property (nonatomic, strong) NSMutableSet *connectionsAwaitingResponse;
-// Keyed by "METHOD path" - holds requests waiting on an already in-flight standalone request for
-// that same endpoint. Guarded by @synchronized(self.standaloneWaiters).
+// Keyed by "METHOD path" - requests waiting on an already in-flight standalone request for that
+// endpoint. Guarded by @synchronized(self.standaloneWaiters).
 @property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableArray<FBPendingRequest *> *> *standaloneWaiters;
-// Keyed by the "sessionID" path param - holds requests currently queued or executing for that
-// session, standalone or not (except DELETE /session itself - see -dispatchMethod:...).
-// See -abandonPendingRequestsForSessionID:. Guarded by @synchronized(self.pendingSessionRequests).
+// Keyed by the "sessionID" path param - requests currently queued or executing for that session,
+// standalone or not (except DELETE /session itself - see -dispatchMethod:). See
+// -abandonPendingRequestsForSessionID:. Guarded by @synchronized(self.pendingSessionRequests).
 @property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableSet<FBPendingRequest *> *> *pendingSessionRequests;
 
 @end
@@ -286,9 +280,8 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 
 #pragma mark - HTTP parsing
 
-// Parses and dispatches at most one request per call. A connection with a request already
-// in flight is left alone - see -connectionsAwaitingResponse - and picks back up, via a fresh
-// call to this method, once that request's response has been written.
+// Parses and dispatches at most one request per call; a connection with one already in flight is
+// left alone (see -connectionsAwaitingResponse) until its response is written.
 - (void)processBufferForClient:(nw_connection_t)client
 {
   NSMutableData *buffer;
@@ -453,9 +446,8 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 
     NSString *sessionID = params[@"sessionID"];
     if (route.isStandalone) {
-      // DELETE /session is what triggers -abandonPendingRequestsForSessionID: (see -kill /
-      // -sessionWasKilled:); tracking its own request here would make it abandon itself and write
-      // a response twice.
+      // DELETE triggers -abandonPendingRequestsForSessionID: itself; tracking its own request
+      // would make it abandon itself and write a response twice.
       NSString *trackedSessionID = [route.verb isEqualToString:@"DELETE"] ? nil : sessionID;
       [self dispatchStandaloneRoute:route request:request response:response client:client method:method pathAndQuery:pathAndQuery sessionID:trackedSessionID];
       return;
@@ -495,8 +487,6 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 
 #pragma mark - Session-scoped request cancellation
 
-// `pendingRequest` identifies one dispatched request - see FBPendingRequest - so pipelined
-// requests that happen to share a connection are tracked independently of one another.
 - (void)trackPendingRequest:(FBPendingRequest *)pendingRequest forSessionID:(NSString *)sessionID
 {
   @synchronized (self.pendingSessionRequests) {
@@ -509,9 +499,8 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
   }
 }
 
-// Returns YES if `pendingRequest` was still tracked (and is now removed) - i.e. this caller won
-// the race to respond to it, as opposed to -abandonPendingRequestsForSessionID: having already
-// claimed it on another thread.
+// Returns YES if this caller won the race to respond, vs. -abandonPendingRequestsForSessionID:
+// already having claimed `pendingRequest` on another thread.
 - (BOOL)untrackPendingRequest:(FBPendingRequest *)pendingRequest forSessionID:(NSString *)sessionID
 {
   @synchronized (self.pendingSessionRequests) {
@@ -549,9 +538,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
                     pathAndQuery:(NSString *)pathAndQuery
                        sessionID:(nullable NSString *)sessionID
 {
-  // Includes the query string, not just the path, so two concurrent requests that would run
-  // route.block with genuinely different `request` objects (e.g. differing query params) are
-  // never coalesced into sharing one response.
+  // Includes the query string so requests with different params are never coalesced together.
   NSString *key = [NSString stringWithFormat:@"%@ %@", method, pathAndQuery];
   FBPendingRequest *waiter = [[FBPendingRequest alloc] initWithClient:client];
   if (nil != sessionID) {
@@ -587,8 +574,6 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
       [strongSelf.standaloneWaiters removeObjectForKey:key];
     }
     for (FBPendingRequest *joinedWaiter in [@[waiter] arrayByAddingObjectsFromArray:joinedWaiters]) {
-      // Whoever untracks a waiter first "wins" and gets to respond - either this normal
-      // completion, or -abandonPendingRequestsForSessionID: on another thread.
       BOOL shouldRespond = (nil == sessionID) || [strongSelf untrackPendingRequest:joinedWaiter forSessionID:sessionID];
       if (shouldRespond) {
         [strongSelf writeResponse:response toClient:joinedWaiter.client];
@@ -627,8 +612,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
       [weakSelf closeClient:client];
     }];
   } else {
-    // Submitted before this connection is allowed to move on to its next pipelined request (see
-    // -processBufferForClient:), so responses can't reach the wire out of order.
+    // Sent before unblocking the next pipelined request, so responses can't reach the wire out of order.
     [self.socket writeData:payload toClient:client];
     @synchronized (self.connectionBuffers) {
       [self.connectionsAwaitingResponse removeObject:client];

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -87,9 +87,8 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 // Per-client cache of the already-parsed request line + headers while its body is still
 // arriving; nil while a client's next unread bytes start with an unparsed header block.
 @property (nonatomic, strong) NSMapTable<id, FBPendingHTTPRequestHeader *> *pendingRequestHeaders;
-// -processBufferForClient: parses a connection's buffer unlocked; safe only because every caller
-// (-client:didReceiveData: and -writeResponse:toClient:thenCloseConnection:) funnels through this
-// one serial queue, so no two calls ever run concurrently.
+// All buffer access - appending new data and -processBufferForClient:'s unlocked parse - is
+// funneled through this one serial queue, so appends can never race a parse.
 @property (nonatomic, strong) dispatch_queue_t bufferProcessingQueue;
 // Connections with a request parsed off the buffer but not yet answered. Blocks
 // -processBufferForClient: from starting the next pipelined request, so responses on one
@@ -264,17 +263,23 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 
 - (void)client:(nw_connection_t)client didReceiveData:(NSData *)data
 {
-  NSMutableData *buffer;
-  @synchronized (self.connectionBuffers) {
-    buffer = [self.connectionBuffers objectForKey:client];
-    if (nil == buffer) {
-      return;
-    }
-    [buffer appendData:data];
-  }
+  // The append itself, not just the parse, must run on bufferProcessingQueue: otherwise a receive
+  // callback here could still mutate the buffer while -processBufferForClient: is reading it
+  // unlocked on that queue.
   __weak typeof(self) weakSelf = self;
   dispatch_async(self.bufferProcessingQueue, ^{
-    [weakSelf processBufferForClient:client];
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    if (nil == strongSelf) {
+      return;
+    }
+    @synchronized (strongSelf.connectionBuffers) {
+      NSMutableData *buffer = [strongSelf.connectionBuffers objectForKey:client];
+      if (nil == buffer) {
+        return;
+      }
+      [buffer appendData:data];
+    }
+    [strongSelf processBufferForClient:client];
   });
 }
 

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -35,6 +35,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 @property (nonatomic, strong) NSRegularExpression *regex;
 @property (nonatomic, copy, nullable) NSArray<NSString *> *keys;
 @property (nonatomic, copy) void (^block)(RouteRequest *request, RouteResponse *response);
+@property (nonatomic, assign) BOOL isStandalone;
 @end
 
 @implementation FBHTTPRoute
@@ -67,6 +68,9 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 // Per-client cache of the already-parsed request line + headers while its body is still
 // arriving; nil while a client's next unread bytes start with an unparsed header block.
 @property (nonatomic, strong) NSMapTable<id, FBPendingHTTPRequestHeader *> *pendingRequestHeaders;
+// Keyed by "METHOD path" - holds connections waiting on an already in-flight standalone request
+// for that same endpoint. Guarded by @synchronized(self.standaloneWaiters).
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableArray *> *standaloneWaiters;
 
 @end
 
@@ -81,6 +85,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
                                                  valueOptions:(NSPointerFunctionsOptions)NSMapTableStrongMemory];
     _pendingRequestHeaders = [NSMapTable mapTableWithKeyOptions:(NSPointerFunctionsOptions)(NSMapTableObjectPointerPersonality | NSMapTableStrongMemory)
                                                     valueOptions:(NSPointerFunctionsOptions)NSMapTableStrongMemory];
+    _standaloneWaiters = [NSMutableDictionary dictionary];
   }
   return self;
 }
@@ -158,9 +163,18 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
             withPath:(NSString *)path
                block:(void (^)(RouteRequest *request, RouteResponse *response))block
 {
+  [self handleMethod:method withPath:path standalone:NO block:block];
+}
+
+- (void)handleMethod:(NSString *)method
+            withPath:(NSString *)path
+          standalone:(BOOL)standalone
+               block:(void (^)(RouteRequest *request, RouteResponse *response))block
+{
   FBHTTPRoute *route = [self compiledRouteWithPath:path];
   route.verb = method.uppercaseString;
   route.block = block;
+  route.isStandalone = standalone;
   [self.routes addObject:route];
 }
 
@@ -281,8 +295,8 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
         // is rejected rather than risking the body being misread as empty and desyncing the rest
         // of the connection's request stream.
         RouteResponse *notImplemented = [RouteResponse new];
-        id<FBResponsePayload> notImplementedPayload = FBResponseWithStatus([FBCommandStatus unknownCommandErrorWithMessage:@"Transfer-Encoding is not supported"
-                                                                                                                  traceback:nil]);
+        id<FBResponsePayload> notImplementedPayload = FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"Transfer-Encoding is not supported"
+                                                                                                                    traceback:nil]);
         [notImplementedPayload dispatchWithResponse:notImplemented];
         [self failClient:client withResponse:notImplemented];
         return;
@@ -290,11 +304,10 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 
       NSUInteger contentLength = (NSUInteger)requestHeaders[@"content-length"].integerValue;
       if (contentLength > FBConfiguration.sharedInstance.httpRequestBodySizeLimit) {
-        // Mirrors CocoaHTTPServer's maxRequestBodySize enforcement. Closes the connection after
-        // responding, since the rest of the oversized body is still incoming.
+        // Closes the connection after responding, since the rest of the oversized body is still incoming.
         RouteResponse *tooLarge = [RouteResponse new];
-        id<FBResponsePayload> tooLargePayload = FBResponseWithStatus([FBCommandStatus unknownCommandErrorWithMessage:@"Request Entity Too Large"
-                                                                                                            traceback:nil]);
+        id<FBResponsePayload> tooLargePayload = FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"The request body exceeds the configured size limit"
+                                                                                                              traceback:nil]);
         [tooLargePayload dispatchWithResponse:tooLarge];
         [self failClient:client withResponse:tooLarge];
         return;
@@ -344,8 +357,8 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 - (void)respondBadRequestToClient:(nw_connection_t)client
 {
   RouteResponse *badRequest = [RouteResponse new];
-  id<FBResponsePayload> payload = FBResponseWithStatus([FBCommandStatus unknownCommandErrorWithMessage:@"The request could not be parsed as valid HTTP"
-                                                                                              traceback:nil]);
+  id<FBResponsePayload> payload = FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"The request could not be parsed as valid HTTP"
+                                                                                                traceback:nil]);
   [payload dispatchWithResponse:badRequest];
   [self failClient:client withResponse:badRequest];
 }
@@ -388,6 +401,11 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
     RouteResponse *response = [RouteResponse new];
     [self applyDefaultHeadersToResponse:response];
 
+    if (route.isStandalone) {
+      [self dispatchStandaloneRoute:route request:request response:response client:client method:method path:path];
+      return;
+    }
+
     void (^invoke)(void) = ^{
       route.block(request, response);
       [self writeResponse:response toClient:client];
@@ -407,6 +425,51 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
   [FBResponseWithStatus(status) dispatchWithResponse:notFound];
   [self applyDefaultHeadersToResponse:notFound];
   [self writeResponse:notFound toClient:client];
+}
+
+#pragma mark - Standalone route dispatch
+
+- (void)dispatchStandaloneRoute:(FBHTTPRoute *)route
+                         request:(RouteRequest *)request
+                        response:(RouteResponse *)response
+                          client:(nw_connection_t)client
+                          method:(NSString *)method
+                            path:(NSString *)path
+{
+  NSString *key = [NSString stringWithFormat:@"%@ %@", method, path];
+  BOOL isInFlight = NO;
+  @synchronized (self.standaloneWaiters) {
+    NSMutableArray *waiters = self.standaloneWaiters[key];
+    if (nil != waiters) {
+      [waiters addObject:client];
+      isInFlight = YES;
+    } else {
+      self.standaloneWaiters[key] = [NSMutableArray array];
+    }
+  }
+  if (isInFlight) {
+    // An identical request is already executing; it will deliver this connection's response too.
+    return;
+  }
+
+  dispatch_queue_t queue = dispatch_queue_create(key.UTF8String, DISPATCH_QUEUE_SERIAL);
+  __weak typeof(self) weakSelf = self;
+  dispatch_async(queue, ^{
+    route.block(request, response);
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    if (nil == strongSelf) {
+      return;
+    }
+    NSArray *joinedClients;
+    @synchronized (strongSelf.standaloneWaiters) {
+      joinedClients = [strongSelf.standaloneWaiters[key] copy];
+      [strongSelf.standaloneWaiters removeObjectForKey:key];
+    }
+    [strongSelf writeResponse:response toClient:client];
+    for (nw_connection_t joinedClient in joinedClients) {
+      [strongSelf writeResponse:response toClient:joinedClient];
+    }
+  });
 }
 
 - (void)writeResponse:(RouteResponse *)response toClient:(nw_connection_t)client

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -145,8 +145,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
   FBHTTPRoute *route = [FBHTTPRoute new];
   NSMutableArray<NSString *> *keys = [NSMutableArray array];
 
-  // Escape regex-significant characters before substituting :param placeholders, like
-  // RoutingHTTPServer.m used to.
+  // Escape regex-significant characters before substituting :param placeholders.
   NSRegularExpression *escapeRegex = [NSRegularExpression regularExpressionWithPattern:@"[.+()]"
                                                                                 options:(NSRegularExpressionOptions)0
                                                                                   error:nil];

--- a/WebDriverAgentLib/Routing/FBRoute.h
+++ b/WebDriverAgentLib/Routing/FBRoute.h
@@ -27,6 +27,9 @@ typedef __nonnull id<FBResponsePayload> (^FBRouteSyncHandler)(FBRouteRequest *re
 /*! Route's path */
 @property (nonatomic, copy, readonly) NSString *path;
 
+/*! Whether this route bypasses the shared route queue - see -standalone */
+@property (nonatomic, assign, readonly) BOOL isStandalone;
+
 /**
  Convenience constructor for GET route with given pathPattern
  */
@@ -66,6 +69,12 @@ typedef __nonnull id<FBResponsePayload> (^FBRouteSyncHandler)(FBRouteRequest *re
  Chain-able constructor for route that does NOT require session
  */
 - (instancetype)withoutSession;
+
+/**
+ Chain-able constructor for a route that bypasses the shared route queue - see FBHTTPServer.h's
+ -handleMethod:withPath:standalone:block: for what that changes about how/when the handler runs.
+ */
+- (instancetype)standalone;
 
 /**
  Dispatches response for request

--- a/WebDriverAgentLib/Routing/FBRoute.m
+++ b/WebDriverAgentLib/Routing/FBRoute.m
@@ -18,6 +18,7 @@
 
 @interface FBRoute ()
 @property (nonatomic, assign, readwrite) BOOL requiresSession;
+@property (nonatomic, assign, readwrite) BOOL isStandalone;
 @property (nonatomic, copy, readwrite) NSString *verb;
 @property (nonatomic, copy, readwrite) NSString *path;
 
@@ -126,10 +127,17 @@ static NSString *const FBRouteSessionPrefix = @"/session/:sessionID";
   return self;
 }
 
+- (instancetype)standalone
+{
+  self.isStandalone = YES;
+  return self;
+}
+
 - (instancetype)respondWithBlock:(FBRouteSyncHandler)handler
 {
   FBRoute_Sync *route = [FBRoute_Sync withVerb:self.verb path:self.path requiresSession:self.requiresSession];
   route.handler = handler;
+  route.isStandalone = self.isStandalone;
   return route;
 }
 
@@ -138,6 +146,7 @@ static NSString *const FBRouteSessionPrefix = @"/session/:sessionID";
   FBRoute_TargetAction *route = [FBRoute_TargetAction withVerb:self.verb path:self.path requiresSession:self.requiresSession];
   route.target = target;
   route.action = action;
+  route.isStandalone = self.isStandalone;
   return route;
 }
 

--- a/WebDriverAgentLib/Routing/FBSession.h
+++ b/WebDriverAgentLib/Routing/FBSession.h
@@ -51,6 +51,13 @@ extern NSString* const FBSessionWasKilledNotification;
 + (nullable instancetype)activeSession;
 
 /**
+ Kills the active session, if any, and blocks until its teardown - including one already started
+ by a concurrent caller - is fully finished. Call this before preparing/launching a replacement
+ application, so it can't race a still-in-progress termination of the outgoing one.
+ */
++ (void)killActiveSessionAndWaitForTeardown;
+
+/**
  Fetches session for given identifier.
  If identifier doesn't match activeSession identifier, will return nil.
 

--- a/WebDriverAgentLib/Routing/FBSession.h
+++ b/WebDriverAgentLib/Routing/FBSession.h
@@ -17,6 +17,12 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString* const FB_SAFARI_BUNDLE_ID;
 
 /**
+ Posted (synchronously, on whatever thread calls -kill) once a session has been torn down. The
+ notification's object is the FBSession instance that was killed - see -identifier.
+ */
+extern NSString* const FBSessionWasKilledNotification;
+
+/**
  Class that represents testing session
  */
 @interface FBSession : NSObject

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -177,13 +177,22 @@ static FBSession *_activeSession = nil;
 
 - (void)kill
 {
-  if (nil == _activeSession) {
+  // DELETE /session and session creation now run concurrently (both can bypass the frozen route
+  // queue), so a session that's already been superseded by a newer one can still reach here via a
+  // stale reference. Check-and-clear must happen as one atomic step, else a belated -kill on the
+  // old session could win the write race and null out the new session's pointer instead of its
+  // own. self != _activeSession means someone else already killed/replaced this session - nothing
+  // left for us to do.
+  BOOL wasActive;
+  @synchronized (self.class) {
+    wasActive = (self == _activeSession);
+    if (wasActive) {
+      _activeSession = nil;
+    }
+  }
+  if (!wasActive) {
     return;
   }
-
-  // Cleared up front, not at the end, so a request arriving mid-teardown resolves to "no such
-  // session" (+sessionWithIdentifier:) instead of running against a half-torn-down one.
-  _activeSession = nil;
 
   // Posted early, before the (potentially slow) teardown below, so anything waiting on this
   // session's pending HTTP requests can stop waiting as soon as possible.

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -34,17 +34,11 @@ NSString *const FBDefaultApplicationAuto = @"auto";
 
 NSString *const FB_SAFARI_BUNDLE_ID = @"com.apple.mobilesafari";
 
-// +[XCUIApplication fb_systemApplication] goes through FBXCAXClientProxy's shared accessibility
-// channel, which can be stuck for as long as some other in-flight request against a frozen app -
-// see -fb_isTestedApplicationSameAsSystemAppWithTimeout: below.
+// FBXCAXClientProxy's shared accessibility channel can be stuck servicing another request.
 static const NSTimeInterval FB_IS_SYSTEM_APP_CHECK_TIMEOUT_SEC = 5.;
-// -[XCUIApplication terminate] hard-asserts off the main thread - see
-// -fb_terminateTestedApplicationWithTimeout: below.
+// -terminate hard-asserts off the main thread, which may itself be busy - see -fb_terminate...:.
 static const NSTimeInterval FB_APP_TERMINATE_TIMEOUT_SEC = 5.;
-// Upper bound on -kill's own teardown (system-app check + terminate above, plus the existing 20s
-// bound on stopping an active screen recording - see FBXCTestDaemonsProxy) - how long a caller that
-// lost the -kill race below will wait for the winner to actually finish, rather than proceeding
-// immediately against a session that's still mid-teardown.
+// How long a -kill caller that lost the race below waits for the winner's teardown to finish.
 static const NSTimeInterval FB_KILL_WAIT_TIMEOUT_SEC = 35.;
 NSString *const FBSessionWasKilledNotification = @"FBSessionWasKilledNotification";
 
@@ -54,8 +48,7 @@ NSString *const FBSessionWasKilledNotification = @"FBSessionWasKilledNotificatio
 @property (nonatomic) BOOL shouldAppsWaitForQuiescence;
 @property (nonatomic, nullable) FBAlertsMonitor *alertsMonitor;
 @property (nonatomic, readwrite) NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber *> *> *elementsVisibilityCache;
-// Lets a -kill caller that loses the atomic race in -kill wait for the winner's teardown to
-// actually finish, instead of returning immediately. Created once per session instance - see -init.
+// Lets a -kill caller that loses the race wait for the winner's teardown to finish. See -init.
 @property (nonatomic, strong, readonly) NSCondition *killCondition;
 @property (nonatomic, assign) BOOL isKillFinished;
 
@@ -198,12 +191,9 @@ static FBSession *_activeSession = nil;
 
 - (void)kill
 {
-  // DELETE /session and session creation now run concurrently (both can bypass the frozen route
-  // queue), so a session that's already been superseded by a newer one can still reach here via a
-  // stale reference. Check-and-clear must happen as one atomic step, else a belated -kill on the
-  // old session could win the write race and null out the new session's pointer instead of its
-  // own. self != _activeSession means someone else already killed/replaced this session - nothing
-  // left for us to do.
+  // DELETE /session and session creation can now run concurrently, so a session already
+  // superseded by a newer one can still reach here via a stale reference. Check-and-clear must be
+  // atomic, else a belated -kill could null out the new session's pointer instead of its own.
   BOOL wasActive;
   @synchronized (self.class) {
     wasActive = (self == _activeSession);
@@ -212,22 +202,18 @@ static FBSession *_activeSession = nil;
     }
   }
   if (!wasActive) {
-    // Someone else is already tearing this exact session down (e.g. a concurrent DELETE and the
-    // pre-kill in session creation both targeting it). Wait for that teardown to actually finish,
-    // bounded, so a caller that's about to act as if the session is gone - e.g. launching a fresh
-    // app for a replacement session - doesn't race a still-in-flight -terminate.
+    // Someone else is already tearing this session down - wait for that to finish (bounded), so
+    // we don't act as if it's gone (e.g. launch a new app) while its -terminate is still in flight.
     [self.killCondition lock];
     NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:FB_KILL_WAIT_TIMEOUT_SEC];
     while (!self.isKillFinished && [self.killCondition waitUntilDate:deadline]) {
-      // Re-checks isKillFinished on every wake, in case of a spurious wakeup.
     }
     [self.killCondition unlock];
     return;
   }
 
   @try {
-    // Posted early, before the (potentially slow) teardown below, so anything waiting on this
-    // session's pending HTTP requests can stop waiting as soon as possible.
+    // Posted before teardown so pending HTTP requests for this session can stop waiting sooner.
     [NSNotificationCenter.defaultCenter postNotificationName:FBSessionWasKilledNotification object:self];
 
     [self disableAlertsMonitor];
@@ -347,22 +333,17 @@ static FBSession *_activeSession = nil;
     : [[XCUIApplication alloc] initWithBundleIdentifier:bundleIdentifier];
 }
 
-// +[XCUIApplication fb_systemApplication] has no async variant and can block for as long as
-// FBXCAXClientProxy's shared accessibility channel is busy servicing some other (possibly stuck)
-// request against a frozen app, unrelated to this session. Run it on its own thread and give up
-// after `timeout`, assuming the tested app IS the system app - the safer assumption, since it
-// means -kill skips terminating it rather than risking terminating springboard - if we can't find
-// out in time.
+// Has no async variant and can block on the shared accessibility channel. Run off-thread and give
+// up after `timeout`, assuming the tested app IS the system app - safer, since it means skipping
+// termination rather than risking terminating springboard.
 - (BOOL)fb_isTestedApplicationSameAsSystemAppWithTimeout:(NSTimeInterval)timeout
 {
   __block XCUIApplication *systemApp = nil;
   __block NSException *caughtException = nil;
   dispatch_semaphore_t sem = dispatch_semaphore_create(0);
   dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-    // +fb_systemApplication is undocumented private API; some of its XCUIApplication siblings
-    // (e.g. -terminate) hard-assert when called off the main thread, so guard against this one
-    // doing the same on some other Xcode/iOS version - an uncaught exception thrown from inside a
-    // bare dispatch_async block has no handler and would crash the whole process.
+    // Undocumented private API; guard in case it hard-asserts off-main like -terminate does on
+    // some Xcode/iOS version - uncaught, that would crash the whole process.
     @try {
       systemApp = XCUIApplication.fb_systemApplication;
     } @catch (NSException *e) {
@@ -378,13 +359,9 @@ static FBSession *_activeSession = nil;
   return [self.testedApplication fb_isSameAppAs:systemApp];
 }
 
-// -[XCUIApplication terminate] hard-asserts when called off the main thread, but -kill (the only
-// caller) can now itself run on a background queue - DELETE /session is a standalone route (see
-// FBHTTPServer.m) that bypasses the main routeQueue. Dispatching to main and waiting indefinitely
-// would reintroduce the exact hang standalone routes exist to avoid, if that's the queue currently
-// stuck servicing some other request against the frozen app; give up after `timeout` instead. The
-// dispatched block still runs (and still terminates the app) whenever main frees up, even after
-// this method has given up waiting on it.
+// -terminate hard-asserts off-main, but -kill can now run on a background queue. Dispatching to
+// main and waiting indefinitely could hang just as long as main is stuck, so give up after
+// `timeout`; the dispatched call still runs (and terminates the app) whenever main frees up.
 - (void)fb_terminateTestedApplicationWithTimeout:(NSTimeInterval)timeout
 {
   XCUIApplication *application = self.testedApplication;

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -181,13 +181,9 @@ static FBSession *_activeSession = nil;
     return;
   }
 
-  // Cleared up front, before the (potentially slow) teardown below - not just at the very end -
-  // so that any request which arrives while that teardown is still running resolves to "no such
-  // session" (see +sessionWithIdentifier:) instead of racing in against a session that's already
-  // mid-teardown, and unlike the notification below, would never get abandoned either.
-  if (self == _activeSession) {
-    _activeSession = nil;
-  }
+  // Cleared up front, not at the end, so a request arriving mid-teardown resolves to "no such
+  // session" (+sessionWithIdentifier:) instead of running against a half-torn-down one.
+  _activeSession = nil;
 
   // Posted early, before the (potentially slow) teardown below, so anything waiting on this
   // session's pending HTTP requests can stop waiting as soon as possible.

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -317,14 +317,23 @@ static FBSession *_activeSession = nil;
 - (BOOL)fb_isTestedApplicationSameAsSystemAppWithTimeout:(NSTimeInterval)timeout
 {
   __block XCUIApplication *systemApp = nil;
+  __block NSException *caughtException = nil;
   dispatch_semaphore_t sem = dispatch_semaphore_create(0);
   dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-    systemApp = XCUIApplication.fb_systemApplication;
+    // +fb_systemApplication is undocumented private API; some of its XCUIApplication siblings
+    // (e.g. -terminate) hard-assert when called off the main thread, so guard against this one
+    // doing the same on some other Xcode/iOS version - an uncaught exception thrown from inside a
+    // bare dispatch_async block has no handler and would crash the whole process.
+    @try {
+      systemApp = XCUIApplication.fb_systemApplication;
+    } @catch (NSException *e) {
+      caughtException = e;
+    }
     dispatch_semaphore_signal(sem);
   });
   int64_t timeoutNs = (int64_t)(timeout * NSEC_PER_SEC);
-  if (0 != dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, timeoutNs))) {
-    [FBLogger logFmt:@"Could not determine the system application within %@ seconds; assuming '%@' might be it and skipping its termination", @(timeout), self.testedApplication.bundleID];
+  if (0 != dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, timeoutNs)) || nil != caughtException) {
+    [FBLogger logFmt:@"Could not determine the system application within %@ seconds%@; assuming '%@' might be it and skipping its termination", @(timeout), nil == caughtException ? @"" : [NSString stringWithFormat:@" (%@)", caughtException.description], self.testedApplication.bundleID];
     return YES;
   }
   return [self.testedApplication fb_isSameAppAs:systemApp];

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -34,12 +34,20 @@ NSString *const FBDefaultApplicationAuto = @"auto";
 
 NSString *const FB_SAFARI_BUNDLE_ID = @"com.apple.mobilesafari";
 
+// +[XCUIApplication fb_systemApplication] goes through FBXCAXClientProxy's shared accessibility
+// channel, which can be stuck for as long as some other in-flight request against a frozen app -
+// see -fb_isTestedApplicationSameAsSystemAppWithTimeout: below.
+static const NSTimeInterval FB_IS_SYSTEM_APP_CHECK_TIMEOUT_SEC = 5.;
+NSString *const FBSessionWasKilledNotification = @"FBSessionWasKilledNotification";
+
 @interface FBSession ()
 @property (nullable, nonatomic) XCUIApplication *testedApplication;
 @property (nonatomic) BOOL isTestedApplicationExpectedToRun;
 @property (nonatomic) BOOL shouldAppsWaitForQuiescence;
 @property (nonatomic, nullable) FBAlertsMonitor *alertsMonitor;
 @property (nonatomic, readwrite) NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber *> *> *elementsVisibilityCache;
+
+- (BOOL)fb_isTestedApplicationSameAsSystemAppWithTimeout:(NSTimeInterval)timeout;
 @end
 
 @interface FBSession (FBAlertsMonitorDelegate)
@@ -173,6 +181,18 @@ static FBSession *_activeSession = nil;
     return;
   }
 
+  // Cleared up front, before the (potentially slow) teardown below - not just at the very end -
+  // so that any request which arrives while that teardown is still running resolves to "no such
+  // session" (see +sessionWithIdentifier:) instead of racing in against a session that's already
+  // mid-teardown, and unlike the notification below, would never get abandoned either.
+  if (self == _activeSession) {
+    _activeSession = nil;
+  }
+
+  // Posted early, before the (potentially slow) teardown below, so anything waiting on this
+  // session's pending HTTP requests can stop waiting as soon as possible.
+  [NSNotificationCenter.defaultCenter postNotificationName:FBSessionWasKilledNotification object:self];
+
   [self disableAlertsMonitor];
 
   FBScreenRecordingPromise *activeScreenRecording = FBScreenRecordingContainer.sharedInstance.screenRecordingPromise;
@@ -187,16 +207,12 @@ static FBSession *_activeSession = nil;
   if (nil != self.testedApplication
       && FBConfiguration.sharedInstance.shouldTerminateApp
       && self.testedApplication.running
-      && ![self.testedApplication fb_isSameAppAs:XCUIApplication.fb_systemApplication]) {
+      && ![self fb_isTestedApplicationSameAsSystemAppWithTimeout:FB_IS_SYSTEM_APP_CHECK_TIMEOUT_SEC]) {
     @try {
       [self.testedApplication terminate];
     } @catch (NSException *e) {
       [FBLogger logFmt:@"%@", e.description];
     }
-  }
-
-  if (self == _activeSession) {
-    _activeSession = nil;
   }
 }
 
@@ -290,6 +306,28 @@ static FBSession *_activeSession = nil;
   return nil != self.testedApplication && [bundleIdentifier isEqualToString:(NSString *)self.testedApplication.bundleID]
     ? self.testedApplication
     : [[XCUIApplication alloc] initWithBundleIdentifier:bundleIdentifier];
+}
+
+// +[XCUIApplication fb_systemApplication] has no async variant and can block for as long as
+// FBXCAXClientProxy's shared accessibility channel is busy servicing some other (possibly stuck)
+// request against a frozen app, unrelated to this session. Run it on its own thread and give up
+// after `timeout`, assuming the tested app IS the system app - the safer assumption, since it
+// means -kill skips terminating it rather than risking terminating springboard - if we can't find
+// out in time.
+- (BOOL)fb_isTestedApplicationSameAsSystemAppWithTimeout:(NSTimeInterval)timeout
+{
+  __block XCUIApplication *systemApp = nil;
+  dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    systemApp = XCUIApplication.fb_systemApplication;
+    dispatch_semaphore_signal(sem);
+  });
+  int64_t timeoutNs = (int64_t)(timeout * NSEC_PER_SEC);
+  if (0 != dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, timeoutNs))) {
+    [FBLogger logFmt:@"Could not determine the system application within %@ seconds; assuming '%@' might be it and skipping its termination", @(timeout), self.testedApplication.bundleID];
+    return YES;
+  }
+  return [self.testedApplication fb_isSameAppAs:systemApp];
 }
 
 @end

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -38,6 +38,14 @@ NSString *const FB_SAFARI_BUNDLE_ID = @"com.apple.mobilesafari";
 // channel, which can be stuck for as long as some other in-flight request against a frozen app -
 // see -fb_isTestedApplicationSameAsSystemAppWithTimeout: below.
 static const NSTimeInterval FB_IS_SYSTEM_APP_CHECK_TIMEOUT_SEC = 5.;
+// -[XCUIApplication terminate] hard-asserts off the main thread - see
+// -fb_terminateTestedApplicationWithTimeout: below.
+static const NSTimeInterval FB_APP_TERMINATE_TIMEOUT_SEC = 5.;
+// Upper bound on -kill's own teardown (system-app check + terminate above, plus the existing 20s
+// bound on stopping an active screen recording - see FBXCTestDaemonsProxy) - how long a caller that
+// lost the -kill race below will wait for the winner to actually finish, rather than proceeding
+// immediately against a session that's still mid-teardown.
+static const NSTimeInterval FB_KILL_WAIT_TIMEOUT_SEC = 35.;
 NSString *const FBSessionWasKilledNotification = @"FBSessionWasKilledNotification";
 
 @interface FBSession ()
@@ -46,8 +54,13 @@ NSString *const FBSessionWasKilledNotification = @"FBSessionWasKilledNotificatio
 @property (nonatomic) BOOL shouldAppsWaitForQuiescence;
 @property (nonatomic, nullable) FBAlertsMonitor *alertsMonitor;
 @property (nonatomic, readwrite) NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber *> *> *elementsVisibilityCache;
+// Lets a -kill caller that loses the atomic race in -kill wait for the winner's teardown to
+// actually finish, instead of returning immediately. Created once per session instance - see -init.
+@property (nonatomic, strong, readonly) NSCondition *killCondition;
+@property (nonatomic, assign) BOOL isKillFinished;
 
 - (BOOL)fb_isTestedApplicationSameAsSystemAppWithTimeout:(NSTimeInterval)timeout;
+- (void)fb_terminateTestedApplicationWithTimeout:(NSTimeInterval)timeout;
 @end
 
 @interface FBSession (FBAlertsMonitorDelegate)
@@ -98,6 +111,14 @@ NSString *const FBSessionWasKilledNotification = @"FBSessionWasKilledNotificatio
 @implementation FBSession
 
 static FBSession *_activeSession = nil;
+
+- (instancetype)init
+{
+  if ((self = [super init])) {
+    _killCondition = [NSCondition new];
+  }
+  return self;
+}
 
 + (instancetype)activeSession
 {
@@ -191,33 +212,46 @@ static FBSession *_activeSession = nil;
     }
   }
   if (!wasActive) {
+    // Someone else is already tearing this exact session down (e.g. a concurrent DELETE and the
+    // pre-kill in session creation both targeting it). Wait for that teardown to actually finish,
+    // bounded, so a caller that's about to act as if the session is gone - e.g. launching a fresh
+    // app for a replacement session - doesn't race a still-in-flight -terminate.
+    [self.killCondition lock];
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:FB_KILL_WAIT_TIMEOUT_SEC];
+    while (!self.isKillFinished && [self.killCondition waitUntilDate:deadline]) {
+      // Re-checks isKillFinished on every wake, in case of a spurious wakeup.
+    }
+    [self.killCondition unlock];
     return;
   }
 
-  // Posted early, before the (potentially slow) teardown below, so anything waiting on this
-  // session's pending HTTP requests can stop waiting as soon as possible.
-  [NSNotificationCenter.defaultCenter postNotificationName:FBSessionWasKilledNotification object:self];
+  @try {
+    // Posted early, before the (potentially slow) teardown below, so anything waiting on this
+    // session's pending HTTP requests can stop waiting as soon as possible.
+    [NSNotificationCenter.defaultCenter postNotificationName:FBSessionWasKilledNotification object:self];
 
-  [self disableAlertsMonitor];
+    [self disableAlertsMonitor];
 
-  FBScreenRecordingPromise *activeScreenRecording = FBScreenRecordingContainer.sharedInstance.screenRecordingPromise;
-  if (nil != activeScreenRecording) {
-    NSError *error;
-    if (![FBXCTestDaemonsProxy stopScreenRecordingWithUUID:activeScreenRecording.identifier error:&error]) {
-      [FBLogger logFmt:@"%@", error];
+    FBScreenRecordingPromise *activeScreenRecording = FBScreenRecordingContainer.sharedInstance.screenRecordingPromise;
+    if (nil != activeScreenRecording) {
+      NSError *error;
+      if (![FBXCTestDaemonsProxy stopScreenRecordingWithUUID:activeScreenRecording.identifier error:&error]) {
+        [FBLogger logFmt:@"%@", error];
+      }
+      [FBScreenRecordingContainer.sharedInstance reset];
     }
-    [FBScreenRecordingContainer.sharedInstance reset];
-  }
 
-  if (nil != self.testedApplication
-      && FBConfiguration.sharedInstance.shouldTerminateApp
-      && self.testedApplication.running
-      && ![self fb_isTestedApplicationSameAsSystemAppWithTimeout:FB_IS_SYSTEM_APP_CHECK_TIMEOUT_SEC]) {
-    @try {
-      [self.testedApplication terminate];
-    } @catch (NSException *e) {
-      [FBLogger logFmt:@"%@", e.description];
+    if (nil != self.testedApplication
+        && FBConfiguration.sharedInstance.shouldTerminateApp
+        && self.testedApplication.running
+        && ![self fb_isTestedApplicationSameAsSystemAppWithTimeout:FB_IS_SYSTEM_APP_CHECK_TIMEOUT_SEC]) {
+      [self fb_terminateTestedApplicationWithTimeout:FB_APP_TERMINATE_TIMEOUT_SEC];
     }
+  } @finally {
+    [self.killCondition lock];
+    self.isKillFinished = YES;
+    [self.killCondition broadcast];
+    [self.killCondition unlock];
   }
 }
 
@@ -342,6 +376,31 @@ static FBSession *_activeSession = nil;
     return YES;
   }
   return [self.testedApplication fb_isSameAppAs:systemApp];
+}
+
+// -[XCUIApplication terminate] hard-asserts when called off the main thread, but -kill (the only
+// caller) can now itself run on a background queue - DELETE /session is a standalone route (see
+// FBHTTPServer.m) that bypasses the main routeQueue. Dispatching to main and waiting indefinitely
+// would reintroduce the exact hang standalone routes exist to avoid, if that's the queue currently
+// stuck servicing some other request against the frozen app; give up after `timeout` instead. The
+// dispatched block still runs (and still terminates the app) whenever main frees up, even after
+// this method has given up waiting on it.
+- (void)fb_terminateTestedApplicationWithTimeout:(NSTimeInterval)timeout
+{
+  XCUIApplication *application = self.testedApplication;
+  dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    @try {
+      [application terminate];
+    } @catch (NSException *e) {
+      [FBLogger logFmt:@"%@", e.description];
+    }
+    dispatch_semaphore_signal(sem);
+  });
+  int64_t timeoutNs = (int64_t)(timeout * NSEC_PER_SEC);
+  if (0 != dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, timeoutNs))) {
+    [FBLogger logFmt:@"Could not terminate '%@' within %@ seconds; the main thread may still be busy servicing another request", application.bundleID, @(timeout)];
+  }
 }
 
 @end

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -195,7 +195,9 @@ static FBSession *_activeSession = nil;
     }
   }
 
-  _activeSession = nil;
+  if (self == _activeSession) {
+    _activeSession = nil;
+  }
 }
 
 - (XCUIApplication *)activeApplication

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -48,9 +48,6 @@ NSString *const FBSessionWasKilledNotification = @"FBSessionWasKilledNotificatio
 @property (nonatomic) BOOL shouldAppsWaitForQuiescence;
 @property (nonatomic, nullable) FBAlertsMonitor *alertsMonitor;
 @property (nonatomic, readwrite) NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber *> *> *elementsVisibilityCache;
-// Lets a -kill caller that loses the race wait for the winner's teardown to finish. See -init.
-@property (nonatomic, strong, readonly) NSCondition *killCondition;
-@property (nonatomic, assign) BOOL isKillFinished;
 
 - (BOOL)fb_isTestedApplicationSameAsSystemAppWithTimeout:(NSTimeInterval)timeout;
 - (void)fb_terminateTestedApplicationWithTimeout:(NSTimeInterval)timeout;
@@ -104,13 +101,30 @@ NSString *const FBSessionWasKilledNotification = @"FBSessionWasKilledNotificatio
 @implementation FBSession
 
 static FBSession *_activeSession = nil;
+// Class-level, not per-instance: a caller that finds _activeSession already nil (a concurrent
+// -kill beat it there) still needs to know whether that -kill's teardown is done, since it cleared
+// the pointer before running it. See +waitForActiveTeardownWithTimeout:.
+static BOOL _isTeardownInProgress = NO;
 
-- (instancetype)init
++ (NSCondition *)teardownCondition
 {
-  if ((self = [super init])) {
-    _killCondition = [NSCondition new];
+  static NSCondition *condition;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    condition = [NSCondition new];
+  });
+  return condition;
+}
+
+// Waits (bounded) for any -kill teardown currently in progress to finish.
++ (void)waitForActiveTeardownWithTimeout:(NSTimeInterval)timeout
+{
+  NSCondition *condition = self.teardownCondition;
+  [condition lock];
+  NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:timeout];
+  while (_isTeardownInProgress && [condition waitUntilDate:deadline]) {
   }
-  return self;
+  [condition unlock];
 }
 
 + (instancetype)activeSession
@@ -118,11 +132,23 @@ static FBSession *_activeSession = nil;
   return _activeSession;
 }
 
++ (void)killActiveSessionAndWaitForTeardown
+{
+  FBSession *session = _activeSession;
+  if (nil != session) {
+    // Runs the real teardown synchronously if this call wins the race in -kill, or waits for
+    // whoever did to finish if it lost - either way, blocks until torn down.
+    [session kill];
+  } else {
+    // _activeSession is already nil, but a concurrent -kill (e.g. from DELETE /session) may still
+    // be mid-teardown - wait for it, so we don't launch a replacement app too early.
+    [self waitForActiveTeardownWithTimeout:FB_KILL_WAIT_TIMEOUT_SEC];
+  }
+}
+
 + (void)markSessionActive:(FBSession *)session
 {
-  if (_activeSession) {
-    [_activeSession kill];
-  }
+  [self killActiveSessionAndWaitForTeardown];
   _activeSession = session;
 }
 
@@ -204,13 +230,14 @@ static FBSession *_activeSession = nil;
   if (!wasActive) {
     // Someone else is already tearing this session down - wait for that to finish (bounded), so
     // we don't act as if it's gone (e.g. launch a new app) while its -terminate is still in flight.
-    [self.killCondition lock];
-    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:FB_KILL_WAIT_TIMEOUT_SEC];
-    while (!self.isKillFinished && [self.killCondition waitUntilDate:deadline]) {
-    }
-    [self.killCondition unlock];
+    [self.class waitForActiveTeardownWithTimeout:FB_KILL_WAIT_TIMEOUT_SEC];
     return;
   }
+
+  NSCondition *teardownCondition = self.class.teardownCondition;
+  [teardownCondition lock];
+  _isTeardownInProgress = YES;
+  [teardownCondition unlock];
 
   @try {
     // Posted before teardown so pending HTTP requests for this session can stop waiting sooner.
@@ -231,13 +258,16 @@ static FBSession *_activeSession = nil;
         && FBConfiguration.sharedInstance.shouldTerminateApp
         && self.testedApplication.running
         && ![self fb_isTestedApplicationSameAsSystemAppWithTimeout:FB_IS_SYSTEM_APP_CHECK_TIMEOUT_SEC]) {
+      // Blocks until the app is either actually terminated or durably given up on (never left
+      // pending) - see -fb_terminateTestedApplicationWithTimeout: - so it's safe to report this
+      // teardown as finished as soon as this returns.
       [self fb_terminateTestedApplicationWithTimeout:FB_APP_TERMINATE_TIMEOUT_SEC];
     }
   } @finally {
-    [self.killCondition lock];
-    self.isKillFinished = YES;
-    [self.killCondition broadcast];
-    [self.killCondition unlock];
+    [teardownCondition lock];
+    _isTeardownInProgress = NO;
+    [teardownCondition broadcast];
+    [teardownCondition unlock];
   }
 }
 
@@ -361,22 +391,33 @@ static FBSession *_activeSession = nil;
 
 // -terminate hard-asserts off-main, but -kill can now run on a background queue. Dispatching to
 // main and waiting indefinitely could hang just as long as main is stuck, so give up after
-// `timeout`; the dispatched call still runs (and terminates the app) whenever main frees up.
+// `timeout` - but a "given up on" call must never still terminate whatever's running by the time
+// main gets to it (e.g. a replacement session's app), so cancellation and the actual terminate
+// call share a lock: whichever gets there first - the dispatched block, or the timeout - wins.
 - (void)fb_terminateTestedApplicationWithTimeout:(NSTimeInterval)timeout
 {
   XCUIApplication *application = self.testedApplication;
+  NSObject *lock = [NSObject new];
+  __block BOOL isAllowedToTerminate = YES;
   dispatch_semaphore_t sem = dispatch_semaphore_create(0);
   dispatch_async(dispatch_get_main_queue(), ^{
-    @try {
-      [application terminate];
-    } @catch (NSException *e) {
-      [FBLogger logFmt:@"%@", e.description];
+    @synchronized (lock) {
+      if (isAllowedToTerminate) {
+        @try {
+          [application terminate];
+        } @catch (NSException *e) {
+          [FBLogger logFmt:@"%@", e.description];
+        }
+      }
     }
     dispatch_semaphore_signal(sem);
   });
   int64_t timeoutNs = (int64_t)(timeout * NSEC_PER_SEC);
   if (0 != dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, timeoutNs))) {
-    [FBLogger logFmt:@"Could not terminate '%@' within %@ seconds; the main thread may still be busy servicing another request", application.bundleID, @(timeout)];
+    @synchronized (lock) {
+      isAllowedToTerminate = NO;
+    }
+    [FBLogger logFmt:@"Could not terminate '%@' within %@ seconds; giving up on it rather than risk terminating a possible replacement session's app later", application.bundleID, @(timeout)];
   }
 }
 

--- a/WebDriverAgentLib/Routing/FBTCPSocket.m
+++ b/WebDriverAgentLib/Routing/FBTCPSocket.m
@@ -135,7 +135,8 @@
       }
       [strongSelf scheduleReceiveForConnection:connection];
     } else if (nw_connection_state_failed == state || nw_connection_state_cancelled == state) {
-      [weakSelf handleDisconnectForConnection:connection];
+      __strong typeof(weakSelf) strongSelf = weakSelf;
+      [strongSelf handleDisconnectForConnection:connection];
     }
   });
   nw_connection_start(connection);

--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -208,7 +208,7 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   for (Class<FBCommandHandler> commandHandler in commandHandlerClasses) {
     NSArray *routes = [commandHandler routes];
     for (FBRoute *route in routes) {
-      [self.server handleMethod:route.verb withPath:route.path block:^(RouteRequest *request, RouteResponse *response) {
+      [self.server handleMethod:route.verb withPath:route.path standalone:route.isStandalone block:^(RouteRequest *request, RouteResponse *response) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (nil == strongSelf) {
           return;

--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -13,8 +13,10 @@
 #import "FBTCPSocket.h"
 
 #import "FBCommandHandler.h"
+#import "FBCommandStatus.h"
 #import "FBErrorBuilder.h"
 #import "FBExceptionHandler.h"
+#import "FBResponsePayload.h"
 #import "FBRouteRequest.h"
 #import "FBRuntimeUtils.h"
 #import "FBSession.h"
@@ -79,6 +81,11 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   [self.server setDefaultHeader:@"Server" value:@"WebDriverAgent/1.0"];
   [self.server setDefaultHeader:@"Access-Control-Allow-Origin" value:@"*"];
   [self.server setDefaultHeader:@"Access-Control-Allow-Headers" value:@"Content-Type, X-Requested-With"];
+
+  [NSNotificationCenter.defaultCenter addObserver:self
+                                          selector:@selector(sessionWasKilled:)
+                                              name:FBSessionWasKilledNotification
+                                            object:nil];
 
   [self registerRouteHandlers:[self.class collectCommandHandlerClasses]];
   [self registerServerKeyRouteHandlers];
@@ -167,8 +174,26 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
   }
 }
 
+- (void)sessionWasKilled:(NSNotification *)notification
+{
+  FBSession *session = notification.object;
+  if (![session isKindOfClass:FBSession.class]) {
+    return;
+  }
+  // Same "invalid session id" shape a still-queued request would eventually get anyway, once
+  // -routeQueue drains and FBRoute.decorateRequest: finds the session gone - just delivered now
+  // instead of after however long the request would otherwise have been stuck waiting.
+  NSString *message = [NSString stringWithFormat:@"Session %@ was deleted while this request was still pending", session.identifier];
+  id<FBResponsePayload> payload = FBResponseWithStatus([FBCommandStatus noSuchDriverErrorWithMessage:message
+                                                                                            traceback:nil]);
+  RouteResponse *response = [RouteResponse new];
+  [payload dispatchWithResponse:response];
+  [self.server abandonPendingRequestsForSessionID:session.identifier withResponse:response];
+}
+
 - (void)stopServing
 {
+  [NSNotificationCenter.defaultCenter removeObserver:self name:FBSessionWasKilledNotification object:nil];
   [FBSession.activeSession kill];
   [self stopScreenshotsBroadcaster];
   if (self.server.isRunning) {

--- a/WebDriverAgentLib/Routing/RouteResponse.m
+++ b/WebDriverAgentLib/Routing/RouteResponse.m
@@ -9,7 +9,7 @@
 #import "RouteResponse.h"
 
 @interface RouteResponse ()
-@property (nonatomic, copy) NSMutableDictionary<NSString *, NSString *> *mutableHeaders;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSString *> *mutableHeaders;
 @end
 
 @implementation RouteResponse

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -124,17 +124,14 @@ static NSString *const axSettingsClassName = @"AXSettings";
 {
   // 'WebDriverAgent --port 8080' can be passed via the arguments to the process
   NSRange rangeFromArguments = [self.class bindingPortRangeFromArguments];
-  if (rangeFromArguments.location != NSNotFound) {
-    return rangeFromArguments;
+  if (rangeFromArguments.location == NSNotFound) {
+    // Existence of USE_PORT in the environment implies the port range is managed by the launching process.
+    NSString *usePort = NSProcessInfo.processInfo.environment[@"USE_PORT"];
+    rangeFromArguments = usePort.length > 0
+      ? NSMakeRange((NSUInteger)usePort.integerValue, 1)
+      : NSMakeRange(DefaultStartingPort, DefaultPortRange);
   }
-
-  // Existence of USE_PORT in the environment implies the port range is managed by the launching process.
-  if (NSProcessInfo.processInfo.environment[@"USE_PORT"] &&
-      [NSProcessInfo.processInfo.environment[@"USE_PORT"] length] > 0) {
-    return NSMakeRange([NSProcessInfo.processInfo.environment[@"USE_PORT"] integerValue] , 1);
-  }
-
-  return NSMakeRange(DefaultStartingPort, DefaultPortRange);
+  return rangeFromArguments;
 }
 
 - (NSString *)bindingIPAddress

--- a/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCTestDaemonsProxy.m
@@ -23,6 +23,7 @@
 #import "XCUIDevice.h"
 
 #define LAUNCH_APP_TIMEOUT_SEC 300
+#define STOP_SCREEN_RECORDING_TIMEOUT_SEC 20
 
 static void (*originalLaunchAppMethod)(id, SEL, NSString*, NSString*, NSArray*, NSDictionary*, void (^)(_Bool, NSError *));
 
@@ -342,14 +343,16 @@ static void swizzledLaunchApp(id self, SEL _cmd, NSString *path, NSString *bundl
   }
 
   __block NSError *innerError = nil;
-  [FBRunLoopSpinner spinUntilCompletion:^(void(^completion)(void)){
-    [session stopScreenRecordingWithUUID:uuid withReply:^(NSError *invokeError) {
-      if (nil != invokeError) {
-        innerError = invokeError;
-      }
-      completion();
-    }];
+  dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+  [session stopScreenRecordingWithUUID:uuid withReply:^(NSError *invokeError) {
+    innerError = invokeError;
+    dispatch_semaphore_signal(sem);
   }];
+  int64_t timeoutNs = (int64_t)(STOP_SCREEN_RECORDING_TIMEOUT_SEC * NSEC_PER_SEC);
+  if (0 != dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, timeoutNs)) && nil == innerError) {
+    NSString *message = [NSString stringWithFormat:@"Did not receive a reply to stop screen recording within %d seconds", STOP_SCREEN_RECORDING_TIMEOUT_SEC];
+    innerError = [[[FBErrorBuilder builder] withDescription:message] build];
+  }
   if (nil != innerError && error) {
     *error = innerError;
   }

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -77,6 +77,8 @@
 
 @end
 
+#define TESTMANAGERD_VERSION_TIMEOUT_SEC 20
+
 NSInteger FBTestmanagerdVersion(void)
 {
   static dispatch_once_t getTestmanagerdVersion;
@@ -85,12 +87,18 @@ NSInteger FBTestmanagerdVersion(void)
     id<XCTMessagingChannel_RunnerToDaemon> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
     if ([(NSObject *)proxy respondsToSelector:@selector(_XCT_exchangeProtocolVersion:reply:)]) {
       id<FBXCTestManagerLegacyProtocolVersionExchanging> legacyProxy = (id<FBXCTestManagerLegacyProtocolVersionExchanging>)proxy;
-      [FBRunLoopSpinner spinUntilCompletion:^(void(^completion)(void)){
-        [legacyProxy _XCT_exchangeProtocolVersion:testmanagerdVersion reply:^(unsigned long long code) {
-          testmanagerdVersion = (NSInteger) code;
-          completion();
-        }];
+      // Assume newest/full-featured on timeout, mirroring the modern-testmanagerd branch below.
+      __block NSInteger receivedVersion = 0xFFFF;
+      dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+      [legacyProxy _XCT_exchangeProtocolVersion:testmanagerdVersion reply:^(unsigned long long code) {
+        receivedVersion = (NSInteger) code;
+        dispatch_semaphore_signal(sem);
       }];
+      int64_t timeoutNs = (int64_t)(TESTMANAGERD_VERSION_TIMEOUT_SEC * NSEC_PER_SEC);
+      if (0 != dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, timeoutNs))) {
+        [FBLogger logFmt:@"Did not receive a testmanagerd protocol version reply within %d seconds; assuming the newest/full-featured protocol", TESTMANAGERD_VERSION_TIMEOUT_SEC];
+      }
+      testmanagerdVersion = receivedVersion;
     } else {
       // Modern testmanagerd (Xcode 15+) has already negotiated named XCTCapabilities by the time
       // a daemon session exists, instead of a single scalar protocol version. There is no direct

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -81,24 +81,42 @@
 
 NSInteger FBTestmanagerdVersion(void)
 {
-  static dispatch_once_t getTestmanagerdVersion;
-  static NSInteger testmanagerdVersion;
-  dispatch_once(&getTestmanagerdVersion, ^{
+  // Not a dispatch_once: a `dispatch_once` here would permanently cache the timeout fallback below
+  // if the very first call's daemon reply merely arrived late (busy, not hung), instead of the real
+  // negotiated version. -1 means "not yet successfully determined" - only a real reply (or the
+  // always-correct modern-testmanagerd branch) is cached; a timeout is retried on the next call.
+  static NSInteger cachedVersion = -1;
+  static dispatch_queue_t syncQueue;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    syncQueue = dispatch_queue_create("com.facebook.wda.testmanagerdVersion", DISPATCH_QUEUE_SERIAL);
+  });
+
+  __block NSInteger result;
+  dispatch_sync(syncQueue, ^{
+    if (cachedVersion >= 0) {
+      result = cachedVersion;
+      return;
+    }
+
     id<XCTMessagingChannel_RunnerToDaemon> proxy = [FBXCTestDaemonsProxy testRunnerProxy];
     if ([(NSObject *)proxy respondsToSelector:@selector(_XCT_exchangeProtocolVersion:reply:)]) {
       id<FBXCTestManagerLegacyProtocolVersionExchanging> legacyProxy = (id<FBXCTestManagerLegacyProtocolVersionExchanging>)proxy;
-      // Assume newest/full-featured on timeout, mirroring the modern-testmanagerd branch below.
-      __block NSInteger receivedVersion = 0xFFFF;
+      __block NSInteger receivedVersion = -1;
       dispatch_semaphore_t sem = dispatch_semaphore_create(0);
-      [legacyProxy _XCT_exchangeProtocolVersion:testmanagerdVersion reply:^(unsigned long long code) {
+      [legacyProxy _XCT_exchangeProtocolVersion:0 reply:^(unsigned long long code) {
         receivedVersion = (NSInteger) code;
         dispatch_semaphore_signal(sem);
       }];
       int64_t timeoutNs = (int64_t)(TESTMANAGERD_VERSION_TIMEOUT_SEC * NSEC_PER_SEC);
       if (0 != dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, timeoutNs))) {
+        // Assume newest/full-featured on timeout, mirroring the modern-testmanagerd branch below -
+        // but don't cache it, so a merely-slow (not hung) daemon gets a real answer on a later call.
         [FBLogger logFmt:@"Did not receive a testmanagerd protocol version reply within %d seconds; assuming the newest/full-featured protocol", TESTMANAGERD_VERSION_TIMEOUT_SEC];
+        result = 0xFFFF;
+        return;
       }
-      testmanagerdVersion = receivedVersion;
+      result = receivedVersion;
     } else {
       // Modern testmanagerd (Xcode 15+) has already negotiated named XCTCapabilities by the time
       // a daemon session exists, instead of a single scalar protocol version. There is no direct
@@ -109,8 +127,9 @@ NSInteger FBTestmanagerdVersion(void)
       if (nil == capabilities) {
         [FBLogger log:@"Could not retrieve testmanagerd capabilities"];
       }
-      testmanagerdVersion = 0xFFFF;
+      result = 0xFFFF;
     }
+    cachedVersion = result;
   });
-  return testmanagerdVersion;
+  return result;
 }

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -81,10 +81,8 @@
 
 NSInteger FBTestmanagerdVersion(void)
 {
-  // Not a dispatch_once: a `dispatch_once` here would permanently cache the timeout fallback below
-  // if the very first call's daemon reply merely arrived late (busy, not hung), instead of the real
-  // negotiated version. -1 means "not yet successfully determined" - only a real reply (or the
-  // always-correct modern-testmanagerd branch) is cached; a timeout is retried on the next call.
+  // Not dispatch_once: that would permanently cache the timeout fallback below if the first call's
+  // reply merely arrived late. -1 means "not yet determined"; a timeout isn't cached, so it retries.
   static NSInteger cachedVersion = -1;
   static dispatch_queue_t syncQueue;
   static dispatch_once_t onceToken;
@@ -110,19 +108,15 @@ NSInteger FBTestmanagerdVersion(void)
       }];
       int64_t timeoutNs = (int64_t)(TESTMANAGERD_VERSION_TIMEOUT_SEC * NSEC_PER_SEC);
       if (0 != dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, timeoutNs))) {
-        // Assume newest/full-featured on timeout, mirroring the modern-testmanagerd branch below -
-        // but don't cache it, so a merely-slow (not hung) daemon gets a real answer on a later call.
+        // Assume newest/full-featured on timeout, but don't cache it - retry on the next call.
         [FBLogger logFmt:@"Did not receive a testmanagerd protocol version reply within %d seconds; assuming the newest/full-featured protocol", TESTMANAGERD_VERSION_TIMEOUT_SEC];
         result = 0xFFFF;
         return;
       }
       result = receivedVersion;
     } else {
-      // Modern testmanagerd (Xcode 15+) has already negotiated named XCTCapabilities by the time
-      // a daemon session exists, instead of a single scalar protocol version. There is no direct
-      // integer equivalent to report here (this value is diagnostic-only, surfaced via the
-      // 'testmanagerdVersion' session capability), so keep reporting the existing "assume
-      // newest/full-featured" sentinel, while confirming capabilities did negotiate successfully.
+      // Modern testmanagerd (Xcode 15+) negotiates named XCTCapabilities instead of a scalar
+      // version; there's no direct integer equivalent, so just confirm capabilities negotiated.
       XCTCapabilities *capabilities = [XCTRunnerDaemonSession sharedSession].remoteInterfaceCapabilities;
       if (nil == capabilities) {
         [FBLogger log:@"Could not retrieve testmanagerd capabilities"];


### PR DESCRIPTION
## Summary

Fixes #1210: when the app under test freezes, WDA's whole HTTP server stops answering — including routes like `GET /status` and `DELETE /session/:id` that don't touch the frozen app at all — because every route handler is funneled through the same main-queue dispatch before it can run.

- Add a `standalone` route flag that bypasses the shared route queue entirely. Concurrent requests to the same endpoint are coalesced into a single in-flight execution (its response is fanned out to all callers); everything else gets its own queue, so distinct standalone endpoints always run in parallel with whatever else is stuck. Mark `GET /status`, `GET /screenshot`, and `DELETE /session` standalone.
- When a session is killed, immediately fail every other request still pending for that session (queued or already executing) with a proper W3C `"invalid session id"` error instead of leaving their HTTP clients waiting on a session that no longer exists. A request that's already executing keeps running to completion in the background — GCD gives no way to abort it — but its result is discarded rather than ever reaching a client.
- `-kill` now clears the active-session pointer up front, before its own teardown, so a request that arrives mid-teardown correctly resolves to "no such session" instead of racing in against a half-torn-down one.
- Bound several previously-unbounded waits found while auditing these routes for hangs of their own:
  - `FBTestmanagerdVersion()` and `stopScreenRecordingWithUUID:error:` used an unbounded wait on a daemon RPC reply.
  - `-kill`'s check for whether the tested app is the system app goes through a shared accessibility client (`FBXCAXClientProxy`) that can itself be stuck behind another in-flight request against a frozen app — now capped at 5s, defaulting to "assume it might be the system app" (skip termination) on timeout to stay on the safe side. That check runs on a background queue now, guarded with `@try`/`@catch` since a sibling `XCUIApplication` method (`-terminate`) is confirmed to hard-assert off the main thread.
