### PR TITLE
fix: do not trust XCUIElement.lastSnapshot for long-lived elements

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
@@ -134,10 +134,8 @@
 - (NSArray<XCUIElement *> *)fb_snapshotDescendantsMatchingChainItems:(NSArray<FBClassChainItem *> *)chainItems shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
   NSMutableArray<FBClassChainItem *> *lookupChain = chainItems.mutableCopy;
-  // Reuse an already-taken snapshot of `self` if one is available (e.g. the
-  // caller just resolved/inspected this same element) instead of always
-  // paying for a fresh one.
-  NSArray<id<FBXCElementSnapshot>> *currentRoots = @[self.lastSnapshot ?: self.fb_cachedSnapshot ?: [self fb_customSnapshot]];
+  // self.lastSnapshot may be stale leftover from an unrelated earlier command.
+  NSArray<id<FBXCElementSnapshot>> *currentRoots = @[self.fb_cachedSnapshot ?: [self fb_customSnapshot]];
   FBClassChainItem *chainItem = lookupChain.firstObject;
   NSArray<id<FBXCElementSnapshot>> *candidates = [self.class fb_snapshotsMatchingItem:chainItem inRoots:currentRoots];
   [lookupChain removeObjectAtIndex:0];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -100,9 +100,11 @@
     }
   }
   NSMutableArray<XCUIElement *> *matchedElements = [NSMutableArray array];
-  NSString *uid = nil == self.lastSnapshot
+  // self.lastSnapshot may be stale leftover from an unrelated earlier command.
+  id<FBXCElementSnapshot> selfSnapshot = self.fb_cachedSnapshot;
+  NSString *uid = nil == selfSnapshot
     ? self.fb_uid
-    : [FBXCElementSnapshotWrapper wdUIDWithSnapshot:self.lastSnapshot];
+    : [FBXCElementSnapshotWrapper wdUIDWithSnapshot:selfSnapshot];
   if (nil != uid && [matchedIds containsObject:uid]) {
     XCUIElement *stableSelf = [self fb_stableInstanceWithUid:uid];
     if (1 == snapshots.count) {

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -258,10 +258,11 @@ static NSString *const topNodeIndexPath = @"top";
       if ([root isKindOfClass:XCUIElement.class]) {
         lookupScopeSnapshot = [self snapshotWithRoot:[(XCUIElement *)root application]
                                            useNative:useNativeSnapshot];
+        // root.lastSnapshot may be stale leftover from an unrelated earlier command.
         contextRootSnapshot = [root isKindOfClass:XCUIApplication.class]
           ? nil
-          : ([(XCUIElement *)root lastSnapshot] ?: [self snapshotWithRoot:(XCUIElement *)root
-                                                                useNative:useNativeSnapshot]);
+          : ([(XCUIElement *)root fb_cachedSnapshot] ?: [self snapshotWithRoot:(XCUIElement *)root
+                                                                     useNative:useNativeSnapshot]);
       } else {
         lookupScopeSnapshot = (id<FBXCElementSnapshot>)root;
         contextRootSnapshot = nil == lookupScopeSnapshot.parent ? nil : (id<FBXCElementSnapshot>)root;

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
@@ -21,6 +21,7 @@
 #import "XCUIElement+FBResolve.h"
 #import "FBXPath.h"
 #import "FBXCodeCompatibility.h"
+#import "XCUIElement+FBUtilities.h"
 
 @interface XCUIElementFBFindTests : FBIntegrationTestCase
 @property (nonatomic, strong) XCUIElement *testedView;
@@ -533,6 +534,27 @@
                                                                      shouldReturnAfterFirstMatch:NO];
     XCTAssertEqual(matches.count, 1);
   }];
+}
+
+@end
+
+@interface XCUIElementFBFindTests_StaleAppSnapshot : FBIntegrationTestCase
+@end
+@implementation XCUIElementFBFindTests_StaleAppSnapshot
+
+// Regression test for https://github.com/appium/appium/issues/22672.
+- (void)testClassChainWithIntermediatePositionAfterStaleAppSnapshot
+{
+  [self launchApplication];
+  // Simulates a stale snapshot cached by an earlier, unrelated command (e.g. GET /source).
+  [self.testedApplication fb_customSnapshot];
+  [self goToDeepHierarchyPage];
+
+  NSString *query = @"**/XCUIElementTypeOther[`label == \"View 10\"`][1]/**/XCUIElementTypeOther[`label BEGINSWITH \"View 19\"`]";
+  NSArray<XCUIElement *> *matches = [self.testedApplication fb_descendantsMatchingClassChain:query
+                                                                   shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(matches.count, 1);
+  XCTAssertEqualObjects(matches.firstObject.label, @"View 19");
 }
 
 @end


### PR DESCRIPTION
lastSnapshot can be a leftover from an unrelated earlier command (e.g. GET /source) when self is a long-lived element such as the tested application or an FBElementCache entry, silently hiding UI content that appeared since. Use fb_cachedSnapshot, which is backed by XCTest's own self-invalidating snapshot cache, in the class chain snapshot-walk strategy, descendant filtering, and XPath context scoping.

Fixes https://github.com/appium/appium/issues/22672