### PR TITLE
fix: cache the testmanagerd protocol version fallback on timeout

### DIFF
--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -81,10 +81,9 @@
 
 NSInteger FBTestmanagerdVersion(void)
 {
-  // -1 means "not yet determined". Every outcome is cached, including the timeout fallback below:
-  // the value is diagnostic-only, and against a degraded daemon that never answers the exchange,
-  // retrying would make every subsequent /status request stall for the full timeout - repeated
-  // health checks would see an already-bound WDA as permanently unavailable.
+  // -1 means "not yet determined". The timeout fallback is cached like any other outcome: the
+  // value is diagnostic-only, and retrying would stall every later /status for the full timeout
+  // against a daemon that never answers.
   static NSInteger cachedVersion = -1;
   static dispatch_queue_t syncQueue;
   static dispatch_once_t onceToken;

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -81,8 +81,10 @@
 
 NSInteger FBTestmanagerdVersion(void)
 {
-  // Not dispatch_once: that would permanently cache the timeout fallback below if the first call's
-  // reply merely arrived late. -1 means "not yet determined"; a timeout isn't cached, so it retries.
+  // -1 means "not yet determined". Every outcome is cached, including the timeout fallback below:
+  // the value is diagnostic-only, and against a degraded daemon that never answers the exchange,
+  // retrying would make every subsequent /status request stall for the full timeout - repeated
+  // health checks would see an already-bound WDA as permanently unavailable.
   static NSInteger cachedVersion = -1;
   static dispatch_queue_t syncQueue;
   static dispatch_once_t onceToken;
@@ -108,12 +110,11 @@ NSInteger FBTestmanagerdVersion(void)
       }];
       int64_t timeoutNs = (int64_t)(TESTMANAGERD_VERSION_TIMEOUT_SEC * NSEC_PER_SEC);
       if (0 != dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, timeoutNs))) {
-        // Assume newest/full-featured on timeout, but don't cache it - retry on the next call.
         [FBLogger logFmt:@"Did not receive a testmanagerd protocol version reply within %d seconds; assuming the newest/full-featured protocol", TESTMANAGERD_VERSION_TIMEOUT_SEC];
         result = 0xFFFF;
-        return;
+      } else {
+        result = receivedVersion;
       }
-      result = receivedVersion;
     } else {
       // Modern testmanagerd (Xcode 15+) negotiates named XCTCapabilities instead of a scalar
       // version; there's no direct integer equivalent, so just confirm capabilities negotiated.


### PR DESCRIPTION
`FBTestmanagerdVersion()` deliberately does not cache its timeout fallback, so it retries the `_XCT_exchangeProtocolVersion:reply:` exchange on every call. Against a legacy or degraded testmanagerd that never answers, that means every caller — notably every `GET /status` request, which reports `testmanagerdVersion` — repeats the full 20-second wait. Since `/status` is the standard health-check endpoint, repeated probes make an already-bound, otherwise-working WDA appear permanently unavailable.

The value is diagnostic-only (per the code's own comments), so the cost of caching a possibly-pessimistic `0xFFFF` fallback after one timeout is negligible, while the cost of retrying is a 20-second stall on every status call. This change caches the fallback like every other outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)