### PR TITLE
fix: prevent a stale teardown from affecting a newer session generation

### DIFF
--- a/WebDriverAgentLib/Routing/FBScreenRecordingContainer.h
+++ b/WebDriverAgentLib/Routing/FBScreenRecordingContainer.h
@@ -45,6 +45,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)reset;
 
 /**
+ Resets the container, but only if it still keeps the given promise. The comparison and the
+ reset are performed atomically, so a promise stored concurrently is never dropped.
+
+ @param screenRecordingPromise the promise the caller expects to be still active
+ @return YES if the container has been reset
+ */
+- (BOOL)resetIfPromiseIs:(FBScreenRecordingPromise *)screenRecordingPromise;
+
+/**
  Transforms the container content to a dictionary.
 
  @return May return nil if no screen recording is currently running

--- a/WebDriverAgentLib/Routing/FBScreenRecordingContainer.m
+++ b/WebDriverAgentLib/Routing/FBScreenRecordingContainer.m
@@ -36,23 +36,39 @@
                                 fps:(NSUInteger)fps
                               codec:(long long)codec;
 {
-  self.fps = fps;
-  self.codec = codec;
-  self.screenRecordingPromise = screenRecordingPromise;
-  self.startedAt = @([NSDate.date timeIntervalSince1970]);
+  @synchronized (self) {
+    self.fps = fps;
+    self.codec = codec;
+    self.screenRecordingPromise = screenRecordingPromise;
+    self.startedAt = @([NSDate.date timeIntervalSince1970]);
+  }
 }
 
 - (void)reset;
 {
-  self.fps = 0;
-  self.codec = 0;
-  if (nil != self.screenRecordingPromise) {
-    [XCTContext runActivityNamed:@"Video Cleanup" block:^(id<XCTActivity> activity){
-      [activity addAttachment:(XCTAttachment *)self.screenRecordingPromise.nativePromise];
-    }];
-    self.screenRecordingPromise = nil;
+  @synchronized (self) {
+    self.fps = 0;
+    self.codec = 0;
+    if (nil != self.screenRecordingPromise) {
+      [XCTContext runActivityNamed:@"Video Cleanup" block:^(id<XCTActivity> activity){
+        [activity addAttachment:(XCTAttachment *)self.screenRecordingPromise.nativePromise];
+      }];
+      self.screenRecordingPromise = nil;
+    }
+    self.startedAt = nil;
   }
-  self.startedAt = nil;
+}
+
+- (BOOL)resetIfPromiseIs:(FBScreenRecordingPromise *)screenRecordingPromise
+{
+  // @synchronized is recursive, so -reset may take the very same lock again below.
+  @synchronized (self) {
+    if (self.screenRecordingPromise != screenRecordingPromise) {
+      return NO;
+    }
+    [self reset];
+    return YES;
+  }
 }
 
 - (nullable NSDictionary *)toDictionary

--- a/WebDriverAgentLib/Routing/FBSession.h
+++ b/WebDriverAgentLib/Routing/FBSession.h
@@ -54,6 +54,9 @@ extern NSString* const FBSessionWasKilledNotification;
  Kills the active session, if any, and blocks until its teardown - including one already started
  by a concurrent caller - is fully finished. Call this before preparing/launching a replacement
  application, so it can't race a still-in-progress termination of the outgoing one.
+
+ @throws FBSessionCreationException if the outgoing application's termination is still in flight
+ after the wait, since a replacement must never start while that termination can still land.
  */
 + (void)killActiveSessionAndWaitForTeardown;
 

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -157,13 +157,20 @@ static NSUInteger _committedTerminationCount = 0;
   // teardown still running, that teardown must be stale by the time the new app exists.
   NSCondition *condition = self.teardownCondition;
   [condition lock];
-  // A committed -terminate cannot be revoked, so wait it out (bounded by its own budget) rather
-  // than hand out the next generation while it is still in flight.
+  // A committed -terminate cannot be revoked, so the next generation must never be handed out
+  // while one is in flight - give up on the new session instead of racing it.
   NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:FB_APP_TERMINATE_TIMEOUT_SEC];
   while (_committedTerminationCount > 0 && [condition waitUntilDate:deadline]) {
   }
-  _sessionGeneration++;
+  BOOL isTerminationPending = _committedTerminationCount > 0;
+  if (!isTerminationPending) {
+    _sessionGeneration++;
+  }
   [condition unlock];
+  if (isTerminationPending) {
+    NSString *reason = [NSString stringWithFormat:@"The termination of a previous session's application is still in progress after %@ seconds. Please retry the session creation later", @(FB_APP_TERMINATE_TIMEOUT_SEC)];
+    @throw [NSException exceptionWithName:FBSessionCreationException reason:reason userInfo:nil];
+  }
 }
 
 + (void)markSessionActive:(FBSession *)session

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -111,6 +111,9 @@ static NSUInteger _activeTeardownCount = 0;
 // Bumped once a caller owns the device, before it launches anything; a teardown still running past
 // the bounded wait re-checks it before touching process-wide state.
 static NSUInteger _sessionGeneration = 0;
+// Teardowns that have claimed the current generation and are committed to terminating the app.
+// The generation bump waits for these to drain, so a claim and a bump can never interleave.
+static NSUInteger _committedTerminationCount = 0;
 
 + (NSCondition *)teardownCondition
 {
@@ -154,6 +157,11 @@ static NSUInteger _sessionGeneration = 0;
   // teardown still running, that teardown must be stale by the time the new app exists.
   NSCondition *condition = self.teardownCondition;
   [condition lock];
+  // A committed -terminate cannot be revoked, so wait it out (bounded by its own budget) rather
+  // than hand out the next generation while it is still in flight.
+  NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:FB_APP_TERMINATE_TIMEOUT_SEC];
+  while (_committedTerminationCount > 0 && [condition waitUntilDate:deadline]) {
+  }
   _sessionGeneration++;
   [condition unlock];
 }
@@ -167,15 +175,27 @@ static NSUInteger _sessionGeneration = 0;
   [condition unlock];
 }
 
-// NO once a newer session has claimed the device, meaning the caller's teardown is stale and must
-// leave process-wide state alone.
-+ (BOOL)isSessionGenerationCurrent:(NSUInteger)generation
+// Validates and claims `generation` in one critical section, so no replacement can be handed the
+// next generation until the matching +endTermination. NO means this teardown is already stale.
++ (BOOL)beginTerminationForGeneration:(NSUInteger)generation
 {
   NSCondition *condition = self.teardownCondition;
   [condition lock];
   BOOL isCurrent = generation == _sessionGeneration;
+  if (isCurrent) {
+    _committedTerminationCount++;
+  }
   [condition unlock];
   return isCurrent;
+}
+
++ (void)endTermination
+{
+  NSCondition *condition = self.teardownCondition;
+  [condition lock];
+  _committedTerminationCount--;
+  [condition broadcast];
+  [condition unlock];
 }
 
 // Read in the same critical section that validates the generation: a replacement would have bumped
@@ -451,11 +471,14 @@ static NSUInteger _sessionGeneration = 0;
     @synchronized (lock) {
       // Re-checked here, not before dispatching: this block can sit on a busy main queue past the
       // teardown wait, and a replacement usually runs the same bundle ID as the app to terminate.
-      if (isAllowedToTerminate && [self.class isSessionGenerationCurrent:generation]) {
+      // The claim is held across -terminate, so no replacement can take the next generation mid-call.
+      if (isAllowedToTerminate && [self.class beginTerminationForGeneration:generation]) {
         @try {
           [application terminate];
         } @catch (NSException *e) {
           [FBLogger logFmt:@"%@", e.description];
+        } @finally {
+          [self.class endTermination];
         }
       }
     }

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -100,6 +100,7 @@ NSString *const FBSessionWasKilledNotification = @"FBSessionWasKilledNotificatio
 
 @implementation FBSession
 
+// Guarded, together with the two counters below, by +teardownCondition.
 static FBSession *_activeSession = nil;
 // Class-level, not per-instance: a caller that finds _activeSession already nil (a concurrent
 // -kill beat it there) still needs to know whether that -kill's teardown is done, since it cleared
@@ -157,26 +158,30 @@ static NSUInteger _sessionGeneration = 0;
   // as soon as this returns. If the bounded wait expired with a teardown still running, that
   // teardown has to be stale before the replacement app exists or it could terminate it. A
   // teardown this call ran to completion is already finished, so invalidating it is a no-op.
-  @synchronized (self.class) {
-    _sessionGeneration++;
-  }
+  NSCondition *condition = self.teardownCondition;
+  [condition lock];
+  _sessionGeneration++;
+  [condition unlock];
 }
 
 + (void)markSessionActive:(FBSession *)session
 {
   [self killActiveSessionAndWaitForTeardown];
-  @synchronized (self.class) {
-    _activeSession = session;
-  }
+  NSCondition *condition = self.teardownCondition;
+  [condition lock];
+  _activeSession = session;
+  [condition unlock];
 }
 
 // NO once a newer session has been marked active, meaning the caller's teardown is stale and must
 // not touch process-wide state that the newer session now owns.
 + (BOOL)isSessionGenerationCurrent:(NSUInteger)generation
 {
-  @synchronized (self.class) {
-    return generation == _sessionGeneration;
-  }
+  NSCondition *condition = self.teardownCondition;
+  [condition lock];
+  BOOL isCurrent = generation == _sessionGeneration;
+  [condition unlock];
+  return isCurrent;
 }
 
 + (instancetype)sessionWithIdentifier:(NSString *)identifier
@@ -247,28 +252,27 @@ static NSUInteger _sessionGeneration = 0;
   // DELETE /session and session creation can now run concurrently, so a session already
   // superseded by a newer one can still reach here via a stale reference. Check-and-clear must be
   // atomic, else a belated -kill could null out the new session's pointer instead of its own.
+  NSCondition *teardownCondition = self.class.teardownCondition;
   BOOL wasActive;
   NSUInteger generation;
-  @synchronized (self.class) {
-    wasActive = (self == _activeSession);
-    // Captured here so the teardown steps below can tell whether a replacement session has been
-    // created in the meantime - see +isSessionGenerationCurrent:.
-    generation = _sessionGeneration;
-    if (wasActive) {
-      _activeSession = nil;
-    }
+  [teardownCondition lock];
+  wasActive = (self == _activeSession);
+  // Captured here so the teardown steps below can tell whether a replacement session has been
+  // created in the meantime - see +isSessionGenerationCurrent:.
+  generation = _sessionGeneration;
+  if (wasActive) {
+    _activeSession = nil;
+    // Registered in the same critical section as the clear above, else a concurrent session
+    // creation could observe neither an active session nor a teardown and skip its wait.
+    _activeTeardownCount++;
   }
+  [teardownCondition unlock];
   if (!wasActive) {
     // Someone else is already tearing this session down - wait for that to finish (bounded), so
     // we don't act as if it's gone (e.g. launch a new app) while its -terminate is still in flight.
     [self.class waitForActiveTeardownWithTimeout:FB_KILL_WAIT_TIMEOUT_SEC];
     return;
   }
-
-  NSCondition *teardownCondition = self.class.teardownCondition;
-  [teardownCondition lock];
-  _activeTeardownCount++;
-  [teardownCondition unlock];
 
   @try {
     // Posted before teardown so pending HTTP requests for this session can stop waiting sooner.

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -105,15 +105,11 @@ static FBSession *_activeSession = nil;
 // Class-level, not per-instance: a caller that finds _activeSession already nil (a concurrent
 // -kill beat it there) still needs to know whether that -kill's teardown is done, since it cleared
 // the pointer before running it. See +waitForActiveTeardownWithTimeout:.
-// A count, not a flag: the wait below is bounded, so teardowns can overlap. A shared flag would
-// let the first to finish wake waiters while the other still ran, and the next session creation
-// would then bump the generation and make that teardown skip its cleanup.
+// A count, not a flag: the bounded wait below lets teardowns overlap, so one of them finishing
+// must not wake waiters while another still runs.
 static NSUInteger _activeTeardownCount = 0;
-// Bumped by +killActiveSessionAndWaitForTeardown, i.e. when a caller takes ownership of the
-// device - before it launches anything. Since the wait there is bounded, a slow teardown can
-// still be running by then; its remaining steps mutate process-wide state (the tested app, whose
-// bundle ID the replacement usually shares, and the recording container), so each re-checks the
-// generation it started with.
+// Bumped once a caller owns the device, before it launches anything; a teardown still running past
+// the bounded wait re-checks it before touching process-wide state.
 static NSUInteger _sessionGeneration = 0;
 
 + (NSCondition *)teardownCondition
@@ -154,10 +150,8 @@ static NSUInteger _sessionGeneration = 0;
     // be mid-teardown - wait for it, so we don't launch a replacement app too early.
     [self waitForActiveTeardownWithTimeout:FB_KILL_WAIT_TIMEOUT_SEC];
   }
-  // Claimed here, not in +markSessionActive:, because the caller starts launching its application
-  // as soon as this returns. If the bounded wait expired with a teardown still running, that
-  // teardown has to be stale before the replacement app exists or it could terminate it. A
-  // teardown this call ran to completion is already finished, so invalidating it is a no-op.
+  // Claimed before the caller launches its replacement app: if the bounded wait expired with a
+  // teardown still running, that teardown must be stale by the time the new app exists.
   NSCondition *condition = self.teardownCondition;
   [condition lock];
   _sessionGeneration++;
@@ -173,8 +167,8 @@ static NSUInteger _sessionGeneration = 0;
   [condition unlock];
 }
 
-// NO once a newer session has been marked active, meaning the caller's teardown is stale and must
-// not touch process-wide state that the newer session now owns.
+// NO once a newer session has claimed the device, meaning the caller's teardown is stale and must
+// leave process-wide state alone.
 + (BOOL)isSessionGenerationCurrent:(NSUInteger)generation
 {
   NSCondition *condition = self.teardownCondition;
@@ -257,8 +251,7 @@ static NSUInteger _sessionGeneration = 0;
   NSUInteger generation;
   [teardownCondition lock];
   wasActive = (self == _activeSession);
-  // Captured here so the teardown steps below can tell whether a replacement session has been
-  // created in the meantime - see +isSessionGenerationCurrent:.
+  // Captured so the teardown steps below can tell whether a replacement has claimed the device.
   generation = _sessionGeneration;
   if (wasActive) {
     _activeSession = nil;
@@ -298,15 +291,14 @@ static NSUInteger _sessionGeneration = 0;
         && self.testedApplication.running
         && ![self fb_isTestedApplicationSameAsSystemAppWithTimeout:FB_IS_SYSTEM_APP_CHECK_TIMEOUT_SEC]) {
       // Blocks until the app is either actually terminated or durably given up on (never left
-      // pending) - see -fb_terminateTestedApplicationWithTimeout:generation: - so it's safe to report this
-      // teardown as finished as soon as this returns.
+      // pending) - see -fb_terminateTestedApplicationWithTimeout:generation: - so it's safe to
+      // report this teardown as finished as soon as this returns.
       [self fb_terminateTestedApplicationWithTimeout:FB_APP_TERMINATE_TIMEOUT_SEC generation:generation];
     }
   } @finally {
     [teardownCondition lock];
     _activeTeardownCount--;
-    // Broadcast unconditionally: waiters re-check the count themselves, so a wake-up while
-    // another teardown is still running simply puts them back to waiting.
+    // Unconditional: waiters re-check the count, so a wake-up mid-teardown just puts them back.
     [teardownCondition broadcast];
     [teardownCondition unlock];
   }
@@ -443,9 +435,8 @@ static NSUInteger _sessionGeneration = 0;
   dispatch_semaphore_t sem = dispatch_semaphore_create(0);
   dispatch_async(dispatch_get_main_queue(), ^{
     @synchronized (lock) {
-      // Re-checked here rather than before dispatching: this block can sit on a busy main queue
-      // longer than the teardown wait allows, and a replacement created in that window usually
-      // runs the same bundle ID - terminating "the old app" would kill the new one.
+      // Re-checked here, not before dispatching: this block can sit on a busy main queue past the
+      // teardown wait, and a replacement usually runs the same bundle ID as the app to terminate.
       if (isAllowedToTerminate && [self.class isSessionGenerationCurrent:generation]) {
         @try {
           [application terminate];

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -110,7 +110,9 @@ static FBSession *_activeSession = nil;
 // waiters while the other was still running, letting the next session creation bump the
 // generation and make that still-running teardown skip its app/recording cleanup entirely.
 static NSUInteger _activeTeardownCount = 0;
-// Bumped whenever a session is marked active. +waitForActiveTeardownWithTimeout: is bounded, so a
+// Bumped by +killActiveSessionAndWaitForTeardown, i.e. as soon as a caller takes ownership of the
+// device - before it launches anything, not once the new session is finally marked active.
+// +waitForActiveTeardownWithTimeout: is bounded, so a
 // pathologically slow teardown can still be running when a replacement session is created; its
 // remaining steps mutate process-wide state (the tested app, whose bundle ID the replacement
 // likely shares, and the screen recording container), which must not be applied on top of a newer
@@ -155,6 +157,15 @@ static NSUInteger _sessionGeneration = 0;
     // be mid-teardown - wait for it, so we don't launch a replacement app too early.
     [self waitForActiveTeardownWithTimeout:FB_KILL_WAIT_TIMEOUT_SEC];
   }
+  // Returning from here is the point where the caller takes ownership of the device and starts
+  // launching its application, so the generation is claimed *here* rather than later in
+  // +markSessionActive:. The wait above is bounded: if it expired with a teardown still running,
+  // that teardown must already be stale by the time the replacement app exists, or it could
+  // terminate the process it just launched (both sessions usually share a bundle identifier).
+  // Any teardown this call actually ran to completion is finished, so invalidating it is a no-op.
+  @synchronized (self.class) {
+    _sessionGeneration++;
+  }
 }
 
 + (void)markSessionActive:(FBSession *)session
@@ -162,8 +173,6 @@ static NSUInteger _sessionGeneration = 0;
   [self killActiveSessionAndWaitForTeardown];
   @synchronized (self.class) {
     _activeSession = session;
-    // Invalidates the remaining steps of any teardown that outlived the bounded wait above.
-    _sessionGeneration++;
   }
 }
 

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -104,7 +104,12 @@ static FBSession *_activeSession = nil;
 // Class-level, not per-instance: a caller that finds _activeSession already nil (a concurrent
 // -kill beat it there) still needs to know whether that -kill's teardown is done, since it cleared
 // the pointer before running it. See +waitForActiveTeardownWithTimeout:.
-static BOOL _isTeardownInProgress = NO;
+// A count rather than a flag: because the wait below is bounded, a replacement session can be
+// created - and later torn down itself - while an earlier teardown is still finishing, so two
+// teardowns can overlap. With a shared flag the first one to finish would clear it and wake
+// waiters while the other was still running, letting the next session creation bump the
+// generation and make that still-running teardown skip its app/recording cleanup entirely.
+static NSUInteger _activeTeardownCount = 0;
 // Bumped whenever a session is marked active. +waitForActiveTeardownWithTimeout: is bounded, so a
 // pathologically slow teardown can still be running when a replacement session is created; its
 // remaining steps mutate process-wide state (the tested app, whose bundle ID the replacement
@@ -122,13 +127,13 @@ static NSUInteger _sessionGeneration = 0;
   return condition;
 }
 
-// Waits (bounded) for any -kill teardown currently in progress to finish.
+// Waits (bounded) for every -kill teardown currently in progress to finish.
 + (void)waitForActiveTeardownWithTimeout:(NSTimeInterval)timeout
 {
   NSCondition *condition = self.teardownCondition;
   [condition lock];
   NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:timeout];
-  while (_isTeardownInProgress && [condition waitUntilDate:deadline]) {
+  while (_activeTeardownCount > 0 && [condition waitUntilDate:deadline]) {
   }
   [condition unlock];
 }
@@ -259,7 +264,7 @@ static NSUInteger _sessionGeneration = 0;
 
   NSCondition *teardownCondition = self.class.teardownCondition;
   [teardownCondition lock];
-  _isTeardownInProgress = YES;
+  _activeTeardownCount++;
   [teardownCondition unlock];
 
   @try {
@@ -293,7 +298,9 @@ static NSUInteger _sessionGeneration = 0;
     }
   } @finally {
     [teardownCondition lock];
-    _isTeardownInProgress = NO;
+    _activeTeardownCount--;
+    // Broadcast unconditionally: waiters re-check the count themselves, so a wake-up while
+    // another teardown is still running simply puts them back to waiting.
     [teardownCondition broadcast];
     [teardownCondition unlock];
   }

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -315,9 +315,8 @@ static NSUInteger _committedTerminationCount = 0;
         [FBLogger logFmt:@"%@", error];
       }
       // Identity, not generation: the stop above may outlast a replacement storing its own promise.
-      if (FBScreenRecordingContainer.sharedInstance.screenRecordingPromise == activeScreenRecording) {
-        [FBScreenRecordingContainer.sharedInstance reset];
-      }
+      // Compare-and-reset, so that replacement's store cannot land between the check and the reset.
+      [FBScreenRecordingContainer.sharedInstance resetIfPromiseIs:activeScreenRecording];
     }
 
     if (nil != self.testedApplication

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -138,12 +138,16 @@ static NSUInteger _committedTerminationCount = 0;
 
 + (instancetype)activeSession
 {
-  return _activeSession;
+  NSCondition *condition = self.teardownCondition;
+  [condition lock];
+  FBSession *session = _activeSession;
+  [condition unlock];
+  return session;
 }
 
 + (void)killActiveSessionAndWaitForTeardown
 {
-  FBSession *session = _activeSession;
+  FBSession *session = self.activeSession;
   if (nil != session) {
     // Runs the real teardown synchronously if this call wins the race in -kill, or waits for
     // whoever did to finish if it lost - either way, blocks until torn down.
@@ -223,10 +227,9 @@ static NSUInteger _committedTerminationCount = 0;
   if (!identifier) {
     return nil;
   }
-  if (![identifier isEqualToString:_activeSession.identifier]) {
-    return nil;
-  }
-  return _activeSession;
+  // A single snapshot: reading the global twice could validate one session and return another.
+  FBSession *session = self.activeSession;
+  return [identifier isEqualToString:session.identifier] ? session : nil;
 }
 
 + (instancetype)initWithApplication:(XCUIApplication *)application

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -50,7 +50,7 @@ NSString *const FBSessionWasKilledNotification = @"FBSessionWasKilledNotificatio
 @property (nonatomic, readwrite) NSMutableDictionary<NSNumber *, NSMutableDictionary<NSString *, NSNumber *> *> *elementsVisibilityCache;
 
 - (BOOL)fb_isTestedApplicationSameAsSystemAppWithTimeout:(NSTimeInterval)timeout;
-- (void)fb_terminateTestedApplicationWithTimeout:(NSTimeInterval)timeout;
+- (void)fb_terminateTestedApplicationWithTimeout:(NSTimeInterval)timeout generation:(NSUInteger)generation;
 @end
 
 @interface FBSession (FBAlertsMonitorDelegate)
@@ -105,6 +105,12 @@ static FBSession *_activeSession = nil;
 // -kill beat it there) still needs to know whether that -kill's teardown is done, since it cleared
 // the pointer before running it. See +waitForActiveTeardownWithTimeout:.
 static BOOL _isTeardownInProgress = NO;
+// Bumped whenever a session is marked active. +waitForActiveTeardownWithTimeout: is bounded, so a
+// pathologically slow teardown can still be running when a replacement session is created; its
+// remaining steps mutate process-wide state (the tested app, whose bundle ID the replacement
+// likely shares, and the screen recording container), which must not be applied on top of a newer
+// generation. Every such step re-checks the generation it started with.
+static NSUInteger _sessionGeneration = 0;
 
 + (NSCondition *)teardownCondition
 {
@@ -149,7 +155,20 @@ static BOOL _isTeardownInProgress = NO;
 + (void)markSessionActive:(FBSession *)session
 {
   [self killActiveSessionAndWaitForTeardown];
-  _activeSession = session;
+  @synchronized (self.class) {
+    _activeSession = session;
+    // Invalidates the remaining steps of any teardown that outlived the bounded wait above.
+    _sessionGeneration++;
+  }
+}
+
+// NO once a newer session has been marked active, meaning the caller's teardown is stale and must
+// not touch process-wide state that the newer session now owns.
++ (BOOL)isSessionGenerationCurrent:(NSUInteger)generation
+{
+  @synchronized (self.class) {
+    return generation == _sessionGeneration;
+  }
 }
 
 + (instancetype)sessionWithIdentifier:(NSString *)identifier
@@ -221,8 +240,12 @@ static BOOL _isTeardownInProgress = NO;
   // superseded by a newer one can still reach here via a stale reference. Check-and-clear must be
   // atomic, else a belated -kill could null out the new session's pointer instead of its own.
   BOOL wasActive;
+  NSUInteger generation;
   @synchronized (self.class) {
     wasActive = (self == _activeSession);
+    // Captured here so the teardown steps below can tell whether a replacement session has been
+    // created in the meantime - see +isSessionGenerationCurrent:.
+    generation = _sessionGeneration;
     if (wasActive) {
       _activeSession = nil;
     }
@@ -251,7 +274,12 @@ static BOOL _isTeardownInProgress = NO;
       if (![FBXCTestDaemonsProxy stopScreenRecordingWithUUID:activeScreenRecording.identifier error:&error]) {
         [FBLogger logFmt:@"%@", error];
       }
-      [FBScreenRecordingContainer.sharedInstance reset];
+      // The stop above targets this session's recording by UUID and is safe either way, but the
+      // container is process-wide: resetting it after a replacement session started recording
+      // would drop that session's promise instead.
+      if ([self.class isSessionGenerationCurrent:generation]) {
+        [FBScreenRecordingContainer.sharedInstance reset];
+      }
     }
 
     if (nil != self.testedApplication
@@ -259,9 +287,9 @@ static BOOL _isTeardownInProgress = NO;
         && self.testedApplication.running
         && ![self fb_isTestedApplicationSameAsSystemAppWithTimeout:FB_IS_SYSTEM_APP_CHECK_TIMEOUT_SEC]) {
       // Blocks until the app is either actually terminated or durably given up on (never left
-      // pending) - see -fb_terminateTestedApplicationWithTimeout: - so it's safe to report this
+      // pending) - see -fb_terminateTestedApplicationWithTimeout:generation: - so it's safe to report this
       // teardown as finished as soon as this returns.
-      [self fb_terminateTestedApplicationWithTimeout:FB_APP_TERMINATE_TIMEOUT_SEC];
+      [self fb_terminateTestedApplicationWithTimeout:FB_APP_TERMINATE_TIMEOUT_SEC generation:generation];
     }
   } @finally {
     [teardownCondition lock];
@@ -394,7 +422,7 @@ static BOOL _isTeardownInProgress = NO;
 // `timeout` - but a "given up on" call must never still terminate whatever's running by the time
 // main gets to it (e.g. a replacement session's app), so cancellation and the actual terminate
 // call share a lock: whichever gets there first - the dispatched block, or the timeout - wins.
-- (void)fb_terminateTestedApplicationWithTimeout:(NSTimeInterval)timeout
+- (void)fb_terminateTestedApplicationWithTimeout:(NSTimeInterval)timeout generation:(NSUInteger)generation
 {
   XCUIApplication *application = self.testedApplication;
   NSObject *lock = [NSObject new];
@@ -402,7 +430,11 @@ static BOOL _isTeardownInProgress = NO;
   dispatch_semaphore_t sem = dispatch_semaphore_create(0);
   dispatch_async(dispatch_get_main_queue(), ^{
     @synchronized (lock) {
-      if (isAllowedToTerminate) {
+      // The generation is re-checked here, not before dispatching: this block can sit on a busy
+      // main queue for longer than +killActiveSessionAndWaitForTeardown is willing to wait, and
+      // a replacement session created in that window usually runs the very same bundle ID -
+      // terminating "the old app" would kill the new session's app instead.
+      if (isAllowedToTerminate && [self.class isSessionGenerationCurrent:generation]) {
         @try {
           [application terminate];
         } @catch (NSException *e) {

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -280,15 +280,15 @@ static NSUInteger _sessionGeneration = 0;
 
     [self disableAlertsMonitor];
 
-    FBScreenRecordingPromise *activeScreenRecording = FBScreenRecordingContainer.sharedInstance.screenRecordingPromise;
-    if (nil != activeScreenRecording) {
-      NSError *error;
-      if (![FBXCTestDaemonsProxy stopScreenRecordingWithUUID:activeScreenRecording.identifier error:&error]) {
-        [FBLogger logFmt:@"%@", error];
-      }
-      // The stop above is by UUID and safe either way, but the container is process-wide:
-      // resetting it would drop a replacement session's promise instead.
-      if ([self.class isSessionGenerationCurrent:generation]) {
+    // The container is process-wide, so its promise may already be a replacement session's: both
+    // the stop and the reset must be skipped once this teardown is stale.
+    if ([self.class isSessionGenerationCurrent:generation]) {
+      FBScreenRecordingPromise *activeScreenRecording = FBScreenRecordingContainer.sharedInstance.screenRecordingPromise;
+      if (nil != activeScreenRecording) {
+        NSError *error;
+        if (![FBXCTestDaemonsProxy stopScreenRecordingWithUUID:activeScreenRecording.identifier error:&error]) {
+          [FBLogger logFmt:@"%@", error];
+        }
         [FBScreenRecordingContainer.sharedInstance reset];
       }
     }

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -178,6 +178,19 @@ static NSUInteger _sessionGeneration = 0;
   return isCurrent;
 }
 
+// Read in the same critical section that validates the generation: a replacement would have bumped
+// the generation before storing anything, so a promise captured here can never be its.
++ (FBScreenRecordingPromise *)activeScreenRecordingForGeneration:(NSUInteger)generation
+{
+  NSCondition *condition = self.teardownCondition;
+  [condition lock];
+  FBScreenRecordingPromise *promise = generation == _sessionGeneration
+    ? FBScreenRecordingContainer.sharedInstance.screenRecordingPromise
+    : nil;
+  [condition unlock];
+  return promise;
+}
+
 + (instancetype)sessionWithIdentifier:(NSString *)identifier
 {
   if (!identifier) {
@@ -273,15 +286,16 @@ static NSUInteger _sessionGeneration = 0;
 
     [self disableAlertsMonitor];
 
-    // The container is process-wide, so its promise may already be a replacement session's: both
-    // the stop and the reset must be skipped once this teardown is stale.
-    if ([self.class isSessionGenerationCurrent:generation]) {
-      FBScreenRecordingPromise *activeScreenRecording = FBScreenRecordingContainer.sharedInstance.screenRecordingPromise;
-      if (nil != activeScreenRecording) {
-        NSError *error;
-        if (![FBXCTestDaemonsProxy stopScreenRecordingWithUUID:activeScreenRecording.identifier error:&error]) {
-          [FBLogger logFmt:@"%@", error];
-        }
+    // The container is process-wide, so only act on a promise captured while this teardown still
+    // owned the generation - nil here means it is stale and must leave the recording alone.
+    FBScreenRecordingPromise *activeScreenRecording = [self.class activeScreenRecordingForGeneration:generation];
+    if (nil != activeScreenRecording) {
+      NSError *error;
+      if (![FBXCTestDaemonsProxy stopScreenRecordingWithUUID:activeScreenRecording.identifier error:&error]) {
+        [FBLogger logFmt:@"%@", error];
+      }
+      // Identity, not generation: the stop above may outlast a replacement storing its own promise.
+      if (FBScreenRecordingContainer.sharedInstance.screenRecordingPromise == activeScreenRecording) {
         [FBScreenRecordingContainer.sharedInstance reset];
       }
     }

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -104,19 +104,15 @@ static FBSession *_activeSession = nil;
 // Class-level, not per-instance: a caller that finds _activeSession already nil (a concurrent
 // -kill beat it there) still needs to know whether that -kill's teardown is done, since it cleared
 // the pointer before running it. See +waitForActiveTeardownWithTimeout:.
-// A count rather than a flag: because the wait below is bounded, a replacement session can be
-// created - and later torn down itself - while an earlier teardown is still finishing, so two
-// teardowns can overlap. With a shared flag the first one to finish would clear it and wake
-// waiters while the other was still running, letting the next session creation bump the
-// generation and make that still-running teardown skip its app/recording cleanup entirely.
+// A count, not a flag: the wait below is bounded, so teardowns can overlap. A shared flag would
+// let the first to finish wake waiters while the other still ran, and the next session creation
+// would then bump the generation and make that teardown skip its cleanup.
 static NSUInteger _activeTeardownCount = 0;
-// Bumped by +killActiveSessionAndWaitForTeardown, i.e. as soon as a caller takes ownership of the
-// device - before it launches anything, not once the new session is finally marked active.
-// +waitForActiveTeardownWithTimeout: is bounded, so a
-// pathologically slow teardown can still be running when a replacement session is created; its
-// remaining steps mutate process-wide state (the tested app, whose bundle ID the replacement
-// likely shares, and the screen recording container), which must not be applied on top of a newer
-// generation. Every such step re-checks the generation it started with.
+// Bumped by +killActiveSessionAndWaitForTeardown, i.e. when a caller takes ownership of the
+// device - before it launches anything. Since the wait there is bounded, a slow teardown can
+// still be running by then; its remaining steps mutate process-wide state (the tested app, whose
+// bundle ID the replacement usually shares, and the recording container), so each re-checks the
+// generation it started with.
 static NSUInteger _sessionGeneration = 0;
 
 + (NSCondition *)teardownCondition
@@ -157,12 +153,10 @@ static NSUInteger _sessionGeneration = 0;
     // be mid-teardown - wait for it, so we don't launch a replacement app too early.
     [self waitForActiveTeardownWithTimeout:FB_KILL_WAIT_TIMEOUT_SEC];
   }
-  // Returning from here is the point where the caller takes ownership of the device and starts
-  // launching its application, so the generation is claimed *here* rather than later in
-  // +markSessionActive:. The wait above is bounded: if it expired with a teardown still running,
-  // that teardown must already be stale by the time the replacement app exists, or it could
-  // terminate the process it just launched (both sessions usually share a bundle identifier).
-  // Any teardown this call actually ran to completion is finished, so invalidating it is a no-op.
+  // Claimed here, not in +markSessionActive:, because the caller starts launching its application
+  // as soon as this returns. If the bounded wait expired with a teardown still running, that
+  // teardown has to be stale before the replacement app exists or it could terminate it. A
+  // teardown this call ran to completion is already finished, so invalidating it is a no-op.
   @synchronized (self.class) {
     _sessionGeneration++;
   }
@@ -288,9 +282,8 @@ static NSUInteger _sessionGeneration = 0;
       if (![FBXCTestDaemonsProxy stopScreenRecordingWithUUID:activeScreenRecording.identifier error:&error]) {
         [FBLogger logFmt:@"%@", error];
       }
-      // The stop above targets this session's recording by UUID and is safe either way, but the
-      // container is process-wide: resetting it after a replacement session started recording
-      // would drop that session's promise instead.
+      // The stop above is by UUID and safe either way, but the container is process-wide:
+      // resetting it would drop a replacement session's promise instead.
       if ([self.class isSessionGenerationCurrent:generation]) {
         [FBScreenRecordingContainer.sharedInstance reset];
       }
@@ -446,10 +439,9 @@ static NSUInteger _sessionGeneration = 0;
   dispatch_semaphore_t sem = dispatch_semaphore_create(0);
   dispatch_async(dispatch_get_main_queue(), ^{
     @synchronized (lock) {
-      // The generation is re-checked here, not before dispatching: this block can sit on a busy
-      // main queue for longer than +killActiveSessionAndWaitForTeardown is willing to wait, and
-      // a replacement session created in that window usually runs the very same bundle ID -
-      // terminating "the old app" would kill the new session's app instead.
+      // Re-checked here rather than before dispatching: this block can sit on a busy main queue
+      // longer than the teardown wait allows, and a replacement created in that window usually
+      // runs the same bundle ID - terminating "the old app" would kill the new one.
       if (isAllowedToTerminate && [self.class isSessionGenerationCurrent:generation]) {
         @try {
           [application terminate];


### PR DESCRIPTION
`+killActiveSessionAndWaitForTeardown` waits at most `FB_KILL_WAIT_TIMEOUT_SEC` (35s) for an in-progress teardown, then proceeds regardless. A worst-case teardown is already close to that budget:

- up to 20s in `stopScreenRecordingWithUUID:` (`STOP_SCREEN_RECORDING_TIMEOUT_SEC`)
- up to 5s in `-fb_isTestedApplicationSameAsSystemAppWithTimeout:`
- up to 5s in `-fb_terminateTestedApplicationWithTimeout:`

plus the notification post and `-disableAlertsMonitor`. So ~30s of bounded work against a 35s wait — an overrunning teardown can still be mid-flight when `POST /session` gives up waiting and starts a replacement session.

The remaining teardown steps then mutate process-wide state on behalf of a session that is already gone:

- `[application terminate]` — the replacement session usually runs the *same bundle identifier*, so "terminate the old app" terminates the new session's app. The existing `isAllowedToTerminate` guard only covers the terminate step overrunning its own 5s timeout, not the overall wait having expired.
- the screen-recording cleanup — the promise is read out of `FBScreenRecordingContainer.sharedInstance` at teardown time, so by then it can already be the replacement session's. Both the `stopScreenRecordingWithUUID:` and the `reset` can therefore hit the new session's recording rather than the old one.

This adds a session generation counter, bumped in `+killActiveSessionAndWaitForTeardown` — i.e. at the moment a caller takes ownership of the device, before it launches anything, since the launch window is itself long enough for a stale teardown to do damage. `-kill` captures the generation it started with, and each step that mutates shared state re-checks it via `+isSessionGenerationCurrent:`. The terminate check happens *inside* the main-queue block rather than before dispatching, since that block is exactly where the unbounded delay occurs; the recording cleanup is skipped as a whole, covering the stop as well as the reset.

Because the wait is bounded, teardowns can genuinely overlap, so `-kill`'s in-progress marker is a count rather than a flag — otherwise the first teardown to finish would wake waiters while another was still running.

`_activeSession`, the teardown count and the generation are all guarded by a single lock (`+teardownCondition`), and `-kill` clears the active session and registers its teardown in one critical section. Without that, a concurrent session creation could observe neither an active session nor a registered teardown, skip its wait, and start launching before the old teardown had registered itself. The lock is only ever held for those short transitions — never across the teardown work, the main-queue dispatch, or the bounded wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
