### PR TITLE
chore: add coordinate screen in the integration app

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -932,6 +932,7 @@
 		BEA2FA45BED17FE03010FECD /* FBFindElementCommands.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9AB7581CAEDF0C008C271F /* FBFindElementCommands.h */; };
 		BF9B191D841681A571BAFED1 /* _XCTestObservationPrivate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = C840A8703A7C8D48897E158A /* _XCTestObservationPrivate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BFF5D9B9446DD542E5D6017D /* XCTTagSelection.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2092D85A7C691F157B1971 /* XCTTagSelection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C01249000000000000000003 /* FBCoordinateProbeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C01249000000000000000002 /* FBCoordinateProbeViewController.m */; };
 		C040AE5F2E3B934E8EEAEE0F /* XCUIApplicationProcessDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 43FCB89739438814F43BCA24 /* XCUIApplicationProcessDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C07F140AF96143A0A5CAA2B0 /* XCTestCaseDiscoveryUIAutomationDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = E29888B75A756D1CCD21604C /* XCTestCaseDiscoveryUIAutomationDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C1414C29C836902466C4D6DB /* XCTestCastMethodNamesUIAutomationDelegate-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = A80A1C12FA9899367D316E8C /* XCTestCastMethodNamesUIAutomationDelegate-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1269,7 +1270,6 @@
 		FEC3A97A4929115A192F947A /* XCUIDeviceEventAndStateInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 003AAAB9CB5FB38E45E05F6F /* XCUIDeviceEventAndStateInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FFA7672B731B57AB9283DD40 /* FBXCElementSnapshotWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 13DE7A53287CA1EC003243C6 /* FBXCElementSnapshotWrapper.h */; };
 		FFD70914E6D8CE5D4FED4B69 /* XCUIAXNotificationHandling-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EA96C2FEDE73CB5148BA4949 /* XCUIAXNotificationHandling-Protocol.h */; };
-		C01249000000000000000003 /* FBCoordinateProbeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C01249000000000000000002 /* FBCoordinateProbeViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1749,6 +1749,8 @@
 		B8A163261EFA440E42CA6AC1 /* XCTRunnerDaemonSessionUIAutomationDelegate-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTRunnerDaemonSessionUIAutomationDelegate-Protocol.h"; sourceTree = "<group>"; };
 		B98A9F937EF98D6359FCCC7A /* XCTRuntimeIssueDetectionPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTRuntimeIssueDetectionPolicy.h; sourceTree = "<group>"; };
 		BCED63DFD03326F6351165FE /* WDAFindIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WDAFindIntegrationTests.swift; sourceTree = "<group>"; };
+		C01249000000000000000001 /* FBCoordinateProbeViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBCoordinateProbeViewController.h; sourceTree = "<group>"; };
+		C01249000000000000000002 /* FBCoordinateProbeViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBCoordinateProbeViewController.m; sourceTree = "<group>"; };
 		C840A8703A7C8D48897E158A /* _XCTestObservationPrivate-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "_XCTestObservationPrivate-Protocol.h"; sourceTree = "<group>"; };
 		C878996F07A9B26E66FC4EAC /* WDAClickIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WDAClickIntegrationTests.swift; sourceTree = "<group>"; };
 		C8FB547322D3949C00B69954 /* LSApplicationWorkspace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LSApplicationWorkspace.h; sourceTree = "<group>"; };
@@ -1960,8 +1962,6 @@
 		FCD1815F2BF21CA0936B04E1 /* XCTMessagingRole_SiriAutomation-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_SiriAutomation-Protocol.h"; sourceTree = "<group>"; };
 		FDB15E393EA0850C004D26B2 /* XCTScreenCapturePolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTScreenCapturePolicy.h; sourceTree = "<group>"; };
 		FF8E3B470FC9639D5F18E2EA /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		C01249000000000000000001 /* FBCoordinateProbeViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBCoordinateProbeViewController.h; sourceTree = "<group>"; };
-		C01249000000000000000002 /* FBCoordinateProbeViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBCoordinateProbeViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -1269,6 +1269,7 @@
 		FEC3A97A4929115A192F947A /* XCUIDeviceEventAndStateInterface-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 003AAAB9CB5FB38E45E05F6F /* XCUIDeviceEventAndStateInterface-Protocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FFA7672B731B57AB9283DD40 /* FBXCElementSnapshotWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 13DE7A53287CA1EC003243C6 /* FBXCElementSnapshotWrapper.h */; };
 		FFD70914E6D8CE5D4FED4B69 /* XCUIAXNotificationHandling-Protocol.h in Headers */ = {isa = PBXBuildFile; fileRef = EA96C2FEDE73CB5148BA4949 /* XCUIAXNotificationHandling-Protocol.h */; };
+		C01249000000000000000003 /* FBCoordinateProbeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C01249000000000000000002 /* FBCoordinateProbeViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1959,6 +1960,8 @@
 		FCD1815F2BF21CA0936B04E1 /* XCTMessagingRole_SiriAutomation-Protocol.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "XCTMessagingRole_SiriAutomation-Protocol.h"; sourceTree = "<group>"; };
 		FDB15E393EA0850C004D26B2 /* XCTScreenCapturePolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = XCTScreenCapturePolicy.h; sourceTree = "<group>"; };
 		FF8E3B470FC9639D5F18E2EA /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C01249000000000000000001 /* FBCoordinateProbeViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBCoordinateProbeViewController.h; sourceTree = "<group>"; };
+		C01249000000000000000002 /* FBCoordinateProbeViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBCoordinateProbeViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2732,6 +2735,8 @@
 				EE55B3231D1D5388003AAAEC /* FBTableDataSource.m */,
 				EE9B76841CF7997600275851 /* ViewController.h */,
 				EE9B76851CF7997600275851 /* ViewController.m */,
+				C01249000000000000000001 /* FBCoordinateProbeViewController.h */,
+				C01249000000000000000002 /* FBCoordinateProbeViewController.m */,
 				315A14FF2518CB8700A3A064 /* TouchableView.h */,
 				315A15002518CB8700A3A064 /* TouchableView.m */,
 				315A15052518CC2800A3A064 /* TouchSpotView.h */,
@@ -4851,6 +4856,7 @@
 				315A15072518CC2800A3A064 /* TouchSpotView.m in Sources */,
 				EE9B76911CF7997600275851 /* main.m in Sources */,
 				EE9B768F1CF7997600275851 /* ViewController.m in Sources */,
+				C01249000000000000000003 /* FBCoordinateProbeViewController.m in Sources */,
 				315A15012518CB8700A3A064 /* TouchableView.m in Sources */,
 				315A150A2518D6F400A3A064 /* TouchViewController.m in Sources */,
 				ADDA07241D6BB2BF001700AC /* FBScrollViewController.m in Sources */,

--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/IntegrationApp_watchOS.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/IntegrationApp_watchOS.xcscheme
@@ -46,6 +46,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "9D6B02D8FC050BAF7159284F"
             BuildableName = "IntegrationApp_watchOS.app"
+            BlueprintName = "IntegrationApp_watchOS"
             ReferencedContainer = "container:WebDriverAgent.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -62,6 +63,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "9D6B02D8FC050BAF7159284F"
             BuildableName = "IntegrationApp_watchOS.app"
+            BlueprintName = "IntegrationApp_watchOS"
             ReferencedContainer = "container:WebDriverAgent.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/WebDriverAgentTests/IntegrationApp/COORDINATE_PROBE.md
+++ b/WebDriverAgentTests/IntegrationApp/COORDINATE_PROBE.md
@@ -1,0 +1,50 @@
+# Coordinate probe
+
+Open **Coordinate Probe** from the IntegrationApp home screen's navigation bar.
+Use the standard Back button to return to the existing fixtures. Opening the probe
+creates a fresh measurement session.
+
+The **Touch** canvas records actual `UITouch.locationInView:` coordinates rather
+than assuming that a gesture succeeded because it hit a large button. **Scroll**
+shows 80 numbered rows, each 44 points high.
+
+## Automation identifiers
+
+| Identifier | Purpose |
+| --- | --- |
+| `coordinate-probe` | Home screen button that opens the probe |
+| `probe-status` | Label containing the measurement JSON |
+| `coordinate-canvas` | Touch target |
+| `probe-mode` | Touch/Scroll segmented control |
+| `probe-table` | Scrollable table |
+| `probe-row-0` through `probe-row-79` | Individual table rows |
+
+The `probe-status` label exposes `start`, `last`, `phase`, and `count` after a
+touch. `start` and `last` are **canvas-local app points**. It also exposes
+`canvasBounds`, `canvasWindowRect`, `windowSize`, `screenSize`, and `scrollY`.
+Geometry is refreshed when the view lays out, including after rotation or window
+resizing. Touch-related fields are absent before the first touch.
+
+For example, locate `coordinate-probe` by accessibility ID and click it. Then
+locate `coordinate-canvas`, send an element-relative action, and read the JSON
+from `probe-status`. Check that `count` increased and compare `start`/`last` with
+the expected canvas-local point within a suitable tolerance. Derive test offsets
+from the current element rectangle rather than hard-coding a device size.
+
+## Native and compatibility builds
+
+The screen uses the same source for both configurations. Keep the IntegrationApp
+scheme and set the build's `TARGETED_DEVICE_FAMILY`:
+
+- `1,2`: native support for iPhone and iPad (the existing default).
+- `1`: iPhone-only; install on iPad to exercise iPhone compatibility mode.
+
+These are build settings, not a switch within the running app. Verify the actual
+window and element frames before interpreting results. An iPad-native app can
+also run in a resized window; maximize it when testing a full-screen native case.
+For the compatibility case, compare app and SpringBoard window sizes and the
+reported element rectangles with the recorded probe geometry.
+
+If keeping both builds installed at once, give them distinct bundle IDs. This
+change does not add another app target or alter the existing bundle ID or signing
+configuration.

--- a/WebDriverAgentTests/IntegrationApp/COORDINATE_PROBE.md
+++ b/WebDriverAgentTests/IntegrationApp/COORDINATE_PROBE.md
@@ -1,6 +1,6 @@
 # Coordinate probe
 
-Open **Coordinate Probe** from the IntegrationApp home screen's navigation bar.
+Open **Coordinate Probe** below **DeepHierarchy** on the IntegrationApp home screen.
 Use the standard Back button to return to the existing fixtures. Opening the probe
 creates a fresh measurement session.
 

--- a/WebDriverAgentTests/IntegrationApp/Classes/FBCoordinateProbeViewController.h
+++ b/WebDriverAgentTests/IntegrationApp/Classes/FBCoordinateProbeViewController.h
@@ -1,0 +1,4 @@
+#import <UIKit/UIKit.h>
+
+@interface FBCoordinateProbeViewController : UIViewController
+@end

--- a/WebDriverAgentTests/IntegrationApp/Classes/FBCoordinateProbeViewController.m
+++ b/WebDriverAgentTests/IntegrationApp/Classes/FBCoordinateProbeViewController.m
@@ -1,0 +1,176 @@
+#import "FBCoordinateProbeViewController.h"
+
+@interface FBCoordinateProbeCanvas : UIView
+@property (nonatomic, copy) void (^onTouch)(NSString *phase, CGPoint point);
+@end
+
+@implementation FBCoordinateProbeCanvas
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  self.onTouch(@"began", [touches.anyObject locationInView:self]);
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  self.onTouch(@"moved", [touches.anyObject locationInView:self]);
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  self.onTouch(@"ended", [touches.anyObject locationInView:self]);
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  self.onTouch(@"cancelled", [touches.anyObject locationInView:self]);
+}
+
+- (void)drawRect:(CGRect)rect
+{
+  CGContextRef context = UIGraphicsGetCurrentContext();
+  CGContextSetStrokeColorWithColor(context, UIColor.whiteColor.CGColor);
+  for (NSInteger i = 1; i < 4; i++) {
+    CGFloat x = CGRectGetWidth(self.bounds) * i / 4.0;
+    CGFloat y = CGRectGetHeight(self.bounds) * i / 4.0;
+    CGContextMoveToPoint(context, x, 0);
+    CGContextAddLineToPoint(context, x, CGRectGetHeight(self.bounds));
+    CGContextMoveToPoint(context, 0, y);
+    CGContextAddLineToPoint(context, CGRectGetWidth(self.bounds), y);
+  }
+  CGContextStrokePath(context);
+}
+
+@end
+
+@interface FBCoordinateProbeViewController () <UITableViewDataSource, UITableViewDelegate>
+@property (nonatomic, strong) UILabel *statusLabel;
+@property (nonatomic, strong) UISegmentedControl *modeControl;
+@property (nonatomic, strong) FBCoordinateProbeCanvas *canvas;
+@property (nonatomic, strong) UITableView *table;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, id> *measurement;
+@property (nonatomic) NSUInteger touchCount;
+@end
+
+@implementation FBCoordinateProbeViewController
+
+- (void)viewDidLoad
+{
+  [super viewDidLoad];
+  self.title = @"Coordinate Probe";
+  self.view.backgroundColor = UIColor.systemBackgroundColor;
+  self.measurement = [NSMutableDictionary dictionary];
+
+  self.statusLabel = [UILabel new];
+  self.statusLabel.accessibilityIdentifier = @"probe-status";
+  self.statusLabel.font = [UIFont monospacedSystemFontOfSize:10 weight:UIFontWeightRegular];
+  self.statusLabel.numberOfLines = 0;
+  [self.view addSubview:self.statusLabel];
+
+  self.modeControl = [[UISegmentedControl alloc] initWithItems:@[@"Touch", @"Scroll"]];
+  self.modeControl.accessibilityIdentifier = @"probe-mode";
+  self.modeControl.selectedSegmentIndex = 0;
+  [self.modeControl addTarget:self action:@selector(modeChanged) forControlEvents:UIControlEventValueChanged];
+  [self.view addSubview:self.modeControl];
+
+  self.canvas = [FBCoordinateProbeCanvas new];
+  self.canvas.backgroundColor = UIColor.systemBlueColor;
+  self.canvas.isAccessibilityElement = YES;
+  self.canvas.accessibilityIdentifier = @"coordinate-canvas";
+  self.canvas.accessibilityLabel = @"Coordinate canvas";
+  self.canvas.accessibilityTraits = UIAccessibilityTraitAllowsDirectInteraction;
+  self.canvas.contentMode = UIViewContentModeRedraw;
+  __weak typeof(self) weakSelf = self;
+  self.canvas.onTouch = ^(NSString *phase, CGPoint point) {
+    FBCoordinateProbeViewController *controller = weakSelf;
+    if (nil == controller) {
+      return;
+    }
+    if ([phase isEqualToString:@"began"]) {
+      controller.touchCount++;
+      controller.measurement[@"start"] = @[@(point.x), @(point.y)];
+    }
+    controller.measurement[@"last"] = @[@(point.x), @(point.y)];
+    controller.measurement[@"phase"] = phase;
+    controller.measurement[@"count"] = @(controller.touchCount);
+    [controller publishMeasurement];
+  };
+  [self.view addSubview:self.canvas];
+
+  self.table = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
+  self.table.accessibilityIdentifier = @"probe-table";
+  self.table.rowHeight = 44;
+  self.table.dataSource = self;
+  self.table.delegate = self;
+  self.table.hidden = YES;
+  [self.view addSubview:self.table];
+}
+
+- (void)viewDidLayoutSubviews
+{
+  [super viewDidLayoutSubviews];
+  // Use the app's actual available area, including navigation bars and resized iPad windows.
+  CGRect safeFrame = self.view.safeAreaLayoutGuide.layoutFrame;
+  CGFloat width = MAX(0, CGRectGetWidth(safeFrame) - 40);
+  CGFloat left = CGRectGetMinX(safeFrame) + 20;
+  CGFloat top = CGRectGetMinY(safeFrame) + 8;
+  self.statusLabel.frame = CGRectMake(left, top, width, 96);
+  self.modeControl.frame = CGRectMake(left, top + 104, width, 30);
+  CGRect contentFrame = CGRectMake(left, top + 146, width,
+                                   MAX(0, CGRectGetMaxY(safeFrame) - top - 166));
+  self.canvas.frame = contentFrame;
+  self.table.frame = contentFrame;
+  [self publishMeasurement];
+}
+
+- (void)publishMeasurement
+{
+  UIWindow *window = self.view.window;
+  if (nil == window) {
+    return;
+  }
+  CGRect bounds = self.canvas.bounds;
+  CGRect frame = [self.canvas convertRect:bounds toView:window];
+  // Touch coordinates are local to the canvas. Window geometry lets tests compare
+  // those measurements with WDA's element rectangles without assuming a screen size.
+  self.measurement[@"canvasBounds"] = @[@(bounds.size.width), @(bounds.size.height)];
+  self.measurement[@"canvasWindowRect"] = @[@(frame.origin.x), @(frame.origin.y),
+                                           @(frame.size.width), @(frame.size.height)];
+  self.measurement[@"windowSize"] = @[@(window.bounds.size.width), @(window.bounds.size.height)];
+  self.measurement[@"screenSize"] = @[@(window.screen.bounds.size.width), @(window.screen.bounds.size.height)];
+  self.measurement[@"scrollY"] = @(self.table.contentOffset.y);
+  NSData *data = [NSJSONSerialization dataWithJSONObject:self.measurement
+                                               options:NSJSONWritingSortedKeys
+                                                 error:nil];
+  self.statusLabel.text = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+}
+
+- (void)modeChanged
+{
+  self.canvas.hidden = self.modeControl.selectedSegmentIndex == 1;
+  self.table.hidden = !self.canvas.hidden;
+  [self publishMeasurement];
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+{
+  return 80;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"probe-row"];
+  if (nil == cell) {
+    cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"probe-row"];
+  }
+  cell.textLabel.text = [NSString stringWithFormat:@"Probe row %ld", (long)indexPath.row];
+  cell.accessibilityIdentifier = [NSString stringWithFormat:@"probe-row-%ld", (long)indexPath.row];
+  return cell;
+}
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView
+{
+  [self publishMeasurement];
+}
+
+@end

--- a/WebDriverAgentTests/IntegrationApp/Classes/ViewController.m
+++ b/WebDriverAgentTests/IntegrationApp/Classes/ViewController.m
@@ -7,6 +7,7 @@
  */
 
 #import "ViewController.h"
+#import "FBCoordinateProbeViewController.h"
 
 @interface ViewController ()
 @property (weak, nonatomic) IBOutlet UILabel *orentationLabel;
@@ -28,6 +29,18 @@
                                              target:self
                                            selector:@selector(handleCustomAction:)];
   self.button.accessibilityCustomActions = @[action1, action2];
+
+  UIBarButtonItem *probeButton = [[UIBarButtonItem alloc] initWithTitle:@"Coordinate Probe"
+                                                               style:UIBarButtonItemStylePlain
+                                                              target:self
+                                                              action:@selector(showCoordinateProbe)];
+  probeButton.accessibilityIdentifier = @"coordinate-probe";
+  self.navigationItem.rightBarButtonItem = probeButton;
+}
+
+- (void)showCoordinateProbe
+{
+  [self.navigationController pushViewController:[FBCoordinateProbeViewController new] animated:NO];
 }
 
 - (BOOL)handleCustomAction:(UIAccessibilityCustomAction *)action

--- a/WebDriverAgentTests/IntegrationApp/Classes/ViewController.m
+++ b/WebDriverAgentTests/IntegrationApp/Classes/ViewController.m
@@ -29,16 +29,9 @@
                                              target:self
                                            selector:@selector(handleCustomAction:)];
   self.button.accessibilityCustomActions = @[action1, action2];
-
-  UIBarButtonItem *probeButton = [[UIBarButtonItem alloc] initWithTitle:@"Coordinate Probe"
-                                                               style:UIBarButtonItemStylePlain
-                                                              target:self
-                                                              action:@selector(showCoordinateProbe)];
-  probeButton.accessibilityIdentifier = @"coordinate-probe";
-  self.navigationItem.rightBarButtonItem = probeButton;
 }
 
-- (void)showCoordinateProbe
+- (IBAction)showCoordinateProbe:(id)sender
 {
   [self.navigationController pushViewController:[FBCoordinateProbeViewController new] animated:NO];
 }

--- a/WebDriverAgentTests/IntegrationApp/Classes/ViewController.m
+++ b/WebDriverAgentTests/IntegrationApp/Classes/ViewController.m
@@ -63,13 +63,13 @@
   // lay out. This page exists purely as a fixture for exercising element
   // lookups (e.g. class chain locators) against a deep accessibility tree.
   UIViewController *deepHierarchyViewController = [UIViewController new];
-  deepHierarchyViewController.view.backgroundColor = UIColor.whiteColor;
+  deepHierarchyViewController.view.backgroundColor = UIColor.systemBackgroundColor;
   deepHierarchyViewController.view.accessibilityIdentifier = @"DeepHierarchyPage";
 
   NSInteger depth = 70;
   // A plain UILabel sibling, not part of the nested chain below, so the
   // fixture stays recognizable to a human glancing at the simulator instead
-  // of showing a blank white screen.
+  // of showing a blank screen.
   UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(20, 60, CGRectGetWidth(UIScreen.mainScreen.bounds) - 40, 60)];
   titleLabel.text = [NSString stringWithFormat:@"Deep Hierarchy\n%ld nested elements", (long)depth];
   titleLabel.numberOfLines = 2;

--- a/WebDriverAgentTests/IntegrationApp/Info.plist
+++ b/WebDriverAgentTests/IntegrationApp/Info.plist
@@ -30,8 +30,6 @@
 	<string>Yo Yo</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Yo Yo</string>
-	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -49,6 +47,8 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/WebDriverAgentTests/IntegrationApp/Resources/Base.lproj/Main.storyboard
+++ b/WebDriverAgentTests/IntegrationApp/Resources/Base.lproj/Main.storyboard
@@ -83,6 +83,17 @@
                                     <action selector="goToDeepHierarchy:" destination="BYZ-38-t0r" eventType="touchUpInside" id="dHi-03-Act"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cPr-01-Btn">
+                                <rect key="frame" x="139" y="418" width="136" height="30"/>
+                                <accessibility key="accessibilityConfiguration" identifier="coordinate-probe"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="cPr-02-Hgt"/>
+                                </constraints>
+                                <state key="normal" title="Coordinate Probe"/>
+                                <connections>
+                                    <action selector="showCoordinateProbe:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cPr-03-Act"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <accessibility key="accessibilityConfiguration" label="MainView"/>
@@ -101,6 +112,8 @@
                             <constraint firstItem="M2N-Yn-ytb" firstAttribute="top" secondItem="YgP-SF-TkS" secondAttribute="bottom" constant="8" id="tMN-gl-smg"/>
                             <constraint firstItem="dHi-01-Btn" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="dHi-04-Cnt"/>
                             <constraint firstItem="dHi-01-Btn" firstAttribute="top" secondItem="1Ht-AF-MGW" secondAttribute="bottom" constant="8" id="dHi-05-Top"/>
+                            <constraint firstItem="cPr-01-Btn" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="cPr-04-Cnt"/>
+                            <constraint firstItem="cPr-01-Btn" firstAttribute="top" secondItem="dHi-01-Btn" secondAttribute="bottom" constant="8" id="cPr-05-Top"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="dmu-Fe-aoT"/>

--- a/WebDriverAgentTests/IntegrationApp/Resources/Base.lproj/Main.storyboard
+++ b/WebDriverAgentTests/IntegrationApp/Resources/Base.lproj/Main.storyboard
@@ -95,7 +95,7 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <accessibility key="accessibilityConfiguration" label="MainView"/>
                         <constraints>
                             <constraint firstItem="YgP-SF-TkS" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="41Q-cm-l5K"/>
@@ -250,7 +250,7 @@
                                     <constraint firstAttribute="height" constant="21" id="VBZ-ac-GvI"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Wim-fT-xNl">
@@ -295,7 +295,7 @@
                                     <constraint firstAttribute="height" constant="21" id="664-Z3-V7W"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="hidden_invisible" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vt6-b1-U0h">
@@ -304,7 +304,7 @@
                                     <constraint firstAttribute="height" constant="21" id="51j-sl-XYd"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GsS-jO-scK">
@@ -332,7 +332,7 @@
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no"/>
                             </textField>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="GsS-jO-scK" firstAttribute="leading" secondItem="Ucg-Ag-VpP" secondAttribute="leadingMargin" constant="154" id="1RA-Fx-3Jh"/>
                             <constraint firstItem="SjL-dx-Zsi" firstAttribute="top" secondItem="U7D-NR-20N" secondAttribute="bottom" constant="8" id="3NW-Hc-tPr"/>
@@ -458,7 +458,7 @@
                                     <constraint firstAttribute="height" constant="21" id="2qA-NT-ddc"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3Zk-wE-jwj">
@@ -479,7 +479,7 @@
                                 <state key="normal" title="Create Alert (Force Touch)"/>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="3Zk-wE-jwj" firstAttribute="centerX" secondItem="JWE-cA-TW0" secondAttribute="centerX" id="83u-1W-xLt"/>
                             <constraint firstItem="D7g-22-s49" firstAttribute="centerX" secondItem="JWE-cA-TW0" secondAttribute="centerX" id="9nT-k0-9gf"/>
@@ -540,7 +540,7 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="vYb-QB-vwU" firstAttribute="centerX" secondItem="55R-aH-x4M" secondAttribute="centerX" id="0MT-Eq-8dG"/>
                             <constraint firstItem="vYb-QB-vwU" firstAttribute="top" secondItem="yvD-8P-ibI" secondAttribute="bottom" constant="20" id="c3y-G3-HCj"/>
@@ -561,7 +561,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="jo0-3M-nUd">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" textLabel="2mC-E2-VxB" style="IBUITableViewCellStyleDefault" id="wCs-18-PFf">
                                 <rect key="frame" x="0.0" y="50" width="414" height="44"/>
@@ -574,7 +574,7 @@
                                             <rect key="frame" x="20" y="0.0" width="374" height="44"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="textColor" systemColor="labelColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -616,7 +616,7 @@
                                 </userDefinedRuntimeAttributes>
                             </scrollView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="xEQ-MI-a2g" firstAttribute="top" secondItem="KLL-RT-L40" secondAttribute="top" id="Bep-no-nwg"/>
                             <constraint firstAttribute="trailing" secondItem="xEQ-MI-a2g" secondAttribute="trailing" id="akP-zz-jsv"/>
@@ -637,6 +637,9 @@
         </scene>
     </scenes>
     <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/WebDriverAgentTests/IntegrationTests/FBConfigurationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBConfigurationTests.m
@@ -21,14 +21,10 @@
 
 @implementation FBConfigurationTests
 
-- (void)setUp
-{
-  [super setUp];
-  [self launchApplication];
-}
-
 - (void)testReduceMotion
 {
+  [self launchApplication];
+
   BOOL defaultReduceMotionEnabled = FBConfiguration.sharedInstance.reduceMotionEnabled;
 
   FBConfiguration.sharedInstance.reduceMotionEnabled = YES;
@@ -43,6 +39,9 @@
   if (FBIntegrationTestCase.isRunningInCI) {
     XCTSkip(@"Deliberately freezes the app for several seconds, too slow/flaky for CI");
   }
+
+  // Launch only after the CI skip so a skipped test cannot time out in app startup.
+  [self launchApplication];
 
   NSTimeInterval previousDeadline = FBConfiguration.sharedInstance.accessibilityDeadline;
   // Also bounds any snapshot-based wait -tap itself may perform once the app is stuck.

--- a/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.m
+++ b/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.m
@@ -34,6 +34,7 @@ NSArray<NSString *> *const FBMainViewButtonLabels = @[
   @"Scrolling",
   @"Touch",
   @"DeepHierarchy",
+  @"Coordinate Probe",
 ];
 
 @interface FBIntegrationTestCase ()


### PR DESCRIPTION
Added to help testing https://github.com/appium/WebDriverAgent/pull/1249

This is helpful to print actual touch points for LLMs as well


|a|b|c|
|:----:|:----:|:----:|
|<img width="1640" height="2360" alt="Screenshot 2026-09-05 at 9 02 44 AM" src="https://github.com/user-attachments/assets/f69b7d3f-e370-42ac-a3e3-3975442f4bd7" />|<img width="1640" height="2360" alt="Screenshot 2026-09-05 at 9 02 59 AM" src="https://github.com/user-attachments/assets/fc2707d1-ee6d-4890-83fd-c62760f5194e" />|<img width="1640" height="2360" alt="Screenshot 2026-09-05 at 9 03 01 AM" src="https://github.com/user-attachments/assets/a9bbe553-8c88-4cbc-862e-46f06d3a2694" />|


WebDriverAgentTests/IntegrationApp/COORDINATE_PROBE.md addresses how to start this with iphone only (compatibility mode) to test out the compatibility mode screen