### PR TITLE
fix: sanitize non-UTF-8-encodable strings before JSON response serialization

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -604,6 +604,7 @@
 		716F0DA12A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 716F0D9F2A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.h */; };
 		716F0DA32A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 716F0DA02A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.m */; };
 		716F0DA62A17323300CDD977 /* NSDictionaryFBUtf8SafeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 716F0DA52A17323300CDD977 /* NSDictionaryFBUtf8SafeTests.m */; };
+		E82332D32C4E06280CBE3F4C /* FBResponseJSONPayloadTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F5C37472190A686297D3534 /* FBResponseJSONPayloadTests.m */; };
 		7182A87F3CAA27F71B624AD2 /* XCTRunnerAutomationSession-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 01AF8E73DD47455B4854E470 /* XCTRunnerAutomationSession-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		718F49C8230844330045FE8B /* FBProtocolHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 718F49C7230844330045FE8B /* FBProtocolHelpersTests.m */; };
 		718F49C923087ACF0045FE8B /* FBProtocolHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 71B155DD23080CA600646AFB /* FBProtocolHelpers.h */; };
@@ -1595,6 +1596,7 @@
 		716F0D9F2A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+FBUtf8SafeDictionary.h"; sourceTree = "<group>"; };
 		716F0DA02A16CA1000CDD977 /* NSDictionary+FBUtf8SafeDictionary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+FBUtf8SafeDictionary.m"; sourceTree = "<group>"; };
 		716F0DA52A17323300CDD977 /* NSDictionaryFBUtf8SafeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSDictionaryFBUtf8SafeTests.m; sourceTree = "<group>"; };
+		3F5C37472190A686297D3534 /* FBResponseJSONPayloadTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBResponseJSONPayloadTests.m; sourceTree = "<group>"; };
 		717C0D702518ED2800CAA6EC /* TVOSSettings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = TVOSSettings.xcconfig; sourceTree = "<group>"; };
 		717C0D862518ED7000CAA6EC /* TVOSTestSettings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = TVOSTestSettings.xcconfig; sourceTree = "<group>"; };
 		7183E8C2B556594311CB8898 /* XCUIRemoteSiriInterface-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCUIRemoteSiriInterface-Protocol.h"; sourceTree = "<group>"; };
@@ -2682,6 +2684,7 @@
 				712A0C841DA3E459007D02E5 /* FBXPathTests.m */,
 				EE9B76581CF7987300275851 /* Info.plist */,
 				716F0DA52A17323300CDD977 /* NSDictionaryFBUtf8SafeTests.m */,
+				3F5C37472190A686297D3534 /* FBResponseJSONPayloadTests.m */,
 				7139145B1DF01A12005896C2 /* NSExpressionFBFormatTests.m */,
 				71A224E71DE326C500844D55 /* NSPredicateFBFormatTests.m */,
 				713914591DF01989005896C2 /* XCUIElementHelpersTests.m */,
@@ -4811,6 +4814,7 @@
 				71A224E81DE326C500844D55 /* NSPredicateFBFormatTests.m in Sources */,
 				EE6A892B1D0B25820083E92B /* XCUIApplicationDouble.m in Sources */,
 				716F0DA62A17323300CDD977 /* NSDictionaryFBUtf8SafeTests.m in Sources */,
+				E82332D32C4E06280CBE3F4C /* FBResponseJSONPayloadTests.m in Sources */,
 				EE6A892D1D0B2AF40083E92B /* FBErrorBuilderTests.m in Sources */,
 				712A0C851DA3E459007D02E5 /* FBXPathTests.m in Sources */,
 				ADBC39981D07842800327304 /* XCUIElementDouble.m in Sources */,

--- a/WebDriverAgentLib/Categories/NSDictionary+FBUtf8SafeDictionary.m
+++ b/WebDriverAgentLib/Categories/NSDictionary+FBUtf8SafeDictionary.m
@@ -18,30 +18,38 @@ const unichar REPLACER = 0xfffd;
   // both misreport strings containing unpaired UTF-16 surrogates, so the
   // code units are validated manually instead of relying on them.
   NSUInteger length = self.length;
-  NSMutableString *result = [NSMutableString stringWithCapacity:length];
-  NSString *replacementStr = [NSString stringWithCharacters:&replacement length:1];
+  NSMutableString *result = nil;
+  NSString *replacementStr = nil;
+  NSUInteger copiedIdx = 0;
   NSUInteger idx = 0;
   while (idx < length) {
     unichar c = [self characterAtIndex:idx];
-    if (c >= 0xD800 && c <= 0xDBFF) {
-      if (idx + 1 < length) {
-        unichar next = [self characterAtIndex:idx + 1];
-        if (next >= 0xDC00 && next <= 0xDFFF) {
-          [result appendString:[self substringWithRange:NSMakeRange(idx, 2)]];
-          idx += 2;
-          continue;
-        }
+    if (c >= 0xD800 && c <= 0xDBFF && idx + 1 < length) {
+      unichar next = [self characterAtIndex:idx + 1];
+      if (next >= 0xDC00 && next <= 0xDFFF) {
+        idx += 2;
+        continue;
       }
-      [result appendString:replacementStr];
-      idx += 1;
-    } else if (c >= 0xDC00 && c <= 0xDFFF) {
-      [result appendString:replacementStr];
-      idx += 1;
-    } else {
-      [result appendString:[self substringWithRange:NSMakeRange(idx, 1)]];
-      idx += 1;
     }
+    if (c < 0xD800 || c > 0xDFFF) {
+      idx += 1;
+      continue;
+    }
+    // Unpaired surrogate found. Lazily allocate the result and copy over
+    // the valid run preceding it, so strings without any are returned as-is.
+    if (nil == result) {
+      result = [NSMutableString stringWithCapacity:length];
+      replacementStr = [NSString stringWithCharacters:&replacement length:1];
+    }
+    [result appendString:[self substringWithRange:NSMakeRange(copiedIdx, idx - copiedIdx)]];
+    [result appendString:replacementStr];
+    idx += 1;
+    copiedIdx = idx;
   }
+  if (nil == result) {
+    return self;
+  }
+  [result appendString:[self substringWithRange:NSMakeRange(copiedIdx, length - copiedIdx)]];
   return result.copy;
 }
 
@@ -72,16 +80,24 @@ const unichar REPLACER = 0xfffd;
 
 - (instancetype)fb_utf8SafeDictionary
 {
-  NSMutableDictionary *result = [self mutableCopy];
+  NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:self.count];
   for (id key in self) {
-    id value = result[key];
+    id value = self[key];
+    id safeValue = value;
     if ([value isKindOfClass:NSString.class]) {
-      result[key] = [(NSString *)value fb_utf8SafeStringWithReplacement:REPLACER];
+      safeValue = [(NSString *)value fb_utf8SafeStringWithReplacement:REPLACER];
     } else if ([value isKindOfClass:NSArray.class]) {
-      result[key] = [(NSArray *)value fb_utf8SafeArray];
+      safeValue = [(NSArray *)value fb_utf8SafeArray];
     } else if ([value isKindOfClass:NSDictionary.class]) {
-      result[key] = [(NSDictionary *)value fb_utf8SafeDictionary];
+      safeValue = [(NSDictionary *)value fb_utf8SafeDictionary];
     }
+    // Sanitized keys could theoretically collide (e.g. two distinct invalid
+    // keys both reducing to the same replacement string); the later one
+    // wins, same as any other NSDictionary literal with duplicate keys.
+    id safeKey = [key isKindOfClass:NSString.class]
+      ? [(NSString *)key fb_utf8SafeStringWithReplacement:REPLACER]
+      : key;
+    result[safeKey] = safeValue;
   }
   return result.copy;
 }

--- a/WebDriverAgentLib/Categories/NSDictionary+FBUtf8SafeDictionary.m
+++ b/WebDriverAgentLib/Categories/NSDictionary+FBUtf8SafeDictionary.m
@@ -14,30 +14,32 @@ const unichar REPLACER = 0xfffd;
 
 - (instancetype)fb_utf8SafeStringWithReplacement:(unichar)replacement
 {
-  if ([self canBeConvertedToEncoding:NSUTF8StringEncoding]) {
-    return self;
-  }
-
-  NSData *data = [self dataUsingEncoding:NSUTF8StringEncoding allowLossyConversion:YES];
-  NSString *convertedString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-  NSMutableString *result = [NSMutableString string];
+  // -canBeConvertedToEncoding: and -dataUsingEncoding:allowLossyConversion:
+  // both misreport strings containing unpaired UTF-16 surrogates, so the
+  // code units are validated manually instead of relying on them.
+  NSUInteger length = self.length;
+  NSMutableString *result = [NSMutableString stringWithCapacity:length];
   NSString *replacementStr = [NSString stringWithCharacters:&replacement length:1];
-  NSUInteger originalIdx = 0;
-  NSUInteger convertedIdx = 0;
-  while (originalIdx < [self length] && convertedIdx < [convertedString length]) {
-    unichar originalChar = [self characterAtIndex:originalIdx];
-    unichar convertedChar = [convertedString characterAtIndex:convertedIdx];
-
-    if (originalChar == convertedChar) {
-      [result appendString:[NSString stringWithCharacters:&originalChar length:1]];
-      originalIdx++;
-      convertedIdx++;
-      continue;
-    }
-
-    while (originalChar != convertedChar && originalIdx < [self length]) {
+  NSUInteger idx = 0;
+  while (idx < length) {
+    unichar c = [self characterAtIndex:idx];
+    if (c >= 0xD800 && c <= 0xDBFF) {
+      if (idx + 1 < length) {
+        unichar next = [self characterAtIndex:idx + 1];
+        if (next >= 0xDC00 && next <= 0xDFFF) {
+          [result appendString:[self substringWithRange:NSMakeRange(idx, 2)]];
+          idx += 2;
+          continue;
+        }
+      }
       [result appendString:replacementStr];
-      originalChar = [self characterAtIndex:++originalIdx];
+      idx += 1;
+    } else if (c >= 0xDC00 && c <= 0xDFFF) {
+      [result appendString:replacementStr];
+      idx += 1;
+    } else {
+      [result appendString:[self substringWithRange:NSMakeRange(idx, 1)]];
+      idx += 1;
     }
   }
   return result.copy;

--- a/WebDriverAgentLib/Routing/FBResponseJSONPayload.m
+++ b/WebDriverAgentLib/Routing/FBResponseJSONPayload.m
@@ -44,7 +44,7 @@
                                                      options:NSJSONWritingPrettyPrinted
                                                        error:&error];
   if (nil == jsonData || nil == [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding]) {
-    [FBLogger log:@"The incoming data cannot be encoded to UTF-8 JSON. Applying lossy conversion as a workaround."];
+    [FBLogger log:@"JSON serialization failed or produced non-UTF-8 data. Applying lossy conversion as a workaround."];
     jsonData = [NSJSONSerialization dataWithJSONObject:[self.dictionary fb_utf8SafeDictionary]
                                                options:NSJSONWritingPrettyPrinted
                                                  error:&error];

--- a/WebDriverAgentLib/Routing/FBResponseJSONPayload.m
+++ b/WebDriverAgentLib/Routing/FBResponseJSONPayload.m
@@ -43,8 +43,7 @@
   NSData *jsonData = [NSJSONSerialization dataWithJSONObject:self.dictionary
                                                      options:NSJSONWritingPrettyPrinted
                                                        error:&error];
-  NSCAssert(jsonData, @"Valid JSON must be responded, error of %@", error);
-  if (nil == [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding]) {
+  if (nil == jsonData || nil == [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding]) {
     [FBLogger log:@"The incoming data cannot be encoded to UTF-8 JSON. Applying lossy conversion as a workaround."];
     jsonData = [NSJSONSerialization dataWithJSONObject:[self.dictionary fb_utf8SafeDictionary]
                                                options:NSJSONWritingPrettyPrinted

--- a/WebDriverAgentTests/UnitTests/FBResponseJSONPayloadTests.m
+++ b/WebDriverAgentTests/UnitTests/FBResponseJSONPayloadTests.m
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FBResponseJSONPayload.h"
+#import "RouteResponse.h"
+
+@interface FBResponseJSONPayloadTests : XCTestCase
+@end
+
+@implementation FBResponseJSONPayloadTests
+
+// https://github.com/appium/appium/issues/22673
+- (void)testDispatchSanitizesNonUtf8EncodableStrings
+{
+  unichar chars[] = {'a', 'b', 'c', 0xD800, 'd', 'e', 'f'};
+  NSString *unsafe = [NSString stringWithCharacters:chars length:sizeof(chars) / sizeof(unichar)];
+  NSDictionary *dictionary = @{@"value": unsafe};
+  FBResponseJSONPayload *payload = [[FBResponseJSONPayload alloc] initWithDictionary:dictionary
+                                                                        httpStatusCode:kHTTPStatusCodeOK];
+  RouteResponse *response = [RouteResponse new];
+
+  XCTAssertNoThrow([payload dispatchWithResponse:response]);
+  XCTAssertNotNil(response.responseData);
+
+  NSError *error;
+  NSDictionary *parsed = [NSJSONSerialization JSONObjectWithData:response.responseData
+                                                           options:0
+                                                             error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqualObjects(parsed[@"value"], @"abc�def");
+}
+
+- (void)testDispatchWithRegularDictionary
+{
+  NSDictionary *dictionary = @{@"value": @"regular string"};
+  FBResponseJSONPayload *payload = [[FBResponseJSONPayload alloc] initWithDictionary:dictionary
+                                                                        httpStatusCode:kHTTPStatusCodeOK];
+  RouteResponse *response = [RouteResponse new];
+
+  [payload dispatchWithResponse:response];
+
+  NSDictionary *parsed = [NSJSONSerialization JSONObjectWithData:response.responseData
+                                                           options:0
+                                                             error:nil];
+  XCTAssertEqualObjects(parsed, dictionary);
+}
+
+@end

--- a/WebDriverAgentTests/UnitTests/FBResponseJSONPayloadTests.m
+++ b/WebDriverAgentTests/UnitTests/FBResponseJSONPayloadTests.m
@@ -29,12 +29,33 @@
   XCTAssertNoThrow([payload dispatchWithResponse:response]);
   XCTAssertNotNil(response.responseData);
 
-  NSError *error;
+  NSError *error = nil;
   NSDictionary *parsed = [NSJSONSerialization JSONObjectWithData:response.responseData
                                                            options:0
                                                              error:&error];
   XCTAssertNil(error);
   XCTAssertEqualObjects(parsed[@"value"], @"abc�def");
+}
+
+// Dictionary keys must be sanitized too, not just values
+- (void)testDispatchSanitizesNonUtf8EncodableKeys
+{
+  unichar chars[] = {'k', 0xD800, 'y'};
+  NSString *unsafeKey = [NSString stringWithCharacters:chars length:sizeof(chars) / sizeof(unichar)];
+  NSDictionary *dictionary = @{unsafeKey: @"value"};
+  FBResponseJSONPayload *payload = [[FBResponseJSONPayload alloc] initWithDictionary:dictionary
+                                                                        httpStatusCode:kHTTPStatusCodeOK];
+  RouteResponse *response = [RouteResponse new];
+
+  XCTAssertNoThrow([payload dispatchWithResponse:response]);
+  XCTAssertNotNil(response.responseData);
+
+  NSError *error = nil;
+  NSDictionary *parsed = [NSJSONSerialization JSONObjectWithData:response.responseData
+                                                           options:0
+                                                             error:&error];
+  XCTAssertNil(error);
+  XCTAssertEqualObjects(parsed[@"k�y"], @"value");
 }
 
 - (void)testDispatchWithRegularDictionary

--- a/WebDriverAgentTests/UnitTests/NSDictionaryFBUtf8SafeTests.m
+++ b/WebDriverAgentTests/UnitTests/NSDictionaryFBUtf8SafeTests.m
@@ -31,4 +31,31 @@
   XCTAssertEqualObjects(d, d.fb_utf8SafeDictionary);
 }
 
+- (void)testUnpairedSurrogateSanitization
+{
+  unichar chars[] = {'a', 'b', 'c', 0xD800, 'd', 'e', 'f'};
+  NSString *unsafe = [NSString stringWithCharacters:chars length:sizeof(chars) / sizeof(unichar)];
+  NSDictionary *d = @{
+    @"key": unsafe,
+    @"nested": @{@"value": @[unsafe]},
+  };
+  NSDictionary *safe = d.fb_utf8SafeDictionary;
+
+  NSString *expected = @"abc�def";
+  XCTAssertEqualObjects(safe[@"key"], expected);
+  XCTAssertEqualObjects(safe[@"nested"][@"value"][0], expected);
+
+  NSError *error;
+  NSData *jsonData = [NSJSONSerialization dataWithJSONObject:safe
+                                                     options:0
+                                                       error:&error];
+  XCTAssertNotNil(jsonData, @"Sanitized dictionary must be serializable to JSON, error of %@", error);
+}
+
+- (void)testValidSurrogatePairIsPreserved
+{
+  NSString *emoji = @"a😀b";
+  XCTAssertEqualObjects([emoji fb_utf8SafeStringWithReplacement:0xfffd], emoji);
+}
+
 @end

--- a/WebDriverAgentTests/UnitTests/NSDictionaryFBUtf8SafeTests.m
+++ b/WebDriverAgentTests/UnitTests/NSDictionaryFBUtf8SafeTests.m
@@ -45,11 +45,27 @@
   XCTAssertEqualObjects(safe[@"key"], expected);
   XCTAssertEqualObjects(safe[@"nested"][@"value"][0], expected);
 
-  NSError *error;
+  NSError *error = nil;
   NSData *jsonData = [NSJSONSerialization dataWithJSONObject:safe
                                                      options:0
                                                        error:&error];
-  XCTAssertNotNil(jsonData, @"Sanitized dictionary must be serializable to JSON, error of %@", error);
+  XCTAssertNotNil(jsonData, @"JSON serialization of the sanitized dictionary unexpectedly failed: %@", error);
+}
+
+- (void)testUnpairedSurrogateKeySanitization
+{
+  unichar chars[] = {'k', 0xD800, 'y'};
+  NSString *unsafeKey = [NSString stringWithCharacters:chars length:sizeof(chars) / sizeof(unichar)];
+  NSDictionary *d = @{unsafeKey: @"value"};
+  NSDictionary *safe = d.fb_utf8SafeDictionary;
+
+  XCTAssertEqualObjects(safe[@"k�y"], @"value");
+
+  NSError *error = nil;
+  NSData *jsonData = [NSJSONSerialization dataWithJSONObject:safe
+                                                     options:0
+                                                       error:&error];
+  XCTAssertNotNil(jsonData, @"JSON serialization of the sanitized dictionary unexpectedly failed: %@", error);
 }
 
 - (void)testValidSurrogatePairIsPreserved


### PR DESCRIPTION
FBResponseJSONPayload asserted before its UTF-8 fallback could run when NSJSONSerialization returned nil outright, and the fallback itself (fb_utf8SafeStringWithReplacement:) mishandled unpaired UTF-16 surrogates since canBeConvertedToEncoding:/dataUsingEncoding:allowLossyConversion: misreport for that case. 

Fixes appium/appium#22673.