### PR TITLE
fix: allow pause action items to appear before any pointer movement

### DIFF
--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -133,7 +133,8 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
     }
     self.duration = durationObj.doubleValue;
     XCUICoordinate *position = [self positionWithError:error];
-    if (nil == position) {
+    // A pause may legally have no position yet (nil position, no error set)
+    if (nil == position && error && nil != *error) {
       return nil;
     }
     self.atPosition = position;
@@ -143,7 +144,7 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
 
 - (nullable XCUICoordinate *)positionWithError:(NSError **)error
 {
-  if (nil == self.previousItem) {
+  if (nil == self.previousItem || nil == self.previousItem.atPosition) {
     NSString *errorDescription = [NSString stringWithFormat:@"The '%@' action item must be preceded by %@ item", self.actionItem, FB_ACTION_ITEM_TYPE_POINTER_MOVE];
     if (error) {
       *error = [[FBErrorBuilder.builder withDescription:errorDescription] build];
@@ -290,7 +291,7 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   }
   
   // origin == FB_ORIGIN_TYPE_POINTER
-  if (nil == self.previousItem) {
+  if (nil == self.previousItem || nil == self.previousItem.atPosition) {
     NSString *errorDescription = [NSString stringWithFormat:@"There is no previous item for '%@' action item, however %@ is set to '%@'", self.actionItem, FB_ACTION_ITEM_KEY_ORIGIN, FB_ORIGIN_TYPE_POINTER];
     if (error) {
       *error = [[FBErrorBuilder.builder withDescription:errorDescription] build];
@@ -332,12 +333,9 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
 
 - (nullable XCUICoordinate *)positionWithError:(NSError **)error
 {
-  // Unlike other gesture items, a pause never touches the screen, so it may
-  // legally be the first item in a sequence (e.g. used by clients to align
-  // ticks across multiple pointers/devices)
-  return self.previousItem.atPosition ?: [self hitpointWithElement:nil
-                                                      positionOffset:[NSValue valueWithCGPoint:CGPointZero]
-                                                               error:error];
+  // A pause has no position of its own; proxy whatever real move preceded
+  // it, or nil (not a fabricated point) if none has run yet
+  return self.previousItem.atPosition;
 }
 
 - (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -320,6 +320,16 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
   return FB_ACTION_ITEM_TYPE_PAUSE;
 }
 
+- (nullable XCUICoordinate *)positionWithError:(NSError **)error
+{
+  // Unlike other gesture items, a pause never touches the screen, so it may
+  // legally be the first item in a sequence (e.g. used by clients to align
+  // ticks across multiple pointers/devices)
+  return self.previousItem.atPosition ?: [self hitpointWithElement:nil
+                                                      positionOffset:[NSValue valueWithCGPoint:CGPointZero]
+                                                               error:error];
+}
+
 - (NSArray<XCPointerEventPath *> *)addToEventPath:(XCPointerEventPath *)eventPath
                                          allItems:(NSArray *)allItems
                                  currentItemIndex:(NSUInteger)currentItemIndex

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -205,9 +205,19 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
                                  currentItemIndex:(NSUInteger)currentItemIndex
                                             error:(NSError **)error
 {
-  if (nil != eventPath && currentItemIndex == 1) {
+  if (nil != eventPath && currentItemIndex >= 1) {
     FBW3CGestureItem *preceedingItem = [allItems objectAtIndex:currentItemIndex - 1];
-    if ([preceedingItem isKindOfClass:FBPointerMoveItem.class]) {
+    // Only skip creating a new touch if the preceding pointerMove is the one that
+    // implicitly opened this touch, i.e. nothing but (possibly zero-duration) pauses
+    // came before it. Pauses never create an event path themselves.
+    BOOL isPreceedingMoveTheFirstRealItem = YES;
+    for (NSInteger index = (NSInteger)currentItemIndex - 2; index >= 0; index--) {
+      if (![[allItems objectAtIndex:index] isKindOfClass:FBPointerPauseItem.class]) {
+        isPreceedingMoveTheFirstRealItem = NO;
+        break;
+      }
+    }
+    if ([preceedingItem isKindOfClass:FBPointerMoveItem.class] && isPreceedingMoveTheFirstRealItem) {
       return @[];
     }
   }

--- a/WebDriverAgentTests/IntegrationTests/FBW3CMultiTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CMultiTouchActionsIntegrationTests.m
@@ -120,5 +120,40 @@
   [self verifyGesture:gesture orientation:UIDeviceOrientationPortrait];
 }
 
+- (void)testTwoFingersTapWithLeadingZeroDurationPause
+{
+  // Selenium clients pad shorter action sequences with a zero-duration pause
+  // so that all pointers/devices end up with the same number of ticks
+  XCUIElement *element = self.testedApplication.buttons[FBShowAlertButtonName];
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[
+    @{
+      @"type": @"pointer",
+      @"id": @"finger1",
+      @"parameters": @{@"pointerType": @"touch"},
+      @"actions": @[
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": element, @"x": @0, @"y": @0},
+          @{@"type": @"pointerDown"},
+          @{@"type": @"pause", @"duration": @100},
+          @{@"type": @"pointerUp"},
+          ],
+      },
+    @{
+      @"type": @"pointer",
+      @"id": @"finger2",
+      @"parameters": @{@"pointerType": @"touch"},
+      @"actions": @[
+          @{@"type": @"pause", @"duration": @0},
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": element, @"x": @0, @"y": @0},
+          @{@"type": @"pointerDown"},
+          @{@"type": @"pause", @"duration": @100},
+          @{@"type": @"pointerUp"},
+          ],
+      },
+    ];
+
+  [self verifyGesture:gesture orientation:UIDeviceOrientationPortrait];
+}
+
 @end
 

--- a/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
@@ -231,6 +231,37 @@
         },
       ],
     
+    // Chain element where a leading pause is followed directly by pointerDown,
+    // with no real pointerMove ever establishing a position
+    @[@{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"type": @"pause", @"duration": @0},
+            @{@"type": @"pointerDown"},
+            @{@"type": @"pause", @"duration": @100},
+            @{@"type": @"pointerUp"},
+            ],
+        },
+      ],
+
+    // Chain element where a leading pause is followed directly by a relative
+    // pointerMove, with no real preceding position to be relative to
+    @[@{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"type": @"pause", @"duration": @0},
+            @{@"type": @"pointerMove", @"duration": @0, @"origin": @"pointer"},
+            @{@"type": @"pointerDown"},
+            @{@"type": @"pause", @"duration": @100},
+            @{@"type": @"pointerUp"},
+            ],
+        },
+      ],
+
     // Chain element where action items start with an incorrect one, because the correct one is canceled
     @[@{
         @"type": @"pointer",

--- a/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
@@ -17,6 +17,10 @@
 #import "XCUIDevice+FBRotation.h"
 #import "FBRunLoopSpinner.h"
 #import "FBXCodeCompatibility.h"
+#import "FBW3CActionsSynthesizer.h"
+#import "XCSynthesizedEventRecord.h"
+#import "XCPointerEventPath.h"
+#import "XCPointerEvent.h"
 
 @interface FBW3CTouchActionsIntegrationTestsPart1 : FBIntegrationTestCase
 @end
@@ -185,21 +189,6 @@
         },
       ],
     
-    // Chain element where action items start with an incorrect item
-    @[@{
-        @"type": @"pointer",
-        @"id": @"finger1",
-        @"parameters": @{@"pointerType": @"touch"},
-        @"actions": @[
-            @{@"type": @"pause", @"duration": @100},
-            @{@"type": @"pointerMove", @"duration": @0, @"x": @1, @"y": @1},
-            @{@"type": @"pointerDown"},
-            @{@"type": @"pause", @"duration": @100},
-            @{@"type": @"pointerUp"},
-            ],
-        },
-      ],
-    
     // Chain element where pointerMove action item does not contain coordinates
     @[@{
         @"type": @"pointer",
@@ -297,6 +286,69 @@
       },
     ];
   [self verifyGesture:gesture orientation:UIDeviceOrientationPortrait];
+}
+
+- (void)testLeadingZeroDurationPauseDoesNotAddExtraTouch
+{
+  // A leading pause must not defeat the down-after-move dedup logic in
+  // FBPointerDownItem and make WDA synthesize a second, separate touch-down
+  // for the same finger. Inspect the actual synthesized XCTest event stream
+  // (without dispatching it) rather than only checking the gesture's visible
+  // side effect, since a duplicate touch at the same point may still produce
+  // the same visible outcome.
+  XCUIElement *element = self.testedApplication.buttons[FBShowAlertButtonName];
+  NSDictionary<NSString *, id> *(^sequenceWithLeadingPause)(BOOL) = ^NSDictionary<NSString *, id> *(BOOL withLeadingPause) {
+    NSMutableArray<NSDictionary<NSString *, id> *> *actions = [NSMutableArray array];
+    if (withLeadingPause) {
+      [actions addObject:@{@"type": @"pause", @"duration": @0}];
+    }
+    [actions addObjectsFromArray:@[
+      @{@"type": @"pointerMove", @"duration": @0, @"origin": element, @"x": @0, @"y": @0},
+      @{@"type": @"pointerDown"},
+      @{@"type": @"pause", @"duration": @100},
+      @{@"type": @"pointerUp"},
+      ]];
+    return @{
+      @"type": @"pointer",
+      @"id": @"finger1",
+      @"parameters": @{@"pointerType": @"touch"},
+      @"actions": actions.copy,
+      };
+  };
+
+  NSError *error;
+  FBW3CActionsSynthesizer *baselineSynthesizer =
+  [[FBW3CActionsSynthesizer alloc] initWithActions:@[sequenceWithLeadingPause(NO)]
+                                     forApplication:self.testedApplication
+                                       elementCache:nil
+                                              error:&error];
+  XCTAssertNotNil(baselineSynthesizer);
+  XCSynthesizedEventRecord *baselineRecord = [baselineSynthesizer synthesizeWithError:&error];
+  XCTAssertNotNil(baselineRecord, @"%@", error);
+
+  FBW3CActionsSynthesizer *pausedSynthesizer =
+  [[FBW3CActionsSynthesizer alloc] initWithActions:@[sequenceWithLeadingPause(YES)]
+                                     forApplication:self.testedApplication
+                                       elementCache:nil
+                                              error:&error];
+  XCTAssertNotNil(pausedSynthesizer);
+  XCSynthesizedEventRecord *pausedRecord = [pausedSynthesizer synthesizeWithError:&error];
+  XCTAssertNotNil(pausedRecord, @"%@", error);
+
+  XCTAssertEqual(baselineRecord.eventPaths.count, (NSUInteger)1);
+  XCTAssertEqual(pausedRecord.eventPaths.count, baselineRecord.eventPaths.count);
+
+  XCPointerEventPath *baselinePath = baselineRecord.eventPaths.firstObject;
+  XCPointerEventPath *pausedPath = pausedRecord.eventPaths.firstObject;
+  XCTAssertEqual(pausedPath.pointerEvents.count, baselinePath.pointerEvents.count);
+  for (NSUInteger i = 0; i < baselinePath.pointerEvents.count; i++) {
+    XCPointerEvent *baselineEvent = baselinePath.pointerEvents[i];
+    XCPointerEvent *pausedEvent = pausedPath.pointerEvents[i];
+    XCTAssertEqual(pausedEvent.eventType, baselineEvent.eventType);
+    XCTAssertEqualWithAccuracy(pausedEvent.offset, baselineEvent.offset, 0.001);
+    XCTAssertEqualWithAccuracy(pausedEvent.coordinate.x, baselineEvent.coordinate.x, 0.001);
+    XCTAssertEqualWithAccuracy(pausedEvent.coordinate.y, baselineEvent.coordinate.y, 0.001);
+  }
 }
 
 - (void)testDoubleTap


### PR DESCRIPTION
W3C clients (e.g. Selenium) pad shorter pointer action sequences with zero-duration pause items to align tick counts across multiple pointers, sometimes placing that pause before the first pointerMove. Since a pause never touches the screen, it should not require a preceding item to resolve its position.
