### PR TITLE
fix: harden FBHTTPServer/FBTCPSocket against races and protocol gaps

### DIFF
--- a/WebDriverAgentLib/Routing/FBHTTPServer.h
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.h
@@ -10,8 +10,8 @@
 // since watchOS forbids BSD sockets outright - see FBTCPSocket.h/.m).
 //
 // No range requests or request pipelining - just request line + headers + Content-Length body,
-// and ":param" path matching. Transfer-Encoding: chunked requests are rejected outright (501)
-// rather than silently mishandled.
+// and ":param" path matching. Any Transfer-Encoding is rejected outright (501) rather than
+// silently mishandled, since no decoder is implemented.
 
 @import Foundation;
 

--- a/WebDriverAgentLib/Routing/FBHTTPServer.h
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.h
@@ -9,8 +9,9 @@
 // A minimal HTTP/1.1 server on top of FBTCPSocket (Network.framework-backed on every platform,
 // since watchOS forbids BSD sockets outright - see FBTCPSocket.h/.m).
 //
-// No chunked encoding, range requests, or pipelining - just request line + headers +
-// Content-Length body, and ":param" path matching.
+// No range requests or request pipelining - just request line + headers + Content-Length body,
+// and ":param" path matching. Transfer-Encoding: chunked requests are rejected outright (501)
+// rather than silently mishandled.
 
 @import Foundation;
 

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -274,12 +274,14 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
         requestHeaders[name.lowercaseString] = value;
       }
 
-      NSString *transferEncoding = requestHeaders[@"transfer-encoding"].lowercaseString;
-      if (nil != transferEncoding && NSNotFound != [transferEncoding rangeOfString:@"chunked"].location) {
-        // De-chunking isn't implemented - fail loudly instead of silently misreading the body as
-        // empty and desyncing the rest of the connection's request stream.
+      NSString *transferEncoding = requestHeaders[@"transfer-encoding"];
+      if (transferEncoding.length > 0) {
+        // No transfer decoder is implemented at all, so any encoding (chunked or otherwise -
+        // including a value only introduced by a duplicate header overwriting "chunked" above)
+        // is rejected rather than risking the body being misread as empty and desyncing the rest
+        // of the connection's request stream.
         RouteResponse *notImplemented = [RouteResponse new];
-        id<FBResponsePayload> notImplementedPayload = FBResponseWithStatus([FBCommandStatus unknownCommandErrorWithMessage:@"Chunked Transfer-Encoding is not supported"
+        id<FBResponsePayload> notImplementedPayload = FBResponseWithStatus([FBCommandStatus unknownCommandErrorWithMessage:@"Transfer-Encoding is not supported"
                                                                                                                   traceback:nil]);
         [notImplementedPayload dispatchWithResponse:notImplemented];
         [self failClient:client withResponse:notImplemented];

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -41,6 +41,20 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 @end
 
 
+// Cached result of parsing a connection's request line + headers, kept around while its body is
+// still streaming in so a slow body doesn't cause the header block to be re-found and re-parsed
+// on every single incoming TCP segment.
+@interface FBPendingHTTPRequestHeader : NSObject
+@property (nonatomic, copy) NSString *method;
+@property (nonatomic, copy) NSString *pathAndQuery;
+@property (nonatomic) NSUInteger bodyStart;
+@property (nonatomic) NSUInteger contentLength;
+@end
+
+@implementation FBPendingHTTPRequestHeader
+@end
+
+
 @interface FBHTTPServer () <FBTCPSocketDelegate>
 
 @property (nonatomic, nullable, strong) FBTCPSocket *socket;
@@ -50,6 +64,9 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 @property (nonatomic, copy, nullable) NSString *interface;
 // nw_connection_t isn't NSCopying, so it can't be an NSDictionary key - use NSMapTable instead.
 @property (nonatomic, strong) NSMapTable<id, NSMutableData *> *connectionBuffers;
+// Per-client cache of the already-parsed request line + headers while its body is still
+// arriving; nil while a client's next unread bytes start with an unparsed header block.
+@property (nonatomic, strong) NSMapTable<id, FBPendingHTTPRequestHeader *> *pendingRequestHeaders;
 
 @end
 
@@ -62,6 +79,8 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
     _defaultHeaders = [NSMutableDictionary dictionary];
     _connectionBuffers = [NSMapTable mapTableWithKeyOptions:(NSPointerFunctionsOptions)(NSMapTableObjectPointerPersonality | NSMapTableStrongMemory)
                                                  valueOptions:(NSPointerFunctionsOptions)NSMapTableStrongMemory];
+    _pendingRequestHeaders = [NSMapTable mapTableWithKeyOptions:(NSPointerFunctionsOptions)(NSMapTableObjectPointerPersonality | NSMapTableStrongMemory)
+                                                    valueOptions:(NSPointerFunctionsOptions)NSMapTableStrongMemory];
   }
   return self;
 }
@@ -103,6 +122,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
                                                                                  error:nil];
   NSMutableString *regexPath = [NSMutableString stringWithString:escapedPath];
   __block NSInteger diff = 0;
+  __block NSUInteger wildcardIndex = 0;
   [paramRegex enumerateMatchesInString:escapedPath
                                 options:(NSMatchingOptions)0
                                   range:NSMakeRange(0, escapedPath.length)
@@ -111,7 +131,11 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
     NSString *capturedString = [escapedPath substringWithRange:result.range];
     NSString *replacementString;
     if ([capturedString isEqualToString:@"*"]) {
-      [keys addObject:@"wildcards"];
+      // Only the first wildcard keeps the plain "wildcards" name - later ones get an index
+      // suffix so multiple "*" segments in one path don't overwrite each other's capture.
+      NSString *wildcardKey = 0 == wildcardIndex ? @"wildcards" : [NSString stringWithFormat:@"wildcards%lu", (unsigned long)wildcardIndex];
+      wildcardIndex++;
+      [keys addObject:wildcardKey];
       replacementString = @"(.*?)";
     } else {
       NSString *keyString = [escapedPath substringWithRange:[result rangeAtIndex:2]];
@@ -166,6 +190,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
   self.socket = nil;
   @synchronized (self.connectionBuffers) {
     [self.connectionBuffers removeAllObjects];
+    [self.pendingRequestHeaders removeAllObjects];
   }
   _isRunning = NO;
 }
@@ -183,6 +208,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 {
   @synchronized (self.connectionBuffers) {
     [self.connectionBuffers removeObjectForKey:client];
+    [self.pendingRequestHeaders removeObjectForKey:client];
   }
 }
 
@@ -205,72 +231,128 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 {
   while (YES) {
     NSMutableData *buffer;
+    FBPendingHTTPRequestHeader *pending;
     @synchronized (self.connectionBuffers) {
       buffer = [self.connectionBuffers objectForKey:client];
-    }
-    if (nil == buffer) {
-      return;
-    }
-
-    NSRange headerEndRange = [buffer rangeOfData:FBCRLFCRLFData() options:(NSDataSearchOptions)0 range:NSMakeRange(0, buffer.length)];
-    if (NSNotFound == headerEndRange.location) {
-      return;
-    }
-
-    NSData *headerData = [buffer subdataWithRange:NSMakeRange(0, headerEndRange.location)];
-    NSString *headerString = [[NSString alloc] initWithData:headerData encoding:NSUTF8StringEncoding];
-    NSArray<NSString *> *lines = [headerString componentsSeparatedByString:@"\r\n"];
-    if (lines.count < 1) {
-      [self closeClient:client];
-      return;
-    }
-
-    NSArray<NSString *> *requestLineParts = [lines.firstObject componentsSeparatedByString:@" "];
-    if (requestLineParts.count < 2) {
-      [self closeClient:client];
-      return;
-    }
-    NSString *method = requestLineParts[0].uppercaseString;
-    NSString *pathAndQuery = requestLineParts[1];
-
-    NSMutableDictionary<NSString *, NSString *> *requestHeaders = [NSMutableDictionary dictionary];
-    for (NSUInteger i = 1; i < lines.count; i++) {
-      NSString *line = lines[i];
-      NSRange colonRange = [line rangeOfString:@":"];
-      if (NSNotFound == colonRange.location) {
-        continue;
+      if (nil == buffer) {
+        return;
       }
-      NSString *name = [line substringToIndex:colonRange.location];
-      NSString *value = [[line substringFromIndex:colonRange.location + 1]
-                          stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
-      requestHeaders[name.lowercaseString] = value;
+      pending = [self.pendingRequestHeaders objectForKey:client];
     }
 
-    NSUInteger contentLength = (NSUInteger)requestHeaders[@"content-length"].integerValue;
-    if (contentLength > FBConfiguration.sharedInstance.httpRequestBodySizeLimit) {
-      // Mirrors CocoaHTTPServer's maxRequestBodySize enforcement. Closes the connection after
-      // responding, since the rest of the oversized body is still incoming.
-      RouteResponse *tooLarge = [RouteResponse new];
-      tooLarge.statusCode = kHTTPStatusCodeRequestEntityTooLarge;
-      [tooLarge respondWithString:@"Request Entity Too Large"];
-      [self writeResponse:tooLarge toClient:client thenCloseConnection:YES];
-      return;
+    if (nil == pending) {
+      NSRange headerEndRange = [buffer rangeOfData:FBCRLFCRLFData() options:(NSDataSearchOptions)0 range:NSMakeRange(0, buffer.length)];
+      if (NSNotFound == headerEndRange.location) {
+        // Wait for the rest of the header block to arrive.
+        return;
+      }
+
+      NSData *headerData = [buffer subdataWithRange:NSMakeRange(0, headerEndRange.location)];
+      NSString *headerString = [[NSString alloc] initWithData:headerData encoding:NSUTF8StringEncoding];
+      NSArray<NSString *> *lines = [headerString componentsSeparatedByString:@"\r\n"];
+      if (lines.count < 1) {
+        [self respondBadRequestToClient:client];
+        return;
+      }
+
+      NSArray<NSString *> *requestLineParts = [lines.firstObject componentsSeparatedByString:@" "];
+      if (requestLineParts.count < 2) {
+        [self respondBadRequestToClient:client];
+        return;
+      }
+
+      NSMutableDictionary<NSString *, NSString *> *requestHeaders = [NSMutableDictionary dictionary];
+      for (NSUInteger i = 1; i < lines.count; i++) {
+        NSString *line = lines[i];
+        NSRange colonRange = [line rangeOfString:@":"];
+        if (NSNotFound == colonRange.location) {
+          continue;
+        }
+        NSString *name = [line substringToIndex:colonRange.location];
+        NSString *value = [[line substringFromIndex:colonRange.location + 1]
+                            stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+        requestHeaders[name.lowercaseString] = value;
+      }
+
+      NSString *transferEncoding = requestHeaders[@"transfer-encoding"].lowercaseString;
+      if (nil != transferEncoding && NSNotFound != [transferEncoding rangeOfString:@"chunked"].location) {
+        // De-chunking isn't implemented - fail loudly instead of silently misreading the body as
+        // empty and desyncing the rest of the connection's request stream.
+        RouteResponse *notImplemented = [RouteResponse new];
+        id<FBResponsePayload> notImplementedPayload = FBResponseWithStatus([FBCommandStatus unknownCommandErrorWithMessage:@"Chunked Transfer-Encoding is not supported"
+                                                                                                                  traceback:nil]);
+        [notImplementedPayload dispatchWithResponse:notImplemented];
+        [self failClient:client withResponse:notImplemented];
+        return;
+      }
+
+      NSUInteger contentLength = (NSUInteger)requestHeaders[@"content-length"].integerValue;
+      if (contentLength > FBConfiguration.sharedInstance.httpRequestBodySizeLimit) {
+        // Mirrors CocoaHTTPServer's maxRequestBodySize enforcement. Closes the connection after
+        // responding, since the rest of the oversized body is still incoming.
+        RouteResponse *tooLarge = [RouteResponse new];
+        id<FBResponsePayload> tooLargePayload = FBResponseWithStatus([FBCommandStatus unknownCommandErrorWithMessage:@"Request Entity Too Large"
+                                                                                                            traceback:nil]);
+        [tooLargePayload dispatchWithResponse:tooLarge];
+        [self failClient:client withResponse:tooLarge];
+        return;
+      }
+
+      pending = [FBPendingHTTPRequestHeader new];
+      pending.method = requestLineParts[0].uppercaseString;
+      pending.pathAndQuery = requestLineParts[1];
+      pending.bodyStart = headerEndRange.location + headerEndRange.length;
+      pending.contentLength = contentLength;
+      @synchronized (self.connectionBuffers) {
+        [self.pendingRequestHeaders setObject:pending forKey:client];
+      }
     }
-    NSUInteger bodyStart = headerEndRange.location + headerEndRange.length;
-    NSUInteger totalRequestLength = bodyStart + contentLength;
+
+    NSUInteger totalRequestLength = pending.bodyStart + pending.contentLength;
     if (buffer.length < totalRequestLength) {
-      // Wait for the rest of the body to arrive.
+      // Wait for the rest of the body to arrive - the parsed header stays cached above, so this
+      // doesn't re-scan/re-parse the header block on every subsequently arriving chunk.
       return;
     }
 
-    NSData *body = contentLength > 0 ? [buffer subdataWithRange:NSMakeRange(bodyStart, contentLength)] : [NSData data];
+    NSData *body = pending.contentLength > 0 ? [buffer subdataWithRange:NSMakeRange(pending.bodyStart, pending.contentLength)] : [NSData data];
 
     @synchronized (self.connectionBuffers) {
       [buffer replaceBytesInRange:NSMakeRange(0, totalRequestLength) withBytes:NULL length:0];
+      [self.pendingRequestHeaders removeObjectForKey:client];
     }
 
-    [self dispatchMethod:method pathAndQuery:pathAndQuery body:body client:client];
+    [self dispatchMethod:pending.method pathAndQuery:pending.pathAndQuery body:body client:client];
   }
+}
+
+// Removes the client's buffered state and responds with a closing error response. Removing the
+// buffer synchronously ensures any request bytes still streaming in for this connection are
+// dropped rather than being re-parsed and re-triggering this same response.
+- (void)failClient:(nw_connection_t)client withResponse:(RouteResponse *)response
+{
+  @synchronized (self.connectionBuffers) {
+    [self.connectionBuffers removeObjectForKey:client];
+    [self.pendingRequestHeaders removeObjectForKey:client];
+  }
+  [self applyDefaultHeadersToResponse:response];
+  [self writeResponse:response toClient:client thenCloseConnection:YES];
+}
+
+- (void)respondBadRequestToClient:(nw_connection_t)client
+{
+  RouteResponse *badRequest = [RouteResponse new];
+  id<FBResponsePayload> payload = FBResponseWithStatus([FBCommandStatus unknownCommandErrorWithMessage:@"The request could not be parsed as valid HTTP"
+                                                                                              traceback:nil]);
+  [payload dispatchWithResponse:badRequest];
+  [self failClient:client withResponse:badRequest];
+}
+
+- (void)applyDefaultHeadersToResponse:(RouteResponse *)response
+{
+  [self.defaultHeaders enumerateKeysAndObjectsUsingBlock:^(NSString *field, NSString *value, BOOL *stop) {
+    [response setHeader:field value:value];
+  }];
 }
 
 - (void)dispatchMethod:(NSString *)method pathAndQuery:(NSString *)pathAndQuery body:(NSData *)body client:(nw_connection_t)client
@@ -302,9 +384,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
     NSURL *url = [NSURL URLWithString:path] ?: [NSURL URLWithString:@"/"];
     RouteRequest *request = [[RouteRequest alloc] initWithURL:url params:params.copy body:body];
     RouteResponse *response = [RouteResponse new];
-    [self.defaultHeaders enumerateKeysAndObjectsUsingBlock:^(NSString *field, NSString *value, BOOL *stop) {
-      [response setHeader:field value:value];
-    }];
+    [self applyDefaultHeadersToResponse:response];
 
     void (^invoke)(void) = ^{
       route.block(request, response);
@@ -323,6 +403,7 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
   FBCommandStatus *status = [FBCommandStatus unknownCommandErrorWithMessage:nil
                                                                    traceback:nil];
   [FBResponseWithStatus(status) dispatchWithResponse:notFound];
+  [self applyDefaultHeadersToResponse:notFound];
   [self writeResponse:notFound toClient:client];
 }
 
@@ -383,6 +464,8 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
     return @"Request Timeout";
   } else if (kHTTPStatusCodeRequestEntityTooLarge == statusCode) {
     return @"Request Entity Too Large";
+  } else if (kHTTPStatusCodeNotImplemented == statusCode) {
+    return @"Not Implemented";
   } else if (kHTTPStatusCodeInternalServerError == statusCode) {
     return @"Internal Server Error";
   }

--- a/WebDriverAgentLib/Routing/FBTCPSocket.m
+++ b/WebDriverAgentLib/Routing/FBTCPSocket.m
@@ -78,12 +78,18 @@
       // NSLocalizedDescriptionKey must be a string, not the underlying NSError itself, or
       // -[NSError localizedDescription] crashes trying to treat it as one.
       NSError *underlyingError = nwError ? (NSError *)CFBridgingRelease(nw_error_copy_cf_error(nwError)) : nil;
-      NSMutableDictionary<NSString *, id> *userInfo = [NSMutableDictionary dictionary];
-      userInfo[NSLocalizedDescriptionKey] = underlyingError.localizedDescription ?: @"The TCP listener failed to start";
-      if (underlyingError) {
-        userInfo[NSUnderlyingErrorKey] = underlyingError;
+      if ([underlyingError.domain isEqualToString:NSPOSIXErrorDomain]) {
+        // Surface POSIX errors (e.g. EADDRINUSE) directly, since callers like FBWebServer check
+        // for them by domain/code on the top-level error to decide whether to retry another port.
+        startupError = underlyingError;
+      } else {
+        NSMutableDictionary<NSString *, id> *userInfo = [NSMutableDictionary dictionary];
+        userInfo[NSLocalizedDescriptionKey] = underlyingError.localizedDescription ?: @"The TCP listener failed to start";
+        if (underlyingError) {
+          userInfo[NSUnderlyingErrorKey] = underlyingError;
+        }
+        startupError = [NSError errorWithDomain:@"FBTCPSocket" code:2 userInfo:userInfo];
       }
-      startupError = [NSError errorWithDomain:@"FBTCPSocket" code:2 userInfo:userInfo];
       dispatch_semaphore_signal(startupSemaphore);
     }
   });
@@ -98,6 +104,10 @@
     if (error) {
       *error = startupError;
     }
+    // Cancel rather than just dropping our reference - otherwise a late ready/failed callback
+    // can still fire and the port stays bound at the OS level even though the caller was told
+    // startup failed.
+    nw_listener_cancel(listener);
     self.listener = nil;
     return NO;
   }
@@ -144,11 +154,9 @@
     }
     if (nil != content) {
       dispatch_data_t nonnullContent = (dispatch_data_t _Nonnull)content;
-      __block NSData *data = nil;
+      NSMutableData *data = [NSMutableData data];
       dispatch_data_apply(nonnullContent, ^bool(dispatch_data_t  _Nonnull region, size_t offset, const void * _Nonnull buffer, size_t size) {
-        NSMutableData *accumulated = [(data ?: [NSData data]) mutableCopy];
-        [accumulated appendBytes:buffer length:size];
-        data = accumulated.copy;
+        [data appendBytes:buffer length:size];
         return true;
       });
       if (data.length > 0) {
@@ -198,13 +206,19 @@
 
 - (void)stop
 {
+  NSArray<nw_connection_t> *clients;
   @synchronized (self.connectedClients) {
-    NSArray<nw_connection_t> *clients = self.connectedClients.copy;
+    clients = self.connectedClients.copy;
     [self.connectedClients removeAllObjects];
+  }
+  // Cancel on socketQueue, the same queue every connection's send/receive is bound to (see
+  // -acceptConnection:), so a write already issued just before -stop (e.g. a shutdown route's
+  // response) is processed before the cancellation rather than racing it.
+  dispatch_async(self.socketQueue, ^{
     for (nw_connection_t client in clients) {
       nw_connection_cancel(client);
     }
-  }
+  });
 
   self.delegate = nil;
   nw_listener_t listener = self.listener;

--- a/WebDriverAgentLib/Routing/FBWebServer.m
+++ b/WebDriverAgentLib/Routing/FBWebServer.m
@@ -261,7 +261,11 @@ static NSString *const FBServerURLEndMarker = @"<-ServerURLHere";
       return;
     }
     [response respondWithString:@"Shutting down"];
-    [strongSelf.delegate webServerDidRequestShutdown:strongSelf];
+    // Deferred so the "Shutting down" response is written to the client before
+    // webServerDidRequestShutdown: tears down the server's socket out from under it.
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [strongSelf.delegate webServerDidRequestShutdown:strongSelf];
+    });
   }];
 
   [self registerRouteHandlers:@[FBUnknownCommands.class]];


### PR DESCRIPTION
Follow-up fixes for the Network.framework HTTP server (#1221) found while porting it to a downstream WebDriverAgent fork:
- Defer FBWebServer's shutdown delegate call so the /wda/shutdown response is actually written before the socket/connections are torn down.
- Cancel FBTCPSocket connections on the socket queue during -stop so an already-issued write isn't raced by the cancellation.
- Cancel the listener on startup timeout/failure instead of just dropping the reference, and surface POSIX errors (e.g. EADDRINUSE) undecorated so FBWebServer's port-retry check can match them.
- Stop accumulating received data via repeated mutableCopy+append (O(n^2)); append into a single NSMutableData instead.
- Cache parsed request headers per connection while the body streams in, instead of re-scanning/re-parsing the whole buffered header block on every incoming chunk.
- Remove a client's buffered state before responding with a terminal error (413/400/501) so a still-streaming body can't re-trigger the same response.
- Reject Transfer-Encoding: chunked explicitly (501) instead of silently treating the request as bodyless and desyncing the connection.
- Apply default headers (CORS, Server) to error responses, not just successfully-routed ones.
- Give multiple "*" wildcard segments in one route path distinct params keys instead of overwriting a single "wildcards" key.
- Return valid WebDriver protocol error JSON for 400/404/413/501 responses instead of raw strings, matching the shape route handlers already use.