### PR TITLE
fix: add missing settings to the exported WDASettings/WDACapabilities types

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,6 +13,16 @@ export interface WDASettings {
   keyboardAutocorrection?: boolean;
   keyboardPrediction?: boolean;
   customSnapshotTimeout?: number;
+  accessibilityDeadline?: number;
+  enforceCustomSnapshots?: boolean;
+  limitXPathContextScope?: boolean;
+  includeHittableInPageSource?: boolean;
+  includeNativeFrameInPageSource?: boolean;
+  includeNativeAccessibilityElementInPageSource?: boolean;
+  includeMinMaxValueInPageSource?: boolean;
+  includeCustomActionsInPageSource?: boolean;
+  respectSystemAlerts?: boolean;
+  autoClickAlertSelector?: string;
   snapshotMaxDepth?: number;
   snapshotMaxChildren?: number;
   useFirstMatch?: boolean;
@@ -50,6 +60,7 @@ export interface WDACapabilities {
   forceSimulatorSoftwareKeyboardPresence?: boolean;
   defaultAlertAction?: 'accept' | 'dismiss';
   appLaunchStateTimeoutSec?: number;
+  accessibilityDeadline?: number;
 }
 
 export interface WebDriverAgentArgs {


### PR DESCRIPTION
`lib/types.ts` documents itself as mirroring `WebDriverAgentLib/Utilities/FBSettings.h`, but ten settings accepted by the settings endpoint are missing from the exported `WDASettings` interface. TypeScript consumers can't set them without an unsafe cast, and hit an excess-property error if they try:

| Setting | Type |
| --- | --- |
| `accessibilityDeadline` | `number` |
| `enforceCustomSnapshots` | `boolean` |
| `limitXPathContextScope` | `boolean` |
| `includeHittableInPageSource` | `boolean` |
| `includeNativeFrameInPageSource` | `boolean` |
| `includeNativeAccessibilityElementInPageSource` | `boolean` |
| `includeMinMaxValueInPageSource` | `boolean` |
| `includeCustomActionsInPageSource` | `boolean` |
| `respectSystemAlerts` | `boolean` |
| `autoClickAlertSelector` | `string` |

Types were taken from each setting's handling in `FBSettingsHandler.m` (`boolValue`/`doubleValue`) and its `FBConfiguration` property declaration.

`accessibilityDeadline` (new in 16.8.0, #1214) is additionally accepted as a session capability in `FBSessionCommands.m`, so it's added to `WDACapabilities` as well.

Types-only change; `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)