### PR TITLE
feat: add displayId

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -174,6 +174,7 @@
     @"statusBarSize": @{@"width": @(statusBarSize.width),
                         @"height": @(statusBarSize.height),
     },
+    @"displayId": @([FBScreen displayID]),
     @"scale": @([FBScreen scale]),
   });
 }

--- a/WebDriverAgentLib/Utilities/FBScreen.h
+++ b/WebDriverAgentLib/Utilities/FBScreen.h
@@ -13,6 +13,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FBScreen : NSObject
 
 /**
+ The identifier of the main device's display
+ */
++ (long long)displayID;
+
+/**
  The scale factor of the main device's screen
  */
 + (double)scale;

--- a/WebDriverAgentLib/Utilities/FBScreen.m
+++ b/WebDriverAgentLib/Utilities/FBScreen.m
@@ -13,6 +13,11 @@
 
 @implementation FBScreen
 
++ (long long)displayID
+{
+  return XCUIScreen.mainScreen.displayID;
+}
+
 + (double)scale
 {
   return [XCUIScreen.mainScreen scale];

--- a/WebDriverAgentTests/IntegrationTests/FBScreenTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBScreenTests.m
@@ -22,10 +22,14 @@
   [self launchApplication];
 }
 
+- (void)testDisplayID
+{
+  XCTAssertGreaterThanOrEqual([FBScreen displayID], 0LL);
+}
+
 - (void)testScreenScale
 {
   XCTAssertTrue([FBScreen scale] >= 2);
 }
 
 @end
-


### PR DESCRIPTION
`GET /wda/screen`:

```
{
  "value" : {
    "statusBarSize" : {
      "width" : 1180,
      "height" : 32
    },
    "scale" : 2,
    "screenSize" : {
      "width" : 1180,
      "height" : 820
    },
    "displayId" : 1
  },
  "sessionId" : null
}
```

This works on tvOS as well