### PR TITLE
fix: reject malformed Content-Length values and bound request header buffering

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -1189,6 +1189,7 @@
 		EE8DDD7F20C5733C004D4925 /* XCUIElement+FBForceTouch.h in Headers */ = {isa = PBXBuildFile; fileRef = EE8DDD7D20C5733C004D4925 /* XCUIElement+FBForceTouch.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EE9AB8011CAEE048008C271F /* UITestingUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9AB7FD1CAEE048008C271F /* UITestingUITests.m */; };
 		EE9B76591CF7987800275851 /* FBRouteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9B76571CF7987300275851 /* FBRouteTests.m */; };
+		DF82F4A8758B79DD91FA20CC /* FBHTTPServerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 76B7399DDF52C85A21433C1D /* FBHTTPServerTests.m */; };
 		EE9B768E1CF7997600275851 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9B76831CF7997600275851 /* AppDelegate.m */; };
 		EE9B768F1CF7997600275851 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9B76851CF7997600275851 /* ViewController.m */; };
 		EE9B76911CF7997600275851 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9B76871CF7997600275851 /* main.m */; };
@@ -1903,6 +1904,7 @@
 		EE9B75D41CF7956C00275851 /* IntegrationApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IntegrationApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE9B75EC1CF7956C00275851 /* IntegrationTests_1.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IntegrationTests_1.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE9B76571CF7987300275851 /* FBRouteTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBRouteTests.m; sourceTree = "<group>"; };
+		76B7399DDF52C85A21433C1D /* FBHTTPServerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBHTTPServerTests.m; sourceTree = "<group>"; };
 		EE9B76581CF7987300275851 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EE9B76821CF7997600275851 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		EE9B76831CF7997600275851 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -2673,6 +2675,7 @@
 				713352FC26CEF31D00523CBC /* FBLRUCacheTests.m */,
 				EE18883C1DA663EB00307AA8 /* FBMathUtilsTests.m */,
 				718F49C7230844330045FE8B /* FBProtocolHelpersTests.m */,
+				76B7399DDF52C85A21433C1D /* FBHTTPServerTests.m */,
 				EE9B76571CF7987300275851 /* FBRouteTests.m */,
 				EE3F8CFD1D08AA17006F02CE /* FBRunLoopSpinnerTests.m */,
 				ADEF63AE1D09DEBE0070A7E3 /* FBRuntimeUtilsTests.m */,
@@ -4806,6 +4809,7 @@
 				719FF5B91DAD21F5008E0099 /* FBElementUtilitiesTests.m in Sources */,
 				716E0BD11E917F260087A825 /* FBXMLSafeStringTests.m in Sources */,
 				ADEF63AF1D09DEBE0070A7E3 /* FBRuntimeUtilsTests.m in Sources */,
+				DF82F4A8758B79DD91FA20CC /* FBHTTPServerTests.m in Sources */,
 				EE9B76591CF7987800275851 /* FBRouteTests.m in Sources */,
 				7139145C1DF01A12005896C2 /* NSExpressionFBFormatTests.m in Sources */,
 				71A224E81DE326C500844D55 /* NSPredicateFBFormatTests.m in Sources */,

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -359,12 +359,23 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
     if (nil == strongSelf) {
       return;
     }
+    BOOL isOverBufferCap = NO;
     @synchronized (strongSelf.connectionBuffers) {
       NSMutableData *buffer = [strongSelf.connectionBuffers objectForKey:client];
       if (nil == buffer) {
         return;
       }
       [buffer appendData:data];
+      // Hard upper bound for everything a connection may have buffered but not yet consumed:
+      // one maximal header block plus one maximal body, with headroom for a pipelined
+      // follow-up. The per-request checks in -processBufferForClient: don't run while a
+      // request is executing (see -connectionsAwaitingResponse), so without this cap a client
+      // could pump data unboundedly for exactly as long as its previous request takes.
+      uint64_t bufferCap = FBConfiguration.sharedInstance.httpRequestBodySizeLimit + 2 * (uint64_t)FBMaxRequestHeaderSize;
+      if (bufferCap < FBConfiguration.sharedInstance.httpRequestBodySizeLimit) {
+        bufferCap = UINT64_MAX;
+      }
+      isOverBufferCap = buffer.length > bufferCap;
       // Body phase (a parsed header is pending): a valid declared body legitimately takes as
       // long as the link is slow - e.g. a large base64 payload over a USB tunnel - so the
       // timeout acts as an idle bound, refreshed on every byte of progress (total buffered size
@@ -376,6 +387,13 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
       if (isBodyPhase || nil == [strongSelf.incompleteRequestStarts objectForKey:client]) {
         [strongSelf.incompleteRequestStarts setObject:[NSDate date] forKey:client];
       }
+    }
+    if (isOverBufferCap) {
+      // No response owed - a peer this far past any legitimate request size isn't reading
+      // responses anyway, and writing one would itself queue inside Network.framework.
+      [FBLogger log:@"Closing a connection that overflowed its request buffer"];
+      [strongSelf closeClient:client];
+      return;
     }
     [strongSelf processBufferForClient:client];
   });
@@ -442,6 +460,15 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
         continue;
       }
       NSString *name = [line substringToIndex:colonRange.location];
+      // RFC 7230 (3.2.4) requires rejecting whitespace between a field name and its colon with
+      // a 400: storing "content-length " as a distinct key would silently drop the real header,
+      // dispatch the request with a zero-length body, and desync the connection's framing - a
+      // request-smuggling primitive when an intermediary normalizes the same header.
+      if (0 == name.length
+          || NSNotFound != [name rangeOfCharacterFromSet:NSCharacterSet.whitespaceAndNewlineCharacterSet].location) {
+        [self respondBadRequestToClient:client];
+        return;
+      }
       NSString *value = [[line substringFromIndex:colonRange.location + 1]
                           stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
       requestHeaders[name.lowercaseString] = value;
@@ -743,15 +770,25 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
       [weakSelf closeClient:client];
     }];
   } else {
-    // Sent before unblocking the next pipelined request, so responses can't reach the wire out of order.
-    [self.socket writeData:payload toClient:client];
-    @synchronized (self.connectionBuffers) {
-      [self.connectionsAwaitingResponse removeObject:client];
-    }
+    // The next pipelined request is only unblocked from the send's completion: response
+    // ordering is preserved either way (nw_connection_send is FIFO per connection), but
+    // unblocking early would let a client that pipelines requests without ever reading
+    // responses accumulate an unbounded number of fully-rendered response buffers inside
+    // Network.framework. If the connection dies mid-send the completion still fires and
+    // -processBufferForClient: simply finds no buffer left.
     __weak typeof(self) weakSelf = self;
-    dispatch_async(self.bufferProcessingQueue, ^{
-      [weakSelf processBufferForClient:client];
-    });
+    [self.socket writeData:payload toClient:client completion:^{
+      __strong typeof(weakSelf) strongSelf = weakSelf;
+      if (nil == strongSelf) {
+        return;
+      }
+      @synchronized (strongSelf.connectionBuffers) {
+        [strongSelf.connectionsAwaitingResponse removeObject:client];
+      }
+      dispatch_async(strongSelf.bufferProcessingQueue, ^{
+        [weakSelf processBufferForClient:client];
+      });
+    }];
   }
 }
 

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -342,6 +342,13 @@ static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
       // Wait for the rest of the header block to arrive.
       return;
     }
+    if (headerEndRange.location > FBMaxRequestHeaderSize) {
+      // The check above only fires while the terminator is still missing; a single large receive
+      // can deliver an oversized header block terminator included, so the completed block must be
+      // bounded too before it gets copied and parsed.
+      [self respondBadRequestToClient:client];
+      return;
+    }
 
     NSData *headerData = [buffer subdataWithRange:NSMakeRange(0, headerEndRange.location)];
     NSString *headerString = [[NSString alloc] initWithData:headerData encoding:NSUTF8StringEncoding];

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -10,6 +10,7 @@
 
 #import "FBCommandStatus.h"
 #import "FBConfiguration.h"
+#import "FBLogger.h"
 #import "FBResponsePayload.h"
 #import "FBTCPSocket.h"
 
@@ -130,8 +131,21 @@ static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
 // standalone or not (except DELETE /session itself - see -dispatchMethod:). See
 // -abandonPendingRequestsForSessionID:. Guarded by @synchronized(self.pendingSessionRequests).
 @property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableSet<FBPendingRequest *> *> *pendingSessionRequests;
+// When each connection started waiting for its current request to complete: set on connect and
+// whenever bytes of a new request begin arriving, cleared once a complete request is dispatched.
+// The reaper below closes connections whose entry outlives FBIncompleteRequestTimeout, so peers
+// that connect and never deliver a complete request cannot be retained forever. Idle keep-alive
+// connections (no entry) are exempt. Guarded by @synchronized(self.connectionBuffers).
+@property (nonatomic, strong) NSMapTable<id, NSDate *> *incompleteRequestStarts;
+@property (nonatomic, nullable) dispatch_source_t staleConnectionReaper;
 
 @end
+
+// How long a connection may take to deliver a complete request (first byte of the request line
+// through the end of the declared body) before it is closed. The previous CocoaHTTPServer stack
+// enforced 30-second header read timeouts; this restores an equivalent bound.
+static const NSTimeInterval FBIncompleteRequestTimeout = 30.0;
+static const int64_t FBStaleConnectionSweepIntervalSec = 10;
 
 @implementation FBHTTPServer
 
@@ -148,6 +162,8 @@ static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
     _connectionsAwaitingResponse = [NSMutableSet set];
     _standaloneWaiters = [NSMutableDictionary dictionary];
     _pendingSessionRequests = [NSMutableDictionary dictionary];
+    _incompleteRequestStarts = [NSMapTable mapTableWithKeyOptions:(NSPointerFunctionsOptions)(NSMapTableObjectPointerPersonality | NSMapTableStrongMemory)
+                                                     valueOptions:(NSPointerFunctionsOptions)NSMapTableStrongMemory];
   }
   return self;
 }
@@ -255,18 +271,57 @@ static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
     return NO;
   }
   self.socket = socket;
+  dispatch_source_t reaper = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.bufferProcessingQueue);
+  dispatch_source_set_timer(reaper,
+                            dispatch_time(DISPATCH_TIME_NOW, FBStaleConnectionSweepIntervalSec * NSEC_PER_SEC),
+                            (uint64_t)FBStaleConnectionSweepIntervalSec * NSEC_PER_SEC,
+                            NSEC_PER_SEC);
+  __weak typeof(self) weakSelf = self;
+  dispatch_source_set_event_handler(reaper, ^{
+    [weakSelf reapStaleConnections];
+  });
+  dispatch_resume(reaper);
+  self.staleConnectionReaper = reaper;
   _isRunning = YES;
   return YES;
 }
 
+- (void)reapStaleConnections
+{
+  NSMutableArray *staleConnections = [NSMutableArray array];
+  @synchronized (self.connectionBuffers) {
+    for (id connection in self.incompleteRequestStarts) {
+      // A connection whose request is already executing is waiting on the handler, not on the
+      // peer - it must not be reaped no matter how long the handler takes.
+      if ([self.connectionsAwaitingResponse containsObject:connection]) {
+        continue;
+      }
+      NSDate *start = [self.incompleteRequestStarts objectForKey:connection];
+      if (nil != start && -start.timeIntervalSinceNow > FBIncompleteRequestTimeout) {
+        [staleConnections addObject:connection];
+      }
+    }
+  }
+  for (id connection in staleConnections) {
+    [FBLogger logFmt:@"Closing a connection that did not deliver a complete request within %@ seconds", @(FBIncompleteRequestTimeout)];
+    [self closeClient:(nw_connection_t)connection];
+  }
+}
+
 - (void)stop:(BOOL)immediately
 {
+  dispatch_source_t reaper = self.staleConnectionReaper;
+  if (nil != reaper) {
+    dispatch_source_cancel(reaper);
+    self.staleConnectionReaper = nil;
+  }
   [self.socket stop];
   self.socket = nil;
   @synchronized (self.connectionBuffers) {
     [self.connectionBuffers removeAllObjects];
     [self.pendingRequestHeaders removeAllObjects];
     [self.connectionsAwaitingResponse removeAllObjects];
+    [self.incompleteRequestStarts removeAllObjects];
   }
   _isRunning = NO;
 }
@@ -277,6 +332,9 @@ static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
 {
   @synchronized (self.connectionBuffers) {
     [self.connectionBuffers setObject:[NSMutableData data] forKey:newClient];
+    // The clock towards FBIncompleteRequestTimeout starts at connect: a peer that connects and
+    // never sends a complete first request gets reaped just like one that stalls mid-request.
+    [self.incompleteRequestStarts setObject:[NSDate date] forKey:newClient];
   }
 }
 
@@ -286,6 +344,7 @@ static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
     [self.connectionBuffers removeObjectForKey:client];
     [self.pendingRequestHeaders removeObjectForKey:client];
     [self.connectionsAwaitingResponse removeObject:client];
+    [self.incompleteRequestStarts removeObjectForKey:client];
   }
 }
 
@@ -306,6 +365,12 @@ static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
         return;
       }
       [buffer appendData:data];
+      if (nil == [strongSelf.incompleteRequestStarts objectForKey:client]) {
+        // First bytes of a new request on an idle keep-alive connection: restart the
+        // incomplete-request clock. Deliberately NOT refreshed on subsequent bytes, so a peer
+        // drip-feeding data cannot keep an incomplete request alive past the timeout.
+        [strongSelf.incompleteRequestStarts setObject:[NSDate date] forKey:client];
+      }
     }
     [strongSelf processBufferForClient:client];
   });
@@ -432,6 +497,14 @@ static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
     [buffer replaceBytesInRange:NSMakeRange(0, totalRequestLength) withBytes:NULL length:0];
     [self.pendingRequestHeaders removeObjectForKey:client];
     [self.connectionsAwaitingResponse addObject:client];
+    if (0 == buffer.length) {
+      // A complete request was delivered and nothing further is buffered: the connection is a
+      // healthy keep-alive and must not be reaped while idle.
+      [self.incompleteRequestStarts removeObjectForKey:client];
+    } else {
+      // Pipelined bytes of the next request are already buffered - restart its clock.
+      [self.incompleteRequestStarts setObject:[NSDate date] forKey:client];
+    }
   }
 
   [self dispatchMethod:pending.method pathAndQuery:pending.pathAndQuery body:body client:client];
@@ -682,6 +755,7 @@ static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
   @synchronized (self.connectionBuffers) {
     [self.connectionBuffers removeObjectForKey:client];
     [self.connectionsAwaitingResponse removeObject:client];
+    [self.incompleteRequestStarts removeObjectForKey:client];
   }
   nw_connection_cancel(client);
 }

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -30,6 +30,35 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
   return (NSData * _Nonnull)[string dataUsingEncoding:NSUTF8StringEncoding];
 }
 
+// Upper bound for a request's header block (the bytes before \r\n\r\n). A connection that keeps
+// sending bytes without ever completing its header block would otherwise grow its buffer without
+// limit. Real WDA requests carry a handful of short headers; 64 KiB is far above anything
+// legitimate.
+static const NSUInteger FBMaxRequestHeaderSize = 64 * 1024;
+
+// Strictly parses a Content-Length value: ASCII decimal digits only, bounded so the value below
+// cannot overflow. Returns NO for anything else - -integerValue must not be used here, since it
+// silently maps garbage ("bogus" -> 0, "12abc" -> 12) to a wrong body length, desyncing the
+// framing of every subsequent request on the connection.
+static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
+{
+  // 15 digits keeps the value far below NSUIntegerMax on every platform; any real body length
+  // that long is rejected by the body size limit anyway.
+  if (value.length < 1 || value.length > 15) {
+    return NO;
+  }
+  unsigned long long result = 0;
+  for (NSUInteger i = 0; i < value.length; i++) {
+    unichar c = [value characterAtIndex:i];
+    if (c < '0' || c > '9') {
+      return NO;
+    }
+    result = result * 10 + (c - '0');
+  }
+  *outLength = (NSUInteger)result;
+  return YES;
+}
+
 @interface FBHTTPRoute : NSObject
 @property (nonatomic, copy) NSString *verb;
 @property (nonatomic, strong) NSRegularExpression *regex;
@@ -304,6 +333,12 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
   if (nil == pending) {
     NSRange headerEndRange = [buffer rangeOfData:FBCRLFCRLFData() options:(NSDataSearchOptions)0 range:NSMakeRange(0, buffer.length)];
     if (NSNotFound == headerEndRange.location) {
+      if (buffer.length > FBMaxRequestHeaderSize) {
+        // The client has sent more than any legitimate header block could occupy without ever
+        // completing it - stop buffering and drop the connection instead of growing without bound.
+        [self respondBadRequestToClient:client];
+        return;
+      }
       // Wait for the rest of the header block to arrive.
       return;
     }
@@ -349,7 +384,14 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
       return;
     }
 
-    NSUInteger contentLength = (NSUInteger)requestHeaders[@"content-length"].integerValue;
+    NSString *contentLengthValue = requestHeaders[@"content-length"];
+    NSUInteger contentLength = 0;
+    if (nil != contentLengthValue && !FBParseContentLength(contentLengthValue, &contentLength)) {
+      // With an unparseable Content-Length the body's extent is unknowable, so the connection
+      // cannot be resynced - reject and close.
+      [self respondBadRequestToClient:client];
+      return;
+    }
     if (contentLength > FBConfiguration.sharedInstance.httpRequestBodySizeLimit) {
       // Closes the connection after responding, since the rest of the oversized body is still incoming.
       RouteResponse *tooLarge = [RouteResponse new];

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -365,10 +365,15 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
         return;
       }
       [buffer appendData:data];
-      if (nil == [strongSelf.incompleteRequestStarts objectForKey:client]) {
-        // First bytes of a new request on an idle keep-alive connection: restart the
-        // incomplete-request clock. Deliberately NOT refreshed on subsequent bytes, so a peer
-        // drip-feeding data cannot keep an incomplete request alive past the timeout.
+      // Body phase (a parsed header is pending): a valid declared body legitimately takes as
+      // long as the link is slow - e.g. a large base64 payload over a USB tunnel - so the
+      // timeout acts as an idle bound, refreshed on every byte of progress (total buffered size
+      // stays bounded by the already-validated Content-Length). During the header phase the
+      // clock is only started (first bytes of a new request on an idle keep-alive connection),
+      // never refreshed: a peer drip-feeding header bytes must not be able to keep an
+      // incomplete header block alive past the timeout.
+      BOOL isBodyPhase = nil != [strongSelf.pendingRequestHeaders objectForKey:client];
+      if (isBodyPhase || nil == [strongSelf.incompleteRequestStarts objectForKey:client]) {
         [strongSelf.incompleteRequestStarts setObject:[NSDate date] forKey:client];
       }
     }

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -43,8 +43,7 @@ static const NSUInteger FBMaxRequestHeaderSize = 64 * 1024;
 // framing of every subsequent request on the connection.
 static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
 {
-  // 15 digits keeps the value far below NSUIntegerMax on every platform; any real body length
-  // that long is rejected by the body size limit anyway.
+  // Bounds the digit count so the accumulation below cannot overflow unsigned long long.
   if (value.length < 1 || value.length > 15) {
     return NO;
   }
@@ -55,6 +54,11 @@ static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
       return NO;
     }
     result = result * 10 + (c - '0');
+  }
+  // NSUInteger is 32-bit on watchOS (arm64_32), where the 15-digit bound above is not enough on
+  // its own: truncating here would resurrect exactly the framing desync this parser prevents.
+  if (result > (unsigned long long)NSUIntegerMax) {
+    return NO;
   }
   *outLength = (NSUInteger)result;
   return YES;
@@ -538,6 +542,14 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
   if (buffer.length < totalRequestLength) {
     // Wait for the rest of the body to arrive - the parsed header stays cached above, so this
     // doesn't re-scan/re-parse the header block on every subsequently arriving chunk.
+    @synchronized (self.connectionBuffers) {
+      // The request is now in its body phase, which is idle-bounded rather than hard-bounded.
+      // -client:didReceiveData: samples that phase before this parse runs, so the receive that
+      // completed a slowly-delivered header (and carried the first body bytes) would otherwise
+      // leave the connection on its header-phase timestamp and let the sweep close it despite
+      // the body having just made progress.
+      [self.incompleteRequestStarts setObject:[NSDate date] forKey:client];
+    }
     return;
   }
 
@@ -822,6 +834,7 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
 {
   @synchronized (self.connectionBuffers) {
     [self.connectionBuffers removeObjectForKey:client];
+    [self.pendingRequestHeaders removeObjectForKey:client];
     [self.connectionsAwaitingResponse removeObject:client];
     [self.incompleteRequestStarts removeObjectForKey:client];
   }

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -32,8 +32,8 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
 }
 
 // Caps a request's header block, so a connection that never completes one cannot grow its buffer
-// without limit. Far above anything a real request needs.
-static const NSUInteger FBMaxRequestHeaderSize = 64 * 1024;
+// without limit. Matches node's default --max-http-header-size.
+static const NSUInteger FBMaxRequestHeaderSize = 16 * 1024;
 
 // ASCII decimal digits only. -integerValue must not be used here: it maps garbage silently
 // ("bogus" -> 0, "12abc" -> 12), desyncing the framing of every later request on the connection.

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -456,8 +456,16 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
     for (NSUInteger i = 1; i < lines.count; i++) {
       NSString *line = lines[i];
       NSRange colonRange = [line rangeOfString:@":"];
-      if (NSNotFound == colonRange.location) {
+      if (0 == line.length) {
         continue;
+      }
+      if (NSNotFound == colonRange.location) {
+        // A non-empty header line without a colon is malformed. Skipping it would silently drop
+        // whatever it was meant to say - "Content-Length 5" would dispatch the request with an
+        // empty body and leave its bytes to be parsed as another request - which defeats the
+        // framing checks below.
+        [self respondBadRequestToClient:client];
+        return;
       }
       NSString *name = [line substringToIndex:colonRange.location];
       // RFC 7230 (3.2.4) requires rejecting whitespace between a field name and its colon with

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -31,16 +31,12 @@ static NSData * _Nonnull FBUTF8Data(NSString *string)
   return (NSData * _Nonnull)[string dataUsingEncoding:NSUTF8StringEncoding];
 }
 
-// Upper bound for a request's header block (the bytes before \r\n\r\n). A connection that keeps
-// sending bytes without ever completing its header block would otherwise grow its buffer without
-// limit. Real WDA requests carry a handful of short headers; 64 KiB is far above anything
-// legitimate.
+// Caps a request's header block, so a connection that never completes one cannot grow its buffer
+// without limit. Far above anything a real request needs.
 static const NSUInteger FBMaxRequestHeaderSize = 64 * 1024;
 
-// Strictly parses a Content-Length value: ASCII decimal digits only, bounded so the value below
-// cannot overflow. Returns NO for anything else - -integerValue must not be used here, since it
-// silently maps garbage ("bogus" -> 0, "12abc" -> 12) to a wrong body length, desyncing the
-// framing of every subsequent request on the connection.
+// ASCII decimal digits only. -integerValue must not be used here: it maps garbage silently
+// ("bogus" -> 0, "12abc" -> 12), desyncing the framing of every later request on the connection.
 static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
 {
   // Bounds the digit count so the accumulation below cannot overflow unsigned long long.
@@ -55,8 +51,7 @@ static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
     }
     result = result * 10 + (c - '0');
   }
-  // NSUInteger is 32-bit on watchOS (arm64_32), where the 15-digit bound above is not enough on
-  // its own: truncating here would resurrect exactly the framing desync this parser prevents.
+  // NSUInteger is 32-bit on watchOS (arm64_32), so the digit bound alone would still truncate.
   if (result > (unsigned long long)NSUIntegerMax) {
     return NO;
   }
@@ -135,19 +130,16 @@ static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
 // standalone or not (except DELETE /session itself - see -dispatchMethod:). See
 // -abandonPendingRequestsForSessionID:. Guarded by @synchronized(self.pendingSessionRequests).
 @property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableSet<FBPendingRequest *> *> *pendingSessionRequests;
-// When each connection started waiting for its current request to complete: set on connect and
-// whenever bytes of a new request begin arriving, cleared once a complete request is dispatched.
-// The reaper below closes connections whose entry outlives FBIncompleteRequestTimeout, so peers
-// that connect and never deliver a complete request cannot be retained forever. Idle keep-alive
-// connections (no entry) are exempt. Guarded by @synchronized(self.connectionBuffers).
+// When each connection started waiting for its current request. The reaper closes connections
+// whose entry outlives FBIncompleteRequestTimeout; idle keep-alive connections have no entry and
+// are exempt. Guarded by @synchronized(self.connectionBuffers).
 @property (nonatomic, strong) NSMapTable<id, NSDate *> *incompleteRequestStarts;
 @property (nonatomic, nullable) dispatch_source_t staleConnectionReaper;
 
 @end
 
-// How long a connection may take to deliver a complete request (first byte of the request line
-// through the end of the declared body) before it is closed. The previous CocoaHTTPServer stack
-// enforced 30-second header read timeouts; this restores an equivalent bound.
+// How long a connection may take to deliver a complete request, matching the header read timeout
+// the previous CocoaHTTPServer stack enforced.
 static const NSTimeInterval FBIncompleteRequestTimeout = 30.0;
 static const int64_t FBStaleConnectionSweepIntervalSec = 10;
 
@@ -295,8 +287,7 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
   NSMutableArray *staleConnections = [NSMutableArray array];
   @synchronized (self.connectionBuffers) {
     for (id connection in self.incompleteRequestStarts) {
-      // A connection whose request is already executing is waiting on the handler, not on the
-      // peer - it must not be reaped no matter how long the handler takes.
+      // Waiting on the handler, not the peer - never reap, however long the handler takes.
       if ([self.connectionsAwaitingResponse containsObject:connection]) {
         continue;
       }
@@ -336,8 +327,7 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
 {
   @synchronized (self.connectionBuffers) {
     [self.connectionBuffers setObject:[NSMutableData data] forKey:newClient];
-    // The clock towards FBIncompleteRequestTimeout starts at connect: a peer that connects and
-    // never sends a complete first request gets reaped just like one that stalls mid-request.
+    // Starts at connect, so a peer that connects and then sends nothing is reaped too.
     [self.incompleteRequestStarts setObject:[NSDate date] forKey:newClient];
   }
 }
@@ -370,31 +360,24 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
         return;
       }
       [buffer appendData:data];
-      // Hard upper bound for everything a connection may have buffered but not yet consumed:
-      // one maximal header block plus one maximal body, with headroom for a pipelined
-      // follow-up. The per-request checks in -processBufferForClient: don't run while a
-      // request is executing (see -connectionsAwaitingResponse), so without this cap a client
-      // could pump data unboundedly for exactly as long as its previous request takes.
+      // One maximal header block plus one maximal body, plus headroom for a pipelined follow-up.
+      // The per-request checks don't run while a request is executing, so without this cap a
+      // client could pump data unboundedly for as long as its previous request takes.
       uint64_t bufferCap = FBConfiguration.sharedInstance.httpRequestBodySizeLimit + 2 * (uint64_t)FBMaxRequestHeaderSize;
       if (bufferCap < FBConfiguration.sharedInstance.httpRequestBodySizeLimit) {
         bufferCap = UINT64_MAX;
       }
       isOverBufferCap = buffer.length > bufferCap;
-      // Body phase (a parsed header is pending): a valid declared body legitimately takes as
-      // long as the link is slow - e.g. a large base64 payload over a USB tunnel - so the
-      // timeout acts as an idle bound, refreshed on every byte of progress (total buffered size
-      // stays bounded by the already-validated Content-Length). During the header phase the
-      // clock is only started (first bytes of a new request on an idle keep-alive connection),
-      // never refreshed: a peer drip-feeding header bytes must not be able to keep an
-      // incomplete header block alive past the timeout.
+      // In the body phase the timeout is an idle bound, refreshed on progress: a declared body
+      // may legitimately be slow and its size is already capped by Content-Length. In the header
+      // phase the clock is only started, never refreshed, so drip-fed headers cannot outlive it.
       BOOL isBodyPhase = nil != [strongSelf.pendingRequestHeaders objectForKey:client];
       if (isBodyPhase || nil == [strongSelf.incompleteRequestStarts objectForKey:client]) {
         [strongSelf.incompleteRequestStarts setObject:[NSDate date] forKey:client];
       }
     }
     if (isOverBufferCap) {
-      // No response owed - a peer this far past any legitimate request size isn't reading
-      // responses anyway, and writing one would itself queue inside Network.framework.
+      // No response owed: a peer this far past any legitimate size is not reading anyway.
       [FBLogger log:@"Closing a connection that overflowed its request buffer"];
       [strongSelf closeClient:client];
       return;
@@ -426,8 +409,7 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
     NSRange headerEndRange = [buffer rangeOfData:FBCRLFCRLFData() options:(NSDataSearchOptions)0 range:NSMakeRange(0, buffer.length)];
     if (NSNotFound == headerEndRange.location) {
       if (buffer.length > FBMaxRequestHeaderSize) {
-        // The client has sent more than any legitimate header block could occupy without ever
-        // completing it - stop buffering and drop the connection instead of growing without bound.
+        // Past any legitimate header block and still unterminated - stop buffering.
         [self respondBadRequestToClient:client];
         return;
       }
@@ -435,9 +417,8 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
       return;
     }
     if (headerEndRange.location > FBMaxRequestHeaderSize) {
-      // The check above only fires while the terminator is still missing; a single large receive
-      // can deliver an oversized header block terminator included, so the completed block must be
-      // bounded too before it gets copied and parsed.
+      // The check above only fires while the terminator is missing; one large receive can deliver
+      // an oversized block with it, so bound the completed block too before parsing it.
       [self respondBadRequestToClient:client];
       return;
     }
@@ -464,18 +445,14 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
         continue;
       }
       if (NSNotFound == colonRange.location) {
-        // A non-empty header line without a colon is malformed. Skipping it would silently drop
-        // whatever it was meant to say - "Content-Length 5" would dispatch the request with an
-        // empty body and leave its bytes to be parsed as another request - which defeats the
-        // framing checks below.
+        // Malformed. Skipping it would drop what it meant to say: "Content-Length 5" would
+        // dispatch with an empty body, leaving its bytes to be parsed as another request.
         [self respondBadRequestToClient:client];
         return;
       }
       NSString *name = [line substringToIndex:colonRange.location];
-      // RFC 7230 (3.2.4) requires rejecting whitespace between a field name and its colon with
-      // a 400: storing "content-length " as a distinct key would silently drop the real header,
-      // dispatch the request with a zero-length body, and desync the connection's framing - a
-      // request-smuggling primitive when an intermediary normalizes the same header.
+      // RFC 7230 (3.2.4): whitespace before the colon MUST be rejected. Storing "content-length "
+      // as its own key would drop the real header and desync the framing.
       if (0 == name.length
           || NSNotFound != [name rangeOfCharacterFromSet:NSCharacterSet.whitespaceAndNewlineCharacterSet].location) {
         [self respondBadRequestToClient:client];
@@ -484,11 +461,8 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
       NSString *value = [[line substringFromIndex:colonRange.location + 1]
                           stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
       NSString *normalizedName = name.lowercaseString;
-      // RFC 7230 (3.3.3): a message with conflicting or repeated framing fields MUST be treated
-      // as unrecoverable. Last-wins assignment would let "Transfer-Encoding: chunked" followed
-      // by an empty "Transfer-Encoding:" slip past the presence check below, and would let the
-      // last of several Content-Length values drive parsing - both classic request-smuggling
-      // primitives whenever an intermediary resolves the duplicate differently than we would.
+      // RFC 7230 (3.3.3): repeated framing fields are unrecoverable. Last-wins would let an empty
+      // "Transfer-Encoding:" mask an earlier "chunked", and the last Content-Length drive parsing.
       if (([normalizedName isEqualToString:@"content-length"] || [normalizedName isEqualToString:@"transfer-encoding"])
           && nil != requestHeaders[normalizedName]) {
         [self respondBadRequestToClient:client];
@@ -499,9 +473,8 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
 
     NSString *transferEncoding = requestHeaders[@"transfer-encoding"];
     if (nil != transferEncoding) {
-      // No transfer decoder is implemented at all, so the header's mere presence is rejected -
-      // including an empty value, which is not a valid encoding list and would otherwise let
-      // the body be misread as empty, desyncing the rest of the connection's request stream.
+      // No transfer decoder exists, so mere presence is rejected - including an empty value,
+      // which is not a valid encoding list and would let the body be misread as empty.
       RouteResponse *notImplemented = [RouteResponse new];
       id<FBResponsePayload> notImplementedPayload = FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"Transfer-Encoding is not supported"
                                                                                                                   traceback:nil]);
@@ -513,8 +486,7 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
     NSString *contentLengthValue = requestHeaders[@"content-length"];
     NSUInteger contentLength = 0;
     if (nil != contentLengthValue && !FBParseContentLength(contentLengthValue, &contentLength)) {
-      // With an unparseable Content-Length the body's extent is unknowable, so the connection
-      // cannot be resynced - reject and close.
+      // The body's extent is unknowable, so the connection cannot be resynced - reject and close.
       [self respondBadRequestToClient:client];
       return;
     }
@@ -800,12 +772,9 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
       [weakSelf closeClient:client];
     }];
   } else {
-    // The next pipelined request is only unblocked from the send's completion: response
-    // ordering is preserved either way (nw_connection_send is FIFO per connection), but
-    // unblocking early would let a client that pipelines requests without ever reading
-    // responses accumulate an unbounded number of fully-rendered response buffers inside
-    // Network.framework. If the connection dies mid-send the completion still fires and
-    // -processBufferForClient: simply finds no buffer left.
+    // Unblocked from the send's completion, not before it: ordering is preserved either way
+    // (nw_connection_send is FIFO per connection), but unblocking early lets a client that
+    // pipelines without reading responses pile up rendered responses inside Network.framework.
     __weak typeof(self) weakSelf = self;
     [self.socket writeData:payload toClient:client completion:^(BOOL didSucceed) {
       __strong typeof(weakSelf) strongSelf = weakSelf;
@@ -813,18 +782,16 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
         return;
       }
       if (!didSucceed) {
-        // The response never reached the peer, so the connection is already unusable. Running
-        // its next pipelined request - possibly a mutating one - would change device state for
-        // a client that can no longer be answered; drop the connection and its buffer instead.
+        // The response never reached the peer, so running its next pipelined request - possibly
+        // a mutating one - would change device state for a client that can no longer be answered.
         [FBLogger log:@"Failed to write a response; dropping the connection and its pending requests"];
         [strongSelf closeClient:client];
         return;
       }
-      // Lifting the reaper exemption and resuming parsing must happen in one step *on*
-      // bufferProcessingQueue - the same serial queue the reaper runs on. Removing the client
-      // from connectionsAwaitingResponse out here would expose it to a sweep already queued
-      // ahead of the parse, which would judge an already fully-buffered pipelined request by
-      // the timestamp of the previous (possibly very slow) request and close the connection.
+      // Lifting the exemption and resuming parsing happen in one step on bufferProcessingQueue,
+      // the queue the reaper also runs on: doing it out here exposes the connection to a sweep
+      // queued ahead of the parse, which would judge a buffered request by the previous one's
+      // timestamp.
       dispatch_async(strongSelf.bufferProcessingQueue, ^{
         __strong typeof(weakSelf) queuedSelf = weakSelf;
         if (nil == queuedSelf) {
@@ -832,9 +799,8 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
         }
         @synchronized (queuedSelf.connectionBuffers) {
           [queuedSelf.connectionsAwaitingResponse removeObject:client];
-          // Mid-request connections (pipelined bytes already buffered) get their window measured
-          // from the moment parsing could actually resume, not from the previous request. Absent
-          // entries are left absent: an idle keep-alive connection stays exempt.
+          // Mid-request connections get their window from when parsing could resume, not from the
+          // previous request. Absent entries stay absent, so idle keep-alives remain exempt.
           if (nil != [queuedSelf.incompleteRequestStarts objectForKey:client]) {
             [queuedSelf.incompleteRequestStarts setObject:[NSDate date] forKey:client];
           }

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -471,15 +471,25 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
       }
       NSString *value = [[line substringFromIndex:colonRange.location + 1]
                           stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
-      requestHeaders[name.lowercaseString] = value;
+      NSString *normalizedName = name.lowercaseString;
+      // RFC 7230 (3.3.3): a message with conflicting or repeated framing fields MUST be treated
+      // as unrecoverable. Last-wins assignment would let "Transfer-Encoding: chunked" followed
+      // by an empty "Transfer-Encoding:" slip past the presence check below, and would let the
+      // last of several Content-Length values drive parsing - both classic request-smuggling
+      // primitives whenever an intermediary resolves the duplicate differently than we would.
+      if (([normalizedName isEqualToString:@"content-length"] || [normalizedName isEqualToString:@"transfer-encoding"])
+          && nil != requestHeaders[normalizedName]) {
+        [self respondBadRequestToClient:client];
+        return;
+      }
+      requestHeaders[normalizedName] = value;
     }
 
     NSString *transferEncoding = requestHeaders[@"transfer-encoding"];
-    if (transferEncoding.length > 0) {
-      // No transfer decoder is implemented at all, so any encoding (chunked or otherwise -
-      // including a value only introduced by a duplicate header overwriting "chunked" above)
-      // is rejected rather than risking the body being misread as empty and desyncing the rest
-      // of the connection's request stream.
+    if (nil != transferEncoding) {
+      // No transfer decoder is implemented at all, so the header's mere presence is rejected -
+      // including an empty value, which is not a valid encoding list and would otherwise let
+      // the body be misread as empty, desyncing the rest of the connection's request stream.
       RouteResponse *notImplemented = [RouteResponse new];
       id<FBResponsePayload> notImplementedPayload = FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"Transfer-Encoding is not supported"
                                                                                                                   traceback:nil]);
@@ -766,7 +776,7 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
 
   if (shouldClose) {
     __weak typeof(self) weakSelf = self;
-    [self.socket writeData:payload toClient:client completion:^{
+    [self.socket writeData:payload toClient:client completion:^(BOOL didSucceed) {
       [weakSelf closeClient:client];
     }];
   } else {
@@ -777,9 +787,17 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
     // Network.framework. If the connection dies mid-send the completion still fires and
     // -processBufferForClient: simply finds no buffer left.
     __weak typeof(self) weakSelf = self;
-    [self.socket writeData:payload toClient:client completion:^{
+    [self.socket writeData:payload toClient:client completion:^(BOOL didSucceed) {
       __strong typeof(weakSelf) strongSelf = weakSelf;
       if (nil == strongSelf) {
+        return;
+      }
+      if (!didSucceed) {
+        // The response never reached the peer, so the connection is already unusable. Running
+        // its next pipelined request - possibly a mutating one - would change device state for
+        // a client that can no longer be answered; drop the connection and its buffer instead.
+        [FBLogger log:@"Failed to write a response; dropping the connection and its pending requests"];
+        [strongSelf closeClient:client];
         return;
       }
       @synchronized (strongSelf.connectionBuffers) {

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -39,23 +39,24 @@ static const NSUInteger FBMaxRequestHeaderSize = 16 * 1024;
 // ("bogus" -> 0, "12abc" -> 12), desyncing the framing of every later request on the connection.
 static BOOL FBParseContentLength(NSString *value, NSUInteger *outLength)
 {
-  // Bounds the digit count so the accumulation below cannot overflow unsigned long long.
-  if (value.length < 1 || value.length > 15) {
+  if (value.length < 1) {
     return NO;
   }
-  unsigned long long result = 0;
+  NSUInteger result = 0;
   for (NSUInteger i = 0; i < value.length; i++) {
     unichar c = [value characterAtIndex:i];
     if (c < '0' || c > '9') {
       return NO;
     }
-    result = result * 10 + (c - '0');
+    NSUInteger digit = (NSUInteger)(c - '0');
+    // NSUInteger is 32-bit on watchOS (arm64_32), so this bounds truncation as well as overflow.
+    // Anything smaller is left to the caller's httpRequestBodySizeLimit check.
+    if (result > (NSUIntegerMax - digit) / 10) {
+      return NO;
+    }
+    result = result * 10 + digit;
   }
-  // NSUInteger is 32-bit on watchOS (arm64_32), so the digit bound alone would still truncate.
-  if (result > (unsigned long long)NSUIntegerMax) {
-    return NO;
-  }
-  *outLength = (NSUInteger)result;
+  *outLength = result;
   return YES;
 }
 

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -407,113 +407,174 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
   }
 
   if (nil == pending) {
-    NSRange headerEndRange = [buffer rangeOfData:FBCRLFCRLFData() options:(NSDataSearchOptions)0 range:NSMakeRange(0, buffer.length)];
-    if (NSNotFound == headerEndRange.location) {
-      if (buffer.length > FBMaxRequestHeaderSize) {
-        // Past any legitimate header block and still unterminated - stop buffering.
-        [self respondBadRequestToClient:client];
-        return;
-      }
-      // Wait for the rest of the header block to arrive.
+    pending = [self parsedRequestHeaderFromBuffer:buffer forClient:client];
+    if (nil == pending) {
+      // Either the header block is still incomplete, or it was rejected and answered already.
       return;
     }
-    if (headerEndRange.location > FBMaxRequestHeaderSize) {
-      // The check above only fires while the terminator is missing; one large receive can deliver
-      // an oversized block with it, so bound the completed block too before parsing it.
-      [self respondBadRequestToClient:client];
-      return;
-    }
-
-    NSData *headerData = [buffer subdataWithRange:NSMakeRange(0, headerEndRange.location)];
-    NSString *headerString = [[NSString alloc] initWithData:headerData encoding:NSUTF8StringEncoding];
-    NSArray<NSString *> *lines = [headerString componentsSeparatedByString:@"\r\n"];
-    if (lines.count < 1) {
-      [self respondBadRequestToClient:client];
-      return;
-    }
-
-    NSArray<NSString *> *requestLineParts = [lines.firstObject componentsSeparatedByString:@" "];
-    if (requestLineParts.count < 2) {
-      [self respondBadRequestToClient:client];
-      return;
-    }
-
-    NSMutableDictionary<NSString *, NSString *> *requestHeaders = [NSMutableDictionary dictionary];
-    for (NSUInteger i = 1; i < lines.count; i++) {
-      NSString *line = lines[i];
-      NSRange colonRange = [line rangeOfString:@":"];
-      if (0 == line.length) {
-        continue;
-      }
-      if (NSNotFound == colonRange.location) {
-        // Malformed. Skipping it would drop what it meant to say: "Content-Length 5" would
-        // dispatch with an empty body, leaving its bytes to be parsed as another request.
-        [self respondBadRequestToClient:client];
-        return;
-      }
-      NSString *name = [line substringToIndex:colonRange.location];
-      // RFC 7230 (3.2.4): whitespace before the colon MUST be rejected. Storing "content-length "
-      // as its own key would drop the real header and desync the framing.
-      if (0 == name.length
-          || NSNotFound != [name rangeOfCharacterFromSet:NSCharacterSet.whitespaceAndNewlineCharacterSet].location) {
-        [self respondBadRequestToClient:client];
-        return;
-      }
-      NSString *value = [[line substringFromIndex:colonRange.location + 1]
-                          stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
-      NSString *normalizedName = name.lowercaseString;
-      // RFC 7230 (3.3.3): repeated framing fields are unrecoverable. Last-wins would let an empty
-      // "Transfer-Encoding:" mask an earlier "chunked", and the last Content-Length drive parsing.
-      if (([normalizedName isEqualToString:@"content-length"] || [normalizedName isEqualToString:@"transfer-encoding"])
-          && nil != requestHeaders[normalizedName]) {
-        [self respondBadRequestToClient:client];
-        return;
-      }
-      requestHeaders[normalizedName] = value;
-    }
-
-    NSString *transferEncoding = requestHeaders[@"transfer-encoding"];
-    if (nil != transferEncoding) {
-      // No transfer decoder exists, so mere presence is rejected - including an empty value,
-      // which is not a valid encoding list and would let the body be misread as empty.
-      RouteResponse *notImplemented = [RouteResponse new];
-      id<FBResponsePayload> notImplementedPayload = FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"Transfer-Encoding is not supported"
-                                                                                                                  traceback:nil]);
-      [notImplementedPayload dispatchWithResponse:notImplemented];
-      [self failClient:client withResponse:notImplemented];
-      return;
-    }
-
-    NSString *contentLengthValue = requestHeaders[@"content-length"];
-    NSUInteger contentLength = 0;
-    if (nil != contentLengthValue && !FBParseContentLength(contentLengthValue, &contentLength)) {
-      // The body's extent is unknowable, so the connection cannot be resynced - reject and close.
-      [self respondBadRequestToClient:client];
-      return;
-    }
-    if (contentLength > FBConfiguration.sharedInstance.httpRequestBodySizeLimit) {
-      // Closes the connection after responding, since the rest of the oversized body is still incoming.
-      RouteResponse *tooLarge = [RouteResponse new];
-      id<FBResponsePayload> tooLargePayload = FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"The request body exceeds the configured size limit"
-                                                                                                            traceback:nil]);
-      [tooLargePayload dispatchWithResponse:tooLarge];
-      [self failClient:client withResponse:tooLarge];
-      return;
-    }
-
-    pending = [FBPendingHTTPRequestHeader new];
-    pending.method = requestLineParts[0].uppercaseString;
-    pending.pathAndQuery = requestLineParts[1];
-    pending.bodyStart = headerEndRange.location + headerEndRange.length;
-    pending.contentLength = contentLength;
     @synchronized (self.connectionBuffers) {
       [self.pendingRequestHeaders setObject:pending forKey:client];
     }
   }
 
+  [self dispatchBufferedRequestWithHeader:pending fromBuffer:buffer forClient:client];
+}
+
+// Locates the CRLFCRLF that ends the buffered header block and bounds the block's size. Returns
+// NO when nothing can be parsed yet - either because more bytes are needed or because the block
+// was rejected, in which case the 400 has already been written.
+- (BOOL)findHeaderBlockEnd:(out NSRange *)outHeaderEndRange
+                  inBuffer:(NSMutableData *)buffer
+                 forClient:(nw_connection_t)client
+{
+  NSRange headerEndRange = [buffer rangeOfData:FBCRLFCRLFData() options:(NSDataSearchOptions)0 range:NSMakeRange(0, buffer.length)];
+  if (NSNotFound == headerEndRange.location) {
+    if (buffer.length > FBMaxRequestHeaderSize) {
+      // Past any legitimate header block and still unterminated - stop buffering.
+      [self respondBadRequestToClient:client];
+    }
+    // Otherwise wait for the rest of the header block to arrive.
+    return NO;
+  }
+  if (headerEndRange.location > FBMaxRequestHeaderSize) {
+    // The check above only fires while the terminator is missing; one large receive can deliver
+    // an oversized block with it, so bound the completed block too before parsing it.
+    [self respondBadRequestToClient:client];
+    return NO;
+  }
+  *outHeaderEndRange = headerEndRange;
+  return YES;
+}
+
+// Turns the header lines that follow the request line into a lowercase-keyed dictionary.
+// Returns nil for the malformed and ambiguous shapes, having written the 400 already.
+- (nullable NSDictionary<NSString *, NSString *> *)parsedHeaderFieldsFromLines:(NSArray<NSString *> *)lines
+                                                                    forClient:(nw_connection_t)client
+{
+  NSMutableDictionary<NSString *, NSString *> *requestHeaders = [NSMutableDictionary dictionary];
+  for (NSUInteger i = 1; i < lines.count; i++) {
+    NSString *line = lines[i];
+    NSRange colonRange = [line rangeOfString:@":"];
+    if (0 == line.length) {
+      continue;
+    }
+    if (NSNotFound == colonRange.location) {
+      // Malformed. Skipping it would drop what it meant to say: "Content-Length 5" would
+      // dispatch with an empty body, leaving its bytes to be parsed as another request.
+      [self respondBadRequestToClient:client];
+      return nil;
+    }
+    NSString *name = [line substringToIndex:colonRange.location];
+    // RFC 7230 (3.2.4): whitespace before the colon MUST be rejected. Storing "content-length "
+    // as its own key would drop the real header and desync the framing.
+    if (0 == name.length
+        || NSNotFound != [name rangeOfCharacterFromSet:NSCharacterSet.whitespaceAndNewlineCharacterSet].location) {
+      [self respondBadRequestToClient:client];
+      return nil;
+    }
+    NSString *value = [[line substringFromIndex:colonRange.location + 1]
+                        stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+    NSString *normalizedName = name.lowercaseString;
+    // RFC 7230 (3.3.3): repeated framing fields are unrecoverable. Last-wins would let an empty
+    // "Transfer-Encoding:" mask an earlier "chunked", and the last Content-Length drive parsing.
+    if (([normalizedName isEqualToString:@"content-length"] || [normalizedName isEqualToString:@"transfer-encoding"])
+        && nil != requestHeaders[normalizedName]) {
+      [self respondBadRequestToClient:client];
+      return nil;
+    }
+    requestHeaders[normalizedName] = value;
+  }
+  return requestHeaders;
+}
+
+// Rejects framing this server cannot honour and resolves the declared body length from the
+// remaining framing headers. Returns NO having written the closing error response already.
+- (BOOL)resolveBodyLength:(out NSUInteger *)outBodyLength
+         fromHeaderFields:(NSDictionary<NSString *, NSString *> *)requestHeaders
+                forClient:(nw_connection_t)client
+{
+  NSString *transferEncoding = requestHeaders[@"transfer-encoding"];
+  if (nil != transferEncoding) {
+    // No transfer decoder exists, so mere presence is rejected - including an empty value,
+    // which is not a valid encoding list and would let the body be misread as empty.
+    RouteResponse *notImplemented = [RouteResponse new];
+    id<FBResponsePayload> notImplementedPayload = FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"Transfer-Encoding is not supported"
+                                                                                                                traceback:nil]);
+    [notImplementedPayload dispatchWithResponse:notImplemented];
+    [self failClient:client withResponse:notImplemented];
+    return NO;
+  }
+
+  NSString *contentLengthValue = requestHeaders[@"content-length"];
+  NSUInteger contentLength = 0;
+  if (nil != contentLengthValue && !FBParseContentLength(contentLengthValue, &contentLength)) {
+    // The body's extent is unknowable, so the connection cannot be resynced - reject and close.
+    [self respondBadRequestToClient:client];
+    return NO;
+  }
+  if (contentLength > FBConfiguration.sharedInstance.httpRequestBodySizeLimit) {
+    // Closes the connection after responding, since the rest of the oversized body is still incoming.
+    RouteResponse *tooLarge = [RouteResponse new];
+    id<FBResponsePayload> tooLargePayload = FBResponseWithStatus([FBCommandStatus invalidArgumentErrorWithMessage:@"The request body exceeds the configured size limit"
+                                                                                                          traceback:nil]);
+    [tooLargePayload dispatchWithResponse:tooLarge];
+    [self failClient:client withResponse:tooLarge];
+    return NO;
+  }
+  *outBodyLength = contentLength;
+  return YES;
+}
+
+// Parses the request line and headers of the request at the head of the buffer. Returns nil
+// while the header block is still incomplete, and for a rejected one, which is answered here.
+- (nullable FBPendingHTTPRequestHeader *)parsedRequestHeaderFromBuffer:(NSMutableData *)buffer
+                                                             forClient:(nw_connection_t)client
+{
+  NSRange headerEndRange;
+  if (![self findHeaderBlockEnd:&headerEndRange inBuffer:buffer forClient:client]) {
+    return nil;
+  }
+
+  NSData *headerData = [buffer subdataWithRange:NSMakeRange(0, headerEndRange.location)];
+  NSString *headerString = [[NSString alloc] initWithData:headerData encoding:NSUTF8StringEncoding];
+  NSArray<NSString *> *lines = [headerString componentsSeparatedByString:@"\r\n"];
+  if (lines.count < 1) {
+    [self respondBadRequestToClient:client];
+    return nil;
+  }
+
+  NSArray<NSString *> *requestLineParts = [lines.firstObject componentsSeparatedByString:@" "];
+  if (requestLineParts.count < 2) {
+    [self respondBadRequestToClient:client];
+    return nil;
+  }
+
+  NSDictionary<NSString *, NSString *> *requestHeaders = [self parsedHeaderFieldsFromLines:lines forClient:client];
+  if (nil == requestHeaders) {
+    return nil;
+  }
+  NSUInteger contentLength = 0;
+  if (![self resolveBodyLength:&contentLength fromHeaderFields:requestHeaders forClient:client]) {
+    return nil;
+  }
+
+  FBPendingHTTPRequestHeader *pending = [FBPendingHTTPRequestHeader new];
+  pending.method = requestLineParts[0].uppercaseString;
+  pending.pathAndQuery = requestLineParts[1];
+  pending.bodyStart = headerEndRange.location + headerEndRange.length;
+  pending.contentLength = contentLength;
+  return pending;
+}
+
+// Consumes the already-parsed request from the head of the buffer and dispatches it, once its
+// whole body has arrived. Returns with the cached header left in place while it hasn't.
+- (void)dispatchBufferedRequestWithHeader:(FBPendingHTTPRequestHeader *)pending
+                               fromBuffer:(NSMutableData *)buffer
+                                forClient:(nw_connection_t)client
+{
   NSUInteger totalRequestLength = pending.bodyStart + pending.contentLength;
   if (buffer.length < totalRequestLength) {
-    // Wait for the rest of the body to arrive - the parsed header stays cached above, so this
+    // Wait for the rest of the body to arrive - the parsed header stays cached, so this
     // doesn't re-scan/re-parse the header block on every subsequently arriving chunk.
     @synchronized (self.connectionBuffers) {
       // The request is now in its body phase, which is idle-bounded rather than hard-bounded.

--- a/WebDriverAgentLib/Routing/FBHTTPServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPServer.m
@@ -820,11 +820,26 @@ static const int64_t FBStaleConnectionSweepIntervalSec = 10;
         [strongSelf closeClient:client];
         return;
       }
-      @synchronized (strongSelf.connectionBuffers) {
-        [strongSelf.connectionsAwaitingResponse removeObject:client];
-      }
+      // Lifting the reaper exemption and resuming parsing must happen in one step *on*
+      // bufferProcessingQueue - the same serial queue the reaper runs on. Removing the client
+      // from connectionsAwaitingResponse out here would expose it to a sweep already queued
+      // ahead of the parse, which would judge an already fully-buffered pipelined request by
+      // the timestamp of the previous (possibly very slow) request and close the connection.
       dispatch_async(strongSelf.bufferProcessingQueue, ^{
-        [weakSelf processBufferForClient:client];
+        __strong typeof(weakSelf) queuedSelf = weakSelf;
+        if (nil == queuedSelf) {
+          return;
+        }
+        @synchronized (queuedSelf.connectionBuffers) {
+          [queuedSelf.connectionsAwaitingResponse removeObject:client];
+          // Mid-request connections (pipelined bytes already buffered) get their window measured
+          // from the moment parsing could actually resume, not from the previous request. Absent
+          // entries are left absent: an idle keep-alive connection stays exempt.
+          if (nil != [queuedSelf.incompleteRequestStarts objectForKey:client]) {
+            [queuedSelf.incompleteRequestStarts setObject:[NSDate date] forKey:client];
+          }
+        }
+        [queuedSelf processBufferForClient:client];
       });
     }];
   }

--- a/WebDriverAgentLib/Routing/FBTCPSocket.h
+++ b/WebDriverAgentLib/Routing/FBTCPSocket.h
@@ -102,9 +102,11 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param data The data to send
  @param client The destination client
- @param completion Called once the send attempt finishes
+ @param completion Called once the send attempt finishes. `didSucceed` is NO if the send failed
+        (e.g. the peer went away mid-write), in which case nothing was delivered and the caller
+        must not treat the connection as usable.
  */
-- (void)writeData:(NSData *)data toClient:(nw_connection_t)client completion:(nullable void (^)(void))completion;
+- (void)writeData:(NSData *)data toClient:(nw_connection_t)client completion:(nullable void (^)(BOOL didSucceed))completion;
 
 @end
 

--- a/WebDriverAgentLib/Routing/FBTCPSocket.m
+++ b/WebDriverAgentLib/Routing/FBTCPSocket.m
@@ -195,12 +195,15 @@
   [self writeData:data toClient:client completion:nil];
 }
 
-- (void)writeData:(NSData *)data toClient:(nw_connection_t)client completion:(nullable void (^)(void))completion
+- (void)writeData:(NSData *)data toClient:(nw_connection_t)client completion:(nullable void (^)(BOOL didSucceed))completion
 {
   dispatch_data_t dispatchData = dispatch_data_create(data.bytes, data.length, self.socketQueue, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
   nw_connection_send(client, dispatchData, NW_CONNECTION_DEFAULT_STREAM_CONTEXT, false, ^(nw_error_t  _Nullable sendError) {
     if (completion) {
-      completion();
+      // The send error must reach the caller: a failed write means the response never reached
+      // the peer, and treating that as success would e.g. let the next pipelined request run
+      // against a connection that can no longer answer it.
+      completion(nil == sendError);
     }
   });
 }

--- a/WebDriverAgentTests/UnitTests/FBHTTPServerTests.m
+++ b/WebDriverAgentTests/UnitTests/FBHTTPServerTests.m
@@ -11,6 +11,7 @@
 #import <arpa/inet.h>
 #import <stdatomic.h>
 #import <sys/socket.h>
+#import <unistd.h>
 
 #import "FBHTTPServer.h"
 
@@ -69,23 +70,43 @@ static atomic_int gFramingProbeHits;
     close(fd);
     return nil;
   }
-  // Ignore send errors: the flood test expects the server to close mid-send.
-  send(fd, payload.bytes, payload.length, 0);
+  // send(2) may write only part of the payload, which would truncate the multi-KiB flood
+  // payloads into something the server answers differently. Errors stay ignored on purpose:
+  // those same tests expect the server to close the connection mid-send.
+  const uint8_t *bytes = payload.bytes;
+  size_t remaining = payload.length;
+  while (remaining > 0) {
+    ssize_t sent = send(fd, bytes, remaining, 0);
+    if (sent <= 0) {
+      break;
+    }
+    bytes += sent;
+    remaining -= (size_t)sent;
+  }
   NSMutableData *received = [NSMutableData data];
   char chunk[4096];
   NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:timeout];
   while (deadline.timeIntervalSinceNow > 0) {
     ssize_t n = recv(fd, chunk, sizeof(chunk), 0);
-    if (n > 0) {
-      [received appendBytes:chunk length:(NSUInteger)n];
-      // The response has started arriving; the server keeps the connection open after a
-      // success, so don't wait the full timeout for an EOF that never comes.
-      struct timeval drainTv = { .tv_sec = 0, .tv_usec = 200000 };
-      setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &drainTv, sizeof(drainTv));
-    } else {
-      *didClose = (n == 0);
+    if (n == 0) {
+      *didClose = YES;
       break;
     }
+    if (n < 0) {
+      // A read timeout. Only stop waiting once the response is a keep-alive success, where no
+      // EOF is ever coming; every other response precedes a close, and giving up here would
+      // report didClose = NO for a connection the server is about to drop.
+      NSString *soFar = [[NSString alloc] initWithData:received encoding:NSUTF8StringEncoding] ?: @"";
+      if ([soFar containsString:@"HTTP/1.1 200"]) {
+        break;
+      }
+      continue;
+    }
+    [received appendBytes:chunk length:(NSUInteger)n];
+    // The response has started arriving; poll in short slices from here so a keep-alive success
+    // doesn't sit out the whole timeout waiting for an EOF that never comes.
+    struct timeval drainTv = { .tv_sec = 0, .tv_usec = 200000 };
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &drainTv, sizeof(drainTv));
   }
   close(fd);
   return [[NSString alloc] initWithData:received encoding:NSUTF8StringEncoding] ?: @"";
@@ -215,6 +236,7 @@ static atomic_int gFramingProbeHits;
                                             timeout:10.0
                                            didClose:&didClose];
   XCTAssertTrue([response containsString:@"400"], @"%@", response);
+  XCTAssertTrue(didClose, @"the connection must be closed rather than left buffering");
 }
 
 - (void)testOversizedCompletedHeaderBlockIsRejected
@@ -236,6 +258,7 @@ static atomic_int gFramingProbeHits;
                                            didClose:&didClose];
   XCTAssertTrue([response containsString:@"400"], @"%@", response);
   XCTAssertFalse([response containsString:@"pong"], @"the oversized request must not be served: %@", response);
+  XCTAssertTrue(didClose, @"the connection must be closed rather than left buffering");
 }
 
 @end

--- a/WebDriverAgentTests/UnitTests/FBHTTPServerTests.m
+++ b/WebDriverAgentTests/UnitTests/FBHTTPServerTests.m
@@ -131,6 +131,20 @@ static atomic_int gFramingProbeHits;
   XCTAssertEqual(atomic_load(&gFramingProbeHits), 0);
 }
 
+- (void)testHeaderLineWithoutColonIsRejected
+{
+  // Silently skipping the malformed line made this dispatch with an empty body while "hello"
+  // stayed in the buffer to be parsed as the next request.
+  NSString *payload = @"POST /framing/probe HTTP/1.1\r\nContent-Length 5\r\n\r\nhello";
+  BOOL didClose;
+  NSString *response = [self responseForRawPayload:(NSData * _Nonnull)[payload dataUsingEncoding:NSUTF8StringEncoding]
+                                            timeout:5.0
+                                           didClose:&didClose];
+  XCTAssertTrue([response containsString:@"400"], @"%@", response);
+  XCTAssertTrue(didClose);
+  XCTAssertEqual(atomic_load(&gFramingProbeHits), 0);
+}
+
 - (void)testDuplicateContentLengthIsRejected
 {
   // RFC 7230 (3.3.3): repeated framing fields are unrecoverable. Last-wins assignment would let

--- a/WebDriverAgentTests/UnitTests/FBHTTPServerTests.m
+++ b/WebDriverAgentTests/UnitTests/FBHTTPServerTests.m
@@ -116,6 +116,35 @@ static atomic_int gFramingProbeHits;
   XCTAssertEqual(atomic_load(&gFramingProbeHits), 0, @"the route must not be dispatched with unknown body extent");
 }
 
+- (void)testWhitespaceBeforeHeaderColonIsRejected
+{
+  // RFC 7230 (3.2.4): whitespace between a field name and its colon MUST be rejected with a 400.
+  // Tolerating it stores "content-length " as a distinct key, dispatches the request with a
+  // zero-length body, and re-parses the declared body as a smuggled pipelined request.
+  NSString *payload = @"POST /framing/probe HTTP/1.1\r\nContent-Length : 5\r\n\r\nhello";
+  BOOL didClose;
+  NSString *response = [self responseForRawPayload:(NSData * _Nonnull)[payload dataUsingEncoding:NSUTF8StringEncoding]
+                                            timeout:5.0
+                                           didClose:&didClose];
+  XCTAssertTrue([response containsString:@"400"], @"%@", response);
+  XCTAssertTrue(didClose);
+  XCTAssertEqual(atomic_load(&gFramingProbeHits), 0);
+}
+
+- (void)testPipelinedRequestsAreServedInOrder
+{
+  // Two requests in one payload: both must be answered on the same connection. Guards the
+  // response backpressure logic - the next pipelined request is only processed once the
+  // previous response's send completed, which must not stall or reorder the pipeline.
+  NSString *payload = @"GET /framing/ping HTTP/1.1\r\n\r\nGET /framing/ping HTTP/1.1\r\n\r\n";
+  BOOL didClose;
+  NSString *response = [self responseForRawPayload:(NSData * _Nonnull)[payload dataUsingEncoding:NSUTF8StringEncoding]
+                                            timeout:5.0
+                                           didClose:&didClose];
+  NSUInteger pongCount = [response componentsSeparatedByString:@"pong"].count - 1;
+  XCTAssertEqual(pongCount, 2, @"both pipelined requests must be answered: %@", response);
+}
+
 - (void)testPartiallyNumericContentLengthIsRejected
 {
   NSString *payload = @"POST /framing/probe HTTP/1.1\r\nContent-Length: 5abc\r\n\r\nhello";

--- a/WebDriverAgentTests/UnitTests/FBHTTPServerTests.m
+++ b/WebDriverAgentTests/UnitTests/FBHTTPServerTests.m
@@ -131,6 +131,35 @@ static atomic_int gFramingProbeHits;
   XCTAssertEqual(atomic_load(&gFramingProbeHits), 0);
 }
 
+- (void)testDuplicateContentLengthIsRejected
+{
+  // RFC 7230 (3.3.3): repeated framing fields are unrecoverable. Last-wins assignment would let
+  // the second value drive parsing while an intermediary used the first - a smuggling primitive.
+  NSString *payload = @"POST /framing/probe HTTP/1.1\r\nContent-Length: 5\r\nContent-Length: 0\r\n\r\nhello";
+  BOOL didClose;
+  NSString *response = [self responseForRawPayload:(NSData * _Nonnull)[payload dataUsingEncoding:NSUTF8StringEncoding]
+                                            timeout:5.0
+                                           didClose:&didClose];
+  XCTAssertTrue([response containsString:@"400"], @"%@", response);
+  XCTAssertTrue(didClose);
+  XCTAssertEqual(atomic_load(&gFramingProbeHits), 0);
+}
+
+- (void)testEmptyTransferEncodingIsRejected
+{
+  // "chunked" followed by an empty value: with last-wins assignment plus a non-empty presence
+  // check, the empty value used to make the header look absent, so the chunked body was parsed
+  // as a zero-length body and its bytes re-read as smuggled requests.
+  NSString *payload = @"POST /framing/probe HTTP/1.1\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: \r\n\r\n0\r\n\r\n";
+  BOOL didClose;
+  NSString *response = [self responseForRawPayload:(NSData * _Nonnull)[payload dataUsingEncoding:NSUTF8StringEncoding]
+                                            timeout:5.0
+                                           didClose:&didClose];
+  XCTAssertTrue([response containsString:@"400"] || [response containsString:@"501"], @"%@", response);
+  XCTAssertTrue(didClose);
+  XCTAssertEqual(atomic_load(&gFramingProbeHits), 0);
+}
+
 - (void)testPipelinedRequestsAreServedInOrder
 {
   // Two requests in one payload: both must be answered on the same connection. Guards the

--- a/WebDriverAgentTests/UnitTests/FBHTTPServerTests.m
+++ b/WebDriverAgentTests/UnitTests/FBHTTPServerTests.m
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <arpa/inet.h>
+#import <stdatomic.h>
+#import <sys/socket.h>
+
+#import "FBHTTPServer.h"
+
+static atomic_int gFramingProbeHits;
+
+// Exercises FBHTTPServer's HTTP framing defenses with raw socket data that URL-loading APIs
+// cannot produce: malformed Content-Length values and header blocks that never terminate.
+@interface FBHTTPServerTests : XCTestCase
+@property (nonatomic, strong) FBHTTPServer *server;
+@property (nonatomic, assign) uint16_t port;
+@end
+
+@implementation FBHTTPServerTests
+
+- (void)setUp
+{
+  [super setUp];
+  atomic_store(&gFramingProbeHits, 0);
+  self.server = [FBHTTPServer new];
+  [self.server handleMethod:@"POST" withPath:@"/framing/probe" block:^(RouteRequest *request, RouteResponse *response) {
+    atomic_fetch_add(&gFramingProbeHits, 1);
+    [response respondWithString:@"probe-ok"];
+  }];
+  [self.server get:@"/framing/ping" withBlock:^(RouteRequest *request, RouteResponse *response) {
+    [response respondWithString:@"pong"];
+  }];
+  self.server.port = 0;
+  NSError *error;
+  XCTAssertTrue([self.server start:&error], @"%@", error);
+  self.port = [[self.server valueForKeyPath:@"socket.port"] unsignedShortValue];
+}
+
+- (void)tearDown
+{
+  [self.server stop:NO];
+  self.server = nil;
+  [super tearDown];
+}
+
+// Sends `payload` as-is and reads until the server closes the connection or `timeout` elapses.
+// Returns everything received (nil on connect failure); *didClose reports whether EOF was seen.
+- (NSString *)responseForRawPayload:(NSData *)payload timeout:(NSTimeInterval)timeout didClose:(BOOL *)didClose
+{
+  *didClose = NO;
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) {
+    return nil;
+  }
+  int noSigpipe = 1;
+  setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigpipe, sizeof(noSigpipe));
+  struct timeval tv = { .tv_sec = (long)timeout, .tv_usec = 0 };
+  setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+  struct sockaddr_in addr = { .sin_family = AF_INET, .sin_port = htons(self.port) };
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  if (0 != connect(fd, (struct sockaddr *)&addr, sizeof(addr))) {
+    close(fd);
+    return nil;
+  }
+  // Ignore send errors: the flood test expects the server to close mid-send.
+  send(fd, payload.bytes, payload.length, 0);
+  NSMutableData *received = [NSMutableData data];
+  char chunk[4096];
+  NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:timeout];
+  while (deadline.timeIntervalSinceNow > 0) {
+    ssize_t n = recv(fd, chunk, sizeof(chunk), 0);
+    if (n > 0) {
+      [received appendBytes:chunk length:(NSUInteger)n];
+      // The response has started arriving; the server keeps the connection open after a
+      // success, so don't wait the full timeout for an EOF that never comes.
+      struct timeval drainTv = { .tv_sec = 0, .tv_usec = 200000 };
+      setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &drainTv, sizeof(drainTv));
+    } else {
+      *didClose = (n == 0);
+      break;
+    }
+  }
+  close(fd);
+  return [[NSString alloc] initWithData:received encoding:NSUTF8StringEncoding] ?: @"";
+}
+
+- (void)testWellFormedRequestStillSucceeds
+{
+  BOOL didClose;
+  NSString *response = [self responseForRawPayload:(NSData * _Nonnull)[@"GET /framing/ping HTTP/1.1\r\n\r\n" dataUsingEncoding:NSUTF8StringEncoding]
+                                            timeout:5.0
+                                           didClose:&didClose];
+  XCTAssertTrue([response containsString:@"200"], @"%@", response);
+  XCTAssertTrue([response containsString:@"pong"], @"%@", response);
+}
+
+- (void)testNonNumericContentLengthIsRejected
+{
+  // Under -integerValue's lenient parsing "bogus" became 0: the probe route would run with an
+  // empty body and the smuggled GET below would be answered as a second pipelined request.
+  NSString *payload = @"POST /framing/probe HTTP/1.1\r\nContent-Length: bogus\r\n\r\nGET /framing/ping HTTP/1.1\r\n\r\n";
+  BOOL didClose;
+  NSString *response = [self responseForRawPayload:(NSData * _Nonnull)[payload dataUsingEncoding:NSUTF8StringEncoding]
+                                            timeout:5.0
+                                           didClose:&didClose];
+  XCTAssertTrue([response containsString:@"400"], @"%@", response);
+  XCTAssertFalse([response containsString:@"pong"], @"the smuggled request must not be answered: %@", response);
+  XCTAssertTrue(didClose, @"the connection must be closed after unparseable framing");
+  XCTAssertEqual(atomic_load(&gFramingProbeHits), 0, @"the route must not be dispatched with unknown body extent");
+}
+
+- (void)testPartiallyNumericContentLengthIsRejected
+{
+  NSString *payload = @"POST /framing/probe HTTP/1.1\r\nContent-Length: 5abc\r\n\r\nhello";
+  BOOL didClose;
+  NSString *response = [self responseForRawPayload:(NSData * _Nonnull)[payload dataUsingEncoding:NSUTF8StringEncoding]
+                                            timeout:5.0
+                                           didClose:&didClose];
+  XCTAssertTrue([response containsString:@"400"], @"%@", response);
+  XCTAssertTrue(didClose);
+  XCTAssertEqual(atomic_load(&gFramingProbeHits), 0);
+}
+
+- (void)testOversizedHeaderBlockIsRejected
+{
+  // A header block that never terminates: 96 KiB of header lines with no \r\n\r\n. The server
+  // must stop buffering and close the connection instead of growing the buffer indefinitely.
+  NSMutableString *payload = [NSMutableString stringWithString:@"GET /framing/ping HTTP/1.1\r\n"];
+  NSString *filler = [@"X-Filler: " stringByAppendingString:[@"" stringByPaddingToLength:1013 withString:@"a" startingAtIndex:0]];
+  while (payload.length < 96 * 1024) {
+    [payload appendString:filler];
+    [payload appendString:@"\r\n"];
+  }
+  BOOL didClose;
+  NSString *response = [self responseForRawPayload:(NSData * _Nonnull)[payload dataUsingEncoding:NSUTF8StringEncoding]
+                                            timeout:10.0
+                                           didClose:&didClose];
+  XCTAssertTrue([response containsString:@"400"], @"%@", response);
+}
+
+@end

--- a/WebDriverAgentTests/UnitTests/FBHTTPServerTests.m
+++ b/WebDriverAgentTests/UnitTests/FBHTTPServerTests.m
@@ -145,4 +145,25 @@ static atomic_int gFramingProbeHits;
   XCTAssertTrue([response containsString:@"400"], @"%@", response);
 }
 
+- (void)testOversizedCompletedHeaderBlockIsRejected
+{
+  // Same flood, but properly terminated with \r\n\r\n. Depending on how the bytes coalesce, the
+  // terminator can arrive in the same receive callback as the bulk of the block, in which case
+  // the incomplete-header cap never fires - the completed block must be rejected too instead of
+  // being copied and parsed.
+  NSMutableString *payload = [NSMutableString stringWithString:@"GET /framing/ping HTTP/1.1\r\n"];
+  NSString *filler = [@"X-Filler: " stringByAppendingString:[@"" stringByPaddingToLength:1013 withString:@"a" startingAtIndex:0]];
+  while (payload.length < 96 * 1024) {
+    [payload appendString:filler];
+    [payload appendString:@"\r\n"];
+  }
+  [payload appendString:@"\r\n"];
+  BOOL didClose;
+  NSString *response = [self responseForRawPayload:(NSData * _Nonnull)[payload dataUsingEncoding:NSUTF8StringEncoding]
+                                            timeout:10.0
+                                           didClose:&didClose];
+  XCTAssertTrue([response containsString:@"400"], @"%@", response);
+  XCTAssertFalse([response containsString:@"pong"], @"the oversized request must not be served: %@", response);
+}
+
 @end


### PR DESCRIPTION
Two hardening gaps in `FBHTTPServer`'s HTTP/1.1 framing, both regressions relative to the CocoaHTTPServer stack that #1221 replaced:

## Malformed Content-Length desyncs request framing

`-processBufferForClient:` parsed the header via `-integerValue`, which silently maps garbage to a number instead of failing: `Content-Length: bogus` becomes `0` and `Content-Length: 12abc` becomes `12`. The route is then dispatched with the wrong body extent, and the remaining body bytes get re-parsed as a smuggled pipelined request — e.g. `Content-Length: bogus` followed by `GET /status ...` in the body produces two responses. CocoaHTTPServer parsed this strictly via `parseString:intoUInt64:` and answered 400.

Now: the value must be all ASCII decimal digits (length-bounded against overflow); anything else gets a 400 and the connection is closed, since the body's extent is unknowable and the stream cannot be resynced.

## Unbounded buffering of incomplete header blocks

A client that keeps sending bytes without ever completing the `\r\n\r\n` header terminator grew its per-connection buffer without limit — the body size limit only applies after headers parse. CocoaHTTPServer bounded this with `MAX_HEADER_LINE_LENGTH`/`MAX_HEADER_LINES`. Now an incomplete header block is capped at 64 KiB; exceeding it gets a 400 and the connection is closed.

## Tests

New `FBHTTPServerTests` drive a real `FBHTTPServer` over raw BSD sockets (URL-loading APIs cannot produce these payloads): non-numeric and partially-numeric `Content-Length` (asserting the handler never runs, the smuggled request is not answered, and the connection closes), a 96 KiB never-terminated header block, and a well-formed request as a control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)