### PR TITLE
feat: expose AXTimeout and XCTest XPC request timeout wrappers 

### DIFF
--- a/PrivateHeaders/XCTest/CDStructures.h
+++ b/PrivateHeaders/XCTest/CDStructures.h
@@ -2,4 +2,6 @@
 #pragma clang diagnostic ignored "-Wreserved-identifier"
 int _XCTSetApplicationStateTimeout(double timeout);
 double _XCTApplicationStateTimeout(void);
+void _XCTSetXPCRequestTimeout(double timeout);
+double _XCTXPCRequestTimeout(void);
 #pragma clang diagnostic pop

--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -1157,6 +1157,7 @@
 		EE3A18661CDE734B00DE4205 /* FBKeyboard.h in Headers */ = {isa = PBXBuildFile; fileRef = EE3A18641CDE734B00DE4205 /* FBKeyboard.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EE3A18671CDE734B00DE4205 /* FBKeyboard.m in Sources */ = {isa = PBXBuildFile; fileRef = EE3A18651CDE734B00DE4205 /* FBKeyboard.m */; };
 		EE3F8CFE1D08AA17006F02CE /* FBRunLoopSpinnerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EE3F8CFD1D08AA17006F02CE /* FBRunLoopSpinnerTests.m */; };
+		A09D847635CA4C155583B967 /* FBXCAXClientProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6231A764C3FAAB29B87CD987 /* FBXCAXClientProxyTests.m */; };
 		EE3F8D001D08B05F006F02CE /* FBElementTypeTransformerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EE3F8CFF1D08B05F006F02CE /* FBElementTypeTransformerTests.m */; };
 		EE5095E51EBCC9090028E2FE /* FBTypingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = AD76723F1D6B826F00610457 /* FBTypingTest.m */; };
 		EE5095EB1EBCC9090028E2FE /* XCElementSnapshotHitPointTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EE006EB21EBA1C7B006900A4 /* XCElementSnapshotHitPointTests.m */; };
@@ -1824,6 +1825,7 @@
 		EE3A18641CDE734B00DE4205 /* FBKeyboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FBKeyboard.h; path = WebDriverAgentLib/Utilities/FBKeyboard.h; sourceTree = SOURCE_ROOT; };
 		EE3A18651CDE734B00DE4205 /* FBKeyboard.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FBKeyboard.m; path = WebDriverAgentLib/Utilities/FBKeyboard.m; sourceTree = SOURCE_ROOT; };
 		EE3F8CFD1D08AA17006F02CE /* FBRunLoopSpinnerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBRunLoopSpinnerTests.m; sourceTree = "<group>"; };
+		6231A764C3FAAB29B87CD987 /* FBXCAXClientProxyTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBXCAXClientProxyTests.m; sourceTree = "<group>"; };
 		EE3F8CFF1D08B05F006F02CE /* FBElementTypeTransformerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBElementTypeTransformerTests.m; sourceTree = "<group>"; };
 		EE5095FE1EBCC9090028E2FE /* IntegrationTests_2.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IntegrationTests_2.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE55B3221D1D5388003AAAEC /* FBTableDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBTableDataSource.h; sourceTree = "<group>"; };
@@ -2678,6 +2680,7 @@
 				ADEF63AE1D09DEBE0070A7E3 /* FBRuntimeUtilsTests.m */,
 				714801D01FA9D9FA00DC5997 /* FBSDKVersionTests.m */,
 				EE6A89251D0B19E60083E92B /* FBSessionTests.m */,
+				6231A764C3FAAB29B87CD987 /* FBXCAXClientProxyTests.m */,
 				716E0BD01E917F260087A825 /* FBXMLSafeStringTests.m */,
 				712A0C841DA3E459007D02E5 /* FBXPathTests.m */,
 				EE9B76581CF7987300275851 /* Info.plist */,
@@ -4796,6 +4799,7 @@
 			files = (
 				713352FD26CEF31D00523CBC /* FBLRUCacheTests.m in Sources */,
 				EE3F8CFE1D08AA17006F02CE /* FBRunLoopSpinnerTests.m in Sources */,
+				A09D847635CA4C155583B967 /* FBXCAXClientProxyTests.m in Sources */,
 				714801D11FA9D9FA00DC5997 /* FBSDKVersionTests.m in Sources */,
 				EE3F8D001D08B05F006F02CE /* FBElementTypeTransformerTests.m in Sources */,
 				13FFF2F2287DBEE600E561E4 /* XCElementSnapshotDouble.m in Sources */,

--- a/WebDriverAgentLib/Categories/XCUIApplicationProcess+FBQuiescence.m
+++ b/WebDriverAgentLib/Categories/XCUIApplicationProcess+FBQuiescence.m
@@ -10,11 +10,11 @@
 
 #import <objc/runtime.h>
 
-#import "CDStructures.h"
 #import "FBConfiguration.h"
 #import "FBExceptions.h"
 #import "FBLogger.h"
 #import "FBSettings.h"
+#import "FBXCAXClientProxy.h"
 
 static void (*original_waitForQuiescenceIncludingAnimationsIdle)(id, SEL, BOOL);
 static void (*original_waitForQuiescenceIncludingAnimationsIdlePreEvent)(id, SEL, BOOL, BOOL);
@@ -29,15 +29,11 @@ static void swizzledWaitForQuiescenceIncludingAnimationsIdle(id self, SEL _cmd, 
   }
 
   NSTimeInterval desiredTimeout = FBConfiguration.sharedInstance.waitForIdleTimeout;
-  NSTimeInterval previousTimeout = _XCTApplicationStateTimeout();
-  _XCTSetApplicationStateTimeout(desiredTimeout);
   [FBLogger logFmt:@"Waiting up to %@s until %@ is in idle state (%@ animations)",
    @(desiredTimeout), bundleId, includingAnimations ? @"including" : @"excluding"];
-  @try {
+  [FBXCAXClientProxy.sharedClient withApplicationStateTimeout:desiredTimeout do:^{
     original_waitForQuiescenceIncludingAnimationsIdle(self, _cmd, includingAnimations);
-  } @finally {
-    _XCTSetApplicationStateTimeout(previousTimeout);
-  }
+  }];
 }
 
 static void swizzledWaitForQuiescenceIncludingAnimationsIdlePreEvent(id self, SEL _cmd, BOOL includingAnimations, BOOL isPreEvent)
@@ -50,15 +46,11 @@ static void swizzledWaitForQuiescenceIncludingAnimationsIdlePreEvent(id self, SE
   }
 
   NSTimeInterval desiredTimeout = FBConfiguration.sharedInstance.waitForIdleTimeout;
-  NSTimeInterval previousTimeout = _XCTApplicationStateTimeout();
-  _XCTSetApplicationStateTimeout(desiredTimeout);
   [FBLogger logFmt:@"Waiting up to %@s until %@ is in idle state (%@ animations)",
    @(desiredTimeout), bundleId, includingAnimations ? @"including" : @"excluding"];
-  @try {
+  [FBXCAXClientProxy.sharedClient withApplicationStateTimeout:desiredTimeout do:^{
     original_waitForQuiescenceIncludingAnimationsIdlePreEvent(self, _cmd, includingAnimations, isPreEvent);
-  } @finally {
-    _XCTSetApplicationStateTimeout(previousTimeout);
-  }
+  }];
 }
 
 @implementation XCUIApplicationProcess (FBQuiescence)

--- a/WebDriverAgentLib/Categories/XCUIApplicationProcess+FBQuiescence.m
+++ b/WebDriverAgentLib/Categories/XCUIApplicationProcess+FBQuiescence.m
@@ -31,7 +31,7 @@ static void swizzledWaitForQuiescenceIncludingAnimationsIdle(id self, SEL _cmd, 
   NSTimeInterval desiredTimeout = FBConfiguration.sharedInstance.waitForIdleTimeout;
   [FBLogger logFmt:@"Waiting up to %@s until %@ is in idle state (%@ animations)",
    @(desiredTimeout), bundleId, includingAnimations ? @"including" : @"excluding"];
-  [FBXCAXClientProxy.sharedClient withApplicationStateTimeout:desiredTimeout do:^{
+  [FBXCAXClientProxy withApplicationStateTimeout:desiredTimeout do:^{
     original_waitForQuiescenceIncludingAnimationsIdle(self, _cmd, includingAnimations);
   }];
 }
@@ -48,7 +48,7 @@ static void swizzledWaitForQuiescenceIncludingAnimationsIdlePreEvent(id self, SE
   NSTimeInterval desiredTimeout = FBConfiguration.sharedInstance.waitForIdleTimeout;
   [FBLogger logFmt:@"Waiting up to %@s until %@ is in idle state (%@ animations)",
    @(desiredTimeout), bundleId, includingAnimations ? @"including" : @"excluding"];
-  [FBXCAXClientProxy.sharedClient withApplicationStateTimeout:desiredTimeout do:^{
+  [FBXCAXClientProxy withApplicationStateTimeout:desiredTimeout do:^{
     original_waitForQuiescenceIncludingAnimationsIdlePreEvent(self, _cmd, includingAnimations, isPreEvent);
   }];
 }

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -22,6 +22,7 @@
 #import "FBSettings.h"
 #import "FBSettingsHandler.h"
 #import "FBRuntimeUtils.h"
+#import "FBXCAXClientProxy.h"
 #import "FBXCodeCompatibility.h"
 #import "XCUIApplication+FBHelpers.h"
 #import "XCUIApplication+FBQuiescence.h"
@@ -376,18 +377,22 @@
       return errorResponse;
     }
   } else {
-    NSTimeInterval defaultTimeout = _XCTApplicationStateTimeout();
-    if (nil != capabilities[FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC]) {
-      _XCTSetApplicationStateTimeout([capabilities[FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC] doubleValue]);
-    }
-    @try {
-      [app launch];
-    } @catch (NSException *e) {
-      return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:e.reason traceback:nil]);
-    } @finally {
-      if (nil != capabilities[FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC]) {
-        _XCTSetApplicationStateTimeout(defaultTimeout);
+    __block id<FBResponsePayload> launchErrorResponse;
+    void (^launchBlock)(void) = ^{
+      @try {
+        [app launch];
+      } @catch (NSException *e) {
+        launchErrorResponse = FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:e.reason traceback:nil]);
       }
+    };
+    if (nil != capabilities[FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC]) {
+      [FBXCAXClientProxy.sharedClient withApplicationStateTimeout:[capabilities[FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC] doubleValue]
+                                                                do:launchBlock];
+    } else {
+      launchBlock();
+    }
+    if (nil != launchErrorResponse) {
+      return launchErrorResponse;
     }
   }
 
@@ -486,12 +491,9 @@
                               withApplication:(nullable NSString *)bundleID
                                       timeout:(nullable NSNumber *)timeout
 {
-  NSError *openError;
-  NSTimeInterval defaultTimeout = _XCTApplicationStateTimeout();
-  if (nil != timeout) {
-    _XCTSetApplicationStateTimeout([timeout doubleValue]);
-  }
-  @try {
+  __block id<FBResponsePayload> response;
+  void (^openBlock)(void) = ^{
+    NSError *openError;
     BOOL result = nil == bundleID
       ? [XCUIDevice.sharedDevice fb_openUrl:initialUrl
                                       error:&openError]
@@ -499,16 +501,18 @@
                             withApplication:(id)bundleID
                                       error:&openError];
     if (result) {
-      return nil;
+      return;
     }
     NSString *errorMsg = [NSString stringWithFormat:@"Cannot open the URL %@ with the %@ application. Original error: %@",
                           initialUrl, bundleID ?: @"default", openError.localizedDescription];
-    return FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:errorMsg traceback:nil]);
-  } @finally {
-    if (nil != timeout) {
-      _XCTSetApplicationStateTimeout(defaultTimeout);
-    }
+    response = FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:errorMsg traceback:nil]);
+  };
+  if (nil != timeout) {
+    [FBXCAXClientProxy.sharedClient withApplicationStateTimeout:[timeout doubleValue] do:openBlock];
+  } else {
+    openBlock();
   }
+  return response;
 }
 
 @end

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -386,8 +386,8 @@
       }
     };
     if (nil != capabilities[FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC]) {
-      [FBXCAXClientProxy.sharedClient withApplicationStateTimeout:[capabilities[FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC] doubleValue]
-                                                                do:launchBlock];
+      [FBXCAXClientProxy withApplicationStateTimeout:[capabilities[FB_CAP_APP_LAUNCH_STATE_TIMEOUT_SEC] doubleValue]
+                                                   do:launchBlock];
     } else {
       launchBlock();
     }
@@ -508,7 +508,7 @@
     response = FBResponseWithStatus([FBCommandStatus sessionNotCreatedError:errorMsg traceback:nil]);
   };
   if (nil != timeout) {
-    [FBXCAXClientProxy.sharedClient withApplicationStateTimeout:[timeout doubleValue] do:openBlock];
+    [FBXCAXClientProxy withApplicationStateTimeout:[timeout doubleValue] do:openBlock];
   } else {
     openBlock();
   }

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
@@ -22,29 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedClient;
 
-/**
- Bounds how long a single accessibility (AX) request issued by this process is allowed
- to wait for a reply from the AX server (the "AXTimeout" property of XCAXClient_iOS/
- XCUIAccessibilityInterface). Every AX-backed call funneled through this proxy -
- systemApplication, activeApplications, snapshotForElement:..., attributesForElement:...
- - is bounded by this single, process-wide value; there is no per-call override.
-
- Important: this only bounds how long the CALLING thread waits for a reply. The AX
- server itself is not told to cancel the request when this timeout elapses - the
- request keeps running/queued on the AX side regardless of whether this process gave
- up waiting on it. All AX requests from this process share one serial channel to the
- AX server, so if the target app's UI is genuinely unresponsive, lowering this value
- does not reduce the amount of queued work or make the server itself more responsive -
- it only makes each individual caller give up sooner, while requests already abandoned
- by their callers keep occupying the channel and can still delay whatever is queued
- behind them by their original, un-shortened duration.
- */
 - (BOOL)setAXTimeout:(NSTimeInterval)timeout error:(NSError **)error;
-
-/**
- The AXTimeout value currently in effect. See -setAXTimeout:error: for what it bounds.
- */
-- (NSTimeInterval)axTimeout;
 
 - (nullable id<FBXCElementSnapshot>)snapshotForElement:(id<FBXCAccessibilityElement>)element
                                             attributes:(nullable NSArray<NSString *> *)attributes
@@ -76,14 +54,37 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable XCUIApplication *)monitoredApplicationWithProcessIdentifier:(int)pid;
 
 /**
- Bounds how long a single XPC round trip of an XCTest automation-session request is
- allowed to take (the private `_XCTXPCRequestTimeout`/`_XCTSetXPCRequestTimeout`
- globals). This is the XCTest-level analog of -setAXTimeout:error:, but scoped wider:
+ Runs `block` synchronously with AXTimeout (the "AXTimeout" property of
+ XCAXClient_iOS/XCUIAccessibilityInterface, backed by the private `_XCTAXIPCTimeout`
+ global) temporarily set to `timeout`, restoring the previous value once `block`
+ returns (even if it throws). Bounds how long a single accessibility (AX) request
+ issued by this process is allowed to wait for a reply from the AX server. Every
+ AX-backed call funneled through this proxy - systemApplication, activeApplications,
+ snapshotForElement:..., attributesForElement:... - is bounded by this single,
+ process-wide value; there is no per-call override. Defaults to 60 seconds.
+
+ Important: this only bounds how long the CALLING thread waits for a reply. The AX
+ server itself is not told to cancel the request when this timeout elapses - the
+ request keeps running/queued on the AX side regardless of whether this process gave
+ up waiting on it. All AX requests from this process share one serial channel to the
+ AX server, so if the target app's UI is genuinely unresponsive, lowering this value
+ does not reduce the amount of queued work or make the server itself more responsive -
+ it only makes each individual caller give up sooner, while requests already abandoned
+ by their callers keep occupying the channel and can still delay whatever is queued
+ behind them by their original, un-shortened duration.
+ */
+- (void)withAXTimeout:(NSTimeInterval)timeout do:(void (^)(void))block;
+
+/**
+ Runs `block` synchronously with the XCTest automation-session XPC request timeout
+ (the private `_XCTXPCRequestTimeout`/`_XCTSetXPCRequestTimeout` globals) temporarily
+ set to `timeout`, restoring the previous value once `block` returns (even if it
+ throws). This is the XCTest-level analog of -withAXTimeout:do:, but scoped wider:
  virtually every timeout-bounded automation call in the process - element matching,
  attribute/snapshot fetches, event confirmation, and the AX-backed calls above - is
  ultimately funneled through `+[XCTFuture futureWithTimeout:description:block:]`,
  which uses this value as its default wait bound. Like AXTimeout, it is a single,
- process-wide setting with no per-call override.
+ process-wide setting with no per-call override. Defaults to 30 seconds.
 
  `futureWithTimeout:description:block:` is a synchronous wait wrapper: it starts the
  real (asynchronous) XPC request and blocks the calling thread until either the reply
@@ -101,13 +102,7 @@ NS_ASSUME_NONNULL_BEGIN
  freeing up the channel, and can never be used to reliably bound end-to-end latency
  while the target is unresponsive.
  */
-- (void)setXPCRequestTimeout:(NSTimeInterval)timeout;
-
-/**
- The XPC request timeout value currently in effect. See -setXPCRequestTimeout: for
- what it bounds.
- */
-- (NSTimeInterval)xpcRequestTimeout;
+- (void)withXPCRequestTimeout:(NSTimeInterval)timeout do:(void (^)(void))block;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
@@ -122,6 +122,31 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)withXPCRequestTimeout:(NSTimeInterval)timeout do:(void (^)(void))block;
 
+/**
+ Runs `block` synchronously with the XCTest application-state timeout (the private
+ `_XCTApplicationStateTimeout`/`_XCTSetApplicationStateTimeout` globals) temporarily
+ set to `timeout`, restoring the previous value once `block` returns (even if it
+ throws). Defaults to 60 seconds, though it may be pre-seeded once from a
+ NSUserDefaults override the first time it is read, before any of this process's own
+ -withApplicationStateTimeout:do: calls run.
+
+ Unlike AXTimeout/the XPC request timeout above, this one is not scoped to a single
+ request/response round trip - it bounds `[XCTWaiter waitForExpectations:timeout:]`
+ inside `-[XCUIApplicationProcess waitForQuiescenceIncludingAnimationsIdle:...]`,
+ which WDA's own XCUIApplicationProcess+FBQuiescence.m swizzle already targets for the
+ per-tap pre/post-event quiescence wait. That wait is gated by a *compound OR*
+ expectation over two independently-notified flags - `eventLoopHasIdled` and (when
+ requested) `animationsHaveFinished` - so it can return as soon as either one changes,
+ not necessarily both; this timeout only bounds how long that race is allowed to run
+ before giving up on both. The same global also bounds XCTest's app-launch/foreground
+ state-transition waits (see -[FBSessionCommands launchApplication:...],
+ +[FBSessionCommands openDeepLink:withApplication:timeout:]), which are a different,
+ non-quiescence consumer of this same timeout.
+
+ Returns YES if `block` returned within `timeout`, NO otherwise.
+ */
+- (BOOL)withApplicationStateTimeout:(NSTimeInterval)timeout do:(void (^)(void))block;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
@@ -22,8 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedClient;
 
-- (BOOL)setAXTimeout:(NSTimeInterval)timeout error:(NSError **)error;
-
 - (nullable id<FBXCElementSnapshot>)snapshotForElement:(id<FBXCAccessibilityElement>)element
                                             attributes:(nullable NSArray<NSString *> *)attributes
                                                inDepth:(BOOL)inDepth

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
@@ -60,8 +60,17 @@ NS_ASSUME_NONNULL_BEGIN
  returns (even if it throws). Bounds how long a single accessibility (AX) request
  issued by this process is allowed to wait for a reply from the AX server. Every
  AX-backed call funneled through this proxy - systemApplication, activeApplications,
- snapshotForElement:..., attributesForElement:... - is bounded by this single,
- process-wide value; there is no per-call override. Defaults to 60 seconds.
+ snapshotForElement:..., attributesForElement:... - is an in-process call into
+ XCAXClient_iOS and is bounded by this single, process-wide value; there is no
+ per-call override. Defaults to 60 seconds.
+
+ These XCAXClient_iOS calls are themselves wrapped in
+ `+[XCTFuture futureWithTimeout:description:block:]`, but that wrapper's own timeout
+ is `_XCTAXClientWrapperTimeout()` - AXTimeout plus a fixed 5-second margin, not
+ -withXPCRequestTimeout:do:'s `_XCTXPCRequestTimeout`. That margin exists so the AX
+ layer's own timeout has a chance to fire and produce a clean error before XCTFuture's
+ wrapper would cut if off anyway; it is not independently tunable. AXTimeout is
+ therefore the only knob that matters for every call this proxy wraps.
 
  Important: this only bounds how long the CALLING thread waits for a reply. The AX
  server itself is not told to cancel the request when this timeout elapses - the
@@ -81,12 +90,19 @@ NS_ASSUME_NONNULL_BEGIN
  Runs `block` synchronously with the XCTest automation-session XPC request timeout
  (the private `_XCTXPCRequestTimeout`/`_XCTSetXPCRequestTimeout` globals) temporarily
  set to `timeout`, restoring the previous value once `block` returns (even if it
- throws). This is the XCTest-level analog of -withAXTimeout:do:, but scoped wider:
- virtually every timeout-bounded automation call in the process - element matching,
- attribute/snapshot fetches, event confirmation, and the AX-backed calls above - is
- ultimately funneled through `+[XCTFuture futureWithTimeout:description:block:]`,
- which uses this value as its default wait bound. Like AXTimeout, it is a single,
- process-wide setting with no per-call override. Defaults to 30 seconds.
+ throws). Defaults to 30 seconds.
+
+ This does NOT bound anything else in this proxy - despite the similar shape, it is
+ not the XCTest-level analog of -withAXTimeout:do: for the calls above. AXTimeout and
+ the XPC request timeout gate two structurally different, non-nested call paths:
+ XCAXClient_iOS (what this proxy wraps) makes its AX-server round trips in-process,
+ bounded solely by AXTimeout (see -withAXTimeout:do:); XCTRunnerAutomationSession -
+ a separate class WDA does not go through here - makes its calls over a real
+ NSXPCConnection (`remoteObjectProxyWithErrorHandler:`) to another process, bounded by
+ this timeout instead. `-[XCTRunnerAutomationSession matchesForQuery:error:]` (the
+ primitive behind XCUIElementQuery/most element-finding lookups) and that class's own,
+ identically-named `attributesForElement:attributes:error:` are the calls this timeout
+ actually bounds - not -[XCAXClient_iOS attributesForElement:attributes:error:] above.
 
  `futureWithTimeout:description:block:` is a synchronous wait wrapper: it starts the
  real (asynchronous) XPC request and blocks the calling thread until either the reply

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
@@ -22,7 +22,29 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedClient;
 
+/**
+ Bounds how long a single accessibility (AX) request issued by this process is allowed
+ to wait for a reply from the AX server (the "AXTimeout" property of XCAXClient_iOS/
+ XCUIAccessibilityInterface). Every AX-backed call funneled through this proxy -
+ systemApplication, activeApplications, snapshotForElement:..., attributesForElement:...
+ - is bounded by this single, process-wide value; there is no per-call override.
+
+ Important: this only bounds how long the CALLING thread waits for a reply. The AX
+ server itself is not told to cancel the request when this timeout elapses - the
+ request keeps running/queued on the AX side regardless of whether this process gave
+ up waiting on it. All AX requests from this process share one serial channel to the
+ AX server, so if the target app's UI is genuinely unresponsive, lowering this value
+ does not reduce the amount of queued work or make the server itself more responsive -
+ it only makes each individual caller give up sooner, while requests already abandoned
+ by their callers keep occupying the channel and can still delay whatever is queued
+ behind them by their original, un-shortened duration.
+ */
 - (BOOL)setAXTimeout:(NSTimeInterval)timeout error:(NSError **)error;
+
+/**
+ The AXTimeout value currently in effect. See -setAXTimeout:error: for what it bounds.
+ */
+- (NSTimeInterval)axTimeout;
 
 - (nullable id<FBXCElementSnapshot>)snapshotForElement:(id<FBXCAccessibilityElement>)element
                                             attributes:(nullable NSArray<NSString *> *)attributes
@@ -52,6 +74,40 @@ NS_ASSUME_NONNULL_BEGIN
                                           error:(NSError**)error;
 
 - (nullable XCUIApplication *)monitoredApplicationWithProcessIdentifier:(int)pid;
+
+/**
+ Bounds how long a single XPC round trip of an XCTest automation-session request is
+ allowed to take (the private `_XCTXPCRequestTimeout`/`_XCTSetXPCRequestTimeout`
+ globals). This is the XCTest-level analog of -setAXTimeout:error:, but scoped wider:
+ virtually every timeout-bounded automation call in the process - element matching,
+ attribute/snapshot fetches, event confirmation, and the AX-backed calls above - is
+ ultimately funneled through `+[XCTFuture futureWithTimeout:description:block:]`,
+ which uses this value as its default wait bound. Like AXTimeout, it is a single,
+ process-wide setting with no per-call override.
+
+ `futureWithTimeout:description:block:` is a synchronous wait wrapper: it starts the
+ real (asynchronous) XPC request and blocks the calling thread until either the reply
+ arrives or this timeout elapses, then returns either way - but elapsing the timeout
+ does NOT cancel the underlying XPC request. It keeps running to completion on the
+ same serial channel regardless of whether anyone is still waiting on it.
+
+ Practical consequence: all XPC-bounded requests from this process share one queue to
+ the automation session. If the target app's main thread/run loop is genuinely stuck,
+ lowering this timeout does not shrink the backlog or make the target more responsive
+ - it only makes the CALLER give up sooner. A request issued right after an earlier
+ one "times out" still has to wait behind that earlier request's real completion (which
+ keeps consuming the channel in the background), so it can take just as long, or longer,
+ to be serviced - repeatedly retrying after a timeout adds more queued work rather than
+ freeing up the channel, and can never be used to reliably bound end-to-end latency
+ while the target is unresponsive.
+ */
+- (void)setXPCRequestTimeout:(NSTimeInterval)timeout;
+
+/**
+ The XPC request timeout value currently in effect. See -setXPCRequestTimeout: for
+ what it bounds.
+ */
+- (NSTimeInterval)xpcRequestTimeout;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
  These XCAXClient_iOS calls are themselves wrapped in
  `+[XCTFuture futureWithTimeout:description:block:]`, but that wrapper's own timeout
  is `_XCTAXClientWrapperTimeout()` - AXTimeout plus a fixed 5-second margin, not
- -withXPCRequestTimeout:do:'s `_XCTXPCRequestTimeout`. That margin exists so the AX
+ +withXPCRequestTimeout:do:'s `_XCTXPCRequestTimeout`. That margin exists so the AX
  layer's own timeout has a chance to fire and produce a clean error before XCTFuture's
  wrapper would cut if off anyway; it is not independently tunable. AXTimeout is
  therefore the only knob that matters for every call this proxy wraps.
@@ -80,9 +80,16 @@ NS_ASSUME_NONNULL_BEGIN
  by their callers keep occupying the channel and can still delay whatever is queued
  behind them by their original, un-shortened duration.
 
- Returns YES if `block` returned within `timeout`, NO otherwise.
+ The whole scope is serialized behind a dedicated lock, so overlapping calls from
+ different threads nest/queue instead of racing to restore the global.
+
+ If installing `timeout` fails, `block` is not run, this returns NO, and `error` (if
+ given) is populated with the underlying failure. A failure while restoring the
+ previous value is logged and reported via `error` independently of the return value,
+ which always reflects `block`'s completion, sampled immediately after it returns and
+ before the restore attempt.
  */
-- (BOOL)withAXTimeout:(NSTimeInterval)timeout do:(void (^)(void))block;
+- (BOOL)withAXTimeout:(NSTimeInterval)timeout do:(void (^)(void))block error:(NSError **)error;
 
 /**
  Runs `block` synchronously with the XCTest automation-session XPC request timeout
@@ -118,9 +125,15 @@ NS_ASSUME_NONNULL_BEGIN
  freeing up the channel, and can never be used to reliably bound end-to-end latency
  while the target is unresponsive.
 
+ A class-level method: it only touches the XPC request timeout global, never the AX
+ client, so calling it does not trigger AX subsystem initialization. The scope is
+ serialized behind a dedicated lock, so overlapping calls nest/queue instead of racing
+ to restore the global. The returned completion result is sampled immediately after
+ `block` returns and before the previous value is restored.
+
  Returns YES if `block` returned within `timeout`, NO otherwise.
  */
-- (BOOL)withXPCRequestTimeout:(NSTimeInterval)timeout do:(void (^)(void))block;
++ (BOOL)withXPCRequestTimeout:(NSTimeInterval)timeout do:(void (^)(void))block;
 
 /**
  Runs `block` synchronously with the XCTest application-state timeout (the private
@@ -128,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
  set to `timeout`, restoring the previous value once `block` returns (even if it
  throws). Defaults to 60 seconds, though it may be pre-seeded once from a
  NSUserDefaults override the first time it is read, before any of this process's own
- -withApplicationStateTimeout:do: calls run.
+ +withApplicationStateTimeout:do: calls run.
 
  Unlike AXTimeout/the XPC request timeout above, this one is not scoped to a single
  request/response round trip - it bounds `[XCTWaiter waitForExpectations:timeout:]`
@@ -143,9 +156,15 @@ NS_ASSUME_NONNULL_BEGIN
  +[FBSessionCommands openDeepLink:withApplication:timeout:]), which are a different,
  non-quiescence consumer of this same timeout.
 
+ A class-level method: it only touches the application-state timeout global, never the
+ AX client, so calling it does not trigger AX subsystem initialization. The scope is
+ serialized behind a dedicated lock, so overlapping calls nest/queue instead of racing
+ to restore the global. The returned completion result is sampled immediately after
+ `block` returns and before the previous value is restored.
+
  Returns YES if `block` returned within `timeout`, NO otherwise.
  */
-- (BOOL)withApplicationStateTimeout:(NSTimeInterval)timeout do:(void (^)(void))block;
++ (BOOL)withApplicationStateTimeout:(NSTimeInterval)timeout do:(void (^)(void))block;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
@@ -72,8 +72,12 @@ NS_ASSUME_NONNULL_BEGIN
  it only makes each individual caller give up sooner, while requests already abandoned
  by their callers keep occupying the channel and can still delay whatever is queued
  behind them by their original, un-shortened duration.
+
+ `block` should return YES if it completed without hitting `timeout`, or NO if it
+ detected a timeout (e.g. via -[NSError(XCTFuture) xct_isFutureTimeout]) - this method
+ returns that same value.
  */
-- (void)withAXTimeout:(NSTimeInterval)timeout do:(void (^)(void))block;
+- (BOOL)withAXTimeout:(NSTimeInterval)timeout do:(BOOL (^)(void))block;
 
 /**
  Runs `block` synchronously with the XCTest automation-session XPC request timeout
@@ -101,8 +105,12 @@ NS_ASSUME_NONNULL_BEGIN
  to be serviced - repeatedly retrying after a timeout adds more queued work rather than
  freeing up the channel, and can never be used to reliably bound end-to-end latency
  while the target is unresponsive.
+
+ `block` should return YES if it completed without hitting `timeout`, or NO if it
+ detected a timeout (e.g. via -[NSError(XCTFuture) xct_isFutureTimeout]) - this method
+ returns that same value.
  */
-- (void)withXPCRequestTimeout:(NSTimeInterval)timeout do:(void (^)(void))block;
+- (BOOL)withXPCRequestTimeout:(NSTimeInterval)timeout do:(BOOL (^)(void))block;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.h
@@ -73,11 +73,9 @@ NS_ASSUME_NONNULL_BEGIN
  by their callers keep occupying the channel and can still delay whatever is queued
  behind them by their original, un-shortened duration.
 
- `block` should return YES if it completed without hitting `timeout`, or NO if it
- detected a timeout (e.g. via -[NSError(XCTFuture) xct_isFutureTimeout]) - this method
- returns that same value.
+ Returns YES if `block` returned within `timeout`, NO otherwise.
  */
-- (BOOL)withAXTimeout:(NSTimeInterval)timeout do:(BOOL (^)(void))block;
+- (BOOL)withAXTimeout:(NSTimeInterval)timeout do:(void (^)(void))block;
 
 /**
  Runs `block` synchronously with the XCTest automation-session XPC request timeout
@@ -106,11 +104,9 @@ NS_ASSUME_NONNULL_BEGIN
  freeing up the channel, and can never be used to reliably bound end-to-end latency
  while the target is unresponsive.
 
- `block` should return YES if it completed without hitting `timeout`, or NO if it
- detected a timeout (e.g. via -[NSError(XCTFuture) xct_isFutureTimeout]) - this method
- returns that same value.
+ Returns YES if `block` returned within `timeout`, NO otherwise.
  */
-- (BOOL)withXPCRequestTimeout:(NSTimeInterval)timeout do:(BOOL (^)(void))block;
+- (BOOL)withXPCRequestTimeout:(NSTimeInterval)timeout do:(void (^)(void))block;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
@@ -43,31 +43,35 @@ static id FBAXClient = nil;
   return [FBAXClient _setAXTimeout:timeout error:error];
 }
 
-- (BOOL)withAXTimeout:(NSTimeInterval)timeout do:(BOOL (^)(void))block
+- (BOOL)withAXTimeout:(NSTimeInterval)timeout do:(void (^)(void))block
 {
   NSTimeInterval previousTimeout = [FBAXClient AXTimeout];
   NSError *error;
   if (![self setAXTimeout:timeout error:&error]) {
     [FBLogger logFmt:@"Failed to set AXTimeout to %@: %@", @(timeout), error];
   }
+  CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent();
   @try {
-    return block();
+    block();
   } @finally {
     if (![self setAXTimeout:previousTimeout error:&error]) {
       [FBLogger logFmt:@"Failed to restore AXTimeout to %@: %@", @(previousTimeout), error];
     }
   }
+  return (CFAbsoluteTimeGetCurrent() - startTime) < timeout;
 }
 
-- (BOOL)withXPCRequestTimeout:(NSTimeInterval)timeout do:(BOOL (^)(void))block
+- (BOOL)withXPCRequestTimeout:(NSTimeInterval)timeout do:(void (^)(void))block
 {
   NSTimeInterval previousTimeout = _XCTXPCRequestTimeout();
   _XCTSetXPCRequestTimeout(timeout);
+  CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent();
   @try {
-    return block();
+    block();
   } @finally {
     _XCTSetXPCRequestTimeout(previousTimeout);
   }
+  return (CFAbsoluteTimeGetCurrent() - startTime) < timeout;
 }
 
 - (id<FBXCElementSnapshot>)snapshotForElement:(id<FBXCAccessibilityElement>)element

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
@@ -8,6 +8,7 @@
 
 #import "FBXCAXClientProxy.h"
 
+#import "CDStructures.h"
 #import "FBXCAccessibilityElement.h"
 #import "FBLogger.h"
 #import "FBMacros.h"
@@ -40,6 +41,21 @@ static id FBAXClient = nil;
 - (BOOL)setAXTimeout:(NSTimeInterval)timeout error:(NSError **)error
 {
   return [FBAXClient _setAXTimeout:timeout error:error];
+}
+
+- (NSTimeInterval)axTimeout
+{
+  return [FBAXClient AXTimeout];
+}
+
+- (void)setXPCRequestTimeout:(NSTimeInterval)timeout
+{
+  _XCTSetXPCRequestTimeout(timeout);
+}
+
+- (NSTimeInterval)xpcRequestTimeout
+{
+  return _XCTXPCRequestTimeout();
 }
 
 - (id<FBXCElementSnapshot>)snapshotForElement:(id<FBXCAccessibilityElement>)element

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
@@ -69,6 +69,19 @@ static id FBAXClient = nil;
   return (CFAbsoluteTimeGetCurrent() - startTime) < timeout;
 }
 
+- (BOOL)withApplicationStateTimeout:(NSTimeInterval)timeout do:(void (^)(void))block
+{
+  NSTimeInterval previousTimeout = _XCTApplicationStateTimeout();
+  _XCTSetApplicationStateTimeout(timeout);
+  CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent();
+  @try {
+    block();
+  } @finally {
+    _XCTSetApplicationStateTimeout(previousTimeout);
+  }
+  return (CFAbsoluteTimeGetCurrent() - startTime) < timeout;
+}
+
 - (id<FBXCElementSnapshot>)snapshotForElement:(id<FBXCAccessibilityElement>)element
                                    attributes:(NSArray<NSString *> *)attributes
                                       inDepth:(BOOL)inDepth

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
@@ -43,19 +43,31 @@ static id FBAXClient = nil;
   return [FBAXClient _setAXTimeout:timeout error:error];
 }
 
-- (NSTimeInterval)axTimeout
+- (void)withAXTimeout:(NSTimeInterval)timeout do:(void (^)(void))block
 {
-  return [FBAXClient AXTimeout];
+  NSTimeInterval previousTimeout = [FBAXClient AXTimeout];
+  NSError *error;
+  if (![self setAXTimeout:timeout error:&error]) {
+    [FBLogger logFmt:@"Failed to set AXTimeout to %@: %@", @(timeout), error];
+  }
+  @try {
+    block();
+  } @finally {
+    if (![self setAXTimeout:previousTimeout error:&error]) {
+      [FBLogger logFmt:@"Failed to restore AXTimeout to %@: %@", @(previousTimeout), error];
+    }
+  }
 }
 
-- (void)setXPCRequestTimeout:(NSTimeInterval)timeout
+- (void)withXPCRequestTimeout:(NSTimeInterval)timeout do:(void (^)(void))block
 {
+  NSTimeInterval previousTimeout = _XCTXPCRequestTimeout();
   _XCTSetXPCRequestTimeout(timeout);
-}
-
-- (NSTimeInterval)xpcRequestTimeout
-{
-  return _XCTXPCRequestTimeout();
+  @try {
+    block();
+  } @finally {
+    _XCTSetXPCRequestTimeout(previousTimeout);
+  }
 }
 
 - (id<FBXCElementSnapshot>)snapshotForElement:(id<FBXCAccessibilityElement>)element

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
@@ -43,7 +43,7 @@ static id FBAXClient = nil;
   return [FBAXClient _setAXTimeout:timeout error:error];
 }
 
-- (void)withAXTimeout:(NSTimeInterval)timeout do:(void (^)(void))block
+- (BOOL)withAXTimeout:(NSTimeInterval)timeout do:(BOOL (^)(void))block
 {
   NSTimeInterval previousTimeout = [FBAXClient AXTimeout];
   NSError *error;
@@ -51,7 +51,7 @@ static id FBAXClient = nil;
     [FBLogger logFmt:@"Failed to set AXTimeout to %@: %@", @(timeout), error];
   }
   @try {
-    block();
+    return block();
   } @finally {
     if (![self setAXTimeout:previousTimeout error:&error]) {
       [FBLogger logFmt:@"Failed to restore AXTimeout to %@: %@", @(previousTimeout), error];
@@ -59,12 +59,12 @@ static id FBAXClient = nil;
   }
 }
 
-- (void)withXPCRequestTimeout:(NSTimeInterval)timeout do:(void (^)(void))block
+- (BOOL)withXPCRequestTimeout:(NSTimeInterval)timeout do:(BOOL (^)(void))block
 {
   NSTimeInterval previousTimeout = _XCTXPCRequestTimeout();
   _XCTSetXPCRequestTimeout(timeout);
   @try {
-    block();
+    return block();
   } @finally {
     _XCTSetXPCRequestTimeout(previousTimeout);
   }

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
@@ -38,23 +38,18 @@ static id FBAXClient = nil;
   return instance;
 }
 
-- (BOOL)setAXTimeout:(NSTimeInterval)timeout error:(NSError **)error
-{
-  return [FBAXClient _setAXTimeout:timeout error:error];
-}
-
 - (BOOL)withAXTimeout:(NSTimeInterval)timeout do:(void (^)(void))block
 {
   NSTimeInterval previousTimeout = [FBAXClient AXTimeout];
   NSError *error;
-  if (![self setAXTimeout:timeout error:&error]) {
+  if (![FBAXClient _setAXTimeout:timeout error:&error]) {
     [FBLogger logFmt:@"Failed to set AXTimeout to %@: %@", @(timeout), error];
   }
   CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent();
   @try {
     block();
   } @finally {
-    if (![self setAXTimeout:previousTimeout error:&error]) {
+    if (![FBAXClient _setAXTimeout:previousTimeout error:&error]) {
       [FBLogger logFmt:@"Failed to restore AXTimeout to %@: %@", @(previousTimeout), error];
     }
   }

--- a/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
+++ b/WebDriverAgentLib/Utilities/FBXCAXClientProxy.m
@@ -18,6 +18,39 @@
 
 static id FBAXClient = nil;
 
+// Guards -withAXTimeout:do:'s save/set/restore of the process-wide AXTimeout global.
+static NSRecursiveLock *FBAXTimeoutLock(void)
+{
+  static NSRecursiveLock *lock;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    lock = [NSRecursiveLock new];
+  });
+  return lock;
+}
+
+// Guards +withXPCRequestTimeout:do:'s save/set/restore of the process-wide XPC request timeout global.
+static NSRecursiveLock *FBXPCRequestTimeoutLock(void)
+{
+  static NSRecursiveLock *lock;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    lock = [NSRecursiveLock new];
+  });
+  return lock;
+}
+
+// Guards +withApplicationStateTimeout:do:'s save/set/restore of the process-wide application-state timeout global.
+static NSRecursiveLock *FBApplicationStateTimeoutLock(void)
+{
+  static NSRecursiveLock *lock;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    lock = [NSRecursiveLock new];
+  });
+  return lock;
+}
+
 @interface FBXCAXClientProxy ()
 
 @property (nonatomic) NSMutableDictionary<NSNumber *, XCUIApplication *> *appsCache;
@@ -39,48 +72,80 @@ static id FBAXClient = nil;
   return instance;
 }
 
-- (BOOL)withAXTimeout:(NSTimeInterval)timeout do:(void (^)(void))block
+- (BOOL)withAXTimeout:(NSTimeInterval)timeout do:(void (^)(void))block error:(NSError **)error
 {
-  NSTimeInterval previousTimeout = [FBAXClient AXTimeout];
-  NSError *error;
-  if (![FBAXClient _setAXTimeout:timeout error:&error]) {
-    [FBLogger logFmt:@"Failed to set AXTimeout to %@: %@", @(timeout), error];
-  }
-  CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent();
+  NSRecursiveLock *lock = FBAXTimeoutLock();
+  [lock lock];
   @try {
-    block();
-  } @finally {
-    if (![FBAXClient _setAXTimeout:previousTimeout error:&error]) {
-      [FBLogger logFmt:@"Failed to restore AXTimeout to %@: %@", @(previousTimeout), error];
+    NSTimeInterval previousTimeout = [FBAXClient AXTimeout];
+    NSError *setError;
+    if (![FBAXClient _setAXTimeout:timeout error:&setError]) {
+      [FBLogger logFmt:@"Failed to set AXTimeout to %@: %@", @(timeout), setError];
+      if (nil != error) {
+        *error = setError;
+      }
+      return NO;
     }
+    NSTimeInterval startTime = NSProcessInfo.processInfo.systemUptime;
+    BOOL completedInTime = NO;
+    @try {
+      block();
+      completedInTime = (NSProcessInfo.processInfo.systemUptime - startTime) < timeout;
+    } @finally {
+      NSError *restoreError;
+      if (![FBAXClient _setAXTimeout:previousTimeout error:&restoreError]) {
+        [FBLogger logFmt:@"Failed to restore AXTimeout to %@: %@", @(previousTimeout), restoreError];
+        if (nil != error) {
+          *error = restoreError;
+        }
+      }
+    }
+    return completedInTime;
+  } @finally {
+    [lock unlock];
   }
-  return (CFAbsoluteTimeGetCurrent() - startTime) < timeout;
 }
 
-- (BOOL)withXPCRequestTimeout:(NSTimeInterval)timeout do:(void (^)(void))block
++ (BOOL)withXPCRequestTimeout:(NSTimeInterval)timeout do:(void (^)(void))block
 {
-  NSTimeInterval previousTimeout = _XCTXPCRequestTimeout();
-  _XCTSetXPCRequestTimeout(timeout);
-  CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent();
+  NSRecursiveLock *lock = FBXPCRequestTimeoutLock();
+  [lock lock];
   @try {
-    block();
+    NSTimeInterval previousTimeout = _XCTXPCRequestTimeout();
+    _XCTSetXPCRequestTimeout(timeout);
+    NSTimeInterval startTime = NSProcessInfo.processInfo.systemUptime;
+    BOOL completedInTime = NO;
+    @try {
+      block();
+      completedInTime = (NSProcessInfo.processInfo.systemUptime - startTime) < timeout;
+    } @finally {
+      _XCTSetXPCRequestTimeout(previousTimeout);
+    }
+    return completedInTime;
   } @finally {
-    _XCTSetXPCRequestTimeout(previousTimeout);
+    [lock unlock];
   }
-  return (CFAbsoluteTimeGetCurrent() - startTime) < timeout;
 }
 
-- (BOOL)withApplicationStateTimeout:(NSTimeInterval)timeout do:(void (^)(void))block
++ (BOOL)withApplicationStateTimeout:(NSTimeInterval)timeout do:(void (^)(void))block
 {
-  NSTimeInterval previousTimeout = _XCTApplicationStateTimeout();
-  _XCTSetApplicationStateTimeout(timeout);
-  CFAbsoluteTime startTime = CFAbsoluteTimeGetCurrent();
+  NSRecursiveLock *lock = FBApplicationStateTimeoutLock();
+  [lock lock];
   @try {
-    block();
+    NSTimeInterval previousTimeout = _XCTApplicationStateTimeout();
+    _XCTSetApplicationStateTimeout(timeout);
+    NSTimeInterval startTime = NSProcessInfo.processInfo.systemUptime;
+    BOOL completedInTime = NO;
+    @try {
+      block();
+      completedInTime = (NSProcessInfo.processInfo.systemUptime - startTime) < timeout;
+    } @finally {
+      _XCTSetApplicationStateTimeout(previousTimeout);
+    }
+    return completedInTime;
   } @finally {
-    _XCTSetApplicationStateTimeout(previousTimeout);
+    [lock unlock];
   }
-  return (CFAbsoluteTimeGetCurrent() - startTime) < timeout;
 }
 
 - (id<FBXCElementSnapshot>)snapshotForElement:(id<FBXCAccessibilityElement>)element

--- a/WebDriverAgentTests/UnitTests/FBXCAXClientProxyTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXCAXClientProxyTests.m
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "CDStructures.h"
+#import "FBXCAXClientProxy.h"
+
+@interface FBXCAXClientProxyTests : XCTestCase
+@end
+
+@implementation FBXCAXClientProxyTests
+
+- (void)testApplicationStateTimeoutSetsValueDuringBlockAndRestoresAfter
+{
+  double original = _XCTApplicationStateTimeout();
+  __block double observed = -1;
+  BOOL completed = [FBXCAXClientProxy withApplicationStateTimeout:12.5 do:^{
+    observed = _XCTApplicationStateTimeout();
+  }];
+  XCTAssertTrue(completed);
+  XCTAssertEqual(observed, 12.5);
+  XCTAssertEqual(_XCTApplicationStateTimeout(), original);
+}
+
+- (void)testApplicationStateTimeoutNestedCallsRestoreCorrectly
+{
+  double original = _XCTApplicationStateTimeout();
+  [FBXCAXClientProxy withApplicationStateTimeout:20 do:^{
+    XCTAssertEqual(_XCTApplicationStateTimeout(), 20);
+    [FBXCAXClientProxy withApplicationStateTimeout:5 do:^{
+      XCTAssertEqual(_XCTApplicationStateTimeout(), 5);
+    }];
+    XCTAssertEqual(_XCTApplicationStateTimeout(), 20);
+  }];
+  XCTAssertEqual(_XCTApplicationStateTimeout(), original);
+}
+
+- (void)testApplicationStateTimeoutOverlappingCallsRestoreOriginalValue
+{
+  double original = _XCTApplicationStateTimeout();
+  NSInteger iterations = 50;
+  dispatch_group_t group = dispatch_group_create();
+  dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0);
+  for (NSInteger i = 0; i < iterations; i++) {
+    dispatch_group_async(group, queue, ^{
+      [FBXCAXClientProxy withApplicationStateTimeout:10 + (double)i do:^{
+        usleep(500);
+      }];
+    });
+  }
+  dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+  XCTAssertEqual(_XCTApplicationStateTimeout(), original);
+}
+
+- (void)testXPCRequestTimeoutSetsValueDuringBlockAndRestoresAfter
+{
+  double original = _XCTXPCRequestTimeout();
+  __block double observed = -1;
+  BOOL completed = [FBXCAXClientProxy withXPCRequestTimeout:7.5 do:^{
+    observed = _XCTXPCRequestTimeout();
+  }];
+  XCTAssertTrue(completed);
+  XCTAssertEqual(observed, 7.5);
+  XCTAssertEqual(_XCTXPCRequestTimeout(), original);
+}
+
+- (void)testXPCRequestTimeoutOverlappingCallsRestoreOriginalValue
+{
+  double original = _XCTXPCRequestTimeout();
+  NSInteger iterations = 50;
+  dispatch_group_t group = dispatch_group_create();
+  dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0);
+  for (NSInteger i = 0; i < iterations; i++) {
+    dispatch_group_async(group, queue, ^{
+      [FBXCAXClientProxy withXPCRequestTimeout:10 + (double)i do:^{
+        usleep(500);
+      }];
+    });
+  }
+  dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+  XCTAssertEqual(_XCTXPCRequestTimeout(), original);
+}
+
+@end


### PR DESCRIPTION
## Summary

Adds three scoped, timeout-bounded block wrappers to `FBXCAXClientProxy` for private XCTest timeout globals: `-withAXTimeout:do:`, `-withXPCRequestTimeout:do:`, and `-withApplicationStateTimeout:do:`. Each temporarily overrides the corresponding global for the duration of `block`, restores the previous value once `block` returns (even if it throws), and returns whether `block` completed within `timeout`.

- **AXTimeout** (`_XCTAXIPCTimeout`/`_XCTSetAXIPCTimeout`, default 60s) bounds `XCAXClient_iOS`'s in-process AX-server round trips — every call this proxy wraps (`systemApplication`, `activeApplications`, `snapshotForElement:...`, `attributesForElement:...`). Their `futureWithTimeout:` wrapper uses `_XCTAXClientWrapperTimeout()` (AXTimeout + a fixed 5s margin), not the XPC global below, so AXTimeout is the only knob that matters for these calls.
- **XPC request timeout** (`_XCTXPCRequestTimeout`/`_XCTSetXPCRequestTimeout`, default 30s) bounds a structurally different, non-nested path: `XCTRunnerAutomationSession`'s `NSXPCConnection`-based calls (`matchesForQuery:`, and that class's own identically-named `attributesForElement:`) — used elsewhere by `XCUIElementQuery`-based element lookups, not by this proxy.
- **Application state timeout** (`_XCTApplicationStateTimeout`/`_XCTSetApplicationStateTimeout`, default 60s) bounds `[XCTWaiter waitForExpectations:timeout:]` inside `-[XCUIApplicationProcess waitForQuiescenceIncludingAnimationsIdle:...]` (a compound *OR* expectation over `eventLoopHasIdled`/`animationsHaveFinished` — it can return once either flips, not necessarily both), and separately bounds app-launch/foreground state-transition waits.

All three are declared as private `extern` C functions in `PrivateHeaders/XCTest/CDStructures.h`, following the existing convention already used for `_XCTApplicationStateTimeout`/`_XCTSetApplicationStateTimeout`.

Docs on all three explain the underlying request-queue mechanics: none of these timeouts cancel the in-flight work when they elapse — it keeps running on its shared serial channel regardless of whether the caller gave up waiting — so lowering them only shortens how long a caller waits, not the actual backlog.

Migrates the three existing manual save/restore call sites onto `-withApplicationStateTimeout:do:`: `XCUIApplicationProcess+FBQuiescence.m`'s two quiescence swizzles, and `FBSessionCommands.m`'s app-launch and `openDeepLink:withApplication:timeout:` paths. Also drops the now-unused public `setAXTimeout:error:` (no external callers; folded into `-withAXTimeout:do:`).

## Test plan

- [x] `xcodebuild build-for-testing` succeeds for `WebDriverAgentRunner`
