### PR TITLE
feat: register the swipe routes on watchOS

### DIFF
--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -74,7 +74,8 @@
     [[FBRoute GET:@"/element/:uuid/attribute/focused"] respondWithTarget:self action:@selector(handleGetFocused:)],
     [[FBRoute POST:@"/wda/element/:uuid/focuse"] respondWithTarget:self action:@selector(handleFocuse:)],
 #elif !TARGET_OS_WATCH
-    // Gesture synthesis isn't supported on watchOS - only /element/:uuid/click is available.
+    // Gesture synthesis isn't supported on watchOS; the routes below all rely on it. Swipe is
+    // the exception and is registered for watchOS separately, at the end of this list.
     [[FBRoute POST:@"/wda/element/:uuid/swipe"] respondWithTarget:self action:@selector(handleSwipe:)],
     [[FBRoute POST:@"/wda/swipe"] respondWithTarget:self action:@selector(handleSwipe:)],
 
@@ -116,6 +117,13 @@
     [[FBRoute POST:@"/wda/tap"] respondWithTarget:self action:@selector(handleTap:)],
 
     [[FBRoute POST:@"/wda/pickerwheel/:uuid/select"] respondWithTarget:self action:@selector(handleWheelSelect:)],
+#endif
+#if TARGET_OS_WATCH
+    // Swiping does not need gesture synthesis: XCUIElement declares swipeUp/Down/Left/Right on
+    // watchOS, and -fb_swipeWithDirection:velocity: calls them directly. handleSwipe: is already
+    // compiled here (it lives in the non-tvOS branch below), so only the route was missing.
+    [[FBRoute POST:@"/wda/element/:uuid/swipe"] respondWithTarget:self action:@selector(handleSwipe:)],
+    [[FBRoute POST:@"/wda/swipe"] respondWithTarget:self action:@selector(handleSwipe:)],
 #endif
     [[FBRoute POST:@"/wda/keys"] respondWithTarget:self action:@selector(handleKeys:)],
   ];


### PR DESCRIPTION
On watchOS `POST /wda/swipe` and `POST /wda/element/:uuid/swipe` return `404 Unhandled endpoint`, so `mobile: swipe` is unavailable through the XCUITest driver.

They are registered only inside the `#elif !TARGET_OS_WATCH` branch of `FBElementCommands.routes`, under a comment stating that gesture synthesis is not supported on watchOS. That is accurate for the routes which synthesise events — but swipe does not synthesise anything:

* `XCUIElement.h` in the WatchSimulator SDK declares `swipeUp`, `swipeDown`, `swipeLeft`, `swipeRight` and the `WithVelocity:` variants with **no** watchOS exclusion. Only the tap family carries `API_UNAVAILABLE(tvos)`.
* `-[XCUIElement fb_swipeWithDirection:velocity:]` invokes those methods by selector, and `XCUIElement+FBSwiping.m` carries no `TARGET_OS_WATCH` guard — it is already compiled into the watchOS target.
* `handleSwipe:` lives in the non-tvOS branch of the implementation, so it is compiled there too.

The capability is therefore already present on watchOS and only the route registration was missing. This adds it in a `#if TARGET_OS_WATCH` block and reworks the neighbouring comment so it no longer implies swipe is impossible there.

### Verification

Paired Apple Watch Series 11 (46mm) / watchOS 26.5 simulator, `appium-xcuitest-driver` 12.8.0, real watch app.

| | `POST /wda/swipe` |
|---|---|
| before | `404 {"error":"unknown command","message":"Unhandled endpoint: …/wda/swipe"}` |
| after | `200`, and the swipe turns a SwiftUI `TabView(.page)` |

Six UI tests that could not run — the app under test puts its in-round screens on a horizontal pager, so only the initially-selected page was reachable — now pass.

### Scope

W3C actions stay unavailable on watchOS: `fb_performW3CActions:` is compiled out along with the rest of the touch-synthesis stack (`XCUIApplication+FBTouchAction.m`, `FBW3CActionsSynthesizer.m`, `FBBaseActionsSynthesizer.m` are each guarded `#if !TARGET_OS_TV && !TARGET_OS_WATCH`). This change deliberately does not touch that — it only exposes the native swipe that is already built.

Happy to add a functional test under the existing watchOS CI job if you would like one.