### PR TITLE
feat: add get screens endpoint

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -53,8 +53,8 @@
     [[FBRoute GET:@"/wda/locked"] respondWithTarget:self action:@selector(handleIsLocked:)],
     [[FBRoute GET:@"/wda/screen"] respondWithTarget:self action:@selector(handleGetScreen:)],
     [[FBRoute GET:@"/wda/screen"].withoutSession respondWithTarget:self action:@selector(handleGetScreen:)],
-    [[FBRoute GET:@"/wda/screens"] respondWithTarget:self action:@selector(handleGetScreens:)],
-    [[FBRoute GET:@"/wda/screens"].withoutSession respondWithTarget:self action:@selector(handleGetScreens:)],
+    [[FBRoute GET:@"/wda/screens"].standalone respondWithTarget:self action:@selector(handleGetScreens:)],
+    [[FBRoute GET:@"/wda/screens"].withoutSession.standalone respondWithTarget:self action:@selector(handleGetScreens:)],
     [[FBRoute GET:@"/wda/activeAppInfo"] respondWithTarget:self action:@selector(handleActiveAppInfo:)],
     [[FBRoute GET:@"/wda/activeAppInfo"].withoutSession respondWithTarget:self action:@selector(handleActiveAppInfo:)],
 #if !TARGET_OS_TV && !TARGET_OS_WATCH // tvOS/watchOS do not provide relevant APIs

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -53,6 +53,8 @@
     [[FBRoute GET:@"/wda/locked"] respondWithTarget:self action:@selector(handleIsLocked:)],
     [[FBRoute GET:@"/wda/screen"] respondWithTarget:self action:@selector(handleGetScreen:)],
     [[FBRoute GET:@"/wda/screen"].withoutSession respondWithTarget:self action:@selector(handleGetScreen:)],
+    [[FBRoute GET:@"/wda/screens"] respondWithTarget:self action:@selector(handleGetScreens:)],
+    [[FBRoute GET:@"/wda/screens"].withoutSession respondWithTarget:self action:@selector(handleGetScreens:)],
     [[FBRoute GET:@"/wda/activeAppInfo"] respondWithTarget:self action:@selector(handleActiveAppInfo:)],
     [[FBRoute GET:@"/wda/activeAppInfo"].withoutSession respondWithTarget:self action:@selector(handleActiveAppInfo:)],
 #if !TARGET_OS_TV && !TARGET_OS_WATCH // tvOS/watchOS do not provide relevant APIs
@@ -177,6 +179,16 @@
     @"displayId": @([FBScreen displayID]),
     @"scale": @([FBScreen scale]),
   });
+}
+
++ (id<FBResponsePayload>)handleGetScreens:(FBRouteRequest *)request
+{
+  NSError *error;
+  NSArray<NSDictionary<NSString *, id> *> *screens = [FBScreen screensWithError:&error];
+  if (nil == screens) {
+    return FBResponseWithUnknownError(error);
+  }
+  return FBResponseWithObject(screens);
 }
 
 + (id<FBResponsePayload>)handleLock:(FBRouteRequest *)request

--- a/WebDriverAgentLib/Utilities/FBScreen.h
+++ b/WebDriverAgentLib/Utilities/FBScreen.h
@@ -13,6 +13,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FBScreen : NSObject
 
 /**
+ Information about all displays available to the device
+ */
++ (nullable NSArray<NSDictionary<NSString *, id> *> *)screensWithError:(NSError **)error;
+
+/**
  The identifier of the main device's display
  */
 + (long long)displayID;

--- a/WebDriverAgentLib/Utilities/FBScreen.m
+++ b/WebDriverAgentLib/Utilities/FBScreen.m
@@ -9,9 +9,36 @@
 #import "FBScreen.h"
 #import "XCUIElement+FBIsVisible.h"
 #import "FBXCodeCompatibility.h"
+#import "XCUIDevice.h"
 #import "XCUIScreen.h"
 
 @implementation FBScreen
+
++ (nullable NSArray<NSDictionary<NSString *, id> *> *)screensWithError:(NSError **)error
+{
+  NSArray<XCUIScreen *> *screens = [XCUIDevice.sharedDevice screensOrError:error];
+  if (nil == screens) {
+    return nil;
+  }
+
+  NSMutableArray<NSDictionary<NSString *, id> *> *result = [NSMutableArray arrayWithCapacity:screens.count];
+  for (XCUIScreen *screen in screens) {
+    CGRect bounds = screen.bounds;
+    [result addObject:@{
+      @"displayId": @(screen.displayID),
+      @"isMain": @(screen.isMainScreen),
+      @"scale": @(screen.scale),
+      @"bounds": @{
+        @"x": @(bounds.origin.x),
+        @"y": @(bounds.origin.y),
+        @"width": @(bounds.size.width),
+        @"height": @(bounds.size.height),
+      },
+      @"traits": @(screen.traits),
+    }];
+  }
+  return result.copy;
+}
 
 + (long long)displayID
 {

--- a/WebDriverAgentTests/IntegrationTests/FBScreenTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBScreenTests.m
@@ -27,6 +27,29 @@
   XCTAssertGreaterThanOrEqual([FBScreen displayID], 0LL);
 }
 
+- (void)testScreens
+{
+  NSError *error = nil;
+  NSArray<NSDictionary<NSString *, id> *> *screens = [FBScreen screensWithError:&error];
+
+  XCTAssertNotNil(screens);
+  XCTAssertNil(error);
+  XCTAssertGreaterThan(screens.count, 0UL);
+
+  NSDictionary<NSString *, id> *mainScreen = nil;
+  for (NSDictionary<NSString *, id> *screen in screens) {
+    if ([screen[@"isMain"] boolValue]) {
+      mainScreen = screen;
+      break;
+    }
+  }
+  XCTAssertNotNil(mainScreen);
+  XCTAssertEqualObjects(mainScreen[@"displayId"], @([FBScreen displayID]));
+  XCTAssertNotNil(mainScreen[@"scale"]);
+  XCTAssertNotNil(mainScreen[@"bounds"]);
+  XCTAssertNotNil(mainScreen[@"traits"]);
+}
+
 - (void)testScreenScale
 {
   XCTAssertTrue([FBScreen scale] >= 2);


### PR DESCRIPTION
e.g.

With external display via iPad.

```
{
  "value" : [
    {
      "scale" : 2,
      "traits" : 1,
      "isMain" : true,
      "bounds" : {
        "y" : 0,
        "x" : 0,
        "width" : 1640,
        "height" : 2360
      },
      "displayId" : 1
    },
    {
      "scale" : 2,
      "traits" : 4,
      "isMain" : false,
      "bounds" : {
        "y" : 0,
        "x" : 0,
        "width" : 6016,
        "height" : 3384
      },
      "displayId" : 2
    }
  ],
  "sessionId" : null
}
```


---

`/wda/screen` shows current 'main' screen while this endpoint shows available screens.

This non-main display does not function right now, but could extend some features at least such as screenshot, element handling etc. For example, `XCUIElement` and `XCElementSnapshot` have displayID


I won't add this endpoint call from xcuitest driver only with this change.