### PR TITLE
fix: return W3C-compliant JSON error for unmatched routes

### DIFF
--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -8,7 +8,9 @@
 
 #import "FBHTTPServer.h"
 
+#import "FBCommandStatus.h"
 #import "FBConfiguration.h"
+#import "FBResponsePayload.h"
 #import "FBTCPSocket.h"
 
 static NSData *FBCRLFCRLFData(void)
@@ -318,8 +320,9 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
   }
 
   RouteResponse *notFound = [RouteResponse new];
-  notFound.statusCode = kHTTPStatusCodeNotFound;
-  [notFound respondWithString:@"Not Found"];
+  FBCommandStatus *status = [FBCommandStatus unknownCommandErrorWithMessage:nil
+                                                                   traceback:nil];
+  [FBResponseWithStatus(status) dispatchWithResponse:notFound];
   [self writeResponse:notFound toClient:client];
 }
 


### PR DESCRIPTION
The 404 fallback in FBHTTPServer previously responded with a plain text "Not Found" body instead of a WebDriver-spec error payload.